### PR TITLE
Bug 1805629: fix chain of trust verification failure on pull requests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -166,7 +166,7 @@ tasks:
                             metadata:
                                 $merge:
                                     - owner: "${ownerEmail}"
-                                      source: 'https://github.com/${repoFullName}/raw/${head_sha}/.taskcluster.yml'
+                                      source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
                                     - $if: 'isPullRequest || tasks_for == "github-push"'
                                       then:
                                           name: "Decision Task"


### PR DESCRIPTION
scriptworker's chain of trust verification expects a decision task's MOBILE_HEAD_REPOSITORY to match the repository URL in metadata.source. For pull requests that means we shouldn't set metadata.source to the base repo.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
