### PR TITLE
Bug 1799696 - part 3: Fix new v3 indices by providing artifact_type befo…

### DIFF
--- a/taskcluster/android_taskgraph/routes.py
+++ b/taskcluster/android_taskgraph/routes.py
@@ -8,10 +8,10 @@ import time
 from taskgraph.transforms.task import index_builder
 
 SIGNING_ROUTE_TEMPLATES = [
-    "index.{trust_domain}.v3.{project}.{variant}.{artifact_type}.latest.{artifact_name}",
-    "index.{trust_domain}.v3.{project}.{variant}.{artifact_type}.{build_date}.revision.{head_rev}.{artifact_name}",
-    "index.{trust_domain}.v3.{project}.{variant}.{artifact_type}.{build_date}.latest.{artifact_name}",
-    "index.{trust_domain}.v3.{project}.{variant}.{artifact_type}.revision.{head_rev}.{artifact_name}",
+    "index.{trust_domain}.v3.{project}.{artifact_type}.{variant}.latest.{artifact_name}",
+    "index.{trust_domain}.v3.{project}.{artifact_type}.{variant}.{build_date}.revision.{head_rev}.{artifact_name}",
+    "index.{trust_domain}.v3.{project}.{artifact_type}.{variant}.{build_date}.latest.{artifact_name}",
+    "index.{trust_domain}.v3.{project}.{artifact_type}.{variant}.revision.{head_rev}.{artifact_name}",
 ]
 
 


### PR DESCRIPTION
…re the variant

The new v3 index is currently wrong: https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v3.firefox-android. Here we should choose `apks` and `components` instead of the variant.

No need to bump the version number. No one uses these routes yet and I'll purge the wrong routes.