### PR TITLE
Fix broken links in contributing page docs

### DIFF
--- a/android-components/docs/components.md
+++ b/android-components/docs/components.md
@@ -10,8 +10,8 @@ permalink: /components/
 
 Every browser will need two core components:
 
-* **[browser-state](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/state)** - Representing the state of the browser (_"What tabs are opened?"_, _"What URLs are they pointing to?"_)
-* **browser-engine** - The browser engine that transforms web pages into an interactive visual representation. The _browser-engine_ component comes in multiple flavors. We are supporting [Android's WebView](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/engine-system) (limited feature set) and **GeckoView** ([Release](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/engine-gecko), [Beta](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/engine-gecko-beta) and [Nightly](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/engine-gecko-nightly) channels) currently. The actual implementation is hidden behind [generic interfaces](https://github.com/mozilla-mobile/android-components/tree/main/components/concept) so that apps can build against multiple engines (e.g. based on product flavor) and so that other components work seemlessly with all implementations.
+* **[browser-state](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/state)** - Representing the state of the browser (_"What tabs are opened?"_, _"What URLs are they pointing to?"_)
+* **browser-engine** - The browser engine that transforms web pages into an interactive visual representation. The _browser-engine_ component comes in multiple flavors. We are supporting [Android's WebView](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/engine-system) (limited feature set) and **GeckoView** ([Release](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/engine-gecko), [Beta](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/engine-gecko-beta) and [Nightly](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/engine-gecko-nightly) channels) currently. The actual implementation is hidden behind [generic interfaces](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/concept) so that apps can build against multiple engines (e.g. based on product flavor) and so that other components work seemlessly with all implementations.
 
 Other high-level browser components may depend on those core components.
 
@@ -19,18 +19,18 @@ Other high-level browser components may depend on those core components.
 
 The following components offer customizable building blocks for browser apps:
 
-* [browser-toolbar](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/toolbar) - A customizable browser toolbar for displaying and editing URLs, actions buttons and menus.
-* [browser-domains](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/domains) - Localized and customizable domain lists for auto-completion in browsers.
-* [browser-errorpages](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/errorpages) - Localized and responsive error pages for mobile browsers.
-* [browser-search](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/search) - Localized search plugins and code for loading and parsing them as well as querying search engines for search suggestions.
-* [browser-tabstray](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/tabstray) - A customizable tabs tray component for mobile browsers.
-* [browser-menu](https://github.com/mozilla-mobile/android-components/tree/main/components/browser/menu) - A customizable overflow menu. Can be used with _browser-toolbar_.
+* [browser-toolbar](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/toolbar) - A customizable browser toolbar for displaying and editing URLs, actions buttons and menus.
+* [browser-domains](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/domains) - Localized and customizable domain lists for auto-completion in browsers.
+* [browser-errorpages](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/errorpages) - Localized and responsive error pages for mobile browsers.
+* [browser-search](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/search) - Localized search plugins and code for loading and parsing them as well as querying search engines for search suggestions.
+* [browser-tabstray](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/tabstray) - A customizable tabs tray component for mobile browsers.
+* [browser-menu](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/browser/menu) - A customizable overflow menu. Can be used with _browser-toolbar_.
 
 ### Features
 
 Feature components connect multiple components together and implement complete browser features.
 
-[List of feature components in the android-components repository](https://github.com/mozilla-mobile/android-components/tree/main/components/feature)
+[List of feature components in the android-components repository](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/feature)
 
 ## Apps
 
@@ -40,34 +40,34 @@ Components for Android apps - browsers and other apps.
 
 Independent, small visual UI elements to use in applications.
 
-* [ui-autocomplete](https://github.com/mozilla-mobile/android-components/tree/main/components/ui/autocomplete) - A user interface element for entering and modifying text with the ability to inline autocomplete.
-* [ui-colors](https://github.com/mozilla-mobile/android-components/tree/main/components/ui/colors) - The standard set of [colors](https://design.firefox.com/photon/visuals/color.html) used in the [Photon Design System](https://design.firefox.com/photon/) for Firefox products.
-* [ui-fonts](https://github.com/mozilla-mobile/android-components/tree/main/components/ui/fonts) - The standard set of fonts used by Mozilla Android products.
-* [ui-icons]({{ site.baseurl }}/components/ui/icons) - Android vector drawable versions of the [icons](https://design.firefox.com/icons/viewer/) from the [Photon Design System](https://design.firefox.com/photon/).
-* [ui-progress](https://github.com/mozilla-mobile/android-components/tree/main/components/ui/progress) - An animated progress bar following the [Photon Design System](https://design.firefox.com/photon/)..
-* [ui-tabcounter](https://github.com/mozilla-mobile/android-components/tree/main/components/ui/tabcounter) - A button that shows the current tab count and can animate state changes.
+* [ui-autocomplete](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/ui/autocomplete) - A user interface element for entering and modifying text with the ability to inline autocomplete.
+* [ui-colors](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/ui/colors) - The standard set of [colors](https://design.firefox.com/photon/visuals/color.html) used in the [Photon Design System](https://design.firefox.com/photon/) for Firefox products.
+* [ui-fonts](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/ui/fonts) - The standard set of fonts used by Mozilla Android products.
+* [ui-icons]({{ site.baseurl }}/android-components/components/ui/icons) - Android vector drawable versions of the [icons](https://design.firefox.com/icons/viewer/) from the [Photon Design System](https://design.firefox.com/photon/).
+* [ui-progress](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/ui/progress) - An animated progress bar following the [Photon Design System](https://design.firefox.com/photon/)..
+* [ui-tabcounter](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/ui/tabcounter) - A button that shows the current tab count and can animate state changes.
 
 ### Services
 
-* [service-contile](https://github.com/mozilla-mobile/android-components/tree/main/components/service/contile) - A library for communicating with the Contile services API.
-* [service-firefox-accounts](https://github.com/mozilla-mobile/android-components/tree/main/components/service/firefox-accounts) - A library for integrating with [Firefox Accounts](https://mozilla.github.io/application-services/docs/accounts/welcome.html).
-* [service-fretboard](https://github.com/mozilla-mobile/android-components/tree/main/components/service/fretboard) - An Android framework for segmenting users in order to run A/B tests and rollout features gradually.
-* [service-pocket](https://github.com/mozilla-mobile/android-components/tree/main/components/service/pocket) - A library for communicating with the Pocket API.
-* [service-telemetry](https://github.com/mozilla-mobile/android-components/tree/main/components/service/telemetry) - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service (Deprecated. Use `service-glean` instead).
-* [service-glean](https://github.com/mozilla-mobile/android-components/tree/main/components/service/glean) - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service.
+* [service-contile](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/service/contile) - A library for communicating with the Contile services API.
+* [service-firefox-accounts](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/service/firefox-accounts) - A library for integrating with [Firefox Accounts](https://mozilla.github.io/application-services/docs/accounts/welcome.html).
+* [service-fretboard](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/service/fretboard) - An Android framework for segmenting users in order to run A/B tests and rollout features gradually.
+* [service-pocket](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/service/pocket) - A library for communicating with the Pocket API.
+* [service-telemetry](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/service/telemetry) - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service (Deprecated. Use `service-glean` instead).
+* [service-glean](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/service/glean) - A generic library for sending telemetry pings from Android applications to Mozilla's telemetry service.
 
 ## Samples
 
 * [Reference Browser (full-featured browser)](https://github.com/mozilla-mobile/reference-browser) - Advanced reference browser implementation based on the browser components.
-* [Simple Browser](https://github.com/mozilla-mobile/android-components/blob/main/samples/browser) - Very basic browser implementation based on the browser components.
-* [Crash](https://github.com/mozilla-mobile/android-components/blob/main/samples/crash) - Sample integration for the [lib-crash](https://github.com/mozilla-mobile/android-components/blob/main/components/lib/crash/README.md) component.
-* [DataProtect](https://github.com/mozilla-mobile/android-components/blob/main/samples/dataprotect) - An app demoing how to use the [Dataprotect](https://github.com/mozilla-mobile/android-components/blob/main/components/lib/dataprotect/README.md) component to load and store encrypted data in SharedPreferences.
-* [Firefox Accounts (FxA)](https://github.com/mozilla-mobile/android-components/blob/main/samples/firefox-accounts) - A simple app demoing Firefox Accounts integration.
-* [Firefox Sync](https://github.com/mozilla-mobile/android-components/blob/main/samples/sync) - A simple app demoing general Firefox Sync integration, with bookmarks and history.
-* [Firefox Sync - Logins](https://github.com/mozilla-mobile/android-components/blob/main/samples/sync-logins) - A simple app demoing Firefox Sync (Logins) integration.
-* [Glean](https://github.com/mozilla-mobile/android-components/blob/main/samples/glean) - An app demoing how to use the [Glean](https://github.com/mozilla-mobile/android-components/blob/main/components/service/glean/README.md) library to collect and send telemetry data.
-* [Toolbar](https://github.com/mozilla-mobile/android-components/blob/main/samples/toolbar) - An app demoing multiple customized toolbars using the [browser-toolbar](https://github.com/mozilla-mobile/android-components/blob/main/components/browser/toolbar/README.md) component.
+* [Simple Browser](https://github.com/mozilla-mobile/firefox-android/blob/main/samples/browser) - Very basic browser implementation based on the browser components.
+* [Crash](https://github.com/mozilla-mobile/firefox-android/blob/main/samples/crash) - Sample integration for the [lib-crash](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/lib/crash/README.md) component.
+* [DataProtect](https://github.com/mozilla-mobile/firefox-android/blob/main/samples/dataprotect) - An app demoing how to use the [Dataprotect](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/lib/dataprotect/README.md) component to load and store encrypted data in SharedPreferences.
+* [Firefox Accounts (FxA)](https://github.com/mozilla-mobile/firefox-android/blob/main/samples/firefox-accounts) - A simple app demoing Firefox Accounts integration.
+* [Firefox Sync](https://github.com/mozilla-mobile/firefox-android/blob/main/samples/sync) - A simple app demoing general Firefox Sync integration, with bookmarks and history.
+* [Firefox Sync - Logins](https://github.com/mozilla-mobile/firefox-android/blob/main/samples/sync-logins) - A simple app demoing Firefox Sync (Logins) integration.
+* [Glean](https://github.com/mozilla-mobile/firefox-android/blob/main/samples/glean) - An app demoing how to use the [Glean](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/service/glean/README.md) library to collect and send telemetry data.
+* [Toolbar](https://github.com/mozilla-mobile/firefox-android/blob/main/samples/toolbar) - An app demoing multiple customized toolbars using the [browser-toolbar](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/browser/toolbar/README.md) component.
 
 ## More
 
-[List of all components in the android-components repository](https://github.com/mozilla-mobile/android-components/blob/main/README.md)
+[List of all components in the android-components repository](https://github.com/mozilla-mobile/firefox-android/blob/main/README.md)

--- a/android-components/docs/contribute/components_inside_app.md
+++ b/android-components/docs/contribute/components_inside_app.md
@@ -95,7 +95,7 @@ This is the fully manual version of the above flow. Generally not recommended fo
 
 #### Setup version number
 
-In the *android-components* repository update the version number [in the configuration](https://github.com/mozilla-mobile/android-components/blob/main/.buildconfig.yml#L1) so that the app will be required to "download" this new version. Try to avoid picking a version number that was or will be officially released. Otherwise you may "pollute" your gradle cache with unofficial releases. To follow [the Maven convention](https://maven.apache.org/guides/getting-started/index.html#What_is_a_SNAPSHOT_version) you may want to use a `-SNAPSHOT` suffix.
+In the *android-components* repository update the version number [in the configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.buildconfig.yml#L1) so that the app will be required to "download" this new version. Try to avoid picking a version number that was or will be officially released. Otherwise you may "pollute" your gradle cache with unofficial releases. To follow [the Maven convention](https://maven.apache.org/guides/getting-started/index.html#What_is_a_SNAPSHOT_version) you may want to use a `-SNAPSHOT` suffix.
 
 #### Publish to local maven repository
 

--- a/android-components/docs/contribute/hosting_code_in_repository.md
+++ b/android-components/docs/contribute/hosting_code_in_repository.md
@@ -4,9 +4,9 @@ title: Hosting Android code in the Android Components repository
 permalink: /contributing/hosting-android-code-in-repository
 ---
 
-When developing a new (Mozilla) Android component - especially one that wraps **Rust** code for multiple platforms - one decision to make is where the Android (Kotlin/Java) code should live. Should it live in a project repository that also contains the Rust code or should it live in the *android-components* repository alongside the other Android code?
+When developing a new (Mozilla) Android component - especially one that wraps **Rust** code for multiple platforms - one decision to make is where the Android (Kotlin/Java) code should live. Should it live in a project repository that also contains the Rust code or should it live in the *firefox-android* repository alongside the other Android code?
 
-This document lists the advantages you get *for free* when hosting your Android code in the *android-components* repository (consuming pre-compiled binaries of your Rust code).
+This document lists the advantages you get *for free* when hosting your Android code in the *firefox-android* repository (consuming pre-compiled binaries of your Rust code).
 
 ## Build
 
@@ -38,7 +38,7 @@ The *Android components* team is planning to release SNAPSHOT builds for every s
 
 #### Consistent versioning and compatibility
 
-All components are released together with a shared version number. This guarantees that all components with the same version number are compatible. With that a consuming app can use the components in the same setup as they were developed and tested in the *android-components* repository.
+All components are released together with a shared version number. This guarantees that all components with the same version number are compatible. With that a consuming app can use the components in the same setup as they were developed and tested in the *firefox-android* repository.
 
 #### Less Fragmentation
 
@@ -59,7 +59,7 @@ Currently we are using:
 * [ktlint](https://github.com/shyiko/ktlint) - *"An anti-bikeshedding Kotlin linter with built-in formatter"*
 * [detekt](https://github.com/arturbosch/detekt) - *"A static code analysis tool for the Kotlin programming language"*
 
-In addition to that the *Android components* team started to write [custom lint rules](https://github.com/mozilla-mobile/android-components/tree/main/components/tooling/lint) that enforce component related rules (e.g. "Use the provided logging class in components instead of android.util.Log").
+In addition to that the *Android components* team started to write [custom lint rules](https://github.com/mozilla-mobile/firefox-android/tree/main/android-components/components/tooling/lint) that enforce component related rules (e.g. "Use the provided logging class in components instead of android.util.Log").
 
 ## Services
 
@@ -100,4 +100,4 @@ You remain the owner of your components code. Each component can have a [CODEOWN
 
 ## Conclusion
 
-The *Android components* team recommends hosting Android component code (Kotlin) in the *android-components* repository for the reasons mentioned above.
+The *Android components* team recommends hosting Android component code (Kotlin) in the *firefox-android* repository for the reasons mentioned above.

--- a/android-components/docs/contribute/release_checklist.md
+++ b/android-components/docs/contribute/release_checklist.md
@@ -13,7 +13,7 @@ These are instructions for preparing a release branch for Android Components and
 1. Create a branch name with the format `releases/[beta_version].0` off of the `main` branch (for example, `releases/98.0`) through the GitHub UI.
 `[beta_version]` should follow the Firefox Beta release number. See [Firefox Release Calendar](https://wiki.mozilla.org/Release_Management/Calendar).
 2. Notify the dev team that they can start the new Nightly development cycle per the steps given in the next section ⬇️
-3. In [Gecko.kt](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt):
+3. In [Gecko.kt](https://github.com/mozilla-mobile/firefox-android/blob/main/buildSrc/src/main/java/Gecko.kt):
    - Set the `channel` to `val channel = GeckoChannel.BETA`.
 
     ```diff
@@ -49,7 +49,7 @@ These are instructions for preparing a release branch for Android Components and
 
 0. Wait for greenlight coming from Release Management.
 1. Create a local development branch off of the `main` branch.
-2. Create a commit named `Start [nightly_version].0.0 development cycle`. In [version.txt](https://github.com/mozilla-mobile/android-components/blob/main/version.txt), bump the major number by 1. `[nightly_version]` should follow the Firefox Nightly release number. See [Firefox Release Calendar](https://wiki.mozilla.org/Release_Management/Calendar).
+2. Create a commit named `Start [nightly_version].0.0 development cycle`. In [version.txt](https://github.com/mozilla-mobile/firefox-android/blob/main/version.txt), bump the major number by 1. `[nightly_version]` should follow the Firefox Nightly release number. See [Firefox Release Calendar](https://wiki.mozilla.org/Release_Management/Calendar).
 
     ```diff
     diff --git a/version.txt b/version.txt
@@ -61,8 +61,8 @@ These are instructions for preparing a release branch for Android Components and
     +99.0.0
     ```
 
-3. Create a new [Github Milestone](https://github.com/mozilla-mobile/android-components/milestones) with the following format `[nightly_version].0.0 <insert an emoji>` (for example, `99.0.0 🛎`). Close the existing milestone and bump all the remaining opened issues to the next milestone or simply remove the tagged milestone depending on what is appropriate.
-4. Create a commit named `Update changelog for [nightly_version].0.0 release` that will update the following in [changelog.md](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md):
+3. Create a new [Github Milestone](https://github.com/mozilla-mobile/firefox-android/milestones) with the following format `[nightly_version].0.0 <insert an emoji>` (for example, `99.0.0 🛎`). Close the existing milestone and bump all the remaining opened issues to the next milestone or simply remove the tagged milestone depending on what is appropriate.
+4. Create a commit named `Update changelog for [nightly_version].0.0 release` that will update the following in [changelog.md](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/docs/changelog.md):
   - Add a new `[nightly_version].0.0 (In Development)` section for the next Nightly version of AC with the next commit and milestone numbers.
   - Update the `[beta_version].0.0` section, change `blob` in the links to `v[beta_version].0.0` and specifying the correct commit ranges.
 
@@ -95,7 +95,7 @@ These are instructions for preparing a release branch for Android Components and
     ```
 
 5. Create a pull request with these 2 commits and land.
-  - If this is landed after the scheduled [cron task](https://github.com/mozilla-mobile/android-components/blob/main/.cron.yml#L13) that will build and bump AC automatically, trigger a manual AC build through the [hook](https://firefox-ci-tc.services.mozilla.com/hooks/project-releng/cron-task-mozilla-mobile-android-components%2Fnightly). At time of writing, the morning cron task is schedule to run at 14:30 UTC (9:30AM EST).
+  - If this is landed after the scheduled [cron task](https://github.com/mozilla-mobile/firefox-android/blob/main/.cron.yml#L13) that will build and bump AC automatically, trigger a manual AC build through the [hook](https://firefox-ci-tc.services.mozilla.com/hooks/project-releng/cron-task-mozilla-mobile-android-components%2Fnightly). At time of writing, the morning cron task is schedule to run at 14:30 UTC (9:30AM EST).
   - When the manual AC build is complete, trigger the [hook](https://firefox-ci-tc.services.mozilla.com/hooks/project-releng/cron-task-mozilla-mobile-fenix%2Fbump-android-components) to bump AC in Fenix.
 6. After an hour, follow up by checking if a new `[nightly_version]` AC build is available in [nightly.maven/components](https://nightly.maven.mozilla.org/?prefix=maven2/org/mozilla/components/). Fenix and Focus will automatically receive the Nightly AC bump.
 
@@ -103,11 +103,11 @@ See [https://github.com/mozilla-mobile/android-components/pull/12956](https://gi
 
 ## After the release
 
-1. Verify that the links in the [changelog.md](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) and new release are working.
+1. Verify that the links in the [changelog.md](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/docs/changelog.md) and new release are working.
 2. Verify that Fenix is receiving the latest `[nightly_version]` AC version in `main`.
 3. Send release message to the [Matrix channel](https://chat.mozilla.org/#/room/#android-components:mozilla.org):
 ```
 **Android Components 0.17 Release (:ocean:)**
-Release notes: https://mozilla-mobile.github.io/android-components/changelog/
-Milestone: https://github.com/mozilla-mobile/android-components/milestone/15?closed=1
+Release notes: https://mozac.org/changelog/
+Milestone: https://github.com/mozilla-mobile/firefox-android/milestone/15?closed=1
 ```

--- a/android-components/docs/contribute/updating_tracking_protection_lists.md
+++ b/android-components/docs/contribute/updating_tracking_protection_lists.md
@@ -53,9 +53,9 @@ commit(shavar-prod-lists) 01dcca911aa7787fd835a1a19cef1012296f4eb7
 
 THE END!
 
-[1]: https://github.com/mozilla-mobile/android-components/blob/main/components/browser/engine-system/src/main/res/raw/domain_blocklist.json
+[1]: https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/browser/engine-system/src/main/res/raw/domain_blocklist.json
 [2]: https://github.com/mozilla-services/shavar-prod-lists/blob/master/disconnect-blocklist.json
 [3]: https://github.com/mozilla-services/shavar-prod-lists/blob/master/README.md#disconnect-blocklist.json
-[4]: https://github.com/mozilla-mobile/android-components/blob/main/components/browser/engine-system/src/main/res/raw/domain_safelist.json
+[4]: https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/browser/engine-system/src/main/res/raw/domain_safelist.json
 [5]: https://github.com/mozilla-services/shavar-prod-lists/blob/master/disconnect-entitylist.json
 [6]: https://github.com/mozilla-services/shavar-prod-lists/blob/master/README.md#disconnect-entitylistjson

--- a/android-components/docs/contributing.md
+++ b/android-components/docs/contributing.md
@@ -17,14 +17,14 @@ Before contributing, please review our [Community Participation Guidelines](http
 
 ### Project
 
-* [Hosting Android code in the Android Components repository]({{ site.baseurl }}{% link contribute/hosting_code_in_repository.md %})
+* [Hosting Android code in the Android Components repository]({{ site.baseurl }}/contributing/hosting-android-code-in-repository)
 
 ### Development
 
 * [Design Axioms]({{ site.baseurl }}/contributing/design-axioms)
 * [Architecture and Overview]({{ site.baseurl }}/contributing/architecture)
 * [Code coverage]({{ site.baseurl }}/contributing/code-coverage)
-* [Working on unreleased component code in an app]({{ site.baseurl }}{% link contribute/components_inside_app.md %})
+* [Working on unreleased component code in an app]({{ site.baseurl }}/contributing/testing-components_inside_app)
 
 ### Process
 

--- a/android-components/docs/ui/icons.md
+++ b/android-components/docs/ui/icons.md
@@ -30,4 +30,4 @@ Android vector drawable versions of the [icons](https://design.firefox.com/icons
 
 ## More
 
-[List of all components in the android-components repository](https://github.com/mozilla-mobile/android-components/blob/main/README.md)
+[List of all components in the android-components repository](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/README.md)


### PR DESCRIPTION
Working through "pages build and deployment" errors. Let's see.

We'll need more adjustment to our docs and website, but for now let's fix the links and get the build green.