### PR TITLE
Revert "Upgrade Jetpack Compose to latest version (1.3.1)"

### DIFF
--- a/android-components/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
+++ b/android-components/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
@@ -92,9 +92,7 @@ fun AwesomeBar(
             .background(colors.background),
     ) {
         val fetcher = remember(groups) { SuggestionFetcher(groups, profiler) }
-        val suggestions = remember {
-            derivedStateOf { fetcher.state.value }
-        }.value.toSortedMap(compareBy { it.title })
+        val suggestions = derivedStateOf { fetcher.state.value }.value.toSortedMap(compareBy { it.title })
 
         LaunchedEffect(text, fetcher) {
             fetcher.fetch(text)

--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -49,7 +49,7 @@ object Versions {
 
     // see https://android-developers.googleblog.com/2022/06/independent-versioning-of-Jetpack-Compose-libraries.html
     // for Jetpack Compose libraries versioning
-    const val compose_version = "1.3.1"
+    const val compose_version = "1.2.1"
     const val compose_compiler = "1.3.2"
 
     object AndroidX {


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-android#183

Reverting due to perma-failures in UI tests:
* https://console.firebase.google.com/project/moz-fenix/testlab/histories/bh.66b7091e15d53d4[…]057345840453/executions/bs.23ac7503c0cc9045/testcases/5
* https://console.firebase.google.com/project/moz-fenix/testlab/histories/bh.66b7091e15d53d4[…]057345840453/executions/bs.15866a6549025185/testcases/3

```
 java.lang.AssertionError: Failed: assertExists.
Reason: Expected exactly '1' node but could not find any node that satisfies: (Text + EditableText contains 'Google' (ignoreCase: false))
at androidx.compose.ui.test.SemanticsNodeInteraction.fetchOneOrDie(SemanticsNodeInteraction.kt:145)
at androidx.compose.ui.test.SemanticsNodeInteraction.assertExists(SemanticsNodeInteraction.kt:120)
at androidx.compose.ui.test.SemanticsNodeInteraction.assertExists$default(SemanticsNodeInteraction.kt:119)
at org.mozilla.fenix.ui.robots.SearchRobotKt.assertSearchEngineList(SearchRobot.kt:460)
at org.mozilla.fenix.ui.robots.SearchRobotKt.access$assertSearchEngineList(SearchRobot.kt:1)
at org.mozilla.fenix.ui.robots.SearchRobot.verifySearchEngineList(SearchRobot.kt:185)
at org.mozilla.fenix.ui.SmokeTest$selectSearchEnginesShortcutTest$2.invoke(SmokeTest.kt:415)
at org.mozilla.fenix.ui.SmokeTest$selectSearchEnginesShortcutTest$2.invoke(SmokeTest.kt:412)
at org.mozilla.fenix.ui.robots.HomeScreenRobot$Transition.openSearch(HomeScreenRobot.kt:451)
at org.mozilla.fenix.ui.SmokeTest.selectSearchEnginesShortcutTest(SmokeTest.kt:412) 
```