### PR TITLE
Bug 1805832 - Add additional checked casts when converting Array<Parcelable>

### DIFF
--- a/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/ext/Bundle.kt
+++ b/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/ext/Bundle.kt
@@ -54,7 +54,7 @@ inline fun <reified T : Parcelable> Bundle.getParcelableArrayCompat(name: String
         getParcelableArray(name, clazz)
     } else {
         @Suppress("DEPRECATION")
-        getParcelableArray(name)?.toArrayOfT()
+        getParcelableArray(name)?.safeCastToArrayOfT()
     }
 }
 
@@ -62,12 +62,8 @@ inline fun <reified T : Parcelable> Bundle.getParcelableArrayCompat(name: String
  * Cast a [Parcelable] [Array] to a <T implements [Parcelable]> [Array]
  */
 @Suppress("UNCHECKED_CAST")
-inline fun <reified T : Parcelable> Array<Parcelable>.toArrayOfT(): Array<T> {
-    return if (this.isArrayOf<T>()) {
-        this as Array<T>
-    } else {
-        Array(this.size) { index ->
-            this[index] as T
-        }
-    }
+inline fun <reified T : Parcelable> Array<Parcelable>.safeCastToArrayOfT(): Array<T> {
+    return Array(this.size) { index ->
+        this[index] as? T
+    }.filterNotNull().toTypedArray()
 }

--- a/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/BundleTest.kt
+++ b/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/BundleTest.kt
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.utils
+
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.support.utils.ext.getParcelableArrayCompat
+import mozilla.components.support.utils.ext.safeCastToArrayOfT
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BundleTest {
+
+    @Test
+    fun `safeCastToArrayOfT with expected elements`() {
+        val testArray = Array<Parcelable>(4) { Expected() }
+
+        val result = testArray.safeCastToArrayOfT<Expected>()
+
+        assertArrayEquals(testArray, result)
+    }
+
+    @Test
+    fun `safeCastToArrayOfT with unexpected elements returns empty array and does not throw exception`() {
+        val testArray = Array<Parcelable>(4) { Unexpected() }
+
+        val result = testArray.safeCastToArrayOfT<Expected>()
+
+        assertArrayEquals(emptyArray(), result)
+    }
+
+    @Test
+    fun `safeCastToArrayOfT with expected and unexpected elements returns array with only expected`() {
+        val testArray = Array<Parcelable>(4) { Expected() }
+        testArray.plus(Unexpected())
+
+        val result = testArray.safeCastToArrayOfT<Expected>()
+
+        assertEquals(4, result.size)
+        assertTrue(result.isArrayOf<Expected>())
+    }
+
+    @Test
+    fun `getParcelableArrayCompat with expected type`() {
+        val bundle = Bundle()
+
+        val testArray = Array(4) { Expected() }
+
+        bundle.putParcelableArray(KEY, testArray)
+
+        val result = bundle.getParcelableArrayCompat(KEY, Expected::class.java)
+
+        assertArrayEquals(testArray, result)
+    }
+
+    @Test
+    fun `getParcelableArrayCompat with unexpected type returns empty array and does not throw exception`() {
+        val bundle = Bundle()
+
+        val testArray = Array(4) { Unexpected() }
+
+        bundle.putParcelableArray(KEY, testArray)
+
+        val result = bundle.getParcelableArrayCompat(KEY, Expected::class.java)
+
+        assertArrayEquals(emptyArray(), result)
+    }
+
+    @Test
+    fun `getParcelableArrayCompat with both expected unexpected type returns array with only expected`() {
+        val bundle = Bundle()
+
+        val testArray = Array<Parcelable>(4) { Expected() }
+
+        testArray.plus(Unexpected())
+
+        bundle.putParcelableArray(KEY, testArray)
+
+        val result = bundle.getParcelableArrayCompat(KEY, Expected::class.java)
+
+        assertEquals(4, result?.size)
+        assertTrue(result?.isArrayOf<Expected>() == true)
+    }
+
+    companion object {
+        private const val KEY = "test key"
+
+        class Expected : Parcelable {
+            override fun describeContents(): Int {
+                return 0
+            }
+
+            override fun writeToParcel(parcel: Parcel, flags: Int) {
+                parcel.writeString("good")
+            }
+        }
+
+        private class Unexpected : Parcelable {
+            override fun describeContents(): Int {
+                return 0
+            }
+
+            override fun writeToParcel(parcel: Parcel, flags: Int) {
+                parcel.writeString("wrong")
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
