### PR TITLE
Bug 1796658 - fix notifications on failure of geckoview nightly bumps

### DIFF
--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -33,8 +33,8 @@ task-defaults:
     notifications:
         by-geckoview-bump:
             nightly:
-                subject: "[Android-Components] Failed to update to geckoview nightly {geckoview_timestamp}"
-                message: "Please check https://github.com/mozilla-mobile/android-components/pull/{pull_request_number}"
+                subject: "[Android-Components] Failed to update geckoview nightly PR#{pull_request_number}"
+                message: "Please check {repository}/pull/{pull_request_number}"
                 emails:
                     - android-components-team@mozilla.com
                     - geckoview-core@mozilla.com


### PR DESCRIPTION
A few years ago the owner and branch names for these bumps changed, so the notification would never actually happen.
Now we look for:
- the complete-pr task
- on the relbot/upgrade-geckoview-ac-main branch of the base repository

Since the branch name no longer includes the geckoview build id, we no longer include it in the email subject and replace it with the PR number.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
