### PR TITLE
Bug 1805840 - Fix layout for add to home screen  with ETP warning.

### DIFF
--- a/focus-android/app/src/main/res/layout/dialog_add_to_homescreen2.xml
+++ b/focus-android/app/src/main/res/layout/dialog_add_to_homescreen2.xml
@@ -53,8 +53,9 @@
         android:id="@+id/addtohomescreen_dialog_add"
         style="@style/ButtonStyle"
         android:layout_marginTop="36dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
         android:text="@string/dialog_addtohomescreen_action_add"
-        app:layout_constraintBottom_toBottomOf="@id/homescreen_dialog_warning_layout"
         app:layout_constraintBottom_toTopOf="@id/homescreen_dialog_warning_layout"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/edit_title" />
@@ -62,18 +63,22 @@
     <Button
         android:id="@+id/addtohomescreen_dialog_cancel"
         style="@style/ButtonStyle"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
         android:text="@string/dialog_addtohomescreen_action_cancel"
         app:layout_constraintEnd_toStartOf="@id/addtohomescreen_dialog_add"
-        app:layout_constraintTop_toTopOf="@id/addtohomescreen_dialog_add" />
+        app:layout_constraintTop_toTopOf="@id/addtohomescreen_dialog_add"
+        app:layout_constraintBottom_toBottomOf="@id/addtohomescreen_dialog_add"/>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/homescreen_dialog_warning_layout"
         android:layout_width="match_parent"
-        android:layout_height="80dp"
+        android:layout_height="wrap_content"
+        android:minHeight="80dp"
         android:layout_marginTop="16dp"
         android:background="@drawable/dialog_warning_background"
-        android:padding="24dp"
         android:visibility="invisible"
+        tools:visibility="visible"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/addtohomescreen_dialog_add">
 
@@ -82,6 +87,9 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_gravity="center_vertical"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="26dp"
+            android:layout_marginBottom="32dp"
             android:tint="@color/photonWhite"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -91,14 +99,15 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
             android:fontFamily="@string/font_roboto_regular"
             android:text="@string/dialog_addtohomescreen_tracking_protection2"
             android:textColor="@color/photonWhite"
             android:textSize="14sp"
-            app:layout_constraintBottom_toBottomOf="@id/homescreen_dialog_block_icon"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/homescreen_dialog_block_icon"
-            app:layout_constraintTop_toTopOf="@id/homescreen_dialog_block_icon" />
+            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This adds margins and constraints according to the initial [design](https://www.figma.com/file/2V6wgf9fRFdYfLaf5c3oPj/Product-UI?node-id=2133%3A282824&t=TFcwwSOB4oYYtlBa-0) .

Also added margin to dialog buttons to avoid text overlapping (Figma design does not have margins, the buttons even overlap).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

**BEFORE:**
English / German (long text) / RTL

<img src = https://user-images.githubusercontent.com/48995920/208151201-eb2a6e2a-0eef-4008-9b20-728ea260afe6.png width = 33%> <img src = https://user-images.githubusercontent.com/48995920/208151199-105c6008-ea01-458a-876f-94f5590e2c93.png width = 33%> <img src = https://user-images.githubusercontent.com/48995920/208151204-e3267153-d655-4cad-b762-5cd7b935a0b4.png width = 33%>


**AFTER:**
English / German (long text) / RTL

<img src = https://user-images.githubusercontent.com/48995920/208151247-5362557a-b2c3-453c-9a1b-677c37b4fb1a.png width = 33%> <img src = https://user-images.githubusercontent.com/48995920/208151245-18856e39-7690-4aca-8abd-ca1070ecff87.png width = 33%> <img src = https://user-images.githubusercontent.com/48995920/208151239-a2509707-1a92-426c-80ac-6e004ba848f7.png width = 33%> 


### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
