### PR TITLE
Bug 1798878 - Let `sync-focus.sh` port the last 2 release branches too

### DIFF
--- a/monorepo-migration/sync-focus.sh
+++ b/monorepo-migration/sync-focus.sh
@@ -10,7 +10,6 @@ MAIN_BRANCH_NAME='main'
 PREP_BRANCH_NAME='focus-prep'
 TMP_REPO_PATH="/tmp/git/$REPO_NAME_TO_SYNC"
 TMP_REPO_BRANCH_NAME='firefox-android'
-TAG_PREFIX='focus-'
 MONOREPO_URL='git@github.com:mozilla-mobile/firefox-android.git'
 MERGE_COMMIT_MESSAGE=$(cat <<EOF
 Merge https://github.com/mozilla-mobile/$REPO_NAME_TO_SYNC repository
@@ -19,7 +18,6 @@ The history was slightly altered before merging it:
   * All files from $REPO_NAME_TO_SYNC are now under its own subdirectory
   * All commits messages were rewritten to link issues and pull requests to the former repository
   * All commits messages were prefixed with [focus]
-  * All tags were were prefixed with $TAG_PREFIX
 EOF
 )
 
@@ -74,15 +72,7 @@ function _rewrite_git_history() {
     git filter-repo \
         --to-subdirectory-filter "$REPO_NAME_TO_SYNC/" \
         --replace-message "$EXPRESSIONS_FILE_PATH" \
-        --tag-rename '':"$TAG_PREFIX" \
         --force
-}
-
-function _remove_old_tags() {
-    cd "$CURRENT_REPO_PATH"
-    set +e
-    git tag | grep "$TAG_PREFIX" | xargs -L 1 | xargs git push "$MONOREPO_URL" --delete
-    set -e
 }
 
 function _back_up_prep_branch() {
@@ -102,7 +92,7 @@ function _reset_prep_branch() {
 
 function _merge_histories() {
     cd "$CURRENT_REPO_PATH"
-    git pull --no-edit --tags --allow-unrelated-histories --no-rebase --force "$TMP_REPO_PATH"
+    git pull --no-edit --allow-unrelated-histories --no-rebase --force "$TMP_REPO_PATH"
     git commit --amend --message "$MERGE_COMMIT_MESSAGE"
 }
 
@@ -116,7 +106,6 @@ _setup_temporary_repo
 _update_repo_branch
 _update_repo_numbers
 _rewrite_git_history
-_remove_old_tags
 _reset_prep_branch
 _merge_histories
 _clean_up_temporary_repo
@@ -127,5 +116,4 @@ $REPO_NAME_TO_SYNC has been sync'd and merged to the current branch.
 You can now inspect the changes and push them once ready:
 
 git push
-git push --tags
 EOF

--- a/monorepo-migration/sync-focus.sh
+++ b/monorepo-migration/sync-focus.sh
@@ -96,10 +96,6 @@ function _merge_histories() {
     git commit --amend --message "$MERGE_COMMIT_MESSAGE"
 }
 
-function _clean_up_temporary_repo() {
-    rm -rf "$TMP_REPO_PATH"
-}
-
 
 _test_prerequisites
 _setup_temporary_repo
@@ -108,7 +104,6 @@ _update_repo_numbers
 _rewrite_git_history
 _reset_prep_branch
 _merge_histories
-_clean_up_temporary_repo
 
 
 cat <<EOF

--- a/monorepo-migration/sync-focus.sh
+++ b/monorepo-migration/sync-focus.sh
@@ -30,6 +30,7 @@ EOF
 
 EXPRESSIONS_FILE_PATH="$SCRIPT_DIR/data/message-expressions.txt"
 UTC_NOW="$(date -u '+%Y%m%d%H%M%S')"
+PREP_BRANCH_BACKUP_SUFFIX="backup-$UTC_NOW"
 
 
 function _is_github_authenticated() {
@@ -87,7 +88,7 @@ function _back_up_prep_branch() {
 
     cd "$CURRENT_REPO_PATH"
     if git rev-parse --quiet --verify "$prep_branch" > /dev/null; then
-        git branch --move "$prep_branch" "$prep_branch-backup-$UTC_NOW"
+        git branch --move "$prep_branch" "$prep_branch-$PREP_BRANCH_BACKUP_SUFFIX"
     fi
 }
 
@@ -140,4 +141,8 @@ $REPO_NAME_TO_SYNC has been sync'd and merged to the following branches:
 
 You are currently on ${PREP_BRANCHES[0]}.
 You can now inspect the changes and push them once ready.
+
+If something went wrong, you still have a copy of the former branches.
+They're suffixed by '$PREP_BRANCH_BACKUP_SUFFIX'
+
 EOF


### PR DESCRIPTION
Depends on https://github.com/mozilla-mobile/firefox-android/pull/121. ~~Only the changes in `monorepo-migration/sync-focus.sh` are worth reviewing here.~~ (#121 was merged)  

I tested the changes locally by just running the script from my branch and then have a look at the `focus-prep`, `focus-prep-107`, and `focus-prep-106` branches. For each branch, the merge looked fine:
 * `git rev-list --parents -n 1 HEAD` showed 3 commits: the merge commit itself, the tip of the main/release branch on the monorepo, then the tip of the main/release branch of focus-android
 * `git log` of each of the commits above shows the right history, including the modified one on focus. 
 * The PR/issues numbers got replaced. I didn't find any number that didn't get replaced when I looked that up with that search `#[0-9]`.
 * All branches got backed up locally, just in case.
 * The final message explains what happened.
 * We don't have to remind ourselves to bump release branches numbers when release day occurs.