### PR TITLE
Bug 1800542 - part 2: Fix decision task by pointing to the new Gecko.…

### DIFF
--- a/taskcluster/ac_taskgraph/target_tasks.py
+++ b/taskcluster/ac_taskgraph/target_tasks.py
@@ -75,7 +75,7 @@ def target_tasks_ac_default(full_task_graph, parameters, graph_config):
 
 def get_gv_version(repo, revision):
     gecko_kt = repo.run(
-        "show", f"{revision}:android-components/buildSrc/src/main/java/Gecko.kt"
+        "show", f"{revision}:android-components/plugins/dependencies/src/main/java/Gecko.kt"
     )
     match = re.search(r'version = "([^"]*)"', gecko_kt, re.MULTILINE)
     if not match:


### PR DESCRIPTION
…kt location

Follows https://github.com/mozilla-mobile/firefox-android/pull/148 up. Fixes[1]:

```
[task 2022-11-17T00:34:54.562Z] 2022-11-17 00:34:54,562 - INFO - Generating target task set
[task 2022-11-17T00:34:54.566Z] fatal: Path 'android-components/buildSrc/src/main/java/Gecko.kt' does not exist in '4335165c898b18d7c1b9ad1690f69ae07c5a5ba2'
[task 2022-11-17T00:34:54.567Z] Traceback (most recent call last):
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/main.py", line 753, in main
[task 2022-11-17T00:34:54.567Z]     args.command(vars(args))
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/main.py", line 626, in decision
[task 2022-11-17T00:34:54.567Z]     taskgraph_decision(options)
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/decision.py", line 114, in taskgraph_decision
[task 2022-11-17T00:34:54.567Z]     write_artifact("target-tasks.json", list(tgg.target_task_set.tasks.keys()))
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 178, in target_task_set
[task 2022-11-17T00:34:54.567Z]     return self._run_until("target_task_set")
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 423, in _run_until
[task 2022-11-17T00:34:54.567Z]     k, v = next(self._run)
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 344, in _run
[task 2022-11-17T00:34:54.567Z]     target_tasks = set(fltr(target_task_set, parameters, graph_config))
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/filter_tasks.py", line 34, in filter_target_tasks
[task 2022-11-17T00:34:54.567Z]     return fn(graph, parameters, graph_config)
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/checkouts/vcs/taskcluster/ac_taskgraph/target_tasks.py", line 68, in target_tasks_ac_default
[task 2022-11-17T00:34:54.567Z]     return [
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/checkouts/vcs/taskcluster/ac_taskgraph/target_tasks.py", line 72, in <listcomp>
[task 2022-11-17T00:34:54.567Z]     and filter(t)
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/checkouts/vcs/taskcluster/ac_taskgraph/target_tasks.py", line 62, in filter
[task 2022-11-17T00:34:54.567Z]     if get_gv_version(repo, parameters["base_rev"]) != get_gv_version(
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/checkouts/vcs/taskcluster/ac_taskgraph/target_tasks.py", line 77, in get_gv_version
[task 2022-11-17T00:34:54.567Z]     gecko_kt = repo.run(
[task 2022-11-17T00:34:54.567Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/vcs.py", line 45, in run
[task 2022-11-17T00:34:54.567Z]     return subprocess.check_output(
[task 2022-11-17T00:34:54.567Z]   File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
[task 2022-11-17T00:34:54.567Z]     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
[task 2022-11-17T00:34:54.567Z]   File "/usr/lib/python3.8/subprocess.py", line 516, in run
[task 2022-11-17T00:34:54.567Z]     raise CalledProcessError(retcode, process.args,
[task 2022-11-17T00:34:54.567Z] subprocess.CalledProcessError: Command '('/usr/bin/git', 'show', '4335165c898b18d7c1b9ad1690f69ae07c5a5ba2:android-components/buildSrc/src/main/java/Gecko.kt')' returned non-zero exit status 128.
[taskcluster 2022-11-17 00:34:55.001Z] === Task Finished ===
[taskcluster 2022-11-17 00:34:56.551Z] Unsuccessful task run with exit code: 1 completed in 176.495 seconds
```

[1] https://firefox-ci-tc.services.mozilla.com/tasks/PHtVmZSYTVSYANF-8aSBnw/runs/3/logs/public/logs/live.log#L259