### PR TITLE
Add an AC prefix to GitHub actions that operates on android-components

### DIFF
--- a/.github/workflows/ac-create-release.yml
+++ b/.github/workflows/ac-create-release.yml
@@ -12,7 +12,7 @@
 # what relbot thinks is current, then nothing happens.
 #
 
-name: "Create Release"
+name: "AC - Create Release"
 
 permissions:
   contents: write

--- a/.github/workflows/ac-sync-strings.yml
+++ b/.github/workflows/ac-sync-strings.yml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-name: "Sync Strings"
+name: "AC - Sync Strings"
 
 permissions:
   contents: write

--- a/.github/workflows/ac-update-geckoview.yml
+++ b/.github/workflows/ac-update-geckoview.yml
@@ -17,7 +17,7 @@
 # to Maven.
 #
 
-name: "Update GeckoView"
+name: "AC - Update GeckoView"
 
 permissions:
   contents: write


### PR DESCRIPTION
We're adding an AC prefix to the existing AC GitHub actions filenames and titles to help differentiate the actions. This will be needed when we migrate the remaining Fenix and Focus GitHub actions in the future where it would be otherwise hard to tell what the action is doing if they are named the same or it is unclear which subfolder the action is operating on.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
