### PR TITLE
Bug 1800542 - part 9: Ensure decision task runs when the gradle config is changed

### DIFF
--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -125,7 +125,7 @@ def loader(kind, path, config, params, loaded_tasks):
         files_changed = get_changed_files(params["head_repository"], params["head_rev"], params["base_rev"])
         affected_components = get_affected_components(files_changed, config.get("files-affecting-components"), upstream_component_dependencies, downstream_component_dependencies)
 
-        if "dependencies-src" in affected_components:
+        if affected_components is not ALL_COMPONENTS and "dependencies-src" in affected_components:
             logger.info("Dependencies plugin changed. Rebuilding every component.")
             affected_components = ALL_COMPONENTS
 


### PR DESCRIPTION
Fixes [1] which occurs in https://github.com/mozilla-mobile/firefox-android/pull/200:

```
[task 2022-11-21T15:12:58.228Z] 2022-11-21 15:12:58,217 - INFO - Looking for changed files to rebuild the modified components only...
[task 2022-11-21T15:12:58.228Z] 2022-11-21 15:12:58,227 - ERROR - Error loading tasks for kind build:
[task 2022-11-21T15:12:58.228Z] Traceback (most recent call last):
[task 2022-11-21T15:12:58.228Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 309, in _run
[task 2022-11-21T15:12:58.228Z]     new_tasks = kind.load_tasks(
[task 2022-11-21T15:12:58.230Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 58, in load_tasks
[task 2022-11-21T15:12:58.230Z]     inputs = loader(self.name, self.path, config, parameters, loaded_tasks)
[task 2022-11-21T15:12:58.230Z]   File "/builds/worker/checkouts/vcs/taskcluster/ac_taskgraph/loader/build_config.py", line 128, in loader
[task 2022-11-21T15:12:58.230Z]     if "dependencies-src" in affected_components:
[task 2022-11-21T15:12:58.230Z] TypeError: argument of type 'object' is not iterable
[task 2022-11-21T15:12:58.230Z] Traceback (most recent call last):
[task 2022-11-21T15:12:58.230Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/main.py", line 753, in main
[task 2022-11-21T15:12:58.230Z]     args.command(vars(args))
[task 2022-11-21T15:12:58.230Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/main.py", line 626, in decision
[task 2022-11-21T15:12:58.230Z]     taskgraph_decision(options)
[task 2022-11-21T15:12:58.230Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/decision.py", line 102, in taskgraph_decision
[task 2022-11-21T15:12:58.230Z]     full_task_json = tgg.full_task_graph.to_json()
[task 2022-11-21T15:12:58.230Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 169, in full_task_graph
[task 2022-11-21T15:12:58.230Z]     return self._run_until("full_task_graph")
[task 2022-11-21T15:12:58.230Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 423, in _run_until
[task 2022-11-21T15:12:58.230Z]     k, v = next(self._run)
[task 2022-11-21T15:12:58.230Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 309, in _run
[task 2022-11-21T15:12:58.231Z]     new_tasks = kind.load_tasks(
[task 2022-11-21T15:12:58.231Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 58, in load_tasks
[task 2022-11-21T15:12:58.231Z]     inputs = loader(self.name, self.path, config, parameters, loaded_tasks)
[task 2022-11-21T15:12:58.231Z]   File "/builds/worker/checkouts/vcs/taskcluster/ac_taskgraph/loader/build_config.py", line 128, in loader
[task 2022-11-21T15:12:58.231Z]     if "dependencies-src" in affected_components:
[task 2022-11-21T15:12:58.231Z] TypeError: argument of type 'object' is not iterable
```



Follows up:
* https://github.com/mozilla-mobile/firefox-android/pull/148
* https://github.com/mozilla-mobile/firefox-android/pull/171
* https://github.com/mozilla-mobile/firefox-android/pull/173
* https://github.com/mozilla-mobile/firefox-android/pull/177
* https://github.com/mozilla-mobile/firefox-android/pull/180
* https://github.com/mozilla-mobile/firefox-android/pull/184
* https://github.com/mozilla-mobile/firefox-android/pull/188
* https://github.com/mozilla-mobile/firefox-android/pull/194

[1] https://firefox-ci-tc.services.mozilla.com/tasks/LUvpkKDOS7mJy9sed8oAyg/runs/0/logs/public/logs/live.log#L235