### PR TITLE
Don't try and record history for URLs with an invalid scheme.

### DIFF
--- a/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
+++ b/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/PlacesHistoryStorage.kt
@@ -420,7 +420,7 @@ open class PlacesHistoryStorage(
         }
 
         val schemasToIgnore = listOf(
-            "about", "imap", "news", "mailbox", "moz-anno", "moz-extension",
+            "", "about", "imap", "news", "mailbox", "moz-anno", "moz-extension",
             "view-source", "chrome", "resource", "data", "javascript", "blob",
         )
 

--- a/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -1423,6 +1423,7 @@ class PlacesHistoryStorageTest {
         assertFalse(history.canAddUri("resource://internal-thingy-js-inspector/script.js"))
         assertFalse(history.canAddUri("javascript:alert('hello!');"))
         assertFalse(history.canAddUri("blob:https://api.mozilla.com/resource.png"))
+        assertFalse(history.canAddUri("://example.com"))
     }
 
     @Test


### PR DESCRIPTION
history.canAddUri() previously treated a URL with an empty scheme as valid, but application-services does not.

While I can't work out an STR to make Fenix actually try and add history using such a URL, I have verified that if it did, we'd end up with an error as reported in https://github.com/mozilla/application-services/issues/5235.