### PR TITLE
Revert "Bug 1795105 - Don't store thumbnails in BrowserState"

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.state.engine
 
 import android.content.Intent
+import android.graphics.Bitmap
 import android.os.Environment
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
@@ -213,6 +214,16 @@ internal class EngineObserver(
                 tabId,
                 layoutInDisplayCutoutMode,
             ),
+        )
+    }
+
+    override fun onThumbnailChange(bitmap: Bitmap?) {
+        store.dispatch(
+            if (bitmap == null) {
+                ContentAction.RemoveThumbnailAction(tabId)
+            } else {
+                ContentAction.UpdateThumbnailAction(tabId, bitmap)
+            },
         )
     }
 

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ContentStateReducer.kt
@@ -29,8 +29,8 @@ internal object ContentStateReducer {
             is ContentAction.RemoveIconAction -> updateContentState(state, action.sessionId) {
                 it.copy(icon = null)
             }
-            is ContentAction.RemoveThumbnailAction -> {
-                throw IllegalStateException("You need to add ThumbnailsMiddleware to your BrowserStore. ($action)")
+            is ContentAction.RemoveThumbnailAction -> updateContentState(state, action.sessionId) {
+                it.copy(thumbnail = null)
             }
             is ContentAction.UpdateUrlAction -> updateContentState(state, action.sessionId) {
                 it.copy(
@@ -92,8 +92,8 @@ internal object ContentStateReducer {
                     it
                 }
             }
-            is ContentAction.UpdateThumbnailAction -> {
-                throw IllegalStateException("You need to add ThumbnailsMiddleware to your BrowserStore. ($action)")
+            is ContentAction.UpdateThumbnailAction -> updateContentState(state, action.sessionId) {
+                it.copy(thumbnail = action.thumbnail)
             }
             is ContentAction.UpdateDownloadAction -> updateContentState(state, action.sessionId) {
                 it.copy(download = action.download.copy(sessionId = action.sessionId))

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SystemReducer.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/SystemReducer.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.state.reducer
 
+import android.content.ComponentCallbacks2
 import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.browser.state.state.BrowserState
 
@@ -13,11 +14,55 @@ internal object SystemReducer {
      */
     fun reduce(state: BrowserState, action: SystemAction): BrowserState {
         return when (action) {
-            is SystemAction.LowMemoryAction -> {
-                // Do nothing for now; our previous implementation here isn't currently needed.
-                // This reducer has value for future actions.
-                state
-            }
+            is SystemAction.LowMemoryAction -> trimMemory(state, action.level)
         }
+    }
+
+    private fun trimMemory(state: BrowserState, level: Int): BrowserState {
+        // We only take care of thumbnails here. EngineMiddleware deals with suspending
+        // EngineSessions if needed.
+
+        if (!shouldClearThumbnails(level)) {
+            return state
+        }
+
+        return state.copy(
+            tabs = state.tabs.map { tab ->
+                if (tab.id != state.selectedTabId) {
+                    tab.copy(
+                        content = tab.content.copy(thumbnail = null),
+                    )
+                } else {
+                    tab
+                }
+            },
+            customTabs = state.customTabs.map { tab ->
+                tab.copy(
+                    content = tab.content.copy(thumbnail = null),
+                )
+            },
+        )
+    }
+}
+
+private fun shouldClearThumbnails(level: Int): Boolean {
+    return when (level) {
+        // Foreground: The device is running much lower on memory. The app is running and not killable, but the
+        // system wants us to release unused resources to improve system performance.
+        ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW,
+        // Foreground: The device is running extremely low on memory. The app is not yet considered a killable
+        // process, but the system will begin killing background processes if apps do not release resources.
+        ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
+        -> true
+
+        // Background: The system is running low on memory and our process is near the middle of the LRU list.
+        // If the system becomes further constrained for memory, there's a chance our process will be killed.
+        ComponentCallbacks2.TRIM_MEMORY_MODERATE,
+        // Background: The system is running low on memory and our process is one of the first to be killed
+        // if the system does not recover memory now.
+        ComponentCallbacks2.TRIM_MEMORY_COMPLETE,
+        -> true
+
+        else -> false
     }
 }

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -30,6 +30,8 @@ import mozilla.components.concept.engine.window.WindowRequest
  * @property securityInfo the security information as [SecurityInfoState],
  * describing whether or not the this session is for a secure URL, as well
  * as the host and SSL certificate authority.
+ * @property thumbnail the last generated [Bitmap] of this session's content, to
+ * be used as a preview in e.g. a tab switcher.
  * @property icon the icon of the page currently loaded by this session.
  * @property download Last unhandled download request.
  * @property share Last unhandled request to share an internet resource that first needs to be downloaded.
@@ -69,6 +71,7 @@ data class ContentState(
     val loading: Boolean = false,
     val searchTerms: String = "",
     val securityInfo: SecurityInfoState = SecurityInfoState(),
+    val thumbnail: Bitmap? = null,
     val icon: Bitmap? = null,
     val download: DownloadState? = null,
     val share: ShareInternetResourceState? = null,

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.browser.state.state
 
+import android.graphics.Bitmap
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSessionState
 import mozilla.components.concept.engine.manifest.WebAppManifest
@@ -80,6 +81,7 @@ fun createTab(
     extensions: Map<String, WebExtensionState> = emptyMap(),
     readerState: ReaderState = ReaderState(),
     title: String = "",
+    thumbnail: Bitmap? = null,
     contextId: String? = null,
     lastAccess: Long = 0L,
     createdAt: Long = System.currentTimeMillis(),
@@ -102,6 +104,7 @@ fun createTab(
             url,
             private,
             title = title,
+            thumbnail = thumbnail,
             webAppManifest = webAppManifest,
             searchTerms = searchTerms,
             previewImageUrl = previewImageUrl,

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -266,6 +266,40 @@ class ContentActionTest {
     }
 
     @Test
+    fun `UpdateThumbnailAction updates thumbnail`() {
+        val thumbnail = spy(Bitmap::class.java)
+
+        assertNotEquals(thumbnail, tab.content.thumbnail)
+        assertNotEquals(thumbnail, otherTab.content.thumbnail)
+
+        store.dispatch(
+            ContentAction.UpdateThumbnailAction(tab.id, thumbnail),
+        ).joinBlocking()
+
+        assertEquals(thumbnail, tab.content.thumbnail)
+        assertNotEquals(thumbnail, otherTab.content.thumbnail)
+    }
+
+    @Test
+    fun `RemoveThumbnailAction removes thumbnail`() {
+        val thumbnail = spy(Bitmap::class.java)
+
+        assertNotEquals(thumbnail, tab.content.thumbnail)
+
+        store.dispatch(
+            ContentAction.UpdateThumbnailAction(tab.id, thumbnail),
+        ).joinBlocking()
+
+        assertEquals(thumbnail, tab.content.thumbnail)
+
+        store.dispatch(
+            ContentAction.RemoveThumbnailAction(tab.id),
+        ).joinBlocking()
+
+        assertNull(tab.content.thumbnail)
+    }
+
+    @Test
     fun `UpdateIconAction updates icon`() {
         val icon = spy(Bitmap::class.java)
 

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/SystemActionTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/SystemActionTest.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.action
+
+import android.content.ComponentCallbacks2
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.EngineState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SystemActionTest {
+
+    @Test
+    fun `LowMemoryAction removes thumbnails`() {
+        val initialState = BrowserState(
+            tabs = listOf(
+                createTab(url = "https://www.mozilla.org", id = "0"),
+                createTab(url = "https://www.firefox.com", id = "1"),
+                createTab(url = "https://www.firefox.com", id = "2"),
+            ),
+        )
+        val store = BrowserStore(initialState)
+
+        store.dispatch(ContentAction.UpdateThumbnailAction("0", mock())).joinBlocking()
+        store.dispatch(ContentAction.UpdateThumbnailAction("1", mock())).joinBlocking()
+        store.dispatch(ContentAction.UpdateThumbnailAction("2", mock())).joinBlocking()
+        store.dispatch(TabListAction.SelectTabAction(tabId = "2")).joinBlocking()
+
+        assertNotNull(store.state.tabs[0].content.thumbnail)
+        assertNotNull(store.state.tabs[1].content.thumbnail)
+        assertNotNull(store.state.tabs[2].content.thumbnail)
+
+        store.dispatch(
+            SystemAction.LowMemoryAction(
+                ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
+            ),
+        ).joinBlocking()
+
+        assertNull(store.state.tabs[0].content.thumbnail)
+        assertNull(store.state.tabs[1].content.thumbnail)
+        // Thumbnail of selected tab should not have been removed
+        assertNotNull(store.state.tabs[2].content.thumbnail)
+    }
+}
+
+private fun createTabWithMockEngineSession(
+    id: String,
+    url: String,
+) = TabSessionState(
+    id,
+    content = ContentState(url),
+    engineState = EngineState(engineSession = mock()),
+)

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.state.engine
 
 import android.content.Intent
+import android.graphics.Bitmap
 import android.view.WindowManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Job
@@ -48,6 +49,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -780,6 +782,21 @@ class EngineObserverTest {
             assertEquals("tab-id", action.sessionId)
             assertEquals(123, action.layoutInDisplayCutoutMode)
         }
+    }
+
+    @Test
+    fun `Engine observer notified when thumbnail is assigned`() {
+        val store: BrowserStore = mock()
+        val observer = EngineObserver("tab-id", store)
+        val emptyBitmap = spy(Bitmap::class.java)
+        observer.onThumbnailChange(emptyBitmap)
+
+        verify(store).dispatch(
+            ContentAction.UpdateThumbnailAction(
+                "tab-id",
+                emptyBitmap,
+            ),
+        )
     }
 
     @Test

--- a/android-components/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
+++ b/android-components/components/browser/tabstray/src/main/java/mozilla/components/browser/tabstray/TabViewHolder.kt
@@ -108,12 +108,14 @@ class DefaultTabViewHolder(
         updateSelectedTabIndicator(isSelected)
 
         // In the final else case, we have no cache or fresh screenshot; do nothing instead of clearing the image.
-        if (thumbnailLoader != null) {
+        if (thumbnailLoader != null && tab.content.thumbnail == null) {
             val thumbnailSize = THUMBNAIL_SIZE.dpToPx(thumbnailView.context.resources.displayMetrics)
             thumbnailLoader.loadIntoView(
                 thumbnailView,
                 ImageLoadRequest(id = tab.id, size = thumbnailSize),
             )
+        } else if (tab.content.thumbnail != null) {
+            thumbnailView.setImageBitmap(tab.content.thumbnail)
         }
 
         iconView?.setImageBitmap(tab.content.icon)

--- a/android-components/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
+++ b/android-components/components/browser/tabstray/src/test/java/mozilla/components/browser/tabstray/DefaultTabViewHolderTest.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.tabstray
 
 import android.content.res.ColorStateList
+import android.graphics.Bitmap
 import android.graphics.drawable.ColorDrawable
 import android.view.LayoutInflater
 import android.view.View
@@ -22,8 +23,10 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 
@@ -122,11 +125,32 @@ class DefaultTabViewHolderTest {
     }
 
     @Test
+    fun `thumbnail from session is assigned to thumbnail image view`() {
+        val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
+        val thumbnailView = view.findViewById<ImageView>(R.id.mozac_browser_tabstray_thumbnail)
+
+        val holder = DefaultTabViewHolder(view)
+        assertEquals(null, thumbnailView.drawable)
+
+        val emptyBitmap = Bitmap.createBitmap(40, 40, Bitmap.Config.ARGB_8888)
+        val session = createTab(id = "a", url = "https://www.mozilla.org", thumbnail = emptyBitmap)
+
+        holder.bind(session, isSelected = false, styling = mock(), mock())
+        assertTrue(thumbnailView.drawable != null)
+    }
+
+    @Test
     fun `thumbnail is set from loader`() {
         val view = LayoutInflater.from(testContext).inflate(R.layout.mozac_browser_tabstray_item, null)
         val loader: ImageLoader = mock()
         val viewHolder = DefaultTabViewHolder(view, loader)
+        val tabWithThumbnail =
+            createTab(id = "123", url = "https://example.com", thumbnail = mock())
         val tab = createTab(id = "123", url = "https://example.com")
+
+        viewHolder.bind(tabWithThumbnail, false, mock(), mock())
+
+        verify(loader, never()).loadIntoView(any(), eq(ImageLoadRequest("123", 100)), nullable(), nullable())
 
         viewHolder.bind(tab, false, mock(), mock())
 

--- a/android-components/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/ThumbnailsMiddleware.kt
+++ b/android-components/components/browser/thumbnails/src/main/java/mozilla/components/browser/thumbnails/ThumbnailsMiddleware.kt
@@ -31,9 +31,6 @@ class ThumbnailsMiddleware(
                 // thumbnail is updated.
                 thumbnailStorage.saveThumbnail(action.sessionId, action.thumbnail)
             }
-            is ContentAction.RemoveThumbnailAction -> {
-                thumbnailStorage.deleteThumbnail(action.sessionId)
-            }
             is TabListAction.RemoveAllNormalTabsAction -> {
                 context.state.tabs.filterNot { it.content.private }.forEach { tab ->
                     thumbnailStorage.deleteThumbnail(tab.id)
@@ -55,8 +52,10 @@ class ThumbnailsMiddleware(
                 action.tabIds.forEach { thumbnailStorage.deleteThumbnail(it) }
             }
             else -> {
-                next(action)
+                // no-op
             }
         }
+
+        next(action)
     }
 }

--- a/android-components/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/ThumbnailsMiddlewareTest.kt
+++ b/android-components/components/browser/thumbnails/src/test/java/mozilla/components/browser/thumbnails/ThumbnailsMiddlewareTest.kt
@@ -6,16 +6,13 @@ package mozilla.components.browser.thumbnails
 
 import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
-import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
 import mozilla.components.support.test.ext.joinBlocking
-import mozilla.components.support.test.middleware.CaptureActionsMiddleware
 import mozilla.components.support.test.mock
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,20 +34,6 @@ class ThumbnailsMiddlewareTest {
         val bitmap: Bitmap = mock()
         store.dispatch(ContentAction.UpdateThumbnailAction(request, bitmap)).joinBlocking()
         verify(thumbnailStorage).saveThumbnail(request, bitmap)
-    }
-
-    @Test
-    fun `thumbnail storage deletes the thumbnail on remove thumbnail action`() {
-        val request = "test-tab1"
-        val tab = createTab("https://www.mozilla.org", id = "test-tab1")
-        val thumbnailStorage: ThumbnailStorage = mock()
-        val store = BrowserStore(
-            initialState = BrowserState(tabs = listOf(tab)),
-            middleware = listOf(ThumbnailsMiddleware(thumbnailStorage)),
-        )
-
-        store.dispatch(ContentAction.RemoveThumbnailAction(request)).joinBlocking()
-        verify(thumbnailStorage).deleteThumbnail(request)
     }
 
     @Test
@@ -146,27 +129,5 @@ class ThumbnailsMiddlewareTest {
 
         store.dispatch(TabListAction.RemoveTabsAction(listOf(sessionIdOrUrl))).joinBlocking()
         verify(thumbnailStorage).deleteThumbnail(sessionIdOrUrl)
-    }
-
-    @Test
-    fun `UpdateThumbnailAction is consumed by the middleware`() {
-        val capture = CaptureActionsMiddleware<BrowserState, BrowserAction>()
-        val store = BrowserStore(
-            initialState = BrowserState(
-                tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "test-tab1"),
-                    createTab("https://www.firefox.com", id = "test-tab2"),
-                ),
-            ),
-            middleware = listOf(
-                ThumbnailsMiddleware(mock()),
-                capture,
-            ),
-        )
-
-        store.dispatch(ContentAction.UpdateThumbnailAction("test-tab1", mock())).joinBlocking()
-        store.dispatch(EngineAction.KillEngineSessionAction("test-tab1")).joinBlocking()
-
-        capture.assertNotDispatched(ContentAction.UpdateThumbnailAction::class)
     }
 }

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -5,6 +5,7 @@
 package mozilla.components.concept.engine
 
 import android.content.Intent
+import android.graphics.Bitmap
 import androidx.annotation.CallSuper
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy.ACCEPT_ALL
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy.ACCEPT_FIRST_PARTY_AND_ISOLATE_OTHERS
@@ -76,6 +77,7 @@ abstract class EngineSession(
          * @param layoutInDisplayCutoutMode value of defined in https://developer.android.com/reference/android/view/WindowManager.LayoutParams#layoutInDisplayCutoutMode
          */
         fun onMetaViewportFitChanged(layoutInDisplayCutoutMode: Int) = Unit
+        fun onThumbnailChange(bitmap: Bitmap?) = Unit
         fun onAppPermissionRequest(permissionRequest: PermissionRequest) = permissionRequest.reject()
         fun onContentPermissionRequest(permissionRequest: PermissionRequest) = permissionRequest.reject()
         fun onCancelContentPermissionRequest(permissionRequest: PermissionRequest) = Unit

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.engine
 
+import android.graphics.Bitmap
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
@@ -35,6 +36,7 @@ class EngineSessionTest {
         val session = spy(DummyEngineSession())
 
         val observer = mock(EngineSession.Observer::class.java)
+        val emptyBitmap = spy(Bitmap::class.java)
         val permissionRequest = mock(PermissionRequest::class.java)
         val windowRequest = mock(WindowRequest::class.java)
         session.register(observer)
@@ -61,6 +63,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onFindResult(0, 1, true) }
         session.notifyInternalObservers { onFullScreenChange(true) }
         session.notifyInternalObservers { onMetaViewportFitChanged(1) }
+        session.notifyInternalObservers { onThumbnailChange(emptyBitmap) }
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
@@ -94,6 +97,7 @@ class EngineSessionTest {
         verify(observer).onFindResult(0, 1, true)
         verify(observer).onFullScreenChange(true)
         verify(observer).onMetaViewportFitChanged(1)
+        verify(observer).onThumbnailChange(emptyBitmap)
         verify(observer).onAppPermissionRequest(permissionRequest)
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
@@ -123,6 +127,7 @@ class EngineSessionTest {
         val otherPermissionRequest = mock(PermissionRequest::class.java)
         val windowRequest = mock(WindowRequest::class.java)
         val otherWindowRequest = mock(WindowRequest::class.java)
+        val emptyBitmap = spy(Bitmap::class.java)
         val tracker = Tracker("tracker")
 
         session.register(observer)
@@ -139,6 +144,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onFindResult(0, 1, true) }
         session.notifyInternalObservers { onFullScreenChange(true) }
         session.notifyInternalObservers { onMetaViewportFitChanged(1) }
+        session.notifyInternalObservers { onThumbnailChange(emptyBitmap) }
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
@@ -167,6 +173,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onFindResult(0, 1, false) }
         session.notifyInternalObservers { onFullScreenChange(false) }
         session.notifyInternalObservers { onMetaViewportFitChanged(2) }
+        session.notifyInternalObservers { onThumbnailChange(null) }
         session.notifyInternalObservers { onContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(otherPermissionRequest) }
@@ -196,6 +203,7 @@ class EngineSessionTest {
         verify(observer).onFindResult(0, 1, true)
         verify(observer).onFullScreenChange(true)
         verify(observer).onMetaViewportFitChanged(1)
+        verify(observer).onThumbnailChange(emptyBitmap)
         verify(observer).onAppPermissionRequest(permissionRequest)
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
@@ -216,6 +224,7 @@ class EngineSessionTest {
         verify(observer, never()).onFindResult(0, 1, false)
         verify(observer, never()).onFullScreenChange(false)
         verify(observer, never()).onMetaViewportFitChanged(2)
+        verify(observer, never()).onThumbnailChange(null)
         verify(observer, never()).onAppPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
@@ -243,6 +252,7 @@ class EngineSessionTest {
         val windowRequest = mock(WindowRequest::class.java)
         val otherWindowRequest = mock(WindowRequest::class.java)
         val otherHitResult = HitResult.UNKNOWN("file://foobaz")
+        val emptyBitmap = spy(Bitmap::class.java)
         val tracker = Tracker("tracker")
 
         session.register(observer)
@@ -260,6 +270,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onFindResult(0, 1, true) }
         session.notifyInternalObservers { onFullScreenChange(true) }
         session.notifyInternalObservers { onMetaViewportFitChanged(1) }
+        session.notifyInternalObservers { onThumbnailChange(emptyBitmap) }
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
@@ -286,6 +297,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onFindResult(0, 1, false) }
         session.notifyInternalObservers { onFullScreenChange(false) }
         session.notifyInternalObservers { onMetaViewportFitChanged(2) }
+        session.notifyInternalObservers { onThumbnailChange(null) }
         session.notifyInternalObservers { onContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(otherPermissionRequest) }
@@ -312,6 +324,7 @@ class EngineSessionTest {
         verify(observer).onFindResult(0, 1, true)
         verify(observer).onFullScreenChange(true)
         verify(observer).onMetaViewportFitChanged(1)
+        verify(observer).onThumbnailChange(emptyBitmap)
         verify(observer).onAppPermissionRequest(permissionRequest)
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
@@ -329,6 +342,7 @@ class EngineSessionTest {
         verify(observer, never()).onFindResult(0, 1, false)
         verify(observer, never()).onFullScreenChange(false)
         verify(observer, never()).onMetaViewportFitChanged(2)
+        verify(observer, never()).onThumbnailChange(null)
         verify(observer, never()).onAppPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
@@ -353,6 +367,7 @@ class EngineSessionTest {
         verify(otherObserver, never()).onFindResult(0, 1, false)
         verify(otherObserver, never()).onFullScreenChange(false)
         verify(otherObserver, never()).onMetaViewportFitChanged(2)
+        verify(otherObserver, never()).onThumbnailChange(null)
         verify(otherObserver, never()).onAppPermissionRequest(otherPermissionRequest)
         verify(otherObserver, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(otherObserver, never()).onCancelContentPermissionRequest(otherPermissionRequest)
@@ -376,6 +391,7 @@ class EngineSessionTest {
         val otherPermissionRequest = mock(PermissionRequest::class.java)
         val windowRequest = mock(WindowRequest::class.java)
         val otherWindowRequest = mock(WindowRequest::class.java)
+        val emptyBitmap = spy(Bitmap::class.java)
         val tracker = Tracker("tracker")
 
         session.register(observer)
@@ -392,6 +408,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onFindResult(0, 1, true) }
         session.notifyInternalObservers { onFullScreenChange(true) }
         session.notifyInternalObservers { onMetaViewportFitChanged(1) }
+        session.notifyInternalObservers { onThumbnailChange(emptyBitmap) }
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
@@ -418,6 +435,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onFindResult(0, 1, false) }
         session.notifyInternalObservers { onFullScreenChange(false) }
         session.notifyInternalObservers { onMetaViewportFitChanged(2) }
+        session.notifyInternalObservers { onThumbnailChange(null) }
         session.notifyInternalObservers { onContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(otherPermissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(otherPermissionRequest) }
@@ -444,6 +462,7 @@ class EngineSessionTest {
         verify(observer).onFindResult(0, 1, true)
         verify(observer).onFullScreenChange(true)
         verify(observer).onMetaViewportFitChanged(1)
+        verify(observer).onThumbnailChange(emptyBitmap)
         verify(observer).onAppPermissionRequest(permissionRequest)
         verify(observer).onContentPermissionRequest(permissionRequest)
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
@@ -461,6 +480,7 @@ class EngineSessionTest {
         verify(observer, never()).onFindResult(0, 1, false)
         verify(observer, never()).onFullScreenChange(false)
         verify(observer, never()).onMetaViewportFitChanged(2)
+        verify(observer, never()).onThumbnailChange(null)
         verify(observer, never()).onAppPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onContentPermissionRequest(otherPermissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(otherPermissionRequest)
@@ -482,6 +502,7 @@ class EngineSessionTest {
         val otherSession = spy(DummyEngineSession())
         val permissionRequest = mock(PermissionRequest::class.java)
         val windowRequest = mock(WindowRequest::class.java)
+        val emptyBitmap = spy(Bitmap::class.java)
         val observer = mock(EngineSession.Observer::class.java)
         val tracker = Tracker("tracker")
         var mediaSessionController: MediaSession.Controller = mock()
@@ -504,6 +525,7 @@ class EngineSessionTest {
         otherSession.notifyInternalObservers { onFindResult(0, 1, true) }
         otherSession.notifyInternalObservers { onFullScreenChange(true) }
         otherSession.notifyInternalObservers { onMetaViewportFitChanged(1) }
+        otherSession.notifyInternalObservers { onThumbnailChange(emptyBitmap) }
         otherSession.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         otherSession.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         otherSession.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
@@ -529,6 +551,7 @@ class EngineSessionTest {
         verify(observer, never()).onFindResult(0, 1, true)
         verify(observer, never()).onFullScreenChange(true)
         verify(observer, never()).onMetaViewportFitChanged(1)
+        verify(observer, never()).onThumbnailChange(emptyBitmap)
         verify(observer, never()).onAppPermissionRequest(permissionRequest)
         verify(observer, never()).onContentPermissionRequest(permissionRequest)
         verify(observer, never()).onCancelContentPermissionRequest(permissionRequest)
@@ -555,6 +578,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onFindResult(0, 1, true) }
         session.notifyInternalObservers { onFullScreenChange(true) }
         session.notifyInternalObservers { onMetaViewportFitChanged(1) }
+        session.notifyInternalObservers { onThumbnailChange(emptyBitmap) }
         session.notifyInternalObservers { onContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onCancelContentPermissionRequest(permissionRequest) }
         session.notifyInternalObservers { onAppPermissionRequest(permissionRequest) }
@@ -580,6 +604,7 @@ class EngineSessionTest {
         verify(observer, times(1)).onFindResult(0, 1, true)
         verify(observer, times(1)).onFullScreenChange(true)
         verify(observer, times(1)).onMetaViewportFitChanged(1)
+        verify(observer, times(1)).onThumbnailChange(emptyBitmap)
         verify(observer, times(1)).onAppPermissionRequest(permissionRequest)
         verify(observer, times(1)).onContentPermissionRequest(permissionRequest)
         verify(observer, times(1)).onCancelContentPermissionRequest(permissionRequest)
@@ -816,6 +841,7 @@ class EngineSessionTest {
         defaultObserver.onNavigationStateChange()
         defaultObserver.onProgress(123)
         defaultObserver.onLoadingStateChange(true)
+        defaultObserver.onThumbnailChange(spy(Bitmap::class.java))
         defaultObserver.onFullScreenChange(true)
         defaultObserver.onMetaViewportFitChanged(1)
         defaultObserver.onAppPermissionRequest(mock(PermissionRequest::class.java))
@@ -897,6 +923,7 @@ class EngineSessionTest {
     @Test
     fun `engine session observer has default methods`() {
         val observer = object : EngineSession.Observer { }
+        val bitmap: Bitmap = mock()
         val permissionRequest = mock(PermissionRequest::class.java)
         val windowRequest = mock(WindowRequest::class.java)
         val tracker: Tracker = mock()
@@ -916,6 +943,7 @@ class EngineSessionTest {
         observer.onFindResult(0, 1, true)
         observer.onFullScreenChange(true)
         observer.onMetaViewportFitChanged(1)
+        observer.onThumbnailChange(bitmap)
         observer.onContentPermissionRequest(permissionRequest)
         observer.onCancelContentPermissionRequest(permissionRequest)
         observer.onAppPermissionRequest(permissionRequest)

--- a/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/TabSessionState.kt
+++ b/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/ext/TabSessionState.kt
@@ -13,6 +13,7 @@ internal fun TabSessionState.toTab() = Tab(
     content.title,
     content.private,
     content.icon,
+    content.thumbnail,
     mediaSessionState?.playbackState,
     mediaSessionState?.controller,
     lastAccess,

--- a/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/Tab.kt
+++ b/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/tabstray/Tab.kt
@@ -17,6 +17,7 @@ import mozilla.components.concept.engine.mediasession.MediaSession
  * @property title Current title of the tab (or an empty [String]]).
  * @property private whether or not the session is private.
  * @property icon Current icon of the tab (or null)
+ * @property thumbnail Current thumbnail of the tab (or null)
  * @property playbackState Current media session playback state for the tab (or null)
  * @property controller Current media session controller for the tab (or null)
  * @property lastAccess The last time this tab was selected.
@@ -30,6 +31,7 @@ internal data class Tab(
     val title: String = "",
     val private: Boolean = false,
     val icon: Bitmap? = null,
+    val thumbnail: Bitmap? = null,
     val playbackState: MediaSession.PlaybackState? = null,
     val controller: MediaSession.Controller? = null,
     val lastAccess: Long = 0L,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,14 +44,6 @@ permalink: /changelog/
 * **service-glean**
   * Re-export TextMetricType, RateMetricType, DenominatorMetricType, NumeratorMetricType to make them usable by applications [#13010](https://github.com/mozilla-mobile/android-components/pull/13010)
 
-* **browser-state**:
-  * `UpdateThumbnailAction` and `RemoveThumbnailAction` now throw an exception if those actions are not handled with a middleware.
-  * See `BrowserThumbnails` and `ThumbnailsMiddleware` for example usages within other features.
-  * Removed handling of `LowMemoryAction` in `SystemReducer` on in-memory thumbnails.
-
-* **browser-tabstray**:
-  * `TabViewHolder` no longer checks if a thumbnail is in memory before retrieving a thumbnail from the `ImageLoader`.
-
 # 107.0.0
 * [Commits](https://github.com/mozilla-mobile/android-components/compare/v106.0.0..v107.0.0)
 * [Milestone](https://github.com/mozilla-mobile/android-components/milestone/154?closed=1)
@@ -60,7 +52,7 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/android-components/blob/v107.0.0/.config.yml)
 
 * **feature-syncedtabs**
-  * 🚒 Bug fixed [issue #12930](https://github.com/mozilla-mobile/android-components/issues/12930) Ensure `DefaultPresenter` will unregister it's `FxaAccountManager` observers when it's `lifecycleOwner` is stopped to prevent memory leaks.
+  * 🚒 Bug fixed [issue #12930](https://github.com/mozilla-mobile/android-components/issues/12930) Ensure `DefaultPresenter` will unregister it's `FxaAccountManager` observers when it's `lifecycleOwner` is stopped to prevent memory leaks. 
 
 * **feature-app-links**
   * 🚒 Bug fixed [issue #12804](https://github.com/mozilla-mobile/android-components/issues/12804) Speculative fix for a TransactionTooLargeException or RuntimeException when querying activities.


### PR DESCRIPTION
This reverts commit d9028ef2b230a03459fe20ab56bdce0acdce3aea.

Fails UI test `openRecentlyClosedItemTest`:

```
androidx.test.uiautomator.UiObjectNotFoundException: UiSelector[RESOURCE_ID=org.mozilla.fenix.debug:id/toolbar]
	at androidx.test.uiautomator.UiObject.click(UiObject.java:416)
	at org.mozilla.fenix.ui.robots.HomeScreenRobot$Transition.openNavigationToolbar(HomeScreenRobot.kt:445)
	at org.mozilla.fenix.ui.SmokeTest.openRecentlyClosedItemTest(SmokeTest.kt:480)
```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
