### PR TITLE
Bug 1802610: Change Focus locale UI test to select a language above the fold

### DIFF
--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/SettingsGeneralTest.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/SettingsGeneralTest.kt
@@ -10,7 +10,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import mozilla.components.support.locale.LocaleManager
 import mozilla.components.support.locale.LocaleUseCases
 import org.junit.After
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
@@ -27,7 +26,6 @@ import org.mozilla.focus.helpers.StringsHelper.AF_LANGUAGE_SYSTEM_DEFAULT
 import org.mozilla.focus.helpers.StringsHelper.AF_SETTINGS
 import org.mozilla.focus.helpers.StringsHelper.EN_AFRIKAANS_LOCALE
 import org.mozilla.focus.helpers.StringsHelper.EN_LANGUAGE_MENU_HEADING
-import org.mozilla.focus.helpers.StringsHelper.FR_ENGLISH_LOCALE
 import org.mozilla.focus.helpers.StringsHelper.FR_GENERAL_HEADING
 import org.mozilla.focus.helpers.StringsHelper.FR_LANGUAGE_MENU
 import org.mozilla.focus.helpers.StringsHelper.FR_LANGUAGE_SYSTEM_DEFAULT
@@ -108,7 +106,6 @@ class SettingsGeneralTest {
         }
     }
 
-    @Ignore("Compose scrolling issue: https://github.com/mozilla-mobile/focus-android/issues/7718")
     @Test
     fun frenchLocaleTest() {
         /* Go to Settings */
@@ -119,14 +116,14 @@ class SettingsGeneralTest {
             openLanguageSelectionMenu(FR_LANGUAGE_MENU)
             verifySystemLocaleSelected(FR_LANGUAGE_SYSTEM_DEFAULT)
             /* change locale to English, verify the locale is changed */
-            selectLanguage(FR_ENGLISH_LOCALE)
-            verifyTranslatedTextExists(EN_LANGUAGE_MENU_HEADING)
+            selectLanguage(EN_AFRIKAANS_LOCALE)
+            verifyTranslatedTextExists(AF_LANGUAGE_MENU)
             exitToTop()
         }
         homeScreen {
         }.openMainMenu {
-            verifySettingsButtonExists()
-            verifyHelpPageLinkExists()
+            verifyTranslatedTextExists(AF_SETTINGS)
+            verifyTranslatedTextExists(AF_HELP)
         }
     }
 


### PR DESCRIPTION
Because UI Automator can't scroll the entire Compose list, and mixing Compose test rule with UIautomator/Espresso was too buggy in this case, I decided to avoid the need to scroll the list just to work around those issues.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
