### PR TITLE
Bug 1796301 - Add paddingEnd in OriginView for RTL config

### DIFF
--- a/android-components/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
+++ b/android-components/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
@@ -104,6 +104,7 @@
         android:layout_width="0dp"
         android:layout_height="40dp"
         android:layout_marginTop="8dp"
+        android:paddingEnd="@dimen/mozac_browser_toolbar_origin_padding_end"
         app:layout_constraintEnd_toStartOf="@+id/mozac_browser_toolbar_page_actions"
         app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_security_indicator"
         app:layout_constraintTop_toTopOf="parent"

--- a/android-components/components/browser/toolbar/src/main/res/values-ldrtl/dimens.xml
+++ b/android-components/components/browser/toolbar/src/main/res/values-ldrtl/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- DisplayToolbar -->
+    <dimen name="mozac_browser_toolbar_origin_padding_end">16dp</dimen>
+</resources>

--- a/android-components/components/browser/toolbar/src/main/res/values-ldrtl/dimens.xml
+++ b/android-components/components/browser/toolbar/src/main/res/values-ldrtl/dimens.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <!-- DisplayToolbar -->
     <dimen name="mozac_browser_toolbar_origin_padding_end">16dp</dimen>

--- a/android-components/components/browser/toolbar/src/main/res/values/dimens.xml
+++ b/android-components/components/browser/toolbar/src/main/res/values/dimens.xml
@@ -13,6 +13,7 @@
     <dimen name="mozac_browser_toolbar_icon_padding">12dp</dimen>
     <dimen name="mozac_browser_toolbar_icon_size">24dp</dimen>
     <dimen name="mozac_browser_toolbar_menu_padding">16dp</dimen>
+    <dimen name="mozac_browser_toolbar_origin_padding_end">0dp</dimen>
 
     <!-- EditToolbar -->
     <dimen name="mozac_browser_toolbar_url_horizontal_padding">8dp</dimen>


### PR DESCRIPTION
### What
• Add `paddingEnd` for RTL layouts, we could add padding for LTR as well and set it directly in the layout, but the idea was to preserve the space in `OriginView` for the title/url.
• No tests since only RTL layout was affected.

### Screenshots

| Hebrew as RTL example | English as LTR example - unchanged | Desktop RTL |
|------|-----|----|
|![Screenshot_20221206_141521](https://user-images.githubusercontent.com/38040960/205922468-ffb040b6-b47d-4b47-9ad4-519932e76346.png)|![Screenshot_20221206_132722](https://user-images.githubusercontent.com/38040960/205920159-26772ae2-f1f1-4c01-9fd8-c3cc41db2885.png)|<img width="1728" alt="Screen Shot 2022-12-07 at 10 45 34 AM" src="https://user-images.githubusercontent.com/1190888/206226392-d536f2ab-3125-491a-8698-2fad45facca4.png">|


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
