### PR TITLE
Removed code to report Sentry errors for Rust `log::error` calls

### DIFF
--- a/android-components/components/support/rustlog/src/test/java/mozilla/components/support/rustlog/RustLogTest.kt
+++ b/android-components/components/support/rustlog/src/test/java/mozilla/components/support/rustlog/RustLogTest.kt
@@ -17,7 +17,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.verifyNoInteractions
 
 @RunWith(AndroidJUnit4::class)
 class RustLogTest {
@@ -46,65 +45,6 @@ class RustLogTest {
 
         RustLog.disable()
         RustLog.enable(mock())
-    }
-
-    @Test
-    fun `maybeSendLogToCrashReporter log processing ignores low priority stuff`() {
-        val crashReporter = mock<CrashReporting>()
-        val onLog = CrashReporterOnLog(crashReporter)
-
-        onLog(android.util.Log.VERBOSE, "sync15:multiple", "Stuff broke")
-        verifyNoInteractions(crashReporter)
-
-        onLog(android.util.Log.DEBUG, "sync15:multiple", "Stuff broke")
-        verifyNoInteractions(crashReporter)
-
-        onLog(android.util.Log.INFO, "sync15:multiple", "Stuff broke")
-        verifyNoInteractions(crashReporter)
-
-        onLog(android.util.Log.WARN, "sync15:multiple", "Stuff broke")
-        verifyNoInteractions(crashReporter)
-
-        onLog(android.util.Log.WARN, null, "Stuff broke")
-        verifyNoInteractions(crashReporter)
-    }
-
-    @Test
-    fun `maybeSendLogToCrashReporter log processing reports error level stuff`() {
-        val crashReporter = TestCrashReporter()
-        val onLog = CrashReporterOnLog(crashReporter)
-
-        onLog(android.util.Log.ERROR, "sync15:multiple", "Stuff broke")
-        crashReporter.assertLastException(1, "sync15:multiple - Stuff broke")
-
-        onLog(android.util.Log.ERROR, null, "Something maybe broke")
-        crashReporter.assertLastException(2, "null - Something maybe broke")
-    }
-
-    @Test
-    fun `maybeSendLogToCrashReporter log processing ignores certain tags`() {
-        val expectedIgnoredTags = listOf("viaduct::backend::ffi")
-        val crashReporter = TestCrashReporter()
-        val onLog = CrashReporterOnLog(crashReporter)
-
-        expectedIgnoredTags.forEach { tag ->
-            onLog(android.util.Log.ERROR, tag, "Stuff broke")
-            assertTrue(crashReporter.exceptions.isEmpty())
-        }
-
-        // null tags are fine
-        onLog(android.util.Log.ERROR, null, "Stuff broke")
-        crashReporter.assertLastException(1, "null - Stuff broke")
-
-        // subsequent non-null and non-ignored are fine
-        onLog(android.util.Log.ERROR, "sync15:places", "DB stuff broke")
-        crashReporter.assertLastException(2, "sync15:places - DB stuff broke")
-
-        // ignored are still ignored
-        expectedIgnoredTags.forEach { tag ->
-            onLog(android.util.Log.ERROR, tag, "Stuff broke")
-            assertEquals(2, crashReporter.exceptions.size)
-        }
     }
 
     @Test


### PR DESCRIPTION
The new system was merged in #12266 and we have started using it for all components in app-services.  I've been checking the Sentry reports and it seems like it's working, so let's remove the old one.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
