### PR TITLE
Bug 1836338 - Improve DownloadUtils.uniqueFileName readability.

### DIFF
--- a/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
+++ b/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
@@ -162,7 +162,6 @@ object DownloadUtils {
      * which unfortunately does not implement RFC 5987.
      */
 
-    @Suppress("Deprecation")
     @JvmStatic
     fun guessFileName(
         contentDisposition: String?,
@@ -210,14 +209,16 @@ object DownloadUtils {
      * Checks if the file exists so as not to overwrite one already in the destination directory
      */
     fun uniqueFileName(directory: File, fileName: String): String {
-        var fileExtension = ".${fileName.substringAfterLast(".")}"
-
-        // Check if an extension was found or not
-        if (fileExtension == ".$fileName") { fileExtension = "" }
-
-        val baseFileName = fileName.replace(fileExtension, "")
-
         var potentialFileName = File(directory, fileName)
+        val baseFileName = potentialFileName.nameWithoutExtension
+        val fileExtension = potentialFileName.extension.let {
+            if (it.isNotEmpty()) {
+                ".$it"
+            } else {
+                it
+            }
+        }
+
         var copyVersionNumber = 1
 
         while (potentialFileName.exists()) {

--- a/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
+++ b/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
@@ -87,6 +87,9 @@ class DownloadUtilsTest {
 
         folder.newFile("test")
         assertEquals("test(1)", DownloadUtils.uniqueFileName(folder.root, "test"))
+
+        folder.newFile("test(1)")
+        assertEquals("test(2)", DownloadUtils.uniqueFileName(folder.root, "test"))
     }
 
     @Test
@@ -95,6 +98,9 @@ class DownloadUtilsTest {
 
         folder.newFile("test.zip")
         assertEquals("test(1).zip", DownloadUtils.uniqueFileName(folder.root, "test.zip"))
+
+        folder.newFile("test(1).zip")
+        assertEquals("test(2).zip", DownloadUtils.uniqueFileName(folder.root, "test.zip"))
     }
 
     @Test


### PR DESCRIPTION
Moved from: https://github.com/mozilla-mobile/android-components/pull/12952

This is just a small simplification I made while I was in the area.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1836338