### PR TITLE
A-C auto publication only needs to hash changes under android-components

### DIFF
--- a/android-components/automation/publish_to_maven_local_if_modified.py
+++ b/android-components/automation/publish_to_maven_local_if_modified.py
@@ -50,10 +50,9 @@ contents_hash.update(
 )
 contents_hash.update(b"\x00")
 
-# Git can efficiently tell us about changes to tracked files, including
-# the diff of their contents, if you give it enough "-v"s.
+# Get a diff of all tracked (staged and unstaged) files.
 
-changes = run_cmd_checked(["git", "status", "-v", "-v"], capture_output=True).stdout
+changes = run_cmd_checked(["git", "diff", "HEAD", "."], capture_output=True).stdout
 contents_hash.update(changes)
 contents_hash.update(b"\x00")
 
@@ -63,7 +62,7 @@ contents_hash.update(b"\x00")
 
 untracked_files = []
 
-# First, get a list of all untracked files sans standard exclusions.
+# Get a list of all untracked files sans standard exclusions.
 
 # -o is for getting other (i.e. untracked) files
 # --exclude-standard is to handle standard Git exclusions: .git/info/exclude, .gitignore in each directory,


### PR DESCRIPTION
Our current working directory is already guaranteed to be the root of the A-C project (the `android-components` folder). To capture changes to untracked files `git ls-files -o -exclude-standard"` (see [L70](https://github.com/mozilla-mobile/firefox-android/compare/main...csadilek:firefox-android:autopublish-hash-fix?expand=1#diff-62202bc6673751b5ccd03ae9865070d9de88eb143fdca34efe569e560cd59f70L71)) already does the right thing and only list files below it. 

We can switch calculating the diff from `git status -v -v` to just `git diff HEAD .` to capture changes to tracked files, both staged and unstaged. This is essentially the same as before, but makes sure we're NOT recording hash changes if files outside the android-componets directory change e.g., in `/firefox-android` or `/firefox-android/focus`.