### PR TITLE
Stop cloning repo through SSH

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -6,8 +6,7 @@ policy:
 tasks:
     - $let:
           trustDomain: mobile
-          canonicalRepo: git@github.com:mozilla-mobile/firefox-android.git
-          canonicalHttpsRepo: https://github.com/mozilla-mobile/firefox-android
+          canonicalRepo: https://github.com/mozilla-mobile/firefox-android
           # Github events have this stuff in different places...
           ownerEmail:
               $if: 'tasks_for in ["cron", "action"]'
@@ -40,19 +39,19 @@ tasks:
 
           baseRepoUrl:
               $if: 'tasks_for == "github-push"'
-              then: '${event.repository.ssh_url}'
+              then: '${event.repository.html_url}'
               else:
                   $if: 'tasks_for == "github-pull-request"'
-                  then: '${event.pull_request.base.repo.ssh_url}'
+                  then: '${event.pull_request.base.repo.html_url}'
                   else:
                       $if: 'tasks_for in ["cron", "action"]'
                       then: '${repository.url}'
           repoUrl:
               $if: 'tasks_for == "github-push"'
-              then: '${event.repository.ssh_url}'
+              then: '${event.repository.html_url}'
               else:
                   $if: 'tasks_for == "github-pull-request"'
-                  then: '${event.pull_request.head.repo.ssh_url}'
+                  then: '${event.pull_request.head.repo.html_url}'
                   else:
                       $if: 'tasks_for in ["cron", "action"]'
                       then: '${repository.url}'
@@ -129,8 +128,7 @@ tasks:
               $let:
                   level:
                       $if: >
-                         (tasks_for in ["github-push", "action"] && repoUrl == canonicalRepo)
-                         || (tasks_for in ["cron"] && repoUrl == canonicalHttpsRepo)
+                         tasks_for in ["github-push", "action", "cron"] && repoUrl == canonicalRepo
                       then: '3'
                       else: '1'
 
@@ -242,7 +240,6 @@ tasks:
                                       MOBILE_HEAD_REV: '${head_sha}'
                                       MOBILE_PIP_REQUIREMENTS: taskcluster/requirements.txt
                                       MOBILE_REPOSITORY_TYPE: git
-                                      MOBILE_SSH_SECRET_NAME: project/mobile/firefox-android/github-clone-ssh
                                       MOZ_AUTOMATION: "1"
                                       REPOSITORIES: {$json: {mobile: "firefox-android"}}
                                     - $if: 'tasks_for in ["github-pull-request"]'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -277,14 +277,10 @@ tasks:
                                       $if: 'tasks_for == "action"'
                                       then: >
                                           cd /builds/worker/checkouts/vcs &&
-                                          git submodule init &&
-                                          git submodule update &&
                                           ln -s /builds/worker/artifacts artifacts &&
                                           ~/.local/bin/taskgraph action-callback
                                       else: >
                                           cd /builds/worker/checkouts/vcs &&
-                                          git submodule init &&
-                                          git submodule update &&
                                           ln -s /builds/worker/artifacts artifacts &&
                                           ~/.local/bin/taskgraph decision
                                           --pushlog-id='0'

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -151,7 +151,6 @@ taskgraph:
     repositories:
         mobile:
             name: firefox-android
-            ssh-secret-name: project/mobile/firefox-android/github-clone-ssh
     cached-task-prefix: mobile.v2.firefox-android
     decision-parameters: 'ac_taskgraph:get_decision_parameters'
 


### PR DESCRIPTION
Now that the repo is public, we don't have to deal with SSH anymore and we can resume using HTTP. This PR just reverts a couple commits we made last month.