### PR TITLE
Update the repo URL in gradle.properties

### DIFF
--- a/android-components/gradle.properties
+++ b/android-components/gradle.properties
@@ -40,8 +40,8 @@ android.defaults.buildfeatures.shaders=false
 
 # Default values for pom.xml
 libRepositoryName=Mozilla-Mobile
-libUrl=https://github.com/mozilla-mobile/android-components
-libVcsUrl=https://github.com/mozilla-mobile/android-components.git
+libUrl=https://github.com/mozilla-mobile/firefox-android/tree/main/android-components
+libVcsUrl=https://github.com/mozilla-mobile/firefox-android.git
 libLicense=MPL-2.0
 libLicenseUrl=https://www.mozilla.org/en-US/MPL/2.0/
 


### PR DESCRIPTION
Right now, the pom files are still pointing to the old repo.