### PR TITLE
Bug 1805750 - Read the version name from version.txt for Focus nightly builds

### DIFF
--- a/focus-android/buildSrc/src/main/java/Config.kt
+++ b/focus-android/buildSrc/src/main/java/Config.kt
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import org.gradle.api.Project
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -30,9 +31,7 @@ object Config {
 
     @JvmStatic
     fun nightlyVersionName(): String {
-        // Nightly versions use the Gecko/A-C major version and append "0.a1", e.g. with A-C 90.0.20210426143115
-        // the Nightly version will be 90.0a1
-        val majorVersion = AndroidComponents.VERSION.split(".")[0]
-        return "$majorVersion.0a1"
+        // Nightly versions will use the version from "version.txt".
+        return File("../version.txt").useLines { it.firstOrNull() ?: "" }
     }
 }


### PR DESCRIPTION



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
