### PR TITLE
Bug 1799230 - Use Non-Transitive R Classes

### DIFF
--- a/android-components/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
+++ b/android-components/components/browser/errorpages/src/main/java/mozilla/components/browser/errorpages/ErrorPages.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import androidx.annotation.StringRes
 import mozilla.components.support.ktx.android.content.appName
 import mozilla.components.support.ktx.kotlin.urlEncode
+import mozilla.components.ui.icons.R as iconsR
 
 object ErrorPages {
 
@@ -111,113 +112,113 @@ enum class ErrorType(
     ERROR_SECURITY_SSL(
         R.string.mozac_browser_errorpages_security_ssl_title,
         R.string.mozac_browser_errorpages_security_ssl_message,
-        imageNameRes = R.string.mozac_error_lock,
+        imageNameRes = iconsR.string.mozac_error_lock,
     ),
     ERROR_SECURITY_BAD_CERT(
         R.string.mozac_browser_errorpages_security_bad_cert_title,
         R.string.mozac_browser_errorpages_security_bad_cert_message,
-        imageNameRes = R.string.mozac_error_lock,
+        imageNameRes = iconsR.string.mozac_error_lock,
     ),
     ERROR_NET_INTERRUPT(
         R.string.mozac_browser_errorpages_net_interrupt_title,
         R.string.mozac_browser_errorpages_net_interrupt_message,
-        imageNameRes = R.string.mozac_error_eye_roll,
+        imageNameRes = iconsR.string.mozac_error_eye_roll,
     ),
     ERROR_NET_TIMEOUT(
         R.string.mozac_browser_errorpages_net_timeout_title,
         R.string.mozac_browser_errorpages_net_timeout_message,
-        imageNameRes = R.string.mozac_error_asleep,
+        imageNameRes = iconsR.string.mozac_error_asleep,
     ),
     ERROR_CONNECTION_REFUSED(
         R.string.mozac_browser_errorpages_connection_failure_title,
         R.string.mozac_browser_errorpages_connection_failure_message,
-        imageNameRes = R.string.mozac_error_confused,
+        imageNameRes = iconsR.string.mozac_error_confused,
     ),
     ERROR_UNKNOWN_SOCKET_TYPE(
         R.string.mozac_browser_errorpages_unknown_socket_type_title,
         R.string.mozac_browser_errorpages_unknown_socket_type_message,
-        imageNameRes = R.string.mozac_error_confused,
+        imageNameRes = iconsR.string.mozac_error_confused,
     ),
     ERROR_REDIRECT_LOOP(
         R.string.mozac_browser_errorpages_redirect_loop_title,
         R.string.mozac_browser_errorpages_redirect_loop_message,
-        imageNameRes = R.string.mozac_error_surprised,
+        imageNameRes = iconsR.string.mozac_error_surprised,
     ),
     ERROR_OFFLINE(
         R.string.mozac_browser_errorpages_offline_title,
         R.string.mozac_browser_errorpages_offline_message,
-        imageNameRes = R.string.mozac_error_no_internet,
+        imageNameRes = iconsR.string.mozac_error_no_internet,
     ),
     ERROR_PORT_BLOCKED(
         R.string.mozac_browser_errorpages_port_blocked_title,
         R.string.mozac_browser_errorpages_port_blocked_message,
-        imageNameRes = R.string.mozac_error_lock,
+        imageNameRes = iconsR.string.mozac_error_lock,
     ),
     ERROR_NET_RESET(
         R.string.mozac_browser_errorpages_net_reset_title,
         R.string.mozac_browser_errorpages_net_reset_message,
-        imageNameRes = R.string.mozac_error_unplugged,
+        imageNameRes = iconsR.string.mozac_error_unplugged,
     ),
     ERROR_UNSAFE_CONTENT_TYPE(
         R.string.mozac_browser_errorpages_unsafe_content_type_title,
         R.string.mozac_browser_errorpages_unsafe_content_type_message,
-        imageNameRes = R.string.mozac_error_inspect,
+        imageNameRes = iconsR.string.mozac_error_inspect,
     ),
     ERROR_CORRUPTED_CONTENT(
         R.string.mozac_browser_errorpages_corrupted_content_title,
         R.string.mozac_browser_errorpages_corrupted_content_message,
-        imageNameRes = R.string.mozac_error_shred_file,
+        imageNameRes = iconsR.string.mozac_error_shred_file,
     ),
     ERROR_CONTENT_CRASHED(
         R.string.mozac_browser_errorpages_content_crashed_title,
         R.string.mozac_browser_errorpages_content_crashed_message,
-        imageNameRes = R.string.mozac_error_surprised,
+        imageNameRes = iconsR.string.mozac_error_surprised,
     ),
     ERROR_INVALID_CONTENT_ENCODING(
         R.string.mozac_browser_errorpages_invalid_content_encoding_title,
         R.string.mozac_browser_errorpages_invalid_content_encoding_message,
-        imageNameRes = R.string.mozac_error_surprised,
+        imageNameRes = iconsR.string.mozac_error_surprised,
     ),
     ERROR_UNKNOWN_HOST(
         R.string.mozac_browser_errorpages_unknown_host_title,
         R.string.mozac_browser_errorpages_unknown_host_message,
-        imageNameRes = R.string.mozac_error_confused,
+        imageNameRes = iconsR.string.mozac_error_confused,
     ),
     ERROR_NO_INTERNET(
         R.string.mozac_browser_errorpages_no_internet_title,
         R.string.mozac_browser_errorpages_no_internet_message,
         R.string.mozac_browser_errorpages_no_internet_refresh_button,
-        imageNameRes = R.string.mozac_error_no_internet,
+        imageNameRes = iconsR.string.mozac_error_no_internet,
     ),
     ERROR_MALFORMED_URI(
         R.string.mozac_browser_errorpages_malformed_uri_title,
         R.string.mozac_browser_errorpages_malformed_uri_message,
-        imageNameRes = R.string.mozac_error_confused,
+        imageNameRes = iconsR.string.mozac_error_confused,
     ),
     ERROR_UNKNOWN_PROTOCOL(
         R.string.mozac_browser_errorpages_unknown_protocol_title,
         R.string.mozac_browser_errorpages_unknown_protocol_message,
-        imageNameRes = R.string.mozac_error_confused,
+        imageNameRes = iconsR.string.mozac_error_confused,
     ),
     ERROR_FILE_NOT_FOUND(
         R.string.mozac_browser_errorpages_file_not_found_title,
         R.string.mozac_browser_errorpages_file_not_found_message,
-        imageNameRes = R.string.mozac_error_confused,
+        imageNameRes = iconsR.string.mozac_error_confused,
     ),
     ERROR_FILE_ACCESS_DENIED(
         R.string.mozac_browser_errorpages_file_access_denied_title,
         R.string.mozac_browser_errorpages_file_access_denied_message,
-        imageNameRes = R.string.mozac_error_question_file,
+        imageNameRes = iconsR.string.mozac_error_question_file,
     ),
     ERROR_PROXY_CONNECTION_REFUSED(
         R.string.mozac_browser_errorpages_proxy_connection_refused_title,
         R.string.mozac_browser_errorpages_proxy_connection_refused_message,
-        imageNameRes = R.string.mozac_error_confused,
+        imageNameRes = iconsR.string.mozac_error_confused,
     ),
     ERROR_UNKNOWN_PROXY_HOST(
         R.string.mozac_browser_errorpages_unknown_proxy_host_title,
         R.string.mozac_browser_errorpages_unknown_proxy_host_message,
-        imageNameRes = R.string.mozac_error_unplugged,
+        imageNameRes = iconsR.string.mozac_error_unplugged,
     ),
     ERROR_SAFEBROWSING_MALWARE_URI(
         R.string.mozac_browser_errorpages_safe_browsing_malware_uri_title,
@@ -238,11 +239,11 @@ enum class ErrorType(
     ERROR_HTTPS_ONLY(
         R.string.mozac_browser_errorpages_httpsonly_title,
         R.string.mozac_browser_errorpages_httpsonly_message,
-        imageNameRes = R.string.mozac_error_lock,
+        imageNameRes = iconsR.string.mozac_error_lock,
     ),
     ERROR_BAD_HSTS_CERT(
         R.string.mozac_browser_errorpages_security_bad_hsts_cert_title,
         R.string.mozac_browser_errorpages_security_bad_hsts_cert_message,
-        imageNameRes = R.string.mozac_error_lock,
+        imageNameRes = iconsR.string.mozac_error_lock,
     ),
 }

--- a/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
+++ b/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.menu.item.WebExtensionBrowserMenuItem
 import mozilla.components.browser.menu.item.WebExtensionPlaceholderMenuItem
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * Browser menu builder with web extension support. It allows [WebExtensionBrowserMenu] to add
@@ -158,8 +159,8 @@ class WebExtensionBrowserMenuBuilder(
         @ColorRes
         val webExtIconTintColorResource: Int = NO_ID,
         @DrawableRes
-        val backPressMenuItemDrawableRes: Int = R.drawable.mozac_ic_back,
+        val backPressMenuItemDrawableRes: Int = iconsR.drawable.mozac_ic_back,
         @DrawableRes
-        val addonsManagerMenuItemDrawableRes: Int = R.drawable.mozac_ic_extensions,
+        val addonsManagerMenuItemDrawableRes: Int = iconsR.drawable.mozac_ic_extensions,
     )
 }

--- a/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
+++ b/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItem.kt
@@ -24,6 +24,7 @@ import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import mozilla.components.concept.menu.candidate.TextMenuIcon
 import mozilla.components.concept.menu.candidate.TextStyle
 import mozilla.components.support.base.log.Log
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * A browser menu item displaying a web extension action.
@@ -129,7 +130,7 @@ class WebExtensionBrowserMenuItem(
                 "Failed to load browser action icon, falling back to default.",
             )
 
-            getDrawable(context, R.drawable.mozac_ic_web_extension_default_icon)
+            getDrawable(context, iconsR.drawable.mozac_ic_web_extension_default_icon)
         }
     }
 

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuHighlightTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuHighlightTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
+import mozilla.components.ui.colors.R as colorsR
 
 @RunWith(AndroidJUnit4::class)
 class BrowserMenuHighlightTest {
@@ -36,12 +37,13 @@ class BrowserMenuHighlightTest {
     @Suppress("Deprecation")
     @Test
     fun `classic highlight effect converts background tint`() {
+        val colorId = colorsR.color.photonRed50
         val highlight = BrowserMenuHighlight.ClassicHighlight(
             startImageResource = 0,
             endImageResource = 0,
             backgroundResource = 0,
-            colorResource = R.color.photonRed50,
+            colorResource = colorId,
         )
-        assertEquals(HighPriorityHighlightEffect(testContext.getColor(R.color.photonRed50)), highlight.asEffect(testContext))
+        assertEquals(HighPriorityHighlightEffect(testContext.getColor(colorId)), highlight.asEffect(testContext))
     }
 }

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt
@@ -27,6 +27,8 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import androidx.appcompat.R as appcompatR
+import mozilla.components.ui.icons.R as iconsR
 
 @RunWith(AndroidJUnit4::class)
 class WebExtensionBrowserMenuBuilderTest {
@@ -70,8 +72,8 @@ class WebExtensionBrowserMenuBuilderTest {
 
         val store = BrowserStore(BrowserState(extensions = extensions))
         val style = WebExtensionBrowserMenuBuilder.Style(
-            addonsManagerMenuItemDrawableRes = R.drawable.mozac_ic_extensions,
-            backPressMenuItemDrawableRes = R.drawable.mozac_ic_back,
+            addonsManagerMenuItemDrawableRes = iconsR.drawable.mozac_ic_extensions,
+            backPressMenuItemDrawableRes = iconsR.drawable.mozac_ic_back,
         )
         val builder = WebExtensionBrowserMenuBuilder(
             listOf(mockMenuItem()),
@@ -251,7 +253,7 @@ class WebExtensionBrowserMenuBuilderTest {
     fun `web extension is moved to main menu when extension id equals WebExtensionPlaceholderMenuItem id`() {
         val promotableWebExtensionId = "promotable extension id"
         val promotableWebExtensionTitle = "promotable extension action title"
-        val testIconTintColorResource = R.color.accent_material_dark
+        val testIconTintColorResource = appcompatR.color.accent_material_dark
 
         val pageAction = WebExtensionBrowserAction("page_action", true, mock(), "", 0, 0) {}
         val pageActionPromotableWebExtension = WebExtensionBrowserAction(promotableWebExtensionTitle, true, mock(), "", 0, 0) {}

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItemTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItemTest.kt
@@ -34,9 +34,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.robolectric.Shadows
+import mozilla.components.ui.colors.R as colorsR
 
 @RunWith(AndroidJUnit4::class)
 class BrowserMenuHighlightableItemTest {
+
+    private val colorId = colorsR.color.photonRed50
 
     @Suppress("Deprecation")
     @Test
@@ -49,8 +52,8 @@ class BrowserMenuHighlightableItemTest {
             textColorResource = android.R.color.black,
             highlight = BrowserMenuHighlightableItem.Highlight(
                 endImageResource = android.R.drawable.ic_menu_report_image,
-                backgroundResource = R.color.photonRed50,
-                colorResource = R.color.photonRed50,
+                backgroundResource = colorId,
+                colorResource = colorId,
             ),
         ) {
             onClickWasPress = true
@@ -74,8 +77,8 @@ class BrowserMenuHighlightableItemTest {
             highlight = BrowserMenuHighlightableItem.Highlight(
                 startImageResource = android.R.drawable.ic_menu_camera,
                 endImageResource = android.R.drawable.ic_menu_add,
-                backgroundResource = R.color.photonRed50,
-                colorResource = R.color.photonRed50,
+                backgroundResource = colorId,
+                colorResource = colorId,
             ),
             isHighlighted = { shouldHighlight },
         )
@@ -98,7 +101,7 @@ class BrowserMenuHighlightableItemTest {
         assertEquals(android.R.drawable.ic_menu_camera, Shadows.shadowOf(view.startImageView.drawable).createdFromResId)
         assertEquals(android.R.drawable.ic_menu_add, Shadows.shadowOf(view.endImageView.drawable).createdFromResId)
         assertNotNull(view.endImageView.imageTintList)
-        assertEquals(R.color.photonRed50, Shadows.shadowOf(view.background).createdFromResId)
+        assertEquals(colorId, Shadows.shadowOf(view.background).createdFromResId)
     }
 
     @Test

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableSwitchTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableSwitchTest.kt
@@ -24,6 +24,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.robolectric.Shadows
+import mozilla.components.ui.colors.R as colorsR
 
 @RunWith(AndroidJUnit4::class)
 class BrowserMenuHighlightableSwitchTest {
@@ -70,7 +71,7 @@ class BrowserMenuHighlightableSwitchTest {
             iconTintColorResource = android.R.color.black,
             textColorResource = android.R.color.black,
             highlight = BrowserMenuHighlight.LowPriority(
-                notificationTint = R.color.photonRed50,
+                notificationTint = colorsR.color.photonRed50,
                 label = "highlight",
             ),
             isHighlighted = { shouldHighlight },

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuItemToolbarTest.kt
@@ -8,11 +8,11 @@ import android.view.LayoutInflater
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.appcompat.R
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.content.ContextCompat.getColor
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu.BrowserMenu
-import mozilla.components.browser.menu.R
 import mozilla.components.concept.menu.candidate.ContainerStyle
 import mozilla.components.concept.menu.candidate.DrawableMenuIcon
 import mozilla.components.concept.menu.candidate.RowMenuCandidate

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/ParentBrowserMenuItemTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/ParentBrowserMenuItemTest.kt
@@ -22,6 +22,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import mozilla.components.ui.icons.R as iconsR
 
 @RunWith(AndroidJUnit4::class)
 class ParentBrowserMenuItemTest {
@@ -77,7 +78,7 @@ class ParentBrowserMenuItemTest {
     fun `onBackPressed after sub menu is shown will dismiss the sub menu`() {
         val backPressMenuItem = BackPressMenuItem(
             label = "back",
-            imageResource = R.drawable.mozac_ic_back,
+            imageResource = iconsR.drawable.mozac_ic_back,
         )
         val backPressView = LayoutInflater.from(testContext).inflate(backPressMenuItem.getLayoutResource(), null)
         val subMenuItem = SimpleBrowserMenuItem("test")
@@ -109,7 +110,7 @@ class ParentBrowserMenuItemTest {
     fun `menu item image text item can be converted to candidate`() {
         val backPressMenuItem = BackPressMenuItem(
             label = "back",
-            imageResource = R.drawable.mozac_ic_back,
+            imageResource = iconsR.drawable.mozac_ic_back,
         )
         val subMenuItem = SimpleBrowserMenuItem("test")
         val subMenuAdapter = BrowserMenuAdapter(testContext, listOf(backPressMenuItem, subMenuItem))

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.notNull
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -288,7 +289,7 @@ class WebExtensionBrowserMenuItemTest {
     @Test
     fun `GIVEN setIcon was called, WHEN bind is called, icon setup uses the tint set`() = runTest {
         val webExtMenuItem = spy(WebExtensionBrowserMenuItem(mock(), mock()))
-        val testIconTintColorResource = R.color.accent_material_dark
+        val testIconTintColorResource = appcompatR.color.accent_material_dark
         val menu: WebExtensionBrowserMenu = mock()
         val imageView: ImageView = mock()
         val badgeView: TextView = mock()

--- a/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
+++ b/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/display/DisplayToolbar.kt
@@ -27,6 +27,7 @@ import mozilla.components.browser.toolbar.internal.ActionContainer
 import mozilla.components.concept.menu.MenuController
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.ktx.android.content.isScreenReaderEnabled
+import mozilla.components.ui.colors.R.color as photonColors
 
 /**
  * Sub-component of the browser toolbar responsible for displaying the URL and related controls ("display mode").
@@ -164,15 +165,15 @@ class DisplayToolbar internal constructor(
      * Customizable colors in "display mode".
      */
     var colors: Colors = Colors(
-        securityIconSecure = ContextCompat.getColor(context, R.color.photonWhite),
-        securityIconInsecure = ContextCompat.getColor(context, R.color.photonWhite),
-        emptyIcon = ContextCompat.getColor(context, R.color.photonWhite),
-        menu = ContextCompat.getColor(context, R.color.photonWhite),
+        securityIconSecure = ContextCompat.getColor(context, photonColors.photonWhite),
+        securityIconInsecure = ContextCompat.getColor(context, photonColors.photonWhite),
+        emptyIcon = ContextCompat.getColor(context, photonColors.photonWhite),
+        menu = ContextCompat.getColor(context, photonColors.photonWhite),
         hint = views.origin.hintColor,
         title = views.origin.titleColor,
         text = views.origin.textColor,
         trackingProtection = null,
-        separator = ContextCompat.getColor(context, R.color.photonGrey80),
+        separator = ContextCompat.getColor(context, photonColors.photonGrey80),
         highlight = null,
     )
         set(value) {

--- a/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -33,6 +33,7 @@ import mozilla.components.support.base.utils.NamedThreadFactory
 import mozilla.components.support.ktx.android.view.showKeyboard
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import java.util.concurrent.Executors
+import mozilla.components.ui.colors.R as colorsR
 
 private const val AUTOCOMPLETE_QUERY_THREADS = 3
 
@@ -132,7 +133,7 @@ class EditToolbar internal constructor(
      * Customizable colors in "edit mode".
      */
     var colors: Colors = Colors(
-        clear = ContextCompat.getColor(context, R.color.photonWhite),
+        clear = ContextCompat.getColor(context, colorsR.color.photonWhite),
         icon = null,
         hint = views.url.currentHintTextColor,
         text = views.url.currentTextColor,

--- a/android-components/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/android-components/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -43,6 +43,7 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.util.ReflectionHelpers
+import mozilla.components.ui.icons.R as iconsR
 
 @RunWith(AndroidJUnit4::class)
 class DisplayToolbarTest {
@@ -553,7 +554,10 @@ class DisplayToolbarTest {
         assertNull(displayToolbar.views.background.drawable)
 
         displayToolbar.setUrlBackground(
-            ContextCompat.getDrawable(testContext, R.drawable.mozac_ic_broken_lock),
+            ContextCompat.getDrawable(
+                testContext,
+                iconsR.drawable.mozac_ic_broken_lock,
+            ),
         )
 
         assertNotNull(displayToolbar.views.background.drawable)

--- a/android-components/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestion.kt
+++ b/android-components/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestion.kt
@@ -38,6 +38,7 @@ import mozilla.components.compose.browser.awesomebar.AwesomeBarColors
 import mozilla.components.compose.browser.awesomebar.AwesomeBarOrientation
 import mozilla.components.compose.browser.awesomebar.R
 import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.ui.icons.R as iconsR
 
 // We only show one row of text, covering at max screen width.
 // Limit bigger texts that could cause slowdowns or even crashes.
@@ -165,7 +166,7 @@ private fun AutocompleteButton(
     modifier: Modifier,
 ) {
     Image(
-        painterResource(R.drawable.mozac_ic_edit_suggestion),
+        painterResource(iconsR.drawable.mozac_ic_edit_suggestion),
         colorFilter = ColorFilter.tint(colors.autocompleteIcon),
         contentDescription = stringResource(R.string.mozac_browser_awesomebar_edit_suggestion),
         modifier = modifier

--- a/android-components/components/compose/browser-toolbar/build.gradle
+++ b/android-components/components/compose/browser-toolbar/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation project(":concept-engine")
     implementation project(":browser-state")
     implementation project(":feature-session")
+    implementation project(":ui-icons")
     implementation Dependencies.androidx_compose_ui
     implementation Dependencies.androidx_compose_ui_tooling
     implementation Dependencies.androidx_compose_foundation

--- a/android-components/components/compose/browser-toolbar/src/main/java/mozilla/components/compose/browser/toolbar/BrowserEditToolbar.kt
+++ b/android-components/components/compose/browser-toolbar/src/main/java/mozilla/components/compose/browser/toolbar/BrowserEditToolbar.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * Sub-component of the [BrowserToolbar] responsible for allowing the user to edit the current
@@ -84,7 +85,7 @@ fun ClearButton(onButtonClicked: () -> Unit = {}) {
         onClick = { onButtonClicked() },
     ) {
         Icon(
-            painter = painterResource(R.drawable.mozac_ic_clear),
+            painter = painterResource(iconsR.drawable.mozac_ic_clear),
             contentDescription = stringResource(R.string.mozac_clear_button_description),
             tint = Color.Black,
         )

--- a/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/CFRPopupContent.kt
+++ b/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/CFRPopupContent.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import mozilla.components.compose.cfr.CFRPopup.IndicatorDirection.DOWN
 import mozilla.components.compose.cfr.CFRPopup.IndicatorDirection.UP
-import mozilla.components.compose.cfr.R.drawable
+import mozilla.components.ui.icons.R
 
 /**
  * Complete content of the popup.
@@ -122,7 +122,7 @@ fun CFRPopupContent(
                 .size(48.dp),
         ) {
             Icon(
-                painter = painterResource(drawable.mozac_ic_close_20),
+                painter = painterResource(R.drawable.mozac_ic_close_20),
                 contentDescription = "Test",
                 modifier = Modifier
                     // Following alignment and padding are intended to visually align the middle

--- a/android-components/components/compose/tabstray/src/main/java/mozilla/components/compose/tabstray/Tab.kt
+++ b/android-components/components/compose/tabstray/src/main/java/mozilla/components/compose/tabstray/Tab.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import mozilla.components.browser.state.state.TabSessionState
-import mozilla.components.compose.browser.tabstray.R
+import mozilla.components.ui.icons.R
 
 /**
  * Renders a single [TabSessionState] as a list item.

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/menu/WebExtensionActionMenuCandidate.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/menu/WebExtensionActionMenuCandidate.kt
@@ -13,7 +13,7 @@ import mozilla.components.concept.menu.candidate.ContainerStyle
 import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import mozilla.components.concept.menu.candidate.TextMenuIcon
 import mozilla.components.concept.menu.candidate.TextStyle
-import mozilla.components.feature.addons.R
+import mozilla.components.ui.icons.R
 
 /**
  * Create a browser menu item for displaying a web extension action.

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/menu/WebExtensionNestedMenuCandidate.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/menu/WebExtensionNestedMenuCandidate.kt
@@ -17,16 +17,17 @@ import mozilla.components.concept.menu.candidate.MenuCandidate
 import mozilla.components.concept.menu.candidate.NestedMenuCandidate
 import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import mozilla.components.feature.addons.R
+import mozilla.components.ui.icons.R as iconsR
 
 private fun createBackMenuItem(
     context: Context,
     @ColorInt webExtIconTintColor: Int?,
 ) = NestedMenuCandidate(
-    id = R.drawable.mozac_ic_back,
+    id = iconsR.drawable.mozac_ic_back,
     text = context.getString(R.string.mozac_feature_addons_addons),
     start = DrawableMenuIcon(
         context,
-        R.drawable.mozac_ic_back,
+        iconsR.drawable.mozac_ic_back,
         tint = webExtIconTintColor,
     ),
     subMenuItems = null,
@@ -40,7 +41,7 @@ private fun createAddonsManagerItem(
     text = context.getString(R.string.mozac_feature_addons_addons_manager),
     start = DrawableMenuIcon(
         context,
-        R.drawable.mozac_ic_extensions,
+        iconsR.drawable.mozac_ic_extensions,
         tint = webExtIconTintColor,
     ),
     onClick = onAddonsManagerTapped,

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragment.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragment.kt
@@ -39,6 +39,7 @@ import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.appName
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import java.io.IOException
+import mozilla.components.ui.icons.R as iconsR
 
 @VisibleForTesting internal const val KEY_INSTALLED_ADDON = "KEY_ADDON"
 private const val KEY_DIALOG_GRAVITY = "KEY_DIALOG_GRAVITY"
@@ -225,7 +226,10 @@ class AddonInstallationDialogFragment : AppCompatDialogFragment() {
                     val att = context.theme.resolveAttribute(android.R.attr.textColorPrimary)
                     iconView.setColorFilter(ContextCompat.getColor(context, att))
                     iconView.setImageDrawable(
-                        ContextCompat.getDrawable(context, R.drawable.mozac_ic_extensions),
+                        ContextCompat.getDrawable(
+                            context,
+                            iconsR.drawable.mozac_ic_extensions,
+                        ),
                     )
                 }
                 logger.error("Attempt to fetch the ${addon.id} icon failed", e)

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -38,6 +38,7 @@ import mozilla.components.feature.addons.ui.CustomViewHolder.UnsupportedSectionV
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import java.io.IOException
+import mozilla.components.ui.icons.R as iconsR
 
 private const val VIEW_HOLDER_TYPE_SECTION = 0
 private const val VIEW_HOLDER_TYPE_NOT_YET_SUPPORTED_SECTION = 1
@@ -273,7 +274,10 @@ class AddonsManagerAdapter(
                     val att = context.theme.resolveAttribute(android.R.attr.textColorPrimary)
                     iconView.setColorFilter(ContextCompat.getColor(context, att))
                     iconView.setImageDrawable(
-                        ContextCompat.getDrawable(context, R.drawable.mozac_ic_extensions),
+                        ContextCompat.getDrawable(
+                            context,
+                            iconsR.drawable.mozac_ic_extensions,
+                        ),
                     )
                 }
                 logger.error("Attempt to fetch the ${addon.id} icon failed", e)

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/update/AddonUpdater.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/update/AddonUpdater.kt
@@ -51,6 +51,7 @@ import java.util.Date
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * Contract to define the behavior for updating addons.
@@ -281,7 +282,7 @@ class DefaultAddonUpdater(
 
         logger.info("Created update notification for add-on ${extension.id}")
         return NotificationCompat.Builder(applicationContext, channelId)
-            .setSmallIcon(mozilla.components.ui.icons.R.drawable.mozac_ic_extensions)
+            .setSmallIcon(iconsR.drawable.mozac_ic_extensions)
             .setContentTitle(getNotificationTitle(extension))
             .setContentText(text)
             .setPriority(NotificationCompat.PRIORITY_MAX)
@@ -358,7 +359,7 @@ class DefaultAddonUpdater(
             applicationContext.getString(R.string.mozac_feature_addons_updater_notification_allow_button)
 
         return NotificationCompat.Action.Builder(
-            mozilla.components.ui.icons.R.drawable.mozac_ic_extensions,
+            iconsR.drawable.mozac_ic_extensions,
             allowText,
             allowPendingIntent,
         ).build()
@@ -378,7 +379,7 @@ class DefaultAddonUpdater(
             applicationContext.getString(R.string.mozac_feature_addons_updater_notification_deny_button)
 
         return NotificationCompat.Action.Builder(
-            mozilla.components.ui.icons.R.drawable.mozac_ic_extensions,
+            iconsR.drawable.mozac_ic_extensions,
             denyText,
             denyPendingIntent,
         ).build()

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsPermissionsAdapterTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsPermissionsAdapterTest.kt
@@ -9,12 +9,12 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import mozilla.components.feature.addons.R
 import mozilla.components.feature.addons.ui.AddonPermissionsAdapter.PermissionViewHolder
 import mozilla.components.feature.addons.ui.AddonPermissionsAdapter.Style
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
+import mozilla.components.ui.colors.R
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify

--- a/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/SimpleRedirectDialogFragmentTest.kt
+++ b/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/SimpleRedirectDialogFragmentTest.kt
@@ -19,10 +19,12 @@ import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.robolectric.Shadows.shadowOf
+import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
 class SimpleRedirectDialogFragmentTest {
     private val webUrl = "https://example.com"
+    private val themeResId = appcompatR.style.Theme_AppCompat_Light
 
     @Test
     fun `Dialog confirmed callback is called correctly`() {
@@ -32,7 +34,7 @@ class SimpleRedirectDialogFragmentTest {
         val onConfirm = { onConfirmCalled = true }
         val onCancel = { onCancelCalled = true }
 
-        val fragment = spy(SimpleRedirectDialogFragment.newInstance(themeResId = R.style.Theme_AppCompat_Light))
+        val fragment = spy(SimpleRedirectDialogFragment.newInstance(themeResId = themeResId))
         doNothing().`when`(fragment).dismiss()
 
         doReturn(testContext).`when`(fragment).requireContext()
@@ -62,7 +64,7 @@ class SimpleRedirectDialogFragmentTest {
         val onConfirm = { onConfirmCalled = true }
         val onCancel = { onCancelCalled = true }
 
-        val fragment = spy(SimpleRedirectDialogFragment.newInstance(themeResId = R.style.Theme_AppCompat_Light))
+        val fragment = spy(SimpleRedirectDialogFragment.newInstance(themeResId = themeResId))
         doNothing().`when`(fragment).dismiss()
 
         doReturn(testContext).`when`(fragment).requireContext()
@@ -92,7 +94,7 @@ class SimpleRedirectDialogFragmentTest {
         val onConfirm = { onConfirmCalled = true }
         val onCancel = { onCancelCalled = true }
 
-        val fragment = spy(SimpleRedirectDialogFragment.newInstance(themeResId = R.style.Theme_AppCompat_Light))
+        val fragment = spy(SimpleRedirectDialogFragment.newInstance(themeResId = themeResId))
         doNothing().`when`(fragment).dismiss()
 
         doReturn(testContext).`when`(fragment).requireContext()

--- a/android-components/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/AuthFillResponseBuilder.kt
+++ b/android-components/components/feature/autofill/src/main/java/mozilla/components/feature/autofill/response/fill/AuthFillResponseBuilder.kt
@@ -23,6 +23,7 @@ import mozilla.components.feature.autofill.R
 import mozilla.components.feature.autofill.response.dataset.createInlinePresentation
 import mozilla.components.feature.autofill.structure.ParsedStructure
 import mozilla.components.feature.autofill.ui.AbstractAutofillUnlockActivity
+import androidx.biometric.R as biometricR
 
 internal data class AuthFillResponseBuilder(
     private val parsedStructure: ParsedStructure,
@@ -81,7 +82,10 @@ internal data class AuthFillResponseBuilder(
         )
         val intentSender: IntentSender = authPendingIntent.intentSender
 
-        val icon: Icon = Icon.createWithResource(context, R.drawable.fingerprint_dialog_fp_icon)
+        val icon: Icon = Icon.createWithResource(
+            context,
+            biometricR.drawable.fingerprint_dialog_fp_icon,
+        )
         val authInlinePresentation = createInlinePresentation(authPendingIntent, imeSpec, title, icon)
         builder.setAuthentication(
             autofillIds.toTypedArray(),

--- a/android-components/components/feature/awesomebar/build.gradle
+++ b/android-components/components/feature/awesomebar/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation project(':support-ktx')
     implementation project(':support-utils')
 
+    implementation project(':ui-icons')
+
     implementation Dependencies.androidx_core_ktx
     implementation Dependencies.kotlin_stdlib
 

--- a/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
+++ b/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/ClipboardSuggestionProvider.kt
@@ -14,11 +14,11 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.concept.engine.Engine
-import mozilla.components.feature.awesomebar.R
 import mozilla.components.feature.awesomebar.facts.emitClipboardSuggestionClickedFact
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.utils.WebURLFinder
 import java.util.UUID
+import mozilla.components.ui.icons.R as iconsR
 
 private const val MIME_TYPE_TEXT_PLAIN = "text/plain"
 private const val MINIMUM_CONFIDENCE_SCORE_FOR_URL = 0.7F
@@ -69,7 +69,7 @@ class ClipboardSuggestionProvider(
                 description = url,
                 editSuggestion = url,
                 flags = setOf(AwesomeBar.Suggestion.Flag.CLIPBOARD),
-                icon = icon ?: ContextCompat.getDrawable(context, R.drawable.mozac_ic_search)?.toBitmap(),
+                icon = icon ?: getSearchIcon(),
                 title = title,
                 onSuggestionClicked = {
                     loadUrlUseCase.invoke(url)
@@ -77,6 +77,11 @@ class ClipboardSuggestionProvider(
                 },
             ),
         )
+    }
+
+    private fun getSearchIcon(): Bitmap? {
+        val drawable = iconsR.drawable.mozac_ic_search
+        return ContextCompat.getDrawable(context, drawable)?.toBitmap()
     }
 }
 

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.awesomebar.provider
 
+import android.graphics.Bitmap
 import androidx.core.graphics.drawable.toBitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -12,7 +13,6 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Request
 import mozilla.components.concept.fetch.Response
-import mozilla.components.feature.awesomebar.R
 import mozilla.components.feature.awesomebar.facts.AwesomeBarFacts
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.search.ext.createSearchEngine
@@ -36,6 +36,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.io.IOException
+import mozilla.components.ui.icons.R as iconsR
 
 private const val GOOGLE_MOCK_RESPONSE = "[\"firefox\",[\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]"
 private const val GOOGLE_MOCK_RESPONSE_WITH_DUPLICATES = "[\"firefox\",[\"firefox\",\"firefox\",\"firefox for mac\",\"firefox quantum\",\"firefox update\",\"firefox esr\",\"firefox esr\",\"firefox focus\",\"firefox addons\",\"firefox extensions\",\"firefox nightly\",\"firefox clear cache\"]]"
@@ -242,6 +243,16 @@ class SearchSuggestionProviderTest {
         }
     }
 
+    private fun getDeviceDesktopIcon(): Bitmap {
+        val drawable = iconsR.drawable.mozac_ic_device_desktop
+        return testContext.getDrawable(drawable)!!.toBitmap()
+    }
+
+    private fun getSearchIcon(): Bitmap {
+        val drawable = iconsR.drawable.mozac_ic_search
+        return testContext.getDrawable(drawable)!!.toBitmap()
+    }
+
     @Test
     fun `Provider should use engine icon by default`() {
         runTest {
@@ -249,7 +260,7 @@ class SearchSuggestionProviderTest {
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
 
-            val engineIcon = testContext.getDrawable(R.drawable.mozac_ic_device_desktop)!!.toBitmap()
+            val engineIcon = getDeviceDesktopIcon()
 
             val searchEngine = createSearchEngine(
                 name = "Test",
@@ -276,7 +287,7 @@ class SearchSuggestionProviderTest {
             server.enqueue(MockResponse().setBody(GOOGLE_MOCK_RESPONSE))
             server.start()
 
-            val engineIcon = testContext.getDrawable(R.drawable.mozac_ic_device_desktop)!!.toBitmap()
+            val engineIcon = getDeviceDesktopIcon()
 
             val searchEngine = createSearchEngine(
                 name = "Test",
@@ -285,7 +296,7 @@ class SearchSuggestionProviderTest {
                 suggestUrl = server.url("/").toString(),
             )
 
-            val paramIcon = testContext.getDrawable(R.drawable.mozac_ic_search)!!.toBitmap()
+            val paramIcon = getSearchIcon()
 
             val provider = SearchSuggestionProvider(
                 searchEngine,

--- a/android-components/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/android-components/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -39,6 +39,7 @@ import mozilla.components.support.ktx.android.view.setNavigationBarTheme
 import mozilla.components.support.ktx.android.view.setStatusBarTheme
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import mozilla.components.support.utils.ColorUtils.getReadableTextColor
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * Initializes and resets the Toolbar for a Custom Tab based on the CustomTabConfig.
@@ -164,7 +165,7 @@ class CustomTabsToolbarFeature(
     @VisibleForTesting
     internal fun addCloseButton(tab: CustomTabSessionState, bitmap: Bitmap?) {
         val drawableIcon = bitmap?.toDrawable(context.resources)
-            ?: getDrawable(context, R.drawable.mozac_ic_close)!!.mutate()
+            ?: getDrawable(context, iconsR.drawable.mozac_ic_close)!!.mutate()
 
         drawableIcon.setTint(readableColor)
 
@@ -215,7 +216,7 @@ class CustomTabsToolbarFeature(
      */
     @VisibleForTesting
     internal fun addShareButton(tab: CustomTabSessionState) {
-        val drawableIcon = getDrawable(context, R.drawable.mozac_ic_share)!!
+        val drawableIcon = getDrawable(context, iconsR.drawable.mozac_ic_share)!!
         drawableIcon.setTint(readableColor)
 
         val button = Toolbar.ActionButton(

--- a/android-components/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragmentTest.kt
+++ b/android-components/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragmentTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.robolectric.annotation.Config
+import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = TestApplication::class)
@@ -149,6 +150,6 @@ class SimpleDownloadDialogFragmentTest {
 class TestApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        setTheme(R.style.Theme_AppCompat)
+        setTheme(appcompatR.style.Theme_AppCompat)
     }
 }

--- a/android-components/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/ui/DownloadAppChooserDialogTest.kt
+++ b/android-components/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/ui/DownloadAppChooserDialogTest.kt
@@ -25,6 +25,7 @@ import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.robolectric.annotation.Config
+import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = TestApplication::class)
@@ -128,6 +129,6 @@ class DownloadAppChooserDialogTest {
 class TestApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        setTheme(R.style.Theme_AppCompat)
+        setTheme(appcompatR.style.Theme_AppCompat)
     }
 }

--- a/android-components/components/feature/media/src/main/java/mozilla/components/feature/media/middleware/RecordingDevicesMiddleware.kt
+++ b/android-components/components/feature/media/src/main/java/mozilla/components/feature/media/middleware/RecordingDevicesMiddleware.kt
@@ -22,6 +22,7 @@ import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
 import mozilla.components.support.base.ids.SharedIdsHelper
 import mozilla.components.support.utils.PendingIntentUtils
+import mozilla.components.ui.icons.R as iconsR
 
 private const val NOTIFICATION_TAG = "mozac.feature.media.recordingDevices"
 private const val NOTIFICATION_ID = 1
@@ -126,17 +127,17 @@ internal sealed class RecordingState {
         get() = this !is None
 
     object CameraAndMicrophone : RecordingState() {
-        override val iconResource = R.drawable.mozac_ic_video
+        override val iconResource = iconsR.drawable.mozac_ic_video
         override val titleResource = R.string.mozac_feature_media_sharing_camera_and_microphone
     }
 
     object Camera : RecordingState() {
-        override val iconResource = R.drawable.mozac_ic_video
+        override val iconResource = iconsR.drawable.mozac_ic_video
         override val titleResource = R.string.mozac_feature_media_sharing_camera
     }
 
     object Microphone : RecordingState() {
-        override val iconResource = R.drawable.mozac_ic_microphone
+        override val iconResource = iconsR.drawable.mozac_ic_microphone
         override val titleResource = R.string.mozac_feature_media_sharing_microphone
     }
 

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/AlertDialogFragmentTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/AlertDialogFragmentTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations.openMocks
 import org.robolectric.Shadows.shadowOf
+import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
 class AlertDialogFragmentTest {
@@ -51,7 +52,7 @@ class AlertDialogFragmentTest {
 
         dialog.show()
 
-        val titleTextView = dialog.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)
+        val titleTextView = dialog.findViewById<TextView>(appcompatR.id.alertTitle)
         val messageTextView = dialog.findViewById<TextView>(R.id.message)
         val checkBox = dialog.findViewById<CheckBox>(id.mozac_feature_prompts_no_more_dialogs_check_box)
 

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/AuthenticationDialogFragmentTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/AuthenticationDialogFragmentTest.kt
@@ -23,6 +23,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations.openMocks
 import org.robolectric.Shadows.shadowOf
+import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
 class AuthenticationDialogFragmentTest {
@@ -56,7 +57,7 @@ class AuthenticationDialogFragmentTest {
 
         dialog.show()
 
-        val titleTextView = dialog.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)
+        val titleTextView = dialog.findViewById<TextView>(appcompatR.id.alertTitle)
         val messageTextView = dialog.findViewById<TextView>(android.R.id.message)
         val usernameEditText = dialog.findViewById<AutofillEditText>(id.username)
         val passwordEditText = dialog.findViewById<AutofillEditText>(id.password)
@@ -132,7 +133,7 @@ class AuthenticationDialogFragmentTest {
 
         dialog.show()
 
-        val titleTextView = dialog.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)
+        val titleTextView = dialog.findViewById<TextView>(appcompatR.id.alertTitle)
 
         val defaultTitle = appCompatContext.getString(AuthenticationDialogFragment.DEFAULT_TITLE)
         assertEquals(titleTextView.text.toString(), defaultTitle)

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/ConfirmDialogFragmentTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/ConfirmDialogFragmentTest.kt
@@ -23,6 +23,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations.openMocks
 import org.robolectric.Shadows.shadowOf
+import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
 class ConfirmDialogFragmentTest {
@@ -54,7 +55,7 @@ class ConfirmDialogFragmentTest {
 
         dialog.show()
 
-        val titleTextView = dialog.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)
+        val titleTextView = dialog.findViewById<TextView>(appcompatR.id.alertTitle)
         val messageTextView = dialog.findViewById<TextView>(R.id.message)
 
         assertEquals(fragment.sessionId, "sessionId")

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/MultiButtonDialogFragmentTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/MultiButtonDialogFragmentTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations.openMocks
 import org.robolectric.Shadows.shadowOf
+import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
 class MultiButtonDialogFragmentTest {
@@ -61,7 +62,7 @@ class MultiButtonDialogFragmentTest {
 
         dialog.show()
 
-        val titleTextView = dialog.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)
+        val titleTextView = dialog.findViewById<TextView>(appcompatR.id.alertTitle)
         val messageTextView = dialog.findViewById<TextView>(R.id.message)
         val checkBox = dialog.findViewById<CheckBox>(id.mozac_feature_prompts_no_more_dialogs_check_box)
         val positiveButton = (dialog as AlertDialog).getButton(BUTTON_POSITIVE)

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragmentTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/SaveLoginDialogFragmentTest.kt
@@ -25,6 +25,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.robolectric.Shadows
+import mozilla.components.ui.icons.R as iconsR
 
 @RunWith(AndroidJUnit4::class)
 class SaveLoginDialogFragmentTest : TestCase() {
@@ -96,7 +97,7 @@ class SaveLoginDialogFragmentTest : TestCase() {
                 icon,
             ),
         )
-        val defaultIconResource = R.drawable.mozac_ic_globe
+        val defaultIconResource = iconsR.drawable.mozac_ic_globe
         doReturn(appCompatContext).`when`(fragment).requireContext()
         doAnswer {
             FrameLayout(appCompatContext).apply {

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/TextPromptDialogFragmentTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/TextPromptDialogFragmentTest.kt
@@ -26,6 +26,7 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.robolectric.Shadows.shadowOf
+import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
 class TextPromptDialogFragmentTest {
@@ -49,7 +50,7 @@ class TextPromptDialogFragmentTest {
 
         dialog.show()
 
-        val titleTextView = dialog.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)
+        val titleTextView = dialog.findViewById<TextView>(appcompatR.id.alertTitle)
         val inputLabel = dialog.findViewById<TextView>(id.input_label)
         val inputValue = dialog.findViewById<TextView>(id.input_value)
         val checkBox = dialog.findViewById<CheckBox>(id.mozac_feature_prompts_no_more_dialogs_check_box)

--- a/android-components/components/feature/readerview/src/test/java/mozilla/ext/context.kt
+++ b/android-components/components/feature/readerview/src/test/java/mozilla/ext/context.kt
@@ -5,8 +5,8 @@
 package mozilla.ext
 
 import android.content.Context
+import androidx.appcompat.R
 import androidx.appcompat.view.ContextThemeWrapper
-import mozilla.components.feature.readerview.R
 import mozilla.components.support.test.robolectric.testContext
 
 /**

--- a/android-components/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
+++ b/android-components/components/feature/sitepermissions/src/main/java/mozilla/components/feature/sitepermissions/SitePermissionsFeature.kt
@@ -68,6 +68,7 @@ import mozilla.components.support.ktx.kotlin.stripDefaultPort
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.filterChanged
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import java.security.InvalidParameterException
+import mozilla.components.ui.icons.R as iconsR
 
 internal const val FRAGMENT_TAG = "mozac_feature_sitepermissions_prompt_dialog"
 
@@ -733,7 +734,7 @@ class SitePermissionsFeature(
                 host,
                 permissionRequest,
                 R.string.mozac_feature_sitepermissions_camera_and_microphone,
-                R.drawable.mozac_ic_microphone,
+                iconsR.drawable.mozac_ic_microphone,
                 showDoNotAskAgainCheckBox = shouldShowDoNotAskAgainCheckBox,
                 shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
                     ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN,
@@ -757,7 +758,7 @@ class SitePermissionsFeature(
                     host,
                     permissionRequest,
                     R.string.mozac_feature_sitepermissions_location_title,
-                    R.drawable.mozac_ic_location,
+                    iconsR.drawable.mozac_ic_location,
                     showDoNotAskAgainCheckBox = shouldShowDoNotAskAgainCheckBox,
                     shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
                         ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN,
@@ -769,7 +770,7 @@ class SitePermissionsFeature(
                     host,
                     permissionRequest,
                     R.string.mozac_feature_sitepermissions_notification_title,
-                    R.drawable.mozac_ic_notification,
+                    iconsR.drawable.mozac_ic_notification,
                     showDoNotAskAgainCheckBox = false,
                     shouldSelectRememberChoice = false,
                     isNotificationRequest = true,
@@ -781,7 +782,7 @@ class SitePermissionsFeature(
                     host,
                     permissionRequest,
                     R.string.mozac_feature_sitepermissions_microfone_title,
-                    R.drawable.mozac_ic_microphone,
+                    iconsR.drawable.mozac_ic_microphone,
                     showDoNotAskAgainCheckBox = shouldShowDoNotAskAgainCheckBox,
                     shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
                         ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN,
@@ -793,7 +794,7 @@ class SitePermissionsFeature(
                     host,
                     permissionRequest,
                     R.string.mozac_feature_sitepermissions_camera_title,
-                    R.drawable.mozac_ic_video,
+                    iconsR.drawable.mozac_ic_video,
                     showDoNotAskAgainCheckBox = shouldShowDoNotAskAgainCheckBox,
                     shouldSelectRememberChoice = dialogConfig?.shouldPreselectDoNotAskAgain
                         ?: DialogConfig.DEFAULT_PRESELECT_DO_NOT_ASK_AGAIN,
@@ -805,7 +806,7 @@ class SitePermissionsFeature(
                     host,
                     permissionRequest,
                     R.string.mozac_feature_sitepermissions_persistent_storage_title,
-                    R.drawable.mozac_ic_storage,
+                    iconsR.drawable.mozac_ic_storage,
                     showDoNotAskAgainCheckBox = false,
                     shouldSelectRememberChoice = true,
                 )
@@ -816,7 +817,7 @@ class SitePermissionsFeature(
                     host,
                     permissionRequest,
                     R.string.mozac_feature_sitepermissions_media_key_system_access_title,
-                    R.drawable.mozac_ic_link,
+                    iconsR.drawable.mozac_ic_link,
                     showDoNotAskAgainCheckBox = false,
                     shouldSelectRememberChoice = true,
                 )
@@ -889,7 +890,7 @@ class SitePermissionsFeature(
         return SitePermissionsDialogFragment.newInstance(
             sessionId = currentSession.id,
             title = title,
-            titleIcon = R.drawable.mozac_ic_cookies,
+            titleIcon = iconsR.drawable.mozac_ic_cookies,
             message = message,
             negativeButtonText = negativeButtonText,
             permissionRequestId = permissionRequest.id,

--- a/android-components/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
+++ b/android-components/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsDialogFragmentTest.kt
@@ -25,11 +25,13 @@ import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import androidx.core.R as coreR
 
 @RunWith(AndroidJUnit4::class)
 class SitePermissionsDialogFragmentTest {
 
     private val permissionRequestId = "permissionID"
+    private val titleIcon = coreR.drawable.notification_icon_background
 
     @Test
     fun `build dialog`() {
@@ -37,7 +39,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = true,
@@ -61,7 +63,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = true,
@@ -86,7 +88,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = true,
@@ -111,7 +113,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -135,7 +137,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -159,7 +161,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -184,7 +186,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -208,7 +210,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = feature,
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -237,7 +239,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mockFeature,
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -269,7 +271,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mockFeature,
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -297,7 +299,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -319,7 +321,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -341,7 +343,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mockFeature,
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -374,7 +376,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mockFeature,
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -407,7 +409,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mockFeature,
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -443,7 +445,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mockFeature,
                 shouldShowDoNotAskAgainCheckBox = false,
@@ -468,7 +470,7 @@ class SitePermissionsDialogFragmentTest {
             SitePermissionsDialogFragment.newInstance(
                 "sessionId",
                 "title",
-                R.drawable.notification_icon_background,
+                titleIcon,
                 permissionRequestId = permissionRequestId,
                 feature = mock(),
                 shouldShowDoNotAskAgainCheckBox = true,

--- a/android-components/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
+++ b/android-components/components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt
@@ -82,6 +82,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.security.InvalidParameterException
 import java.util.UUID
+import mozilla.components.ui.icons.R as iconsR
 
 @RunWith(AndroidJUnit4::class)
 class SitePermissionsFeatureTest {
@@ -1094,7 +1095,7 @@ class SitePermissionsFeatureTest {
             ),
             dialog.title,
         )
-        assertEquals(R.drawable.mozac_ic_cookies, dialog.icon)
+        assertEquals(iconsR.drawable.mozac_ic_cookies, dialog.icon)
         assertEquals(permissionRequest.id, dialog.permissionRequestId)
         assertEquals(sitePermissionFeature, dialog.feature)
         assertEquals(false, dialog.shouldShowDoNotAskAgainCheckBox)

--- a/android-components/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/toolbar/TabCounterToolbarButtonTest.kt
+++ b/android-components/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/toolbar/TabCounterToolbarButtonTest.kt
@@ -18,12 +18,12 @@ import mozilla.components.browser.state.state.recover.RecoverableTab
 import mozilla.components.browser.state.state.recover.TabState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.menu.MenuController
-import mozilla.components.feature.tabs.R
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.whenever
+import mozilla.components.ui.tabcounter.R
 import mozilla.components.ui.tabcounter.TabCounter
 import mozilla.components.ui.tabcounter.TabCounterMenu
 import org.junit.Assert.assertEquals

--- a/android-components/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ContainerToolbarAction.kt
+++ b/android-components/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/ContainerToolbarAction.kt
@@ -19,6 +19,7 @@ import mozilla.components.concept.toolbar.Toolbar.Action
 import mozilla.components.support.base.android.Padding
 import mozilla.components.support.ktx.android.view.setPadding
 import mozilla.components.support.utils.DrawableUtils.loadAndTintDrawable
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * An action button that represents a container to be added to the toolbar.
@@ -56,19 +57,19 @@ class ContainerToolbarAction(
         @ColorInt val tint = getTint(context, container.color)
 
         return when (container.icon) {
-            Icon.FINGERPRINT -> loadAndTintDrawable(context, R.drawable.mozac_ic_fingerprint, tint)
-            Icon.BRIEFCASE -> loadAndTintDrawable(context, R.drawable.mozac_ic_briefcase, tint)
-            Icon.DOLLAR -> loadAndTintDrawable(context, R.drawable.mozac_ic_dollar, tint)
-            Icon.CART -> loadAndTintDrawable(context, R.drawable.mozac_ic_cart, tint)
-            Icon.CIRCLE -> loadAndTintDrawable(context, R.drawable.mozac_ic_circle, tint)
-            Icon.GIFT -> loadAndTintDrawable(context, R.drawable.mozac_ic_gift, tint)
-            Icon.VACATION -> loadAndTintDrawable(context, R.drawable.mozac_ic_vacation, tint)
-            Icon.FOOD -> loadAndTintDrawable(context, R.drawable.mozac_ic_food, tint)
-            Icon.FRUIT -> loadAndTintDrawable(context, R.drawable.mozac_ic_fruit, tint)
-            Icon.PET -> loadAndTintDrawable(context, R.drawable.mozac_ic_pet, tint)
-            Icon.TREE -> loadAndTintDrawable(context, R.drawable.mozac_ic_tree, tint)
-            Icon.CHILL -> loadAndTintDrawable(context, R.drawable.mozac_ic_chill, tint)
-            Icon.FENCE -> loadAndTintDrawable(context, R.drawable.mozac_ic_fence, tint)
+            Icon.FINGERPRINT -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_fingerprint, tint)
+            Icon.BRIEFCASE -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_briefcase, tint)
+            Icon.DOLLAR -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_dollar, tint)
+            Icon.CART -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_cart, tint)
+            Icon.CIRCLE -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_circle, tint)
+            Icon.GIFT -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_gift, tint)
+            Icon.VACATION -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_vacation, tint)
+            Icon.FOOD -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_food, tint)
+            Icon.FRUIT -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_fruit, tint)
+            Icon.PET -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_pet, tint)
+            Icon.TREE -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_tree, tint)
+            Icon.CHILL -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_chill, tint)
+            Icon.FENCE -> loadAndTintDrawable(context, iconsR.drawable.mozac_ic_fence, tint)
         }
     }
 

--- a/android-components/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarAction.kt
+++ b/android-components/components/feature/toolbar/src/main/java/mozilla/components/feature/toolbar/WebExtensionToolbarAction.kt
@@ -21,6 +21,7 @@ import mozilla.components.support.base.android.Padding
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.support.ktx.android.view.setPadding
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * An action button that represents an web extension item to be added to the toolbar.
@@ -76,7 +77,9 @@ open class WebExtensionToolbarAction(
                 }
             } catch (throwable: Throwable) {
                 MainScope().launch {
-                    imageView.setImageResource(R.drawable.mozac_ic_web_extension_default_icon)
+                    imageView.setImageResource(
+                        iconsR.drawable.mozac_ic_web_extension_default_icon,
+                    )
                 }
                 Log.log(
                     Log.Priority.ERROR,

--- a/android-components/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarTest.kt
+++ b/android-components/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarTest.kt
@@ -30,6 +30,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import mozilla.components.ui.icons.R as iconsR
 
 @RunWith(AndroidJUnit4::class)
 class WebExtensionToolbarTest {
@@ -97,7 +98,9 @@ class WebExtensionToolbarTest {
         action.iconJob?.joinBlocking()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        verify(imageView).setImageResource(R.drawable.mozac_ic_web_extension_default_icon)
+        verify(imageView).setImageResource(
+            iconsR.drawable.mozac_ic_web_extension_default_icon,
+        )
     }
 
     @Test

--- a/android-components/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
+++ b/android-components/components/ui/autocomplete/src/main/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditText.kt
@@ -37,6 +37,7 @@ import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.Fact
 import mozilla.components.support.base.facts.collect
 import mozilla.components.support.utils.SafeUrl
+import androidx.appcompat.R as appcompatR
 
 typealias OnCommitListener = () -> Unit
 typealias OnFilterListener = (String) -> Unit
@@ -95,7 +96,7 @@ interface AutocompleteView {
 open class InlineAutocompleteEditText @JvmOverloads constructor(
     ctx: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = R.attr.editTextStyle,
+    defStyleAttr: Int = appcompatR.attr.editTextStyle,
 ) : AppCompatEditText(ctx, attrs, defStyleAttr), AutocompleteView {
 
     data class AutocompleteResult(

--- a/android-components/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
+++ b/android-components/components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt
@@ -77,7 +77,7 @@ class InlineAutocompleteEditTextTest {
 
     @Test
     fun onFocusChange() {
-        val et = InlineAutocompleteEditText(testContext, attributes, R.attr.editTextStyle)
+        val et = InlineAutocompleteEditText(testContext, attributes)
         val searchStates = mutableListOf<Boolean>()
 
         et.setOnSearchStateChangeListener { b: Boolean -> searchStates.add(searchStates.size, b) }

--- a/android-components/components/ui/tabcounter/build.gradle
+++ b/android-components/components/ui/tabcounter/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation project(':concept-menu')
     implementation project(':browser-menu2')
     implementation project(':support-base')
+    implementation project(':ui-icons')
 
     testImplementation project(":support-test")
 

--- a/android-components/components/ui/tabcounter/src/main/java/mozilla/components/ui/tabcounter/TabCounterMenu.kt
+++ b/android-components/components/ui/tabcounter/src/main/java/mozilla/components/ui/tabcounter/TabCounterMenu.kt
@@ -11,6 +11,7 @@ import mozilla.components.concept.menu.MenuController
 import mozilla.components.concept.menu.candidate.DrawableMenuIcon
 import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import mozilla.components.concept.menu.candidate.TextStyle
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * The menu that is shown when clicking on the [TabCounter]
@@ -53,7 +54,7 @@ open class TabCounterMenu(
             text = context.getString(R.string.mozac_browser_menu_new_tab),
             start = DrawableMenuIcon(
                 context,
-                R.drawable.mozac_ic_new,
+                iconsR.drawable.mozac_ic_new,
                 tint = iconColor ?: getColor(context, R.color.mozac_ui_tabcounter_default_text),
             ),
             textStyle = TextStyle(),
@@ -65,7 +66,7 @@ open class TabCounterMenu(
             text = context.getString(R.string.mozac_browser_menu_new_private_tab),
             start = DrawableMenuIcon(
                 context,
-                R.drawable.mozac_ic_private_browsing,
+                iconsR.drawable.mozac_ic_private_browsing,
                 tint = iconColor ?: getColor(context, R.color.mozac_ui_tabcounter_default_text),
             ),
             textStyle = TextStyle(),
@@ -77,7 +78,7 @@ open class TabCounterMenu(
             text = context.getString(R.string.mozac_close_tab),
             start = DrawableMenuIcon(
                 context,
-                R.drawable.mozac_ic_close,
+                iconsR.drawable.mozac_ic_close,
                 tint = iconColor ?: getColor(context, R.color.mozac_ui_tabcounter_default_text),
             ),
             textStyle = TextStyle(),
@@ -89,7 +90,7 @@ open class TabCounterMenu(
             text = context.getString(R.string.mozac_ui_tabcounter_duplicate_tab),
             start = DrawableMenuIcon(
                 context,
-                R.drawable.mozac_ic_tab,
+                iconsR.drawable.mozac_ic_tab,
                 tint = iconColor ?: getColor(context, R.color.mozac_ui_tabcounter_default_text),
             ),
             textStyle = TextStyle(),

--- a/android-components/components/ui/widgets/src/test/java/mozilla/components/ui/widgets/WidgetSiteItemViewTest.kt
+++ b/android-components/components/ui/widgets/src/test/java/mozilla/components/ui/widgets/WidgetSiteItemViewTest.kt
@@ -19,6 +19,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import mozilla.components.ui.icons.R as iconsR
 
 @RunWith(AndroidJUnit4::class)
 class WidgetSiteItemViewTest {
@@ -69,8 +70,8 @@ class WidgetSiteItemViewTest {
         val secondaryButton = view.findViewById<ImageButton>(R.id.secondary_button)
         var clicked = false
         view.setSecondaryButton(
-            icon = R.drawable.mozac_ic_lock,
-            contentDescription = R.string.mozac_error_lock,
+            icon = iconsR.drawable.mozac_ic_lock,
+            contentDescription = iconsR.string.mozac_error_lock,
             onClickListener = { clicked = true },
         )
         assertTrue(secondaryButton.isVisible)

--- a/android-components/gradle.properties
+++ b/android-components/gradle.properties
@@ -48,3 +48,5 @@ libLicenseUrl=https://www.mozilla.org/en-US/MPL/2.0/
 android.useAndroidX=true
 android.enableJetifier=false
 
+# Non-Transitive R Classes
+android.nonTransitiveRClass=true

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -87,6 +87,8 @@ import org.mozilla.samples.browser.ext.components
 import org.mozilla.samples.browser.integration.FindInPageIntegration
 import org.mozilla.samples.browser.request.SampleUrlEncodedRequestInterceptor
 import java.util.concurrent.TimeUnit
+import mozilla.components.ui.colors.R.color as photonColors
+import mozilla.components.ui.icons.R as iconsR
 
 private const val DAY_IN_MINUTES = 24 * 60L
 
@@ -253,7 +255,7 @@ open class DefaultComponents(private val applicationContext: Context) {
             menuItems,
             store = store,
             style = WebExtensionBrowserMenuBuilder.Style(
-                webExtIconTintColorResource = R.color.photonGrey90,
+                webExtIconTintColorResource = photonColors.photonGrey90,
             ),
             onAddonsManagerTapped = {
                 val intent = Intent(applicationContext, AddonsActivity::class.java)
@@ -268,7 +270,7 @@ open class DefaultComponents(private val applicationContext: Context) {
             menuToolbar,
             BrowserMenuHighlightableItem(
                 "No Highlight",
-                R.drawable.mozac_ic_share,
+                iconsR.drawable.mozac_ic_share,
                 android.R.color.black,
                 highlight = BrowserMenuHighlight.LowPriority(
                     notificationTint = ContextCompat.getColor(applicationContext, android.R.color.holo_green_dark),
@@ -277,7 +279,7 @@ open class DefaultComponents(private val applicationContext: Context) {
             ) {
                 Toast.makeText(applicationContext, "Highlight", Toast.LENGTH_SHORT).show()
             },
-            BrowserMenuImageText("Share", R.drawable.mozac_ic_share, android.R.color.black) {
+            BrowserMenuImageText("Share", iconsR.drawable.mozac_ic_share, android.R.color.black) {
                 Toast.makeText(applicationContext, "Share", Toast.LENGTH_SHORT).show()
             },
             SimpleBrowserMenuItem("Settings") {
@@ -350,41 +352,41 @@ open class DefaultComponents(private val applicationContext: Context) {
 
     private val menuToolbar by lazy {
         val back = BrowserMenuItemToolbar.TwoStateButton(
-            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_back,
-            primaryImageTintResource = R.color.photonBlue90,
+            primaryImageResource = iconsR.drawable.mozac_ic_back,
+            primaryImageTintResource = photonColors.photonBlue90,
             primaryContentDescription = "Back",
             isInPrimaryState = {
                 store.state.selectedTab?.content?.canGoBack ?: true
             },
             disableInSecondaryState = true,
-            secondaryImageTintResource = R.color.photonGrey40,
+            secondaryImageTintResource = photonColors.photonGrey40,
         ) {
             sessionUseCases.goBack()
         }
 
         val forward = BrowserMenuItemToolbar.TwoStateButton(
-            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
+            primaryImageResource = iconsR.drawable.mozac_ic_forward,
             primaryContentDescription = "Forward",
-            primaryImageTintResource = R.color.photonBlue90,
+            primaryImageTintResource = photonColors.photonBlue90,
             isInPrimaryState = {
                 store.state.selectedTab?.content?.canGoForward ?: true
             },
             disableInSecondaryState = true,
-            secondaryImageTintResource = R.color.photonGrey40,
+            secondaryImageTintResource = photonColors.photonGrey40,
         ) {
             sessionUseCases.goForward()
         }
 
         val refresh = BrowserMenuItemToolbar.TwoStateButton(
-            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
+            primaryImageResource = iconsR.drawable.mozac_ic_refresh,
             primaryContentDescription = "Refresh",
-            primaryImageTintResource = R.color.photonBlue90,
+            primaryImageTintResource = photonColors.photonBlue90,
             isInPrimaryState = {
                 store.state.selectedTab?.content?.loading == false
             },
-            secondaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
+            secondaryImageResource = iconsR.drawable.mozac_ic_stop,
             secondaryContentDescription = "Stop",
-            secondaryImageTintResource = R.color.photonBlue90,
+            secondaryImageTintResource = photonColors.photonBlue90,
             disableInSecondaryState = false,
         ) {
             if (store.state.selectedTab?.content?.loading == true) {

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/TabsTrayFragment.kt
@@ -21,6 +21,7 @@ import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.samples.browser.databinding.FragmentTabstrayBinding
 import org.mozilla.samples.browser.ext.components
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * A fragment for displaying the tabs tray.
@@ -35,7 +36,7 @@ class TabsTrayFragment : Fragment(), UserInteractionHandler {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentTabstrayBinding.bind(view)
-        binding.toolbar.setNavigationIcon(R.drawable.mozac_ic_back)
+        binding.toolbar.setNavigationIcon(iconsR.drawable.mozac_ic_back)
         binding.toolbar.setNavigationOnClickListener {
             closeTabsTray()
         }

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonDetailsActivity.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonDetailsActivity.kt
@@ -26,6 +26,7 @@ import org.mozilla.samples.browser.R
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Locale
+import mozilla.components.feature.addons.R as addonsR
 
 /**
  * An activity to show the details of an add-on.
@@ -64,7 +65,9 @@ class AddonDetailsActivity : AppCompatActivity() {
             val ratingView = findViewById<RatingBar>(R.id.rating_view)
             val userCountView = findViewById<TextView>(R.id.users_count)
 
-            val ratingContentDescription = getString(R.string.mozac_feature_addons_rating_content_description)
+            val ratingContentDescription = getString(
+                addonsR.string.mozac_feature_addons_rating_content_description,
+            )
             ratingView.contentDescription = String.format(ratingContentDescription, it.average)
             ratingView.rating = it.average
 

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
@@ -29,6 +29,9 @@ import org.mozilla.samples.browser.databinding.FragmentAddOnsBinding
 import org.mozilla.samples.browser.databinding.OverlayAddOnProgressBinding
 import org.mozilla.samples.browser.ext.components
 import java.util.concurrent.CancellationException
+import androidx.browser.R as androidxBrowserR
+import mozilla.components.browser.menu.R as menuR
+import mozilla.components.feature.addons.R as addonsR
 
 /**
  * Fragment use for managing add-ons.
@@ -82,8 +85,8 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
                 val addons = context.components.addonManager.getAddons()
 
                 val style = AddonsManagerAdapter.Style(
-                    dividerColor = R.color.browser_actions_divider_color,
-                    dividerHeight = R.dimen.mozac_browser_menu_item_divider_height,
+                    dividerColor = androidxBrowserR.color.browser_actions_divider_color,
+                    dividerHeight = menuR.dimen.mozac_browser_menu_item_divider_height,
                 )
 
                 scope.launch(Dispatchers.Main) {
@@ -103,7 +106,7 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
                 scope.launch(Dispatchers.Main) {
                     Toast.makeText(
                         activity,
-                        R.string.mozac_feature_addons_failed_to_query_add_ons,
+                        addonsR.string.mozac_feature_addons_failed_to_query_add_ons,
                         Toast.LENGTH_SHORT,
                     ).show()
                 }
@@ -213,7 +216,7 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
                     Toast.makeText(
                         requireContext(),
                         getString(
-                            R.string.mozac_feature_addons_failed_to_install,
+                            addonsR.string.mozac_feature_addons_failed_to_install,
                             addon.translateName(requireContext()),
                         ),
                         Toast.LENGTH_SHORT,

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/InstalledAddonDetailsActivity.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
 import kotlinx.coroutines.CoroutineScope
@@ -19,6 +20,7 @@ import mozilla.components.feature.addons.ui.translateName
 import org.mozilla.samples.browser.BrowserActivity
 import org.mozilla.samples.browser.R
 import org.mozilla.samples.browser.ext.components
+import mozilla.components.feature.addons.R as addonsR
 
 /**
  * An activity to show the details of a installed add-on.
@@ -52,7 +54,7 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
                 scope.launch(Dispatchers.Main) {
                     Toast.makeText(
                         baseContext,
-                        R.string.mozac_feature_addons_failed_to_query_add_ons,
+                        addonsR.string.mozac_feature_addons_failed_to_query_add_ons,
                         Toast.LENGTH_SHORT,
                     ).show()
                 }
@@ -85,18 +87,16 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
                     addon,
                     onSuccess = {
                         switch.setState(true)
-                        Toast.makeText(
-                            this,
-                            getString(R.string.mozac_feature_addons_successfully_enabled, addon.translateName(this)),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                        showAddonToast(
+                            addonsR.string.mozac_feature_addons_successfully_enabled,
+                            addon,
+                        )
                     },
                     onError = {
-                        Toast.makeText(
-                            this,
-                            getString(R.string.mozac_feature_addons_failed_to_enable, addon.translateName(this)),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                        showAddonToast(
+                            addonsR.string.mozac_feature_addons_failed_to_enable,
+                            addon,
+                        )
                     },
                 )
             } else {
@@ -104,18 +104,16 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
                     addon,
                     onSuccess = {
                         switch.setState(false)
-                        Toast.makeText(
-                            this,
-                            getString(R.string.mozac_feature_addons_successfully_disabled, addon.translateName(this)),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                        showAddonToast(
+                            addonsR.string.mozac_feature_addons_successfully_disabled,
+                            addon,
+                        )
                     },
                     onError = {
-                        Toast.makeText(
-                            this,
-                            getString(R.string.mozac_feature_addons_failed_to_disable, addon.translateName(this)),
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                        showAddonToast(
+                            addonsR.string.mozac_feature_addons_failed_to_disable,
+                            addon,
+                        )
                     },
                 )
             }
@@ -175,29 +173,35 @@ class InstalledAddonDetailsActivity : AppCompatActivity() {
             this.components.addonManager.uninstallAddon(
                 addon,
                 onSuccess = {
-                    Toast.makeText(
-                        this,
-                        getString(R.string.mozac_feature_addons_successfully_uninstalled, addon.translateName(this)),
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                    showAddonToast(
+                        addonsR.string.mozac_feature_addons_successfully_uninstalled,
+                        addon,
+                    )
                     finish()
                 },
                 onError = { _, _ ->
-                    Toast.makeText(
-                        this,
-                        getString(R.string.mozac_feature_addons_failed_to_uninstall, addon.translateName(this)),
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                    showAddonToast(
+                        addonsR.string.mozac_feature_addons_failed_to_uninstall,
+                        addon,
+                    )
                 },
             )
         }
     }
 
+    private fun showAddonToast(@StringRes textId: Int, addon: Addon) {
+        Toast.makeText(
+            this,
+            getString(textId, addon.translateName(context = this)),
+            Toast.LENGTH_SHORT,
+        ).show()
+    }
+
     private fun SwitchCompat.setState(checked: Boolean) {
         val text = if (checked) {
-            R.string.mozac_feature_addons_enabled
+            addonsR.string.mozac_feature_addons_enabled
         } else {
-            R.string.mozac_feature_addons_disabled
+            addonsR.string.mozac_feature_addons_disabled
         }
         setText(text)
         isChecked = checked

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ReaderViewIntegration.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/integration/ReaderViewIntegration.kt
@@ -5,6 +5,7 @@
 package org.mozilla.samples.browser.integration
 
 import android.content.Context
+import android.graphics.drawable.Drawable
 import androidx.core.content.ContextCompat
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import mozilla.components.browser.state.selector.selectedTab
@@ -16,6 +17,8 @@ import mozilla.components.feature.readerview.view.ReaderViewControlsView
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import org.mozilla.samples.browser.R
+import mozilla.components.ui.colors.R as colorsR
+import mozilla.components.ui.icons.R as iconsR
 
 @Suppress("UndocumentedPublicClass")
 class ReaderViewIntegration(
@@ -30,9 +33,9 @@ class ReaderViewIntegration(
     private var readerViewButtonVisible = false
 
     private val readerViewButton: BrowserToolbar.ToggleButton = BrowserToolbar.ToggleButton(
-        image = ContextCompat.getDrawable(context, R.drawable.mozac_ic_reader_mode)!!,
-        imageSelected = ContextCompat.getDrawable(context, R.drawable.mozac_ic_reader_mode)!!.mutate().apply {
-            setTint(ContextCompat.getColor(context, R.color.photonBlue40))
+        image = getReaderDrawable(context),
+        imageSelected = getReaderDrawable(context).mutate().apply {
+            setTint(ContextCompat.getColor(context, colorsR.color.photonBlue40))
         },
         contentDescription = context.getString(R.string.mozac_reader_view_description),
         contentDescriptionSelected = context.getString(R.string.mozac_reader_view_description_selected),
@@ -73,4 +76,9 @@ class ReaderViewIntegration(
     override fun onBackPressed(): Boolean {
         return feature.onBackPressed()
     }
+}
+
+private fun getReaderDrawable(context: Context): Drawable {
+    val drawable = iconsR.drawable.mozac_ic_reader_mode
+    return ContextCompat.getDrawable(context, drawable)!!
 }

--- a/android-components/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
+++ b/android-components/samples/toolbar/src/main/java/org/mozilla/samples/toolbar/ToolbarActivity.kt
@@ -48,6 +48,10 @@ import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.support.utils.URLStringUtils
 import mozilla.components.ui.tabcounter.TabCounter
 import org.mozilla.samples.toolbar.databinding.ActivityToolbarBinding
+import mozilla.components.browser.menu.R as menuR
+import mozilla.components.browser.toolbar.R as toolbarR
+import mozilla.components.ui.colors.R as colorsR
+import mozilla.components.ui.icons.R as iconsR
 
 /**
  * This sample application shows how to use and customize the browser-toolbar component.
@@ -100,7 +104,7 @@ class ToolbarActivity : AppCompatActivity() {
      */
     private fun setupDefaultToolbar(private: Boolean = false) {
         binding.toolbar.setBackgroundColor(
-            ContextCompat.getColor(this, mozilla.components.ui.colors.R.color.photonBlue80),
+            ContextCompat.getColor(this, colorsR.color.photonBlue80),
         )
 
         binding.toolbar.private = private
@@ -124,7 +128,7 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val back = BrowserToolbar.Button(
-            resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_back)!!,
+            resources.getThemedDrawable(iconsR.drawable.mozac_ic_back)!!,
             "Back",
         ) {
             simulateReload()
@@ -133,7 +137,7 @@ class ToolbarActivity : AppCompatActivity() {
         binding.toolbar.addNavigationAction(back)
 
         val forward = BrowserToolbar.Button(
-            resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_forward)!!,
+            resources.getThemedDrawable(iconsR.drawable.mozac_ic_forward)!!,
             "Forward",
         ) {
             simulateReload()
@@ -146,9 +150,9 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val reload = BrowserToolbar.TwoStateButton(
-            primaryImage = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_refresh)!!,
+            primaryImage = resources.getThemedDrawable(iconsR.drawable.mozac_ic_refresh)!!,
             primaryContentDescription = "Reload",
-            secondaryImage = resources.getThemedDrawable(mozilla.components.ui.icons.R.drawable.mozac_ic_stop)!!,
+            secondaryImage = resources.getThemedDrawable(iconsR.drawable.mozac_ic_stop)!!,
             secondaryContentDescription = "Stop",
             isInPrimaryState = { loading.value != true },
             disableInSecondaryState = false,
@@ -186,7 +190,7 @@ class ToolbarActivity : AppCompatActivity() {
      */
     private fun setupCustomMenu() {
         binding.toolbar.setBackgroundColor(
-            ContextCompat.getColor(this, mozilla.components.ui.colors.R.color.photonBlue80),
+            ContextCompat.getColor(this, colorsR.color.photonBlue80),
         )
 
         // //////////////////////////////////////////////////////////////////////////////////////////
@@ -195,12 +199,12 @@ class ToolbarActivity : AppCompatActivity() {
 
         val share = TextMenuCandidate(
             "Share",
-            start = DrawableMenuIcon(this, R.drawable.mozac_ic_share),
+            start = DrawableMenuIcon(this, iconsR.drawable.mozac_ic_share),
         ) { /* Do nothing */ }
 
         val search = TextMenuCandidate(
             "Search",
-            start = DrawableMenuIcon(this, R.drawable.mozac_ic_search),
+            start = DrawableMenuIcon(this, iconsR.drawable.mozac_ic_search),
         ) { /* Do nothing */ }
 
         binding.toolbar.display.menuController = BrowserMenuController(Side.START).apply {
@@ -230,7 +234,7 @@ class ToolbarActivity : AppCompatActivity() {
         // //////////////////////////////////////////////////////////////////////////////////////////
 
         val forward = BrowserMenuItemToolbar.Button(
-            mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
+            iconsR.drawable.mozac_ic_forward,
             "Forward",
             isEnabled = { canGoForward() },
         ) {
@@ -238,9 +242,9 @@ class ToolbarActivity : AppCompatActivity() {
         }
 
         val reload = BrowserMenuItemToolbar.TwoStateButton(
-            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
+            primaryImageResource = iconsR.drawable.mozac_ic_refresh,
             primaryContentDescription = "Reload",
-            secondaryImageResource = R.drawable.mozac_ic_stop,
+            secondaryImageResource = iconsR.drawable.mozac_ic_stop,
             secondaryContentDescription = "Stop",
             isInPrimaryState = { loading.value != true },
             disableInSecondaryState = false,
@@ -344,10 +348,10 @@ class ToolbarActivity : AppCompatActivity() {
         val homeScreen = TextMenuCandidate("Add to Home screen") { /* Do nothing */ }
         val open = TextMenuCandidate("Open in…") { /* Do nothing */ }
         val settings = NestedMenuCandidate(
-            id = R.id.mozac_browser_toolbar_menu,
+            id = toolbarR.id.mozac_browser_toolbar_menu,
             text = "Settings",
             subMenuItems = listOf(
-                NestedMenuCandidate(id = R.id.container, text = "Back", subMenuItems = null),
+                NestedMenuCandidate(id = menuR.id.container, text = "Back", subMenuItems = null),
                 TextMenuCandidate("Setting 1") { /* Do nothing */ },
                 TextMenuCandidate("Setting 2") { /* Do nothing */ },
             ),
@@ -376,7 +380,7 @@ class ToolbarActivity : AppCompatActivity() {
             ContextCompat.getDrawable(this, R.drawable.fenix_url_background),
         )
         binding.toolbar.edit.setIcon(
-            ContextCompat.getDrawable(this, R.drawable.mozac_ic_search)!!,
+            ContextCompat.getDrawable(this, iconsR.drawable.mozac_ic_search)!!,
             "Search",
         )
 
@@ -424,7 +428,7 @@ class ToolbarActivity : AppCompatActivity() {
 
         binding.toolbar.url = "https://www.mozilla.org/en-US/firefox/mobile/"
 
-        val drawableIcon = ContextCompat.getDrawable(this, R.drawable.mozac_ic_close)
+        val drawableIcon = ContextCompat.getDrawable(this, iconsR.drawable.mozac_ic_close)
 
         drawableIcon?.apply {
             setTint(0xFF20123a.toInt())
@@ -438,7 +442,7 @@ class ToolbarActivity : AppCompatActivity() {
             binding.toolbar.addNavigationAction(button)
         }
 
-        val drawable = ContextCompat.getDrawable(this, R.drawable.mozac_ic_share)?.apply {
+        val drawable = ContextCompat.getDrawable(this, iconsR.drawable.mozac_ic_share)?.apply {
             setTint(0xFF20123a.toInt())
         }
 


### PR DESCRIPTION
According to [Android documentation](https://developer.android.com/studio/build/optimize-your-build.html#use-non-transitive-r-classes):

>You should use non-transitive [R classes](https://developer.android.com/reference/android/R) to have faster builds for applications with multiple modules. Doing so helps prevent resource duplication by ensuring that each module's R class only contains references to its own resources, without pulling references from its dependencies. This leads to faster builds and the corresponding benefits of compilation avoidance.

Full clean build before (`./gradlew --profile --rerun-tasks assembleDebug`): ~14m 50s
Full clean build after (`./gradlew --profile --rerun-tasks assembleDebug`): ~12m 30s

I didn't test incremental compilation, but it should show stronger results on changes to modules that have resources that aren't used by (many) other modules.

This also appears to decrease the apk size of Fenix by ~1MB.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
