### PR TITLE
Bug 1804260 - Add method to specify the cursor placement when switching to URL editing mode

### DIFF
--- a/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
+++ b/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/BrowserToolbar.kt
@@ -333,13 +333,23 @@ class BrowserToolbar @JvmOverloads constructor(
 
     /**
      * Switches to URL editing mode.
+     *
+     * @param cursorPlacement Where the cursor should be placed after focusing on the URL input field.
      */
-    override fun editMode() {
+    override fun editMode(cursorPlacement: Toolbar.CursorPlacement) {
         val urlValue = if (searchTerms.isEmpty()) url else searchTerms
         edit.updateUrl(urlValue.toString(), false)
         updateState(State.EDIT)
         edit.focus()
-        edit.selectAll()
+
+        when (cursorPlacement) {
+            Toolbar.CursorPlacement.ALL -> {
+                edit.selectAll()
+            }
+            Toolbar.CursorPlacement.END -> {
+                edit.selectEnd()
+            }
+        }
     }
 
     /**

--- a/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
+++ b/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/edit/EditToolbar.kt
@@ -274,6 +274,13 @@ class EditToolbar internal constructor(
     }
 
     /**
+     * Places the cursor at the end of the URL input field.
+     */
+    internal fun selectEnd() {
+        views.url.setSelection(views.url.text.length)
+    }
+
+    /**
      * Applies the given search terms for further editing, requesting new suggestions along the way.
      */
     internal fun editSuggestion(searchTerms: String) {

--- a/android-components/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
+++ b/android-components/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt
@@ -947,4 +947,18 @@ class BrowserToolbarTest {
         toolbar.setSearchTerms("")
         verify(toolbar.edit.editListener)?.onTextChanged("")
     }
+
+    @Test
+    fun `WHEN switching to edit mode AND the cursor placement parameter is specified THEN call the correct method to place the cursor`() {
+        val toolbar = BrowserToolbar(testContext)
+        toolbar.edit = spy(toolbar.edit)
+
+        toolbar.editMode(Toolbar.CursorPlacement.ALL)
+
+        verify(toolbar.edit).selectAll()
+
+        toolbar.editMode(Toolbar.CursorPlacement.END)
+
+        verify(toolbar.edit).selectEnd()
+    }
 }

--- a/android-components/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
+++ b/android-components/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt
@@ -183,9 +183,12 @@ interface Toolbar {
     fun displayMode()
 
     /**
-     * Switches to URL editing mode (from displaying mode) if supported by the toolbar implementation.
+     * Switches to URL editing mode (from display mode) if supported by the toolbar implementation,
+     * and focuses the URL input field based on the cursor selection.
+     *
+     * @param cursorPlacement Where the cursor should be set after focusing on the URL input field.
      */
-    fun editMode()
+    fun editMode(cursorPlacement: CursorPlacement = CursorPlacement.ALL)
 
     /**
      * Dismisses the display toolbar popup menu
@@ -492,6 +495,21 @@ interface Toolbar {
          * The site does not show a dot indicator.
          */
         NONE,
+    }
+
+    /**
+     * Indicates where the cursor should be set after focusing on the URL input field.
+     */
+    enum class CursorPlacement {
+        /**
+         * All of the text in the input field should be selected.
+         */
+        ALL,
+
+        /**
+         * No text should be selected and the cursor should be placed at the end of the text.
+         */
+        END,
     }
 }
 

--- a/android-components/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
+++ b/android-components/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/feature/CustomTabSessionTitleObserverTest.kt
@@ -93,7 +93,7 @@ class CustomTabSessionTitleObserverTest {
         override fun removeEditActionEnd(action: Toolbar.Action) = Unit
         override fun setOnEditListener(listener: Toolbar.OnEditListener) = Unit
         override fun displayMode() = Unit
-        override fun editMode() = Unit
+        override fun editMode(cursorPlacement: Toolbar.CursorPlacement) = Unit
         override fun dismissMenu() = Unit
         override fun enableScrolling() = Unit
         override fun disableScrolling() = Unit

--- a/android-components/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/android-components/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -100,7 +100,7 @@ class ToolbarAutocompleteFeatureTest {
             fail()
         }
 
-        override fun editMode() {
+        override fun editMode(cursorPlacement: Toolbar.CursorPlacement) {
             fail()
         }
 

--- a/android-components/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
+++ b/android-components/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarInteractorTest.kt
@@ -85,7 +85,7 @@ class ToolbarInteractorTest {
             fail()
         }
 
-        override fun editMode() {
+        override fun editMode(cursorPlacement: Toolbar.CursorPlacement) {
             fail()
         }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,7 +20,10 @@ permalink: /changelog/
 
 * **feature-awesomebar**
   * `SuggestionProviderGroup` now has a new parameter `priority` that decides the order of this group in the AwesomeBar suggestions. Priority is same as the `score` of `AwesomeBar.Suggestions`. Group having the highest integer value will have the highest priority.
-  
+
+* **concept-toolbar**
+  * Added optional parameter `cursorPlacement` to `editMode` which allows cursor placement to be specified when switching to edit mode.
+
 # 109.0.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/v108.0.0...v109.0.0)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/v109.0.0/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)


### PR DESCRIPTION
Added optional parameter `cursorPlacement` to `editMode` function which allows clients to specify where the cursor should be placed when switching to URL edit mode.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
