### PR TITLE
Bug 1796340 - Consume login and credit card select prompts on dismiss

### DIFF
--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/creditcard/CreditCardPicker.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/creditcard/CreditCardPicker.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.prompts.creditcard
 
 import androidx.annotation.VisibleForTesting
+import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.storage.CreditCardEntry
@@ -92,6 +93,9 @@ class CreditCardPicker(
         try {
             if (promptRequest != null) {
                 promptRequest.onDismiss()
+                sessionId?.let {
+                    store.dispatch(ContentAction.ConsumePromptRequestAction(it, promptRequest))
+                }
                 return
             }
 

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/login/LoginPicker.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/login/LoginPicker.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.prompts.login
 
+import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.storage.Login
@@ -54,11 +55,17 @@ internal class LoginPicker(
     @Suppress("TooGenericExceptionCaught")
     fun dismissCurrentLoginSelect(promptRequest: PromptRequest.SelectLoginPrompt? = null) {
         try {
-            promptRequest
-                ?.let { it.onDismiss() }
-                ?: store.consumePromptFrom<PromptRequest.SelectLoginPrompt>(sessionId) {
-                    it.onDismiss()
+            if (promptRequest != null) {
+                promptRequest.onDismiss()
+                sessionId?.let {
+                    store.dispatch(ContentAction.ConsumePromptRequestAction(it, promptRequest))
                 }
+                return
+            }
+
+            store.consumePromptFrom<PromptRequest.SelectLoginPrompt>(sessionId) {
+                it.onDismiss()
+            }
         } catch (e: RuntimeException) {
             Logger.error("Can't dismiss this login select prompt", e)
         }

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardPickerTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardPickerTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.prompts.creditcard
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.CustomTabSessionState
@@ -12,6 +13,7 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.storage.CreditCardEntry
+import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
@@ -20,6 +22,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -136,6 +139,42 @@ class CreditCardPickerTest {
 
         assertNull(creditCardPicker.selectedCreditCard)
         assertTrue(onDismissCalled)
+    }
+
+    @Test
+    fun `WHEN dismissSelectCreditCardRequest is invoked without a parameter THEN the active prompt request is dismissed and removed from the session`() {
+        val session = setupSessionState(promptRequest)
+        creditCardPicker = CreditCardPicker(
+            store = store,
+            creditCardSelectBar = creditCardSelectBar,
+            manageCreditCardsCallback = manageCreditCardsCallback,
+            selectCreditCardCallback = selectCreditCardCallback,
+            sessionId = session.id,
+        )
+
+        verify(store, never()).dispatch(any())
+        creditCardPicker.dismissSelectCreditCardRequest()
+
+        assertTrue(onDismissCalled)
+        verify(store).dispatch(ContentAction.ConsumePromptRequestAction(session.id, promptRequest))
+    }
+
+    @Test
+    fun `WHEN dismissSelectCreditCardRequest is invoked with the active prompt request as parameter THEN the request is dismissed and removed from the session`() {
+        val session = setupSessionState(promptRequest)
+        creditCardPicker = CreditCardPicker(
+            store = store,
+            creditCardSelectBar = creditCardSelectBar,
+            manageCreditCardsCallback = manageCreditCardsCallback,
+            selectCreditCardCallback = selectCreditCardCallback,
+            sessionId = session.id,
+        )
+
+        verify(store, never()).dispatch(any())
+        creditCardPicker.dismissSelectCreditCardRequest(promptRequest)
+
+        assertTrue(onDismissCalled)
+        verify(store).dispatch(ContentAction.ConsumePromptRequestAction(session.id, promptRequest))
     }
 
     private fun setupSessionState(request: PromptRequest? = null): TabSessionState {

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/login/LoginPickerTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/login/LoginPickerTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.prompts.login
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.CustomTabSessionState
@@ -12,6 +13,7 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.storage.Login
+import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
@@ -19,6 +21,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -100,6 +103,30 @@ class LoginPickerTest {
         assertTrue(manageLoginsCalled)
         assertTrue(onDismissWasCalled)
         verify(loginSelectBar).hidePrompt()
+    }
+
+    @Test
+    fun `WHEN dismissCurrentLoginSelect is called without a parameter THEN the active login prompt is dismissed`() {
+        val selectedSession = prepareSelectedSession(request)
+        loginPicker = LoginPicker(store, loginSelectBar, onManageLogins, selectedSession.id)
+
+        verify(store, never()).dispatch(any())
+        loginPicker.dismissCurrentLoginSelect()
+
+        assertTrue(onDismissWasCalled)
+        verify(store).dispatch(ContentAction.ConsumePromptRequestAction(selectedSession.id, request))
+    }
+
+    @Test
+    fun `WHEN dismissCurrentLoginSelect is called with the active login prompt passed as parameter THEN the prompt is dismissed`() {
+        val selectedSession = prepareSelectedSession(request)
+        loginPicker = LoginPicker(store, loginSelectBar, onManageLogins, selectedSession.id)
+
+        verify(store, never()).dispatch(any())
+        loginPicker.dismissCurrentLoginSelect(request)
+
+        assertTrue(onDismissWasCalled)
+        verify(store).dispatch(ContentAction.ConsumePromptRequestAction(selectedSession.id, request))
     }
 
     private fun prepareSelectedSession(request: PromptRequest? = null): TabSessionState {


### PR DESCRIPTION
Consume login and credit card select prompts when calling dismissCurrentLoginSelect and dismissSelectCreditCardRequest with the active prompt request as parameter.

More context can be found here https://github.com/mozilla-mobile/android-components/pull/12142#discussion_r873096373

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1796340