### PR TITLE
Bug 1791084 - Add "AC-" to treeherder platform names

### DIFF
--- a/taskcluster/ci/build-samples-browser/kind.yml
+++ b/taskcluster/ci/build-samples-browser/kind.yml
@@ -33,7 +33,7 @@ task-defaults:
     run-on-tasks-for: [github-pull-request, github-push]
     treeherder:
         kind: build
-        platform: android-all/opt
+        platform: AC-android-all/opt
         tier: 1
     worker-type: b-android
     worker:

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -121,7 +121,7 @@ task-defaults:
                 release: '{component}(BR)'
                 nightly: '{component}(BN)'
                 default: '{component}(B)'
-        platform: android-all/opt
+        platform: AC-android-all/opt
         tier: 1
     worker-type: b-android
     worker:

--- a/taskcluster/ci/github-release/kind.yml
+++ b/taskcluster/ci/github-release/kind.yml
@@ -37,6 +37,6 @@ task-template:
                 default: Android-Components fake release {version}
     treeherder:
         kind: build
-        platform: android-all/opt
+        platform: AC-android-all/opt
         job-symbol: github-release
         tier: 1

--- a/taskcluster/ci/post-beetmover/kind.yml
+++ b/taskcluster/ci/post-beetmover/kind.yml
@@ -20,7 +20,7 @@ task-template:
     worker-type: succeed
     treeherder:
         kind: build
-        platform: android-all/opt
+        platform: AC-android-all/opt
         symbol:
             by-build-type:
                 release: post-beetmover-release

--- a/taskcluster/ci/post-signing/kind.yml
+++ b/taskcluster/ci/post-signing/kind.yml
@@ -20,7 +20,7 @@ task-template:
     worker-type: succeed
     treeherder:
         kind: build
-        platform: android-all/opt
+        platform: AC-android-all/opt
         symbol:
             by-build-type:
                 release: post-signing-release

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -35,7 +35,7 @@ task-defaults:
     run-on-tasks-for: [github-push]
     treeherder:
             kind: test
-            platform: 'ui-test/opt'
+            platform: 'AC-ui-test/opt'
             tier: 2
     worker-type: b-android
     worker:


### PR DESCRIPTION
Here's the simplest approach: Just add AC- to the existing treeherder "platform" names. I'm thinking that keeps things looking very similar to the way they do today for the android-components repo. When the other projects are added we can have "Focus-ui-tests" and "Fenix-ui-tests", etc, keeping each project's tests grouped on one line ("platform").

Since these are all in task defaults, the tricky part will come when incorporating focus and fenix. I don't have a clear vision for how that will work out, but I'm sure we can sort something out. Keep it simple for now?

I don't have strong feelings here, as long as we don't end up with a mish-mash of a-c/focus/fenix tasks on treeherder -- happy to hear other suggestions.