### PR TITLE
Bug 1800542 - part 4: Rebuild every component when the dependencies p…

### DIFF
--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -125,6 +125,10 @@ def loader(kind, path, config, params, loaded_tasks):
         files_changed = get_changed_files(params["head_repository"], params["head_rev"], params["base_rev"])
         affected_components = get_affected_components(files_changed, config.get("files-affecting-components"), upstream_component_dependencies, downstream_component_dependencies)
 
+    if "dependencies-src" in affected_components:
+        logger.info("Dependencies plugin changed. Rebuilding every component.")
+        affected_components = ALL_COMPONENTS
+
     logger.info("Files changed: %s" % " ".join(files_changed))
     if affected_components is ALL_COMPONENTS:
         logger.info("Affected components: ALL")


### PR DESCRIPTION
…lugin changes

Follows up  https://github.com/mozilla-mobile/firefox-android/pull/173, https://github.com/mozilla-mobile/firefox-android/pull/148, and https://github.com/mozilla-mobile/firefox-android/pull/171

Fixes the error @rvandermeulen saw with https://github.com/mozilla-mobile/firefox-android/pull/169. We didn't schedule all the expected tasks[1]:


```
[task 2022-11-17T16:44:15.475Z] 2022-11-17 16:44:15,470 - INFO - Looking for changed files to rebuild the modified components only...
[task 2022-11-17T16:44:15.479Z] 2022-11-17 16:44:15,479 - INFO - Files changed: android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
[task 2022-11-17T16:44:15.479Z] 2022-11-17 16:44:15,479 - INFO - Affected components: dependencies-src
[task 2022-11-17T16:44:15.486Z] 2022-11-17 16:44:15,485 - INFO - Generated 0 tasks for kind build
[task 2022-11-17T16:44:15.489Z] 2022-11-17 16:44:15,489 - INFO - Generated 0 tasks for kind signing
```

https://github.com/mozilla-mobile/firefox-android/pull/148 moved Dependencies.kt into its own gradle module. That's why it now shows up as an affected component and strips out all other components. This fix makes sure we rebuild everything.

[1] https://firefox-ci-tc.services.mozilla.com/tasks/Zs7U0a1DQp6pe0VLodpuHA/runs/0/logs/public/logs/live.log#L216