### PR TITLE
Bug 1798873 - Exclude current app from share text targets

### DIFF
--- a/android-components/components/feature/contextmenu/src/main/AndroidManifest.xml
+++ b/android-components/components/feature/contextmenu/src/main/AndroidManifest.xml
@@ -2,11 +2,4 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="mozilla.components.feature.contextmenu">
-    <queries>
-        <intent>
-            <action android:name="android.intent.action.SEND" />
-            <data android:mimeType="text/plain" />
-        </intent>
-    </queries>
-</manifest>
+    package="mozilla.components.feature.contextmenu"/>

--- a/android-components/components/support/ktx/src/main/AndroidManifest.xml
+++ b/android-components/components/support/ktx/src/main/AndroidManifest.xml
@@ -2,4 +2,11 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="mozilla.components.support.ktx" />
+    package="mozilla.components.support.ktx">
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+</manifest>

--- a/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
+++ b/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt
@@ -107,11 +107,12 @@ fun Context.share(text: String, subject: String = getString(R.string.mozac_suppo
             flags = FLAG_ACTIVITY_NEW_TASK
         }
 
-        val shareIntent = Intent.createChooser(intent, getString(R.string.mozac_support_ktx_menu_share_with)).apply {
-            flags = FLAG_ACTIVITY_NEW_TASK
-        }
-
-        startActivity(shareIntent)
+        startActivity(
+            intent.createChooserExcludingCurrentApp(
+                this,
+                getString(R.string.mozac_support_ktx_menu_share_with),
+            ),
+        )
         true
     } catch (e: ActivityNotFoundException) {
         Log.log(Log.Priority.WARN, message = "No activity to share to found", throwable = e, tag = "Reference-Browser")

--- a/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Intent.kt
+++ b/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Intent.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.ktx.android.content
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.LabeledIntent
+import android.os.Build
+import android.os.Parcelable
+import mozilla.components.support.utils.ext.queryIntentActivitiesCompat
+
+/**
+ * Modify the current intent to be used in an intent chooser excluding the current app.
+ *
+ * @param context Android context used for various system interactions.
+ * @param title Title that will be displayed in the chooser.
+ *
+ * @return a new Intent object that you can hand to Context.startActivity() and related methods.
+ */
+fun Intent.createChooserExcludingCurrentApp(
+    context: Context,
+    title: CharSequence,
+): Intent {
+    val chooserIntent: Intent
+    val resolveInfos = context.packageManager.queryIntentActivitiesCompat(this, 0).toHashSet()
+
+    val excludedComponentNames = resolveInfos
+        .map { it.activityInfo }
+        .filter { it.packageName == context.packageName }
+        .map { ComponentName(it.packageName, it.name) }
+
+    // Starting with Android N we can use Intent.EXTRA_EXCLUDE_COMPONENTS to exclude components
+    // other way we are constrained to use Intent.EXTRA_INITIAL_INTENTS.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        chooserIntent = Intent.createChooser(this, title)
+            .putExtra(
+                Intent.EXTRA_EXCLUDE_COMPONENTS,
+                excludedComponentNames.toTypedArray(),
+            )
+    } else {
+        var targetIntents = resolveInfos
+            .filterNot { it.activityInfo.packageName == context.packageName }
+            .map { resolveInfo ->
+                val activityInfo = resolveInfo.activityInfo
+                val targetIntent = Intent(this).apply {
+                    component = ComponentName(activityInfo.packageName, activityInfo.name)
+                }
+                LabeledIntent(
+                    targetIntent,
+                    activityInfo.packageName,
+                    resolveInfo.labelRes,
+                    resolveInfo.icon,
+                )
+            }
+
+        // Sometimes on Android M and below an empty chooser is displayed, problem reported also here
+        // https://issuetracker.google.com/issues/37085761
+        // To fix that we are creating a chooser with an empty intent
+        chooserIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Intent.createChooser(Intent(), title)
+        } else {
+            targetIntents = targetIntents.toMutableList()
+            Intent.createChooser(targetIntents.removeAt(0), title)
+        }
+        chooserIntent.putExtra(
+            Intent.EXTRA_INITIAL_INTENTS,
+            targetIntents.toTypedArray<Parcelable>(),
+        )
+    }
+    chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    return chooserIntent
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **support-ktx, feature-contextmenu**
+  * 🚒 Bug fixed [bug #1798873](https://bugzilla.mozilla.org/show_bug.cgi?id=1798873) Added a way to exclude current app from share targets. Used when sharing text.
+
 * **feature-top-sites**
   * 🆕 A new filter `hasHost` was added when getting top frecent sites in order to remove duplicate frecent top sites that have same host/domain as provided top sites. For more references see [bug #1801285](https://bugzilla.mozilla.org/show_bug.cgi?id=1801285).
 


### PR DESCRIPTION
Behavior Before:

https://user-images.githubusercontent.com/32488956/199718372-f4a7640c-0502-4580-b7ef-f217cd5e8d53.mp4

Behavior After:

https://user-images.githubusercontent.com/32488956/199718569-7b91e0e0-6fbf-478b-8a00-d41d250ca85c.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
