### PR TITLE
Bug 1801285 - Add filter by host/domain to frecent top sites

### DIFF
--- a/android-components/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
+++ b/android-components/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/DefaultTopSitesStorage.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
+import mozilla.components.feature.top.sites.ext.hasHost
 import mozilla.components.feature.top.sites.ext.hasUrl
 import mozilla.components.feature.top.sites.ext.toTopSite
 import mozilla.components.feature.top.sites.facts.emitTopSitesCountFact
@@ -121,7 +122,7 @@ class DefaultTopSitesStorage(
                 .map { it.toTopSite() }
                 .filter {
                     !pinnedSites.hasUrl(it.url) &&
-                        !providerTopSites.hasUrl(it.url) &&
+                        !providerTopSites.hasHost(it.url) &&
                         frecencyConfig.frecencyFilter?.invoke(it) ?: true
                 }
                 .take(numSitesRequired)

--- a/android-components/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/ext/TopSite.kt
+++ b/android-components/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/ext/TopSite.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.top.sites.ext
 
 import mozilla.components.feature.top.sites.TopSite
+import mozilla.components.support.ktx.kotlin.getRepresentativeSnippet
 import mozilla.components.support.ktx.util.URLStringUtils
 
 /**
@@ -21,4 +22,13 @@ fun List<TopSite>.hasUrl(url: String): Boolean {
     }
 
     return false
+}
+
+/**
+ * Returns true if the given url host/domain is in the list top site and false otherwise.
+ *
+ * @param url The URL string.
+ */
+fun List<TopSite>.hasHost(url: String): Boolean {
+    return this.any { it.url.getRepresentativeSnippet().equals(url.getRepresentativeSnippet(), true) }
 }

--- a/android-components/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/ext/TopSiteTest.kt
+++ b/android-components/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/ext/TopSiteTest.kt
@@ -4,11 +4,14 @@
 
 package mozilla.components.feature.top.sites.ext
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.top.sites.TopSite
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class TopSiteTest {
 
     @Test
@@ -34,5 +37,72 @@ class TopSiteTest {
         assertFalse(topSites.hasUrl("https://firefox.com"))
         assertFalse(topSites.hasUrl("https://mozilla.com/path/is/long"))
         assertFalse(topSites.hasUrl("https://mozilla.com/path#anchor"))
+    }
+
+    @Test
+    fun hasHostOneItem() {
+        val topSites = listOf(
+            TopSite.Frecent(
+                id = 1,
+                title = "Amazon",
+                url = "https://amazon.com/playstation",
+                createdAt = 1,
+            ),
+        )
+
+        assertTrue(topSites.hasHost("https://amazon.com"))
+        assertTrue(topSites.hasHost("https://www.amazon.com"))
+        assertTrue(topSites.hasHost("http://amazon.com"))
+        assertTrue(topSites.hasHost("http://www.amazon.com"))
+        assertTrue(topSites.hasHost("amazon.com"))
+        assertTrue(topSites.hasHost("https://amazon.com/"))
+        assertTrue(topSites.hasHost("HTTPS://AMAZON.COM/"))
+        assertFalse(topSites.hasHost("https://amzn.com/"))
+        assertFalse(topSites.hasHost("https://aws.amazon.com/"))
+        assertFalse(topSites.hasHost("https://youtube.com/"))
+    }
+
+    @Test
+    fun hasHostNoItem() {
+        val topSites = emptyList<TopSite.Frecent>()
+
+        assertFalse(topSites.hasHost("https://amazon.com"))
+        assertFalse(topSites.hasHost("https://www.amazon.com"))
+        assertFalse(topSites.hasHost("http://amazon.com"))
+        assertFalse(topSites.hasHost("http://www.amazon.com"))
+        assertFalse(topSites.hasHost("amazon.com"))
+        assertFalse(topSites.hasHost("https://amazon.com/"))
+        assertFalse(topSites.hasHost("HTTPS://AMAZON.COM/"))
+        assertFalse(topSites.hasHost("https://amzn.com/"))
+        assertFalse(topSites.hasHost("https://aws.amazon.com/"))
+    }
+
+    @Test
+    fun hasHostMultipleItems() {
+        val topSites = listOf(
+            TopSite.Frecent(
+                id = 1,
+                title = "Amazon",
+                url = "https://amazon.com/playstation",
+                createdAt = 1,
+            ),
+            TopSite.Frecent(
+                id = 2,
+                title = "Hotels",
+                url = "https://www.hotels.com/",
+                createdAt = 2,
+            ),
+            TopSite.Frecent(
+                id = 3,
+                title = "eBay",
+                url = "https://www.ebay.com/n/all-categories",
+                createdAt = 3,
+            ),
+        )
+
+        assertTrue(topSites.hasHost("https://amazon.com"))
+        assertTrue(topSites.hasHost("https://hotels.com"))
+        assertTrue(topSites.hasHost("http://ebay.com"))
+        assertFalse(topSites.hasHost("http://google.com"))
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **feature-top-sites**
+  * 🆕 A new filter `hasHost` was added when getting top frecent sites in order to remove duplicate frecent top sites that have same host/domain as provided top sites. For more references see [bug #1801285](https://bugzilla.mozilla.org/show_bug.cgi?id=1801285).
+
 * **browser-menu**:
   * 🚒 Bug Fixed [bug #1800885](https://bugzilla.mozilla.org/show_bug.cgi?id=1800885) Increase touch target of Add/Edit checkbox from `mozac_browser_menu_item_image_text_checkbox_button.xml` to improve accessibility.
   


### PR DESCRIPTION
Add a new filter when getting top frecent sites to prevent duplicate frecent site with same host/domain as a provided top site.

https://user-images.githubusercontent.com/32488956/202701303-59f6255f-94be-44fb-8137-9c724a29610c.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
