### PR TITLE
Bug 1800542 - part 5: Bump relbot from 4.0.0 to 4.0.1

### DIFF
--- a/.github/workflows/ac-create-release.yml
+++ b/.github/workflows/ac-create-release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Create Release"
-        uses: mozilla-mobile/relbot@4.0.0
+        uses: mozilla-mobile/relbot@4.0.1
         if: github.repository == 'mozilla-mobile/firefox-android'
         with:
           project: android-components

--- a/.github/workflows/ac-update-geckoview.yml
+++ b/.github/workflows/ac-update-geckoview.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Update GV (On Main)"
-        uses: mozilla-mobile/relbot@4.0.0
+        uses: mozilla-mobile/relbot@4.0.1
         if: github.repository == 'mozilla-mobile/firefox-android' || github.repository == 'mozilla-releng/staging-firefox-android'
         with:
           project: android-components
@@ -41,7 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Update GV (On Releases)"
-        uses: mozilla-mobile/relbot@4.0.0
+        uses: mozilla-mobile/relbot@4.0.1
         if: github.repository == 'mozilla-mobile/firefox-android' || github.repository == 'mozilla-releng/staging-firefox-android'
         with:
           project: android-components


### PR DESCRIPTION
Let's use https://github.com/mozilla-mobile/relbot/pull/93 to bump Geckoview on release branches too. 

Follows up:
* https://github.com/mozilla-mobile/firefox-android/pull/148 (the regressing PR)
* https://github.com/mozilla-mobile/firefox-android/pull/171
* https://github.com/mozilla-mobile/firefox-android/pull/173
* https://github.com/mozilla-mobile/firefox-android/pull/177