### PR TITLE
Bug 1795903 - Introduce StorageMaintenanceWorker in A-C that runs periodically to prune places storage.

### DIFF
--- a/android-components/components/browser/storage-sync/build.gradle
+++ b/android-components/components/browser/storage-sync/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation project(':support-sync-telemetry')
 
     implementation Dependencies.kotlin_stdlib
+    implementation Dependencies.androidx_work_runtime
 
     testImplementation project(':support-test')
 
@@ -47,6 +48,8 @@ dependencies {
     testImplementation Dependencies.testing_robolectric
     testImplementation Dependencies.testing_mockito
     testImplementation Dependencies.testing_coroutines
+    testImplementation Dependencies.androidx_work_testing
+    testImplementation Dependencies.kotlin_reflect
 
     testImplementation Dependencies.mozilla_places
     testImplementation Dependencies.mozilla_remote_tabs

--- a/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/GlobalPlacesDependencyProvider.kt
+++ b/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/GlobalPlacesDependencyProvider.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.storage.sync
+
+import androidx.annotation.VisibleForTesting
+
+/**
+ * Provides global access to the dependencies needed for places storage operations.
+ * */
+object GlobalPlacesDependencyProvider {
+
+    @VisibleForTesting
+    internal var placesStorage: PlacesStorage? = null
+
+    /**
+     * Initializes places storage for running the maintenance task via [PlacesHistoryStorageWorker].
+     * This method should be called in client application's onCreate method and before
+     * [PlacesHistoryStorage.registerStorageMaintenanceWorker] in order to run the worker while
+     * the app is not running.
+     * */
+    fun initialize(placesStorage: PlacesStorage) {
+        this.placesStorage = placesStorage
+    }
+
+    /**
+     * Provides [PlacesStorage] globally when needed for [PlacesHistoryStorageWorker]
+     * to run maintenance on the storage.
+     * */
+    internal fun requirePlacesStorage(): PlacesStorage {
+        return requireNotNull(placesStorage) {
+            "GlobalPlacesDependencyProvider.initialize must be called before accessing the Places storage"
+        }
+    }
+}

--- a/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageWorker.kt
+++ b/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageWorker.kt
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.storage.sync
+
+import android.content.Context
+import androidx.work.WorkerParameters
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * A WorkManager Worker that executes [PlacesStorage.runMaintenance].
+ *
+ * If there is a failure or the worker constraints are no longer met during execution,
+ * active write operations on [PlacesStorage] are cancelled.
+ *
+ * See also [StorageMaintenanceWorker].
+ */
+internal class PlacesHistoryStorageWorker(context: Context, params: WorkerParameters) :
+    StorageMaintenanceWorker(context, params) {
+
+    val logger = Logger(PLACES_HISTORY_STORAGE_WORKER_TAG)
+
+    override suspend fun operate() {
+        GlobalPlacesDependencyProvider.requirePlacesStorage()
+            .runMaintenance(DB_SIZE_LIMIT_IN_BYTES.toUInt())
+    }
+
+    override fun onError(exception: Exception) {
+        GlobalPlacesDependencyProvider.requirePlacesStorage().cancelWrites()
+        logger.error("An exception occurred while running the maintenance task: ${exception.message}")
+    }
+
+    companion object {
+        private const val IDENTIFIER_PREFIX = "mozilla.components.browser.storage.sync"
+        private const val PLACES_HISTORY_STORAGE_WORKER_TAG = "$IDENTIFIER_PREFIX.PlacesHistoryStorageWorker"
+
+        internal const val DB_SIZE_LIMIT_IN_BYTES = 75 * 1024 * 1024 // corresponds to 75MiB (in bytes)
+        internal const val UNIQUE_NAME = "$IDENTIFIER_PREFIX.PlacesHistoryStorageWorker"
+    }
+}

--- a/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
+++ b/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
@@ -83,8 +83,8 @@ open class RemoteTabsStorage(
         }
     }
 
-    override suspend fun runMaintenance() {
-        // There's no such thing as maintenance for remote tabs, as it is a in-memory store.
+    override suspend fun runMaintenance(dbSizeLimit: UInt) {
+        // Storage maintenance workflow for remote tabs is not implemented yet.
     }
 
     override fun cleanup() {

--- a/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/StorageExtensions.kt
+++ b/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/StorageExtensions.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.storage.sync
+
+import androidx.work.Constraints
+import androidx.work.PeriodicWorkRequest
+import androidx.work.PeriodicWorkRequestBuilder
+import mozilla.components.concept.storage.Storage
+import java.util.concurrent.TimeUnit
+
+/**
+ * Builds and returns a [PeriodicWorkRequest] based on [PeriodicWorkRequestBuilder]
+ * with a given [StorageMaintenanceWorker].
+ *
+ * @param repeatInterval Repeat interval of the periodic work request.
+ * @param repeatIntervalTimeUnit Time unit for the repeat interval of the work request.
+ * @param tag Work request's tag.
+ * @param constraints A block that returns the [Constraints] for the work.
+ * @return [PeriodicWorkRequest].
+ * */
+inline fun <reified T : StorageMaintenanceWorker> Storage.periodicStorageWorkRequest(
+    repeatInterval: Long = StorageMaintenanceWorker.WORKER_PERIOD_IN_HOURS,
+    repeatIntervalTimeUnit: TimeUnit = TimeUnit.HOURS,
+    tag: String?,
+    constraints: Storage.() -> Constraints,
+): PeriodicWorkRequest {
+    return PeriodicWorkRequestBuilder<T>(
+        repeatInterval,
+        repeatIntervalTimeUnit,
+    ).apply {
+        setConstraints(constraints())
+        tag?.let { addTag(tag) }
+    }.build()
+}
+
+/**
+ * Builds and returns a [Constraints] based on [Constraints.Builder] provided by [block].
+ * @return [Constraints].
+ * */
+fun constraints(block: Constraints.Builder.() -> Unit): Constraints {
+    return Constraints.Builder().apply { block() }.build()
+}

--- a/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/StorageMaintenanceWorker.kt
+++ b/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/StorageMaintenanceWorker.kt
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.storage.sync
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * An abstract WorkManager Worker class that executes maintenance task provided via [operate].
+ *
+ * If there is a failure or the constraints of worker are no longer met during execution,
+ * cancellation tasks are executed via [onError].
+ */
+abstract class StorageMaintenanceWorker(context: Context, params: WorkerParameters) :
+    CoroutineWorker(context, params) {
+
+    @Suppress("TooGenericExceptionCaught")
+    final override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        try {
+            operate()
+            Result.success()
+        } catch (exception: Exception) {
+            onError(exception)
+            Result.failure()
+        }
+    }
+
+    /**
+     * Called when [doWork] is being executed.
+     * */
+    abstract suspend fun operate()
+
+    /**
+     * Called when [doWork] causes an exception while being executed.
+     *
+     * @param exception Exception is passed to the child overriding the method.
+     * */
+    abstract fun onError(exception: Exception)
+
+    companion object {
+        const val WORKER_PERIOD_IN_HOURS = 24L
+    }
+}

--- a/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/GlobalPlacesDependencyProviderTest.kt
+++ b/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/GlobalPlacesDependencyProviderTest.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.storage.sync
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.test.mock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GlobalPlacesDependencyProviderTest {
+
+    @Before
+    @After
+    fun cleanUp() {
+        GlobalPlacesDependencyProvider.placesStorage = null
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `requirePlacesStorage called without calling initialize, exception returned`() {
+        GlobalPlacesDependencyProvider.requirePlacesStorage()
+    }
+
+    @Test
+    fun `requirePlacesStorage called after calling initialize, placesStorage returned`() {
+        val placesStorage = mock<PlacesStorage>()
+        GlobalPlacesDependencyProvider.initialize(placesStorage)
+        assertEquals(placesStorage, GlobalPlacesDependencyProvider.requirePlacesStorage())
+    }
+}

--- a/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -4,7 +4,12 @@
 
 package mozilla.components.browser.storage.sync
 
+import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import mozilla.appservices.places.PlacesReaderConnection
@@ -27,6 +32,7 @@ import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
+import org.hamcrest.core.Is.`is`
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -34,6 +40,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
@@ -43,7 +50,9 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.robolectric.annotation.Config
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 @ExperimentalCoroutinesApi // for runTestOnMain
 @RunWith(AndroidJUnit4::class)
@@ -587,8 +596,50 @@ class PlacesHistoryStorageTest {
     }
 
     @Test
-    fun `can run maintanence on the store`() = runTestOnMain {
-        history.runMaintenance()
+    fun `can run maintenance on the store`() = runTestOnMain {
+        history.runMaintenance(0U)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
+    fun `When periodicStorageWorkRequest is called, worker with input specs is created`() {
+        val request = history.periodicStorageWorkRequest<PlacesHistoryStorageWorker>(
+            tag = PlacesHistoryStorageWorker.UNIQUE_NAME,
+        ) {
+            constraints {
+                setRequiresBatteryNotLow(true)
+                setRequiresDeviceIdle(true)
+            }
+        }
+
+        assertEquals(request.workSpec.isPeriodic, true)
+        assertEquals(request.workSpec.intervalDuration, TimeUnit.HOURS.toMillis(StorageMaintenanceWorker.WORKER_PERIOD_IN_HOURS))
+        assertEquals(request.workSpec.constraints.requiresBatteryNotLow(), true)
+        assertEquals(request.workSpec.constraints.requiresDeviceIdle(), true)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
+    fun `When storage maintenance work request is registered, the worker is enqueued`() {
+        val config = Configuration.Builder().build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(testContext, config)
+
+        val request = history.periodicStorageWorkRequest<PlacesHistoryStorageWorker>(
+            tag = PlacesHistoryStorageWorker.UNIQUE_NAME,
+        ) {
+            constraints {
+                setRequiresBatteryNotLow(true)
+                setRequiresDeviceIdle(true)
+            }
+        }
+
+        val workManager = WorkManager.getInstance(testContext)
+        val testDriver = WorkManagerTestInitHelper.getTestDriver(testContext)
+        workManager.enqueue(request).result.get()
+        testDriver?.setPeriodDelayMet(request.id)
+
+        val workInfo = workManager.getWorkInfoById(request.id).get()
+        assertThat(workInfo.state, `is`(WorkInfo.State.ENQUEUED))
     }
 
     @Test

--- a/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageWorkerTest.kt
+++ b/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageWorkerTest.kt
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.storage.sync
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.work.ListenableWorker.Result
+import androidx.work.testing.TestListenableWorkerBuilder
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import kotlin.reflect.KVisibility
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class PlacesHistoryStorageWorkerTest {
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    @After
+    fun tearDown() {
+        GlobalPlacesDependencyProvider.placesStorage = null
+    }
+
+    @Test
+    fun `PlacesHistoryStorage's runMaintenance is called when worker's startWork is called`() =
+        runTestOnMain {
+            val placesStorage = mock<PlacesStorage>()
+            GlobalPlacesDependencyProvider.initialize(placesStorage)
+            val worker =
+                TestListenableWorkerBuilder<PlacesHistoryStorageWorker>(testContext).build()
+
+            worker.doWork()
+            verify(placesStorage).runMaintenance(PlacesHistoryStorageWorker.DB_SIZE_LIMIT_IN_BYTES.toUInt())
+        }
+
+    @Test
+    fun `PlacesHistoryStorage's runMaintenance operation is successful, successful result returned by the worker`() =
+        runTestOnMain {
+            val placesStorage = mock<PlacesStorage>()
+            GlobalPlacesDependencyProvider.initialize(placesStorage)
+            val worker =
+                TestListenableWorkerBuilder<PlacesHistoryStorageWorker>(testContext).build()
+
+            val result = worker.doWork()
+            assertEquals(Result.success(), result)
+        }
+
+    @Test
+    fun `PlacesHistoryStorage's runMaintenance is called, exception is thrown and failure result is returned`() =
+        runTestOnMain {
+            val placesStorage = mock<PlacesStorage>()
+            `when`(placesStorage.runMaintenance(PlacesHistoryStorageWorker.DB_SIZE_LIMIT_IN_BYTES.toUInt()))
+                .thenThrow(CancellationException())
+            GlobalPlacesDependencyProvider.initialize(placesStorage)
+            val worker =
+                TestListenableWorkerBuilder<PlacesHistoryStorageWorker>(testContext).build()
+
+            val result = worker.doWork()
+            assertEquals(Result.failure(), result)
+        }
+
+    @Test
+    fun `PlacesHistoryStorage's runMaintenance is called, exception is thrown and active write operations are cancelled`() =
+        runTestOnMain {
+            val placesStorage = mock<PlacesStorage>()
+            `when`(placesStorage.runMaintenance(PlacesHistoryStorageWorker.DB_SIZE_LIMIT_IN_BYTES.toUInt()))
+                .thenThrow(CancellationException())
+            GlobalPlacesDependencyProvider.initialize(placesStorage)
+            val worker =
+                TestListenableWorkerBuilder<PlacesHistoryStorageWorker>(testContext).build()
+
+            worker.doWork()
+            verify(placesStorage).cancelWrites()
+        }
+
+    @Test
+    fun `PlacesHistoryStorageWorker's visibility is internal`() {
+        assertEquals(PlacesHistoryStorageWorker::class.visibility, KVisibility.INTERNAL)
+    }
+}

--- a/android-components/components/concept/storage/src/main/java/mozilla/components/concept/storage/Storage.kt
+++ b/android-components/components/concept/storage/src/main/java/mozilla/components/concept/storage/Storage.kt
@@ -16,5 +16,5 @@ interface Storage : Cancellable {
     /**
      * Runs internal database maintenance tasks
      */
-    suspend fun runMaintenance()
+    suspend fun runMaintenance(dbSizeLimit: UInt)
 }

--- a/android-components/components/concept/storage/src/main/java/mozilla/components/concept/storage/StorageMaintenanceRegistry.kt
+++ b/android-components/components/concept/storage/src/main/java/mozilla/components/concept/storage/StorageMaintenanceRegistry.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.storage
+
+/**
+ * An interface which registers and unregisters storage maintenance WorkManager workers
+ * that run maintenance on storages.
+ */
+interface StorageMaintenanceRegistry {
+
+    /**
+     * Registers a storage maintenance worker that prunes database when its size exceeds a size limit.
+     * See also [Storage.runMaintenance].
+     * */
+    fun registerStorageMaintenanceWorker()
+
+    /**
+     * Unregisters the storage maintenance worker that is registered
+     * by [StorageMaintenanceRegistry.registerStorageMaintenanceWorker].
+     * See also [Storage.runMaintenance].
+     *
+     * @param uniqueWorkName Unique name of the work request that needs to be unregistered.
+     * */
+    fun unregisterStorageMaintenanceWorker(uniqueWorkName: String)
+}

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
@@ -246,7 +246,7 @@ class BookmarksStorageSuggestionProviderTest {
             throw NotImplementedError()
         }
 
-        override suspend fun runMaintenance() {
+        override suspend fun runMaintenance(dbSizeLimit: UInt) {
             // "Not needed for the test"
             throw NotImplementedError()
         }

--- a/android-components/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
+++ b/android-components/components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt
@@ -174,7 +174,7 @@ class HistoryDelegateTest {
             fail()
         }
 
-        override suspend fun runMaintenance() {
+        override suspend fun runMaintenance(dbSizeLimit: UInt) {
             fail()
         }
 

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -49,6 +49,7 @@ open class BrowserActivity : AppCompatActivity(), ComponentCallbacks2 {
         }
 
         lifecycle.addObserver(webExtensionPopupFeature)
+        components.historyStorage.registerStorageMaintenanceWorker()
     }
 
     override fun onBackPressed() {

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/SampleApplication.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mozilla.appservices.Megazord
 import mozilla.components.browser.state.action.SystemAction
+import mozilla.components.browser.storage.sync.GlobalPlacesDependencyProvider
 import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.glean.BuildInfo
@@ -85,6 +86,7 @@ class SampleApplication : Application() {
         }
         components.downloadsUseCases.restoreDownloads()
         try {
+            GlobalPlacesDependencyProvider.initialize(components.historyStorage)
             GlobalAddonDependencyProvider.initialize(
                 components.addonManager,
                 components.addonUpdater,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,15 @@ permalink: /changelog/
 
 * **concept-engine**:
   * Added support for changing the cookie banner handling setting in regular and private browsing. [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1796144)
+  
+* **concept-storage**:
+  * 🆕 New API: `StorageMaintenanceRegistry` in `concept-storage` that deals with registering/unregistering storage maintenance workers.
+  * ⚠️ **This is a breaking change**: Added a new parameter `dbSizeLimit` to `Storage.runMaintenance` API to indicate Maximum DB size to aim for, in bytes.
+
+* **browser-storage-sync**:
+  * 🆕 New: An abstract WorkManager Worker class `StorageMaintenanceWorker` is introduced. [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1795903)
+  * 🆕 New: A Kotlin object `GlobalPlacesDependencyProvider` is introduced to provide `placesStorage: PlacesStorage` globally when needed.
+  * ⚠️ **This is a breaking change**: `PlacesStorage.runMaintenance` API has changed. Now it needs `dbSizeLimit` parameter as it implements new version of `Storage` API.
 
 * **support-ktx**:
   * The colors of the icons from the status bar should be in contrast with the status bar background color [#1795650](https://bugzilla.mozilla.org/show_bug.cgi?id=1795650)


### PR DESCRIPTION
WorkManager's Worker is created for periodically running storage maintenance operation on places database. DB size limit is exposed from A-S that indicates the maximum DB size to aim for, in bytes. If the database exceeds this size, a small number of visits will be pruned. This operation is done periodically by a periodic work request that, optimally, will run once a day as long as the worker constraints are met.


### How to test
WorkManager's periodic worker is running in A-C. Testing the feature is a bit tricky: see [pruning logic in A-S](https://mozilla.github.io/application-services/book/rust-docs/src/places/storage/history.rs.html#415-428)
As seen from the code snippet, we are pruning the elements starting from earliest 7 days ago.

Worker initialization is not enabled in SampleApplication in this PR as I was not sure whether it would be feasible to have this feature on the SampleApplication or not.
To test this feature on SampleApplication please follow the instructions:

1. Add `GlobalPlacesDependencyProvider.initialize(components.historyStorage)` and  `components.historyStorage.registerStorageMaintenanceWorker()` one after another in `SampleApplication`'s `onCreate` method. 
2. You can change the `dBSizeLimit` locally to set a smaller size in order to test in case your DB (`places.sqlite`) size is not as big as `75MiB`. In order to meet 7-days condition in the pruning process, you can change the date/time of your emulator/device (go back in time for at least 7 days), populate your db and then rollback to the current time.
3. For triggering the worker periodically, you can change the date/time of your emulator/device to a future date.

_**Note:** WorkManager does not ensure that the Worker will run exactly at the same time after the period delay passes, so the periodic waiting times may change while testing because of the work request constraints and OS operations. In addition, one of the work request's constraints is `setRequiresDeviceIdle(true)` and it is hard to meet immediately. Tried forcing the idle mode but could not trigger the worker right away. (My guess is the retry time intervals that are bound to `BackoffPolicy` which is, by default, `EXPONENTIAL`. Though, it is not quite clear from the docs whether OS retries the work request to run right after the constraints are met or it aligns with the `BackoffPolicy`.) I suspect that if the user is using the device actively, meeting the same 24h execution window for the work request is going be very hard._ 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
