### PR TITLE
Bug - 1804690 Expose allowEmulatorLoopback 

### DIFF
--- a/android-components/components/support/rusthttp/src/main/java/mozilla/components/support/rusthttp/RustHttpConfig.kt
+++ b/android-components/components/support/rusthttp/src/main/java/mozilla/components/support/rusthttp/RustHttpConfig.kt
@@ -24,4 +24,15 @@ object RustHttpConfig {
     fun setClient(c: Lazy<Client>) {
         AppSvcHttpConfig.setClient(c)
     }
+
+    /**
+     * Allows connections to the hard-coded address the Android Emulator uses
+     * to connect to the emulator's host (ie, http://10.0.2.2).
+     *
+     * Only call this in debug builds or if you are sure you are running on an emulator. If this is
+     * not called, viaduct will fail to use that address as it isn't https.
+     */
+    fun allowEmulatorLoopback() {
+        AppSvcHttpConfig.allowAndroidEmulatorLoopback()
+    }
 }


### PR DESCRIPTION
### What
– To allow emulator to access network of the host machine sidestepping the TLS error
– Application Services exposing the method --> https://github.com/mozilla/application-services/issues/5214

### Next up
Once this is reviewed and released, will create a PR for `fenix` to enable this in debug builds.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
