### PR TITLE
Bug 1797997 - part 8: Fix nit on event name

### DIFF
--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -33,7 +33,7 @@ task-defaults:
         using: gradlew
         use-caches: false
     run-on-tasks-for:
-        - github-pull-requests
+        - github-pull-request
         - github-push
     treeherder:
             kind: test


### PR DESCRIPTION
Fixes up #113. This patch makes the tests run on ~~https://github.com/mozilla-mobile/firefox-android/pull/81~~ https://github.com/mozilla-mobile/firefox-android/pull/117