### PR TITLE
Bug 1642977 - part 4: Final `complete` tasks should only depend on ch…

### DIFF
--- a/taskcluster/ac_taskgraph/transforms/chunk.py
+++ b/taskcluster/ac_taskgraph/transforms/chunk.py
@@ -40,7 +40,7 @@ def add_dependencies(config, tasks):
         regular_deps = set()
         chunked_labels = set()
 
-        soft_dep_labels = list(task.get('soft-dependencies', []))
+        soft_dep_labels = list(task.pop('soft-dependencies', []))
         regular_dep_labels = list(task.get('dependencies', {}).keys())
         # sort for deterministic chunking
         all_dep_labels = sorted(set(soft_dep_labels + regular_dep_labels))


### PR DESCRIPTION
…unked `complete` and not soft-depend on every single task

Fixes[1]:

```
[task 2022-12-02T14:47:06.759Z] 2022-12-02 14:47:06,758 - INFO - Creating task with taskId MSTov6m4Qee4U0Sj0N8shA for complete-push-1
[task 2022-12-02T14:47:07.617Z] 2022-12-02 14:47:07,617 - INFO - Creating task with taskId KCV4prp3Rc2Xvu-5Qt35-Q for complete-push
[task 2022-12-02T14:47:07.632Z] 2022-12-02 14:47:07,631 - ERROR - 
[task 2022-12-02T14:47:07.632Z] Schema Validation Failed!
[task 2022-12-02T14:47:07.632Z] Rejecting Schema: https://firefox-ci-tc.services.mozilla.com/schemas/queue/v1/create-task-request.json#
[task 2022-12-02T14:47:07.632Z] Errors:
[task 2022-12-02T14:47:07.632Z]   * data/dependencies should NOT have more than 100 items
[task 2022-12-02T14:47:07.632Z] 
[task 2022-12-02T14:47:07.632Z] ---
[task 2022-12-02T14:47:07.632Z] 
[task 2022-12-02T14:47:07.632Z] * method:     createTask
[task 2022-12-02T14:47:07.632Z] * errorCode:  InputValidationError
[task 2022-12-02T14:47:07.632Z] * statusCode: 400
[task 2022-12-02T14:47:07.632Z] * time:       2022-12-02T14:47:07.627Z
```

I made a silly mistake in https://github.com/mozilla-mobile/firefox-android/pull/243 and more precisely at [2]

[1] https://firefox-ci-tc.services.mozilla.com/tasks/F3flOnIzQESAxDRpXxAw7A/runs/0/logs/public/logs/live.log
[2] https://github.com/mozilla-mobile/firefox-android/pull/243/commits/a727c2fe17baa4b7787c0530a3929249c803ff76#diff-f730aeba1757ce21a360e0d6bb9caf4e550a4b62ed004cb17999f67f9151dd9dL42