### PR TITLE
Bug 1796319 - Add functionality in SelectOrAddUsecase to ignore the fragment identifier part of the url

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
@@ -8,6 +8,9 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.CustomTabSessionState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.support.base.log.logger.Logger
+import java.net.URI
+import java.net.URISyntaxException
 
 // Extension functions for querying and dissecting [BrowserState]
 
@@ -107,6 +110,23 @@ fun BrowserState.findNormalOrPrivateTabByUrl(url: String, private: Boolean): Tab
 }
 
 /**
+ * Finds and returns the tab with the given url ignoring the fragment/reference part of the url.
+ * Returns null if no matching tab could be found.
+ *
+ * @param url A mandatory url of the searched tab.
+ * @param private Whether to look for a matching private or normal tab.
+ * @return The tab with the provided url.
+ */
+fun BrowserState.findNormalOrPrivateTabByUrlIgnoringFragment(
+    url: String,
+    private: Boolean,
+): TabSessionState? {
+    return tabs.firstOrNull { tab ->
+        isSameUrlIgnoringFragment(tab.content.url, url) && tab.content.private == private
+    }
+}
+
+/**
  * Gets a list of normal or private tabs depending on the requested type.
  * @param private If true, all private tabs will be returned.
  * If false, all normal tabs will be returned.
@@ -132,3 +152,34 @@ val BrowserState.normalTabs: List<TabSessionState>
  */
 val BrowserState.allTabs: List<SessionState>
     get() = tabs + customTabs
+
+/**
+ * Returns true if the two urls are the same ignoring the fragment - the part after #.
+ *
+ * @param tabUrl A mandatory url of the tab.
+ * @param url A mandatory url that's being checked.
+ * @return true if the check passes, otherwise false.
+ */
+private fun isSameUrlIgnoringFragment(tabUrl: String, url: String): Boolean {
+    return try {
+        val tabUri = URI.create(tabUrl)
+        val uri = URI.create(url)
+        URI(tabUri.scheme, tabUri.authority, tabUri.path, tabUri.query, null).removeTrailingSlash() ==
+            URI(uri.scheme, uri.authority, uri.path, uri.query, null).removeTrailingSlash()
+    } catch (e: URISyntaxException) {
+        Logger.error("Unable to compare urls", e)
+        false
+    } catch (e: IllegalArgumentException){
+        Logger.error("Unable to compare urls", e)
+        false
+    }
+}
+
+/**
+ * Removes trailing slash on the URI if present
+ * @return String with trailing slash removed if it's the last character,
+ * otherwise the original string.
+ */
+private fun URI.removeTrailingSlash(): String {
+    return toString().trimEnd('/')
+}

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/selector/Selectors.kt
@@ -110,7 +110,7 @@ fun BrowserState.findNormalOrPrivateTabByUrl(url: String, private: Boolean): Tab
 }
 
 /**
- * Finds and returns the tab with the given url ignoring the fragment/reference part of the url.
+ * Finds and returns the tab with the given url ignoring the fragment identifier part of the url.
  * Returns null if no matching tab could be found.
  *
  * @param url A mandatory url of the searched tab.
@@ -154,7 +154,8 @@ val BrowserState.allTabs: List<SessionState>
     get() = tabs + customTabs
 
 /**
- * Returns true if the two urls are the same ignoring the fragment - the part after #.
+ * Returns true if the two urls are the same ignoring the fragment identifier - the string after
+ * the # in a url (eg, http://foo/bar#buzz).
  *
  * @param tabUrl A mandatory url of the tab.
  * @param url A mandatory url that's being checked.
@@ -169,14 +170,15 @@ private fun isSameUrlIgnoringFragment(tabUrl: String, url: String): Boolean {
     } catch (e: URISyntaxException) {
         Logger.error("Unable to compare urls", e)
         false
-    } catch (e: IllegalArgumentException){
+    } catch (e: IllegalArgumentException) {
         Logger.error("Unable to compare urls", e)
         false
     }
 }
 
 /**
- * Removes trailing slash on the URI if present
+ * Removes trailing slash on the URI if present.
+ *
  * @return String with trailing slash removed if it's the last character,
  * otherwise the original string.
  */

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
@@ -286,4 +286,21 @@ class SelectorsKtTest {
             assertNull(state.findNormalOrPrivateTabByUrl("https://www.mozilla.org", true))
         }
     }
+
+    @Test
+    fun `findNormalOrPrivateTabByUrlIgnoringFragment extension function`() {
+        val tab1 = createTab("https://www.firefox.com/query?isMorning=yes#hello", private = false)
+        val tab2 = createTab("moz-extension://4d1a24b3-bdd1-4763-a766-b5a8c1a0012c/dashboard.html#settings.html", private = false)
+        val privateTab1 = createTab("https://getpocket.com", private = true)
+        val privateTab2 = createTab("https://mozilla.org", private = true)
+        val state = BrowserState(tabs = listOf(tab1, privateTab1, tab2, privateTab2))
+
+        assertEquals(tab1, state.findNormalOrPrivateTabByUrlIgnoringFragment("https://www.firefox.com/query?isMorning=yes", false))
+        assertEquals(tab1, state.findNormalOrPrivateTabByUrlIgnoringFragment("https://www.firefox.com/query?isMorning=yes#bye", false))
+        assertEquals(tab2, state.findNormalOrPrivateTabByUrlIgnoringFragment("moz-extension://4d1a24b3-bdd1-4763-a766-b5a8c1a0012c/dashboard.html", false))
+        assertEquals(privateTab2, state.findNormalOrPrivateTabByUrlIgnoringFragment("https://mozilla.org/", true))
+        assertNull(state.findNormalOrPrivateTabByUrlIgnoringFragment("https://firefox.com/query?isMorning=yes", false))
+        // This asserts that the function doesn't throw if an illegal url is checked
+        assertNull(state.findNormalOrPrivateTabByUrlIgnoringFragment("https://getpocket.com/#/private#now", true))
+    }
 }

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt
@@ -295,12 +295,12 @@ class SelectorsKtTest {
         val privateTab2 = createTab("https://mozilla.org", private = true)
         val state = BrowserState(tabs = listOf(tab1, privateTab1, tab2, privateTab2))
 
-        assertEquals(tab1, state.findNormalOrPrivateTabByUrlIgnoringFragment("https://www.firefox.com/query?isMorning=yes", false))
-        assertEquals(tab1, state.findNormalOrPrivateTabByUrlIgnoringFragment("https://www.firefox.com/query?isMorning=yes#bye", false))
-        assertEquals(tab2, state.findNormalOrPrivateTabByUrlIgnoringFragment("moz-extension://4d1a24b3-bdd1-4763-a766-b5a8c1a0012c/dashboard.html", false))
-        assertEquals(privateTab2, state.findNormalOrPrivateTabByUrlIgnoringFragment("https://mozilla.org/", true))
-        assertNull(state.findNormalOrPrivateTabByUrlIgnoringFragment("https://firefox.com/query?isMorning=yes", false))
+        assertEquals(tab1, state.findNormalOrPrivateTabByUrlIgnoringFragment("https://www.firefox.com/query?isMorning=yes", private = false))
+        assertEquals(tab1, state.findNormalOrPrivateTabByUrlIgnoringFragment("https://www.firefox.com/query?isMorning=yes#bye", private = false))
+        assertEquals(tab2, state.findNormalOrPrivateTabByUrlIgnoringFragment("moz-extension://4d1a24b3-bdd1-4763-a766-b5a8c1a0012c/dashboard.html", private = false))
+        assertEquals(privateTab2, state.findNormalOrPrivateTabByUrlIgnoringFragment("https://mozilla.org/", private = true))
+        assertNull(state.findNormalOrPrivateTabByUrlIgnoringFragment("https://firefox.com/query?isMorning=yes", private = false))
         // This asserts that the function doesn't throw if an illegal url is checked
-        assertNull(state.findNormalOrPrivateTabByUrlIgnoringFragment("https://getpocket.com/#/private#now", true))
+        assertNull(state.findNormalOrPrivateTabByUrlIgnoringFragment("https://getpocket.com/#/private#now", private = true))
     }
 }

--- a/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -439,8 +439,8 @@ class TabsUseCases(
          * @param private Whether or not this session should use private mode.
          * @param source The origin of a session to describe how and why it was created.
          * @param flags The [LoadUrlFlags] to use when loading the provided URL.
-         * @param ignoreFragment Whether to ignore the fragment/anchor of the url while comparing
-         * with existing tabs.
+         * @param ignoreFragment Whether to ignore the fragment identifier of the url while
+         * comparing with existing tabs.
          * @return The ID of the selected or created tab.
          */
         operator fun invoke(

--- a/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.state.action.RestoreCompleteAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.UndoAction
 import mozilla.components.browser.state.selector.findNormalOrPrivateTabByUrl
+import mozilla.components.browser.state.selector.findNormalOrPrivateTabByUrlIgnoringFragment
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.SessionState
@@ -121,7 +122,11 @@ class TabsUseCases(
          * @param url The URL to be loaded in the new tab.
          * @param flags the [LoadUrlFlags] to use when loading the provided URL.
          */
-        override fun invoke(url: String, flags: LoadUrlFlags, additionalHeaders: Map<String, String>?) {
+        override fun invoke(
+            url: String,
+            flags: LoadUrlFlags,
+            additionalHeaders: Map<String, String>?,
+        ) {
             this.invoke(url, selectTab = true, startLoading = true, parentId = null, flags = flags)
         }
 
@@ -198,7 +203,11 @@ class TabsUseCases(
          * @param url The URL to be loaded in the new private tab.
          * @param flags the [LoadUrlFlags] to use when loading the provided URL.
          */
-        override fun invoke(url: String, flags: LoadUrlFlags, additionalHeaders: Map<String, String>?) {
+        override fun invoke(
+            url: String,
+            flags: LoadUrlFlags,
+            additionalHeaders: Map<String, String>?,
+        ) {
             this.invoke(url, selectTab = true, startLoading = true, parentId = null, flags = flags)
         }
 
@@ -333,7 +342,11 @@ class TabsUseCases(
          */
         operator fun invoke(tabs: List<RecoverableTab>, selectTabId: String? = null) {
             store.dispatch(
-                TabListAction.RestoreAction(tabs, selectTabId, TabListAction.RestoreAction.RestoreLocation.BEGINNING),
+                TabListAction.RestoreAction(
+                    tabs,
+                    selectTabId,
+                    TabListAction.RestoreAction.RestoreLocation.BEGINNING,
+                ),
             )
         }
 
@@ -426,6 +439,8 @@ class TabsUseCases(
          * @param private Whether or not this session should use private mode.
          * @param source The origin of a session to describe how and why it was created.
          * @param flags The [LoadUrlFlags] to use when loading the provided URL.
+         * @param ignoreFragment Whether to ignore the fragment/anchor of the url while comparing
+         * with existing tabs.
          * @return The ID of the selected or created tab.
          */
         operator fun invoke(
@@ -433,8 +448,13 @@ class TabsUseCases(
             private: Boolean = false,
             source: SessionState.Source = SessionState.Source.Internal.NewTab,
             flags: LoadUrlFlags = LoadUrlFlags.none(),
+            ignoreFragment: Boolean = false,
         ): String {
-            val existingTab = store.state.findNormalOrPrivateTabByUrl(url, private)
+            val existingTab = if (ignoreFragment) {
+                store.state.findNormalOrPrivateTabByUrlIgnoringFragment(url, private)
+            } else {
+                store.state.findNormalOrPrivateTabByUrl(url, private)
+            }
 
             return if (existingTab != null) {
                 store.dispatch(TabListAction.SelectTabAction(existingTab.id))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ permalink: /changelog/
 
 * **browser-state**, **feature-search**
   * Added a new parameter `isGeneral` to `SearchEngine` to specify whether or not the search engine is a general search engine (eg, provides broad search results). Search engines read from storage will now have this parameter set based on a list of general search engines. [bug #1804594](https://bugzilla.mozilla.org/show_bug.cgi?id=1804594)
+  * Added Selector `BrowserState.findNormalOrPrivateTabByUrlIgnoringFragment` to match urls ignoring the fragment/anchor of the url, allowing `SelectorAddUseCase` to use this functionality.
+
+* **feature-tabs**
+  * Added `ignoreFragment` param in `SelectOrAddUseCase` to match urls ignoring the anchor/fragment. This sets the the foundation to fix [bug 1796319](https://bugzilla.mozilla.org/show_bug.cgi?id=1796319).
 
 * **lib-crash-sentry**
   * 🚒 Bug fixed [bug #1801349](https://bugzilla.mozilla.org/show_bug.cgi?id=1801349).  Properly synchronize access to the crash reporter breadcrumb list.


### PR DESCRIPTION
### How
• Add `BrowserState.findNormalOrPrivateTabByUrlIgnoringFragment` extension function to find tabs which have the same url except the fragment/anchor part - [The part after `# ` in the url that's always at the end](https://datatracker.ietf.org/doc/html/rfc3986#section-3).
• Add `ignoreFragment` param in the `SelectOrAddUsecase` so callers can specify - defaults to false.

### Video (with changes in Fenix)
https://user-images.githubusercontent.com/38040960/207867953-dc434a0e-5047-47f2-b388-810171b82232.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
