### PR TITLE
Bug 1804594 - Differentiate search engines between "general" and "topic specific" when they are loaded

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/search/SearchEngine.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/search/SearchEngine.kt
@@ -19,6 +19,7 @@ const val OS_SEARCH_ENGINE_TERMS_PARAM = "{" + "searchTerms" + "}"
  * @property type the type of this search engine.
  * @property resultUrls the list of the queried suggestions result urls.
  * @property suggestUrl the search suggestion url.
+ * @property isGeneral whether the search engine is a general search engine.
  */
 data class SearchEngine(
     val id: String,
@@ -27,6 +28,7 @@ data class SearchEngine(
     val type: Type,
     val resultUrls: List<String> = emptyList(),
     val suggestUrl: String? = null,
+    val isGeneral: Boolean = false,
 ) {
     /**
      * A enum class representing a search engine type.

--- a/android-components/components/feature/search/src/main/java/mozilla/components/feature/search/ext/SearchEngine.kt
+++ b/android-components/components/feature/search/src/main/java/mozilla/components/feature/search/ext/SearchEngine.kt
@@ -26,6 +26,7 @@ fun createSearchEngine(
     url: String,
     icon: Bitmap,
     suggestUrl: String? = null,
+    isGeneral: Boolean = false,
 ): SearchEngine {
     if (!url.contains(OS_SEARCH_ENGINE_TERMS_PARAM)) {
         throw IllegalArgumentException("URL does not contain search terms placeholder")
@@ -38,6 +39,7 @@ fun createSearchEngine(
         type = SearchEngine.Type.CUSTOM,
         resultUrls = listOf(url),
         suggestUrl = suggestUrl,
+        isGeneral = isGeneral,
     )
 }
 

--- a/android-components/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchEngineReader.kt
+++ b/android-components/components/feature/search/src/main/java/mozilla/components/feature/search/storage/SearchEngineReader.kt
@@ -22,6 +22,23 @@ internal const val URL_TYPE_SUGGEST_JSON = "application/x-suggestions+json"
 internal const val URL_TYPE_SEARCH_HTML = "text/html"
 internal const val URL_REL_MOBILE = "mobile"
 internal const val IMAGE_URI_PREFIX = "data:image/png;base64,"
+internal const val GOOGLE_ID = "google"
+
+// List of general search engine ids, taken from
+// https://searchfox.org/mozilla-central/rev/ef0aa879e94534ffd067a3748d034540a9fc10b0/toolkit/components/search/SearchUtils.sys.mjs#200
+internal val GENERAL_SEARCH_ENGINE_IDS = setOf(
+    GOOGLE_ID,
+    "ddg",
+    "bing",
+    "baidu",
+    "ecosia",
+    "qwant",
+    "yahoo-jp",
+    "seznam-cz",
+    "leit-is",
+    "coccoc",
+    "baidu",
+)
 
 /**
  * A simple XML reader for search engine plugins.
@@ -47,7 +64,17 @@ internal class SearchEngineReader(
             type = type,
             resultUrls = resultsUrls,
             suggestUrl = suggestUrl,
+            isGeneral = isGeneralSearchEngine(identifier, type),
         )
+
+        /**
+         * Returns true if the provided [type] is a custom search engine or the [identifier] is
+         * included in [GENERAL_SEARCH_ENGINE_IDS].
+         */
+        private fun isGeneralSearchEngine(identifier: String, type: SearchEngine.Type): Boolean =
+            type == SearchEngine.Type.CUSTOM ||
+                identifier.startsWith(GOOGLE_ID) ||
+                GENERAL_SEARCH_ENGINE_IDS.contains(identifier)
     }
 
     /**

--- a/android-components/components/feature/search/src/test/java/mozilla/components/feature/search/ext/SearchEngineKtTest.kt
+++ b/android-components/components/feature/search/src/test/java/mozilla/components/feature/search/ext/SearchEngineKtTest.kt
@@ -4,12 +4,14 @@
 
 package mozilla.components.feature.search.ext
 
+import android.graphics.Bitmap
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.state.SearchState
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,6 +19,31 @@ import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class SearchEngineKtTest {
+
+    @Test
+    fun `WHEN search engine is created THEN the correct properties are set`() {
+        val name = "name"
+        val url = "https://www.example.com/search?q={searchTerms}"
+        val icon: Bitmap = mock()
+        val suggestUrl = "https://www.example.com/search"
+        val isGeneral = true
+        val searchEngine = createSearchEngine(
+            name = name,
+            url = url,
+            icon = icon,
+            suggestUrl = suggestUrl,
+            isGeneral = isGeneral,
+        )
+
+        assertNotNull(searchEngine.id)
+        assertEquals(name, searchEngine.name)
+        assertEquals(icon, searchEngine.icon)
+        assertEquals(SearchEngine.Type.CUSTOM, searchEngine.type)
+        assertEquals(listOf(url), searchEngine.resultUrls)
+        assertEquals(suggestUrl, searchEngine.suggestUrl)
+        assertEquals(isGeneral, searchEngine.isGeneral)
+    }
+
     @Test
     fun `Create search URL for startpage`() {
         val searchEngine = SearchEngine(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,10 +9,13 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **browser-state**, **feature-search**
+  * Added a new parameter `isGeneral` to `SearchEngine` to specify whether or not the search engine is a general search engine (eg, provides broad search results). Search engines read from storage will now have this parameter set based on a list of general search engines. [bug #1804594](https://bugzilla.mozilla.org/show_bug.cgi?id=1804594)
+
 # 109.0.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/v108.0.0...v109.0.0)
-* [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/v109.0.0/android-components/buildSrc/src/main/java/Dependencies.kt)
-* [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/v109.0.0/android-components/buildSrc/src/main/java/Gecko.kt)
+* [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/v109.0.0/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)
+* [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/v109.0.0/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/v109.0.0/android-components/.config.yml)
 
 * **support-ktx, feature-contextmenu**
@@ -23,7 +26,7 @@ permalink: /changelog/
 
 * **browser-menu**:
   * 🚒 Bug Fixed [bug #1800885](https://bugzilla.mozilla.org/show_bug.cgi?id=1800885) Increase touch target of Add/Edit checkbox from `mozac_browser_menu_item_image_text_checkbox_button.xml` to improve accessibility.
-  
+
 * **All components**
   * ⚠️Increased `compileSdkVersion` to 33 (Android 13)
 * **feature-awesomebar**


### PR DESCRIPTION



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
