### PR TITLE
Bug 1802579 - Add extra granular media permissions for devices with Android 13 and above.

### DIFF
--- a/android-components/components/feature/prompts/src/main/AndroidManifest.xml
+++ b/android-components/components/feature/prompts/src/main/AndroidManifest.xml
@@ -3,6 +3,12 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="mozilla.components.feature.prompts">
+
+    <!-- Needed for uploading media files on devices with Android 13 and later. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+
     <application>
         <provider
             android:name="mozilla.components.feature.prompts.provider.FileProvider"

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/FilePicker.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/FilePicker.kt
@@ -62,7 +62,7 @@ internal class FilePicker(
     @Suppress("ComplexMethod")
     fun handleFileRequest(promptRequest: File, requestPermissions: Boolean = true) {
         // Track which permissions are needed.
-        val neededPermissions = mutableListOf<String>()
+        val neededPermissions = mutableSetOf<String>()
         // Build a list of intents for capturing media and opening the file picker to combine later.
         val intents = mutableListOf<Intent>()
         captureUri = null
@@ -87,7 +87,7 @@ internal class FilePicker(
                         intents.add(it)
                     }
                 } else {
-                    neededPermissions.add(type.permission)
+                    neededPermissions.addAll(type.permission)
                 }
             }
         }
@@ -216,7 +216,7 @@ internal class FilePicker(
         intent.getParcelableExtraCompat(EXTRA_OUTPUT, Uri::class.java)?.let { captureUri = it }
 
     @VisibleForTesting
-    fun askAndroidPermissionsForRequest(permissions: List<String>, request: File) {
+    fun askAndroidPermissionsForRequest(permissions: Set<String>, request: File) {
         currentRequest = request
         onNeedToRequestPermissions(permissions.toTypedArray())
     }

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/file/FilePickerTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/file/FilePickerTest.kt
@@ -284,7 +284,7 @@ class FilePickerTest {
 
     @Test
     fun `askAndroidPermissionsForRequest should cache the current request and then ask for permissions`() {
-        val permissions = listOf("PermissionA")
+        val permissions = setOf("PermissionA")
         var permissionsRequested = emptyArray<String>()
         filePicker = spy(
             FilePicker(fragment, store, null) { requested ->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 * **browser-state**, **feature-search**
   * Added a new parameter `isGeneral` to `SearchEngine` to specify whether or not the search engine is a general search engine (eg, provides broad search results). Search engines read from storage will now have this parameter set based on a list of general search engines. [bug #1804594](https://bugzilla.mozilla.org/show_bug.cgi?id=1804594)
 
+* **feature-prompts**:
+  * Added permission requests for accessing media files (`READ_MEDIA_AUDIO`, `READ_MEDIA_AUDIO`, `READ_MEDIA_AUDIO`) when uploading files on devices with Android 13 and later.
+
 # 109.0.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/v108.0.0...v109.0.0)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/v109.0.0/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
