### PR TITLE
Check the correct file path when returning a list of AC files changed in build_config.py

### DIFF
--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -31,13 +31,13 @@ ALL_COMPONENTS = object()
 def get_components_changed(files_changed):
     """Translate a list of files changed into a list of components. Eg:
         [
-            "components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegate.kt",
-            "components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt",
+            "android-components/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegate.kt",
+            "android-components/components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt",
         ]
         ->
         {service-sync-logins}
     """
-    return {"-".join(f.split("/")[1:3]) for f in files_changed if f.startswith("components")}
+    return {"-".join(f.split("/")[2:4]) for f in files_changed if f.startswith("android-components")}
 
 
 cached_deps = {}


### PR DESCRIPTION
The decision task was returning an empty set for PRs that needed to run AC build tasks because it was still assuming the old path.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
