### PR TITLE
Bug 1786785 - Enable mergify bot

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Create Release"
-        uses: mozilla-mobile/relbot@2.0.0
+        uses: mozilla-mobile/relbot@2.1.0
         if: github.repository == 'mozilla-mobile/firefox-android'
         with:
           project: android-components

--- a/.github/workflows/update-geckoview.yml
+++ b/.github/workflows/update-geckoview.yml
@@ -33,16 +33,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Update GV (On Main)"
-        uses: mozilla-mobile/relbot@2.0.0
-        if: github.repository == 'mozilla-mobile/firefox-android'
+        uses: mozilla-mobile/relbot@2.1.0
+        if: github.repository == 'mozilla-mobile/firefox-android' || github.repository == 'mozilla-releng/staging-firefox-android'
         with:
           project: android-components
           command: update-main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Update GV (On Releases)"
-        uses: mozilla-mobile/relbot@2.0.0
-        if: github.repository == 'mozilla-mobile/firefox-android'
+        uses: mozilla-mobile/relbot@2.1.0
+        if: github.repository == 'mozilla-mobile/firefox-android' || github.repository == 'mozilla-releng/staging-firefox-android'
         with:
           project: android-components
           command: update-releases

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,78 @@
+queue_rules:
+  - name: default
+    conditions:
+      - status-success=complete-pr
+pull_request_rules:
+  - name: Resolve conflict
+    conditions:
+      - conflict
+    actions:
+        comment:
+          message: This pull request has conflicts when rebasing. Could you fix it @{{author}}? 🙏
+  - name: MickeyMoz - Auto Merge
+    conditions:
+      - author=MickeyMoz
+      - status-success=complete-pr
+      - files~=(Gecko.kt|publicsuffixes)
+    actions:
+      review:
+        type: APPROVE
+        message: MickeyMoz 💪
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none
+  - name: L10N - Auto Merge
+    conditions:
+      - author~=(mozilla-l10n-automation-bot|github-actions\[bot\])
+      - status-success=complete-pr
+      - files~=(strings.xml|l10n.toml)
+    actions:
+      review:
+        type: APPROVE
+        message: LGTM 😎
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none
+  - name: Release automation
+    conditions:
+      - author=github-actions[bot]
+      - status-success=complete-pr
+      - files~=(.buildconfig.yml|Gecko.kt)
+    actions:
+      review:
+        type: APPROVE
+        message: 🚢
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none
+      delete_head_branch:
+        force: false
+  - name: Needs landing - Rebase
+    conditions:
+      - status-success=complete-pr
+      - label=🛬 needs landing
+      - "#approved-reviews-by>=1"
+      - -draft
+      - label!=work in progress
+      - label!=do not land
+    actions:
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none
+  - name: Needs landing - Squash
+    conditions:
+      - status-success=complete-pr
+      - label=🛬 needs landing (squash)
+      - "#approved-reviews-by>=1"
+      - -draft
+      - label!=work in progress
+      - label!=do not land
+    actions:
+      queue:
+        method: squash
+        name: default
+        rebase_fallback: none

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,8 +41,8 @@ pull_request_rules:
     conditions:
       - author=github-actions[bot]
       - status-success=complete-pr
-      - files~=^android-components/(\.buildconfig\.yml|buildSrc/src/main/java/Gecko\.kt)
-      - -files~=^(?!android-components/(\.buildconfig\.yml|buildSrc/src/main/java/Gecko\.kt)).+$
+      - files~=^android-components/(\.buildconfig\.yml|.+/NimbusGradlePlugin\.groovy|buildSrc/src/main/java/(Gecko|Dependencies)\.kt)
+      - -files~=^(?!android-components/(\.buildconfig\.yml|.+/NimbusGradlePlugin\.groovy|buildSrc/src/main/java/(Gecko|Dependencies)\.kt)).+$
     actions:
       review:
         type: APPROVE

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,6 +14,7 @@ pull_request_rules:
       - author=MickeyMoz
       - status-success=complete-pr
       - files~=^android-components/(Gecko.kt|components/lib/publicsuffixlist/src/main/assets/publicsuffixes)
+      - -files~=^(?!android-components/(Gecko.kt|components/lib/publicsuffixlist/src/main/assets/publicsuffixes)).+$
     actions:
       review:
         type: APPROVE
@@ -27,6 +28,7 @@ pull_request_rules:
       - author~=(mozilla-l10n-automation-bot|github-actions\[bot\])
       - status-success=complete-pr
       - files~=^android-components/(.+/strings.xml|l10n.toml)
+      - -files~=^(?!android-components/(.+/strings.xml|l10n.toml)).+$
     actions:
       review:
         type: APPROVE
@@ -40,6 +42,7 @@ pull_request_rules:
       - author=github-actions[bot]
       - status-success=complete-pr
       - files~=^android-components/(.buildconfig.yml|buildSrc/src/main/java/Gecko.kt)
+      - -files~=^(?!android-components/(.buildconfig.yml|buildSrc/src/main/java/Gecko.kt)).+$
     actions:
       review:
         type: APPROVE

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,7 @@ pull_request_rules:
     conditions:
       - author=MickeyMoz
       - status-success=complete-pr
-      - files~=(Gecko.kt|publicsuffixes)
+      - files~=^android-components/(Gecko.kt|components/lib/publicsuffixlist/src/main/assets/publicsuffixes)
     actions:
       review:
         type: APPROVE
@@ -26,7 +26,7 @@ pull_request_rules:
     conditions:
       - author~=(mozilla-l10n-automation-bot|github-actions\[bot\])
       - status-success=complete-pr
-      - files~=(strings.xml|l10n.toml)
+      - files~=^android-components/(.+/strings.xml|l10n.toml)
     actions:
       review:
         type: APPROVE
@@ -39,7 +39,7 @@ pull_request_rules:
     conditions:
       - author=github-actions[bot]
       - status-success=complete-pr
-      - files~=(.buildconfig.yml|Gecko.kt)
+      - files~=^android-components/(.buildconfig.yml|buildSrc/src/main/java/Gecko.kt)
     actions:
       review:
         type: APPROVE

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,8 +13,8 @@ pull_request_rules:
     conditions:
       - author=MickeyMoz
       - status-success=complete-pr
-      - files~=^android-components/(Gecko.kt|components/lib/publicsuffixlist/src/main/assets/publicsuffixes)
-      - -files~=^(?!android-components/(Gecko.kt|components/lib/publicsuffixlist/src/main/assets/publicsuffixes)).+$
+      - files~=^android-components/(Gecko\.kt|components/lib/publicsuffixlist/src/main/assets/publicsuffixes)
+      - -files~=^(?!android-components/(Gecko\.kt|components/lib/publicsuffixlist/src/main/assets/publicsuffixes)).+$
     actions:
       review:
         type: APPROVE
@@ -27,8 +27,8 @@ pull_request_rules:
     conditions:
       - author~=(mozilla-l10n-automation-bot|github-actions\[bot\])
       - status-success=complete-pr
-      - files~=^android-components/(.+/strings.xml|l10n.toml)
-      - -files~=^(?!android-components/(.+/strings.xml|l10n.toml)).+$
+      - files~=^android-components/(.+/strings\.xml|l10n\.toml)
+      - -files~=^(?!android-components/(.+/strings\.xml|l10n\.toml)).+$
     actions:
       review:
         type: APPROVE
@@ -41,8 +41,8 @@ pull_request_rules:
     conditions:
       - author=github-actions[bot]
       - status-success=complete-pr
-      - files~=^android-components/(.buildconfig.yml|buildSrc/src/main/java/Gecko.kt)
-      - -files~=^(?!android-components/(.buildconfig.yml|buildSrc/src/main/java/Gecko.kt)).+$
+      - files~=^android-components/(\.buildconfig\.yml|buildSrc/src/main/java/Gecko\.kt)
+      - -files~=^(?!android-components/(\.buildconfig\.yml|buildSrc/src/main/java/Gecko\.kt)).+$
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
Needs to be tested in staging first. It happen once the Mergify app gets added on https://github.com/mozilla-releng/staging-firefox-android. After that, we need to land this on the `main` branch to get this tested. Mergify only takes the config in the `main` into account.