### PR TITLE
Fix local/auto publication to not rely on LICENSE file

### DIFF
--- a/android-components/automation/publish_to_maven_local_if_modified.py
+++ b/android-components/automation/publish_to_maven_local_if_modified.py
@@ -24,10 +24,11 @@ def run_cmd_checked(*args, **kwargs):
 
 def find_project_root():
     """Find the absolute path of the project repository root."""
-    cur_dir = Path(__file__).parent
-    while not Path(cur_dir, "LICENSE").exists():
-        cur_dir = cur_dir.parent
-    return cur_dir.absolute()
+    # As a convention, we expect this file in [project-root]/automation/. 
+    automation_dir = Path(__file__).parent
+
+    # Therefore the automation dir's parent is the project root we're looking for.
+    return automation_dir.parent
 
 LAST_CONTENTS_HASH_FILE = ".lastAutoPublishContentsHash"
 


### PR DESCRIPTION
This broke when I removed the now redundant LICENSE file, but it's also surprising to me that we look up the project root based on the LICENSE. It's technically already a convention (and relied on) that this script lives under project-root/automation so we can just rely on it when inferring the project root.