### PR TITLE
Bug 1800542 - part 3: Fix condition on `head_ref` to rebuild all comp…

### DIFF
--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -120,7 +120,7 @@ def loader(kind, path, config, params, loaded_tasks):
     # Disable the affected_components optimization to make sure we execute all tests to get
     # a complete code coverage report for pushes to 'main'.
     # See https://github.com/mozilla-mobile/android-components/issues/9382#issuecomment-760506327
-    if params["tasks_for"] in ("github-pull-request", "github-pull-request-untrusted", "github-push") and params["head_ref"] != "refs/heads/main":
+    if params["tasks_for"] in ("github-pull-request", "github-pull-request-untrusted", "github-push") and params["head_ref"] not in ("main", "refs/heads/main"):
         logger.info("Looking for changed files to rebuild the modified components only...")
         files_changed = get_changed_files(params["head_repository"], params["head_rev"], params["base_rev"])
         affected_components = get_affected_components(files_changed, config.get("files-affecting-components"), upstream_component_dependencies, downstream_component_dependencies)


### PR DESCRIPTION
…onents on GeckoView bump

Found by @rvandermeulen.

Follows up https://github.com/mozilla-mobile/firefox-android/pull/148 and https://github.com/mozilla-mobile/firefox-android/pull/171. 

https://github.com/mozilla-mobile/firefox-android/pull/148 introduced a new component for Gecko.kt which uncovered another bug: `head_ref` is not set to `"refs/heads/main"`. That's why it just identified a single component to rebuild:

```
[task 2022-11-17T13:54:07.014Z] 2022-11-17 13:54:07,002 - INFO - Looking for changed files to rebuild the modified components only...
[task 2022-11-17T13:54:07.014Z] 2022-11-17 13:54:07,008 - INFO - Files changed: android-components/plugins/dependencies/src/main/java/Gecko.kt
[task 2022-11-17T13:54:07.014Z] 2022-11-17 13:54:07,008 - INFO - Affected components: dependencies-src
```

I'm not sure if this is occasional or not. That's why I just expanded to condition to support both the short and the long branch name. I'd like to revisit the logic of `build_config.py` in the future, anyway. The fact that we're sometimes generating a full graph that's actually incomplete bothers me. 

[1] https://firefox-ci-tc.services.mozilla.com/tasks/ZB2QVPFPQVaUj1CyeU52hw/runs/0/logs/public/logs/live.log#L209