### PR TITLE
Bug 1803141 - part 1-6: Build/test components only when they change

### DIFF
--- a/taskcluster/ac_taskgraph/gradle.py
+++ b/taskcluster/ac_taskgraph/gradle.py
@@ -1,0 +1,45 @@
+import logging
+import subprocess
+
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+CONFIGURATIONS_WITH_DEPENDENCIES = (
+    "api",
+    "compileOnly",
+    "implementation",
+    "testImplementation"
+)
+
+
+def get_upstream_deps_for_gradle_projects(gradle_projects, gradle_root):
+    """Return the full list of local upstream dependencies of a component."""
+    project_dependencies = defaultdict(set)
+
+    for configuration in CONFIGURATIONS_WITH_DEPENDENCIES:
+        logger.info(f"Looking for dependencies in {configuration} configuration in {gradle_root}")
+
+        cmd = ["./gradlew", "--console=plain", "--parallel"]
+        # This is eventually going to fail if there's ever enough projects to make the command line
+        # too long. If that happens, we'll need to split this list up and run gradle more than once.
+        for gradle_project in sorted(gradle_projects):
+            cmd.extend([f"{gradle_project}:dependencies", "--configuration", configuration])
+
+        # Parsing output like this is not ideal but bhearsum couldn't find a way
+        # to get the dependencies printed in a better format. If we could convince
+        # gradle to spit out JSON that would be much better.
+        # This is filed as https://bugzilla.mozilla.org/show_bug.cgi?id=1795152
+        current_project_name = None
+        for line in subprocess.check_output(cmd, universal_newlines=True, cwd=gradle_root).splitlines():
+            # If we find the start of a new component section, update our tracking variable
+            if line.startswith("Project"):
+                current_project_name = line.split(":")[1].strip("'")
+
+            # If we find a new local dependency, add it.
+            if line.startswith("+--- project") or line.startswith(r"\--- project"):
+                project_dependencies[current_project_name].add(line.split(" ")[2])
+
+    return {
+        project_name: sorted(project_dependencies[project_name]) for project_name in project_dependencies
+    }

--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -4,15 +4,12 @@
 
 
 import logging
-import os
 import re
 import subprocess
 
 from collections import defaultdict
-from copy import deepcopy
 from taskgraph.files_changed import get_changed_files
 from taskgraph.loader.transform import loader as base_loader
-from taskgraph.util.taskcluster import get_session
 from taskgraph.util.templates import merge
 
 from ..build_config import get_components, ANDROID_COMPONENTS_DIR
@@ -39,8 +36,6 @@ def get_components_changed(files_changed):
     """
     return {"-".join(f.split("/")[2:4]) for f in files_changed if f.startswith("android-components")}
 
-
-cached_deps = {}
 
 def get_upstream_deps_for_components(components):
     """Return the full list of local upstream dependencies of a component."""

--- a/taskcluster/ac_taskgraph/loader/build_config.py
+++ b/taskcluster/ac_taskgraph/loader/build_config.py
@@ -3,107 +3,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-import logging
-import re
-
-from collections import defaultdict
-from taskgraph.files_changed import get_changed_files
 from taskgraph.loader.transform import loader as base_loader
 from taskgraph.util.templates import merge
 
-from ..build_config import get_components, ANDROID_COMPONENTS_DIR
-from ..gradle import get_upstream_deps_for_gradle_projects
-
-
-logger = logging.getLogger(__name__)
-
-ALL_COMPONENTS = object()
-
-def get_components_changed(files_changed):
-    """Translate a list of files changed into a list of components. Eg:
-        [
-            "android-components/components/service/sync-logins/src/main/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegate.kt",
-            "android-components/components/service/sync-logins/src/test/java/mozilla/components/service/sync/logins/GeckoLoginStorageDelegateTest.kt",
-        ]
-        ->
-        {service-sync-logins}
-    """
-    return {"-".join(f.split("/")[2:4]) for f in files_changed if f.startswith("android-components")}
-
-
-def get_affected_components(files_changed, files_affecting_components, upstream_component_dependencies, downstream_component_dependencies):
-    affected_components = set()
-
-    # First, find the list of changed components
-    for c in get_components_changed(files_changed):
-        affected_components.add(c)
-
-    # Then, look for any other affected components based on the files changed.
-    for pattern, components in files_affecting_components.items():
-        if any([re.match(pattern, f) for f in files_changed]):
-            # Some file changes may necessitate rebuilding _all_ components.
-            # In this we can just return immediately.
-            if components == "all-components":
-                return ALL_COMPONENTS
-
-            affected_components.update(components)
-
-    # Finally, go through all of the affected components and recursively
-    # find their upstream and downstream dependencies.
-    for c in affected_components.copy():
-        if upstream_component_dependencies[c]:
-            logger.info("Adding direct upstream dependencies for '{}': {}".format(c, " ".join(sorted(upstream_component_dependencies[c]))))
-            affected_components.update(upstream_component_dependencies[c])
-        if downstream_component_dependencies[c]:
-            logger.info("Adding direct downstream dependencies for '{}': {}".format(c, " ".join(sorted(downstream_component_dependencies[c]))))
-            affected_components.update(downstream_component_dependencies[c])
-
-    return affected_components
+from ..build_config import get_components
 
 
 def loader(kind, path, config, params, loaded_tasks):
-    # Build everything unless we have an optimization strategy (defined below).
-    files_changed = []
-    affected_components = ALL_COMPONENTS
-    upstream_component_dependencies = defaultdict(set)
-    downstream_component_dependencies = defaultdict(set)
-
-    deps_per_component = get_upstream_deps_for_gradle_projects([c["name"] for c in get_components()], gradle_root=ANDROID_COMPONENTS_DIR)
-
-    for component, deps in deps_per_component.items():
-        if deps:
-            logger.info(f"Found direct upstream dependencies for component '{component}': {deps}")
-        else:
-            logger.info("No direct upstream dependencies found for component '%s'" % component)
-        upstream_component_dependencies[component] = deps
-        for d in deps:
-            downstream_component_dependencies[d].add(component)
-
-    # Disable the affected_components optimization to make sure we execute all tests to get
-    # a complete code coverage report for pushes to 'main'.
-    # See https://github.com/mozilla-mobile/android-components/issues/9382#issuecomment-760506327
-    should_take_out_tasks = all((
-        params["tasks_for"] in ("github-pull-request", "github-pull-request-untrusted", "github-push"),
-        params["head_ref"] not in ("main", "refs/heads/main"),
-        # try_task_config.json can override `target_tasks_method`` to make staging nightly
-        # for instance
-        params["target_tasks_method"] == "default",
-    ))
-    if should_take_out_tasks:
-        logger.info("Looking for changed files to rebuild the modified components only...")
-        files_changed = get_changed_files(params["head_repository"], params["head_rev"], params["base_rev"])
-        affected_components = get_affected_components(files_changed, config.get("files-affecting-components"), upstream_component_dependencies, downstream_component_dependencies)
-
-        if affected_components is not ALL_COMPONENTS and "dependencies-src" in affected_components:
-            logger.info("Dependencies plugin changed. Rebuilding every component.")
-            affected_components = ALL_COMPONENTS
-
-    logger.info("Files changed: %s" % " ".join(files_changed))
-    if affected_components is ALL_COMPONENTS:
-        logger.info("Affected components: ALL")
-    else:
-        logger.info("Affected components: %s" % " ".join(sorted(affected_components)))
-
     not_for_components = config.get("not-for-components", [])
     tasks = {
         '{}{}'.format(
@@ -118,14 +24,11 @@ def loader(kind, path, config, params, loaded_tasks):
         for component in get_components()
         for build_type in ('regular', 'nightly', 'release')
         if (
-            (affected_components is ALL_COMPONENTS or component['name'] in affected_components)
-            and component['name'] not in not_for_components
+            component['name'] not in not_for_components
             and (component['shouldPublish'] or build_type == 'regular')
         )
     }
-    # Filter away overridden tasks that we wouldn't build anyways to avoid ending up with
-    # partial task entries.
-    overridden_tasks = {k: v for k, v in config.pop('overriden-tasks', {}).items() if affected_components is ALL_COMPONENTS or k in tasks.keys()}
+    overridden_tasks = config.pop('overriden-tasks', {})
     tasks = merge(tasks, overridden_tasks)
 
     config['tasks'] = tasks

--- a/taskcluster/ac_taskgraph/transforms/build.py
+++ b/taskcluster/ac_taskgraph/transforms/build.py
@@ -4,7 +4,6 @@
 
 
 import datetime
-import re
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by
@@ -24,6 +23,7 @@ def resolve_keys(config, tasks):
             'attributes.code-review',
             'expose-artifacts',
             'include-coverage',
+            'optimization',
             'run-on-tasks-for',
             'run.gradlew',
             'treeherder.symbol',

--- a/taskcluster/ac_taskgraph/transforms/gradle_optimization.py
+++ b/taskcluster/ac_taskgraph/transforms/gradle_optimization.py
@@ -1,0 +1,28 @@
+from taskgraph.transforms.base import TransformSequence
+
+from ..build_config import get_path, ANDROID_COMPONENTS_DIR
+from ..gradle import get_upstream_deps_for_gradle_projects
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def extend_optimization_if_one_already_exists(config, tasks):
+    deps_per_component = get_upstream_deps_for_gradle_projects(ANDROID_COMPONENTS_DIR)
+
+    for task in tasks:
+        optimization = task.get("optimization")
+        if optimization:
+            skip_unless_changed = optimization["skip-unless-changed"]
+
+            component = task["attributes"]["component"]
+            dependencies = deps_per_component[component]
+            component_and_deps = [component] + dependencies
+
+            skip_unless_changed.extend([
+                f"android-components/{get_path(component)}/**"
+                for component in component_and_deps
+            ])
+
+        yield task

--- a/taskcluster/ac_taskgraph/transforms/gradle_optimization.py
+++ b/taskcluster/ac_taskgraph/transforms/gradle_optimization.py
@@ -17,6 +17,10 @@ def extend_optimization_if_one_already_exists(config, tasks):
             skip_unless_changed = optimization["skip-unless-changed"]
 
             component = task["attributes"]["component"]
+            # TODO Remove this special case when ui-test.sh is able to accept "browser-engine-gecko"
+            if component == "browser":
+                component = "browser-engine-gecko"
+
             dependencies = deps_per_component[component]
             component_and_deps = [component] + dependencies
 

--- a/taskcluster/ac_taskgraph/transforms/ui_tests.py
+++ b/taskcluster/ac_taskgraph/transforms/ui_tests.py
@@ -1,0 +1,52 @@
+from taskgraph.transforms.base import TransformSequence
+
+
+transforms = TransformSequence()
+
+
+_ANDROID_TASK_NAME_PREFIX = "android-"
+
+
+@transforms.add
+def set_component_attribute(config, tasks):
+    for task in tasks:
+        component_name = task.pop("component", None)
+        if not component_name:
+            task_name = task["name"]
+            if task_name.startswith(_ANDROID_TASK_NAME_PREFIX):
+                component_name = task_name[len(_ANDROID_TASK_NAME_PREFIX):]
+            else:
+                raise NotImplementedError(f"Cannot determine component name from task {task_name}")
+
+        attributes = task.setdefault("attributes", {})
+        attributes["component"] = component_name
+
+        yield task
+
+
+@transforms.add
+def define_ui_test_command_line(config, tasks):
+    for task in tasks:
+        run = task.setdefault("run", {})
+        post_gradlew = run.setdefault("post-gradlew", [])
+        post_gradlew.append(
+            ['automation/taskcluster/androidTest/ui-test.sh', task["attributes"]["component"], 'arm', '1']
+        )
+
+        yield task
+
+
+@transforms.add
+def define_treeherder_symbol(config, tasks):
+    for task in tasks:
+        treeherder = task.setdefault("treeherder")
+        treeherder.setdefault("symbol", f"{task['attributes']['component']}(unit)")
+
+        yield task
+
+
+@transforms.add
+def define_description(config, tasks):
+    for task in tasks:
+        task.setdefault("description", f"Run unit/ui tests on device for {task['attributes']['component']}")
+        yield task

--- a/taskcluster/ci/build-samples-browser/kind.yml
+++ b/taskcluster/ci/build-samples-browser/kind.yml
@@ -6,6 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - ac_taskgraph.transforms.build:transforms
+    - ac_taskgraph.transforms.gradle_optimization:transforms
     - taskgraph.transforms.code_review:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -6,6 +6,7 @@ loader: ac_taskgraph.loader.build_config:loader
 
 transforms:
     - ac_taskgraph.transforms.build:transforms
+    - ac_taskgraph.transforms.gradle_optimization:transforms
     - taskgraph.transforms.code_review:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
@@ -15,17 +16,6 @@ not-for-components:
 
 kind-dependencies:
     - toolchain
-
-# We always build components that have changed files or dependencies, but we also need
-# to rebuild some or all components when other files change. This structure
-# maintains the latter mapping. The value may either be a list of specific components,
-# or the special sentinel value `all-components`.
-files-affecting-components:
-    ^android-components/build.gradle$: all-components
-    ^android-components/settings.gradle$: all-components
-    ^android-components/buildSrc.*$: all-components
-    ^android-components/gradle.properties$: all-components
-    ^android-components/gradle/wrapper/gradle-wrapper.properties$: all-components
 
 task-defaults:
     artifact-template:
@@ -69,6 +59,18 @@ task-defaults:
             release: false
             nightly: false
             default: true
+    optimization:
+        by-build-type:
+            (nightly|release): {}
+            default:
+                skip-unless-changed:
+                    - android-components/build.gradle
+                    - android-components/settings.gradle
+                    - android-components/buildSrc.*
+                    - android-components/gradle.properties
+                    - android-components/gradle/wrapper/gradle-wrapper.properties
+                    - android-components/plugins/dependencies/**
+                    # More paths are dynamically added by transforms
     run:
         gradlew:
             by-build-type:

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -6,6 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - ac_taskgraph.transforms.ui_tests:transforms
+    - ac_taskgraph.transforms.gradle_optimization:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
@@ -51,6 +52,16 @@ task-defaults:
             GOOGLE_APPLICATION_CREDENTIALS: '.firebase_token.json'
             GOOGLE_PROJECT: moz-android-components-230120
         max-run-time: 2400
+    optimization:
+        skip-unless-changed:
+            - android-components/build.gradle
+            - android-components/settings.gradle
+            - android-components/buildSrc.*
+            - android-components/gradle.properties
+            - android-components/gradle/wrapper/gradle-wrapper.properties
+            - android-components/plugins/dependencies/**
+            - android-components/automation/taskcluster/androidTest/ui-test.sh
+            # More paths are dynamically added by transforms
 
 
 tasks:

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -5,6 +5,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+    - ac_taskgraph.transforms.ui_tests:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
@@ -54,96 +55,33 @@ task-defaults:
 
 tasks:
     unit-browser-engine-gecko-nightly:
+        component: browser
         description: 'Run unit tests on device for browser component'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'browser', 'arm', '1']
         treeherder:
             symbol: 'ui-components'
     ui-browser:
+        component: samples-browser
         description: 'Run ui tests for browser sample'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'samples-browser', 'arm', '1']
         treeherder:
             symbol: 'ui-samples-browser'
     ui-glean:
+        component: samples-glean
         description: 'Run ui tests for glean sample'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'samples-glean', 'arm', '1']
         treeherder:
             symbol: 'ui-samples-glean'
-    android-feature-containers:
-        description: 'Run unit tests on device for feature containers'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'feature-containers', 'arm', '1']
-        treeherder:
-            symbol: 'unit-feature-containers'
-    android-feature-pwa:
-        description: 'Run unit tests on device for feature pwa'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'feature-pwa', 'arm', '1']
-        treeherder:
-            symbol: 'unit-feature-pwa'
-    android-feature-share:
-        description: 'Run unit tests on device for feature share'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'feature-share', 'arm', '1']
-        treeherder:
-            symbol: 'unit-share'
-    android-feature-sitepermissions:
-        description: 'Run unit tests on device for feature site permissions'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'feature-sitepermissions', 'arm', '1']
-        treeherder:
-            symbol: 'unit-sitepermissions'
-    android-feature-top-sites:
-        description: 'Run unit tests on device for feature top sites'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'feature-top-sites', 'arm', '1']
-        treeherder:
-            symbol: 'unit-feature-top-sites'
-    android-feature-logins:
-        description: 'Run unit tests on device for feature logins'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'feature-logins', 'arm', '1']
-        treeherder:
-            symbol: 'unit-logins'
-    android-feature-prompts:
-        description: 'Run unit tests on device for feature prompts'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'feature-prompts', 'arm', '1']
-        treeherder:
-            symbol: 'unit-feature-prompts'
-    android-support-ktx:
-        description: 'Run unit tests on device for support ktx'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'support-ktx', 'arm', '1']
-        treeherder:
-            symbol: 'unit-support-ktx'
+    android-feature-containers: {}
+    android-feature-pwa: {}
+    android-feature-share: {}
+    android-feature-sitepermissions: {}
+    android-feature-top-sites: {}
+    android-feature-logins: {}
+    android-feature-prompts: {}
+    android-support-ktx: {}
     android-feature-downloads:
-        description: 'Run unit tests on device for feature downloads'
         run:
             post-gradlew:
                 - ['automation/taskcluster/androidTest/ui-test.sh', 'support-ktx', 'arm', '1']
-        treeherder:
-            symbol: 'unit-feature-downloads'
 
 overriden-tasks:
     # names too long to fit in 25 chars
-    android-feature-recentlyclosed:
-        description: 'Run unit tests on device for feature recentlyclosed'
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'feature-recentlyclosed', 'arm', '1']
-        treeherder:
-            symbol: 'unit-feature-recentlyclosed'
+    android-feature-recentlyclosed: {}

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -77,11 +77,5 @@ tasks:
     android-feature-logins: {}
     android-feature-prompts: {}
     android-support-ktx: {}
-    android-feature-downloads:
-        run:
-            post-gradlew:
-                - ['automation/taskcluster/androidTest/ui-test.sh', 'support-ktx', 'arm', '1']
-
-overriden-tasks:
-    # names too long to fit in 25 chars
+    android-feature-downloads: {}
     android-feature-recentlyclosed: {}


### PR DESCRIPTION
Depends on https://github.com/mozilla-mobile/firefox-android/pull/243

I've had this PR at the back of my mind for many months. We optimized the number of build jobs we spawn in https://github.com/mozilla-mobile/android-components/pull/7617. That said, at that time we knew we implemented a hack. I left more details in [bug 1803141 comment 0](https://bugzilla.mozilla.org/show_bug.cgi?id=1803141#c0). 

Basically, this PR removes the hack and makes the logic more generic. This enable UI tests as well as `samples-browser` to be scheduled only when necessary. Before then, they were run for any type of change. In addition to that, we **won't schedule all A-C jobs on pushes to `main` anymore**. The reason is: with Focus coming to the monorepo soon, it doesn't make sense to run all these jobs even though the underlying code hasn't changed. 

I also took the liberty to factorize the configuration of the UI tests and I realized a couple of jobs weren't testing the right thing nor they were even scheduled. I re-enabled them and they're luckily green. 

Suggested reviews: 
 * @AaronMT: part 4 to 6. They're about UI tests and when we should schedule them
 * @csadilek: part 3, 6, and 7. They change when tasks are scheduled based on what changed file
 * @jcristau: all commits but part 6 and 7 maybe? 