### PR TITLE
Bug 1805438 - Don't lint components when building Focus

### DIFF
--- a/focus-android/settings.gradle
+++ b/focus-android/settings.gradle
@@ -92,11 +92,16 @@ gradle.projectsLoaded { ->
     )
     gradle.rootProject.ext.buildConfig = buildconfig
 
-    // Disables A-C tests when building Focus.
+    // Disables A-C tests and lint when building Focus.
     gradle.allprojects { project ->
         if (project.projectDir.absolutePath.contains("/android-components/")) {
             project.tasks.withType(Test) {
                 enabled = false
+            }
+            project.tasks.whenTaskAdded { task ->
+                if (task.name.contains("lint")) {
+                    task.enabled = false
+                }
             }
         }
     }


### PR DESCRIPTION
No reason to run the linter on A-C when building Focus. Let's see what the difference is in ⏲️ .