### PR TITLE
Bug 1786793 - Bump sync-strings-action to 1.0.3

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -31,7 +31,7 @@ jobs:
           path: work
           ref: "releases/${{ steps.ac-version-for-fenix-beta.outputs.major-ac-version }}.0"
       - name: "Sync Strings"
-        uses: mozilla-mobile/sync-strings-action@1.0.2
+        uses: mozilla-mobile/sync-strings-action@1.0.3
         with:
           src: main
           dst: work


### PR DESCRIPTION
This fixes the path to the strings xml in the sync-strings-action script that was required due to https://github.com/mozilla-mobile/firefox-android/commit/293174cb840491681de4c512f8140f33ae05e60e



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
