### PR TITLE
Bug 1800816 - Allow option to set initial desktop mode status

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -1200,6 +1200,10 @@ class GeckoEngineSession(
         defaultSettings?.testingModeEnabled?.let {
             geckoSession.settings.fullAccessibilityTree = it
         }
+        if (defaultSettings?.initialDesktopMode == true) {
+            geckoSession.settings.viewportMode = GeckoSessionSettings.VIEWPORT_MODE_DESKTOP
+            geckoSession.settings.userAgentMode = GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
+        }
         defaultSettings?.userAgentString?.let { geckoSession.settings.userAgentOverride = it }
         defaultSettings?.suspendMediaWhenInactive?.let {
             geckoSession.settings.suspendMediaWhenInactive = it

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -2256,6 +2256,30 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `GIVEN initialDesktopMode flag is true WHEN creating GeckoEngineSession THEN set desktop mode`() {
+        GeckoEngineSession(
+            runtime,
+            geckoSessionProvider = geckoSessionProvider,
+            defaultSettings = DefaultSettings(initialDesktopMode = true),
+        )
+
+        verify(geckoSession.settings).viewportMode = GeckoSessionSettings.VIEWPORT_MODE_DESKTOP
+        verify(geckoSession.settings).userAgentMode = GeckoSessionSettings.USER_AGENT_MODE_DESKTOP
+    }
+
+    @Test
+    fun `GIVEN initialDesktopMode flag is false WHEN creating GeckoEngineSession THEN desktop mode is not set`() {
+        GeckoEngineSession(
+            runtime,
+            geckoSessionProvider = geckoSessionProvider,
+            defaultSettings = DefaultSettings(initialDesktopMode = false),
+        )
+
+        verify(geckoSession.settings, never()).viewportMode = anyInt()
+        verify(geckoSession.settings, never()).userAgentMode = anyInt()
+    }
+
+    @Test
     fun checkForMobileSite() {
         val mUrl = "https://m.example.com"
         val mobileUrl = "https://mobile.example.com"

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/ContentState.kt
@@ -56,7 +56,7 @@ import mozilla.components.concept.engine.window.WindowRequest
  * cancel or abort before a page is refreshed.
  * @property recordingDevices List of recording devices (e.g. camera or microphone) currently in use
  * by web content.
- * @property desktopMode true if desktop mode is enabled, otherwise false.
+ * @property desktopMode true if desktop mode is enabled, null for default desktop mode, otherwise false.
  * @property appIntent the last received [AppIntentState].
  * @property showToolbarAsExpanded whether the dynamic toolbar should be forced as expanded.
  * @property previewImageUrl the preview image of the page (e.g. the hero image), if available.
@@ -91,7 +91,7 @@ data class ContentState(
     val loadRequest: LoadRequestState? = null,
     val refreshCanceled: Boolean = false,
     val recordingDevices: List<RecordingDevice> = emptyList(),
-    val desktopMode: Boolean = false,
+    val desktopMode: Boolean? = null,
     val appIntent: AppIntentState? = null,
     val showToolbarAsExpanded: Boolean = false,
     val previewImageUrl: String? = null,

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/ContentActionTest.kt
@@ -697,18 +697,18 @@ class ContentActionTest {
 
     @Test
     fun `UpdateDesktopModeEnabledAction updates desktopModeEnabled`() {
-        assertFalse(tab.content.desktopMode)
-        assertFalse(otherTab.content.desktopMode)
+        assertNull(tab.content.desktopMode)
+        assertNull(otherTab.content.desktopMode)
 
         store.dispatch(ContentAction.UpdateDesktopModeAction(tab.id, true)).joinBlocking()
 
-        assertTrue(tab.content.desktopMode)
-        assertFalse(otherTab.content.desktopMode)
+        assertTrue(tab.content.desktopMode == true)
+        assertNull(otherTab.content.desktopMode)
 
         store.dispatch(ContentAction.UpdateDesktopModeAction(tab.id, false)).joinBlocking()
 
-        assertFalse(tab.content.desktopMode)
-        assertFalse(otherTab.content.desktopMode)
+        assertTrue(tab.content.desktopMode == false)
+        assertNull(otherTab.content.desktopMode)
     }
 
     @Test

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -81,6 +81,11 @@ abstract class Settings {
     open var userAgentString: String? by UnsupportedSetting()
 
     /**
+     * Setting to control whether or not desktop mode is initially enabled.
+     */
+    open var initialDesktopMode: Boolean by UnsupportedSetting()
+
+    /**
      * Setting to control whether or not a user gesture is required to play media.
      */
     open var mediaPlaybackRequiresUserGesture: Boolean by UnsupportedSetting()
@@ -216,6 +221,7 @@ data class DefaultSettings(
     override var requestInterceptor: RequestInterceptor? = null,
     override var historyTrackingDelegate: HistoryTrackingDelegate? = null,
     override var userAgentString: String? = null,
+    override var initialDesktopMode: Boolean = false,
     override var javaScriptCanOpenWindowsAutomatically: Boolean = false,
     override var displayZoomControls: Boolean = true,
     override var loadWithOverviewMode: Boolean = false,


### PR DESCRIPTION
This also makes the associated ContentState boolean property to a nullable in order to defer to the default session value.

I have an associated Fenix PR that I'll submit shortly.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
