### PR TITLE
Bug 1794933 - Remove autocomplete when not applicable anymore

### DIFF
--- a/android-components/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/android-components/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -575,9 +575,24 @@ open class InlineAutocompleteEditText @JvmOverloads constructor(
                 return super.deleteSurroundingText(beforeLength, afterLength)
             }
 
+            /**
+             * Optionally remove the current autocompletion depending on the new [text].
+             *
+             * Cases in which the autocompletion will be removed:
+             *  - if the user pressed the backspace to remove the autocompletion or
+             *  - if the user modified their input such that the autocompletion does not apply anymore.
+             *
+             * @return `true` if this method consumed the user input, `false` otherwise.
+             */
             @Suppress("ComplexCondition")
             private fun removeAutocompleteOnComposing(text: CharSequence): Boolean {
                 val editable = getText()
+
+                // Remove the autocomplete text as soon as possible if not applicable anymore.
+                if (!editableText.startsWith(text) && removeAutocomplete(editable)) {
+                    return false // If the user modified their input then allow the new text to be set.
+                }
+
                 val composingStart = BaseInputConnection.getComposingSpanStart(editable)
                 val composingEnd = BaseInputConnection.getComposingSpanEnd(editable)
                 // We only delete the autocomplete text when the user is backspacing,

--- a/android-components/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/android-components/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -352,6 +352,26 @@ class InlineAutocompleteEditTextTest {
     }
 
     @Test
+    fun `GIVEN the current text contains an autocompletion WHEN a new character does not match the autocompletion THEN remove the autocompletion`() {
+        val et = InlineAutocompleteEditText(testContext, attributes)
+        val ic = et.onCreateInputConnection(mock(EditorInfo::class.java))
+
+        ic?.setComposingText("mo", 1)
+        assertEquals("mo", et.text.toString())
+
+        et.applyAutocompleteResult(AutocompleteResult("mozilla", "source", 1))
+        assertEquals("mozilla", et.text.toString())
+
+        // Simulating the user entering a new character which makes the current autocomplete invalid
+        ic?.setComposingText("mod", 1)
+        assertEquals("mod", et.text.toString())
+
+        // Verify that autocompletion works for the new text
+        et.applyAutocompleteResult(AutocompleteResult("moderator", "source", 1))
+        assertEquals("moderator", et.text.toString())
+    }
+
+    @Test
     fun `GIVEN empty edit field WHEN text 'g' added THEN autocomplete to google`() {
         val et = InlineAutocompleteEditText(testContext, attributes)
         et.setText("")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/android-components/blob/main/buildSrc/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/main/.config.yml)
 
+* **ui-autocomplete**
+  * 🚒 Bug fixed [bug #1794933](https://bugzilla.mozilla.org/show_bug.cgi?id=1794933) Immediately remove autocomplete when not applicable anymore.
+
 * **concept-engine**
   * [bug #1798359](https://bugzilla.mozilla.org/show_bug.cgi?id=1798359) Set Total Cookie Protection as the default cookie policy for all Tracking Protection modes. Read more about Total Cookie Protection [here](https://blog.mozilla.org/en/mozilla/firefox-rolls-out-total-cookie-protection-by-default-to-all-users-worldwide/).
 


### PR DESCRIPTION
Immediately after the user modified it's input text to something that doesn't match the current autocompleted text the autocompletion will be removed.

| Initial problem 25% speed | Fixed version 25% speed | Fixed version 100% speed |
| --- | --- | --- |
| <video src="https://user-images.githubusercontent.com/11428869/199284462-fb8612fe-139e-4043-ab94-a248ee7b1c2a.mov" /> | <video src="https://user-images.githubusercontent.com/11428869/199284532-16b2570d-6ce0-40ca-8e72-4b34acadffb0.mp4" /> | <video src="https://user-images.githubusercontent.com/11428869/199284609-c3fc3e57-e30b-4765-8d59-a5e3462baba9.mp4" /> |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
