### PR TITLE
Bug 27998 – Add settings to BrowserMenu to overlap anchor view completely

### DIFF
--- a/android-components/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/BrowserMenuController.kt
+++ b/android-components/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/BrowserMenuController.kt
@@ -64,7 +64,7 @@ class BrowserMenuController(
             view.onDismiss = ::dismiss
             view.onReopenMenu = ::reopenMenu
             setOnDismissListener(menuDismissListener)
-            displayPopup(view, anchor, orientation)
+            displayPopup(view, anchor, orientation, style)
         }.also {
             currentPopupInfo = PopupMenuInfo(
                 window = it,
@@ -92,7 +92,7 @@ class BrowserMenuController(
             // Display the new nested list
             view.submitList(nested?.subMenuItems ?: menuCandidates)
             // Reopen the menu
-            displayPopup(view, info.anchor, info.orientation)
+            displayPopup(view, info.anchor, info.orientation, style)
         }
         currentPopupInfo = info.copy(nested = nested)
     }

--- a/android-components/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/ext/MenuPositioningData.kt
+++ b/android-components/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/ext/MenuPositioningData.kt
@@ -1,0 +1,255 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.menu2.ext
+
+import android.graphics.Rect
+import android.view.View
+import androidx.annotation.Px
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.browser.menu2.R
+import mozilla.components.concept.menu.MenuStyle
+import mozilla.components.concept.menu.Orientation
+import mozilla.components.support.ktx.android.view.isRTL
+import kotlin.math.roundToInt
+
+const val HALF_MENU_ITEM = 0.5
+
+@Suppress("ComplexMethod")
+internal fun inferMenuPositioningData(
+    containerView: View,
+    anchor: View,
+    style: MenuStyle? = null,
+    orientation: Orientation?,
+): MenuPositioningData? {
+    // Measure the menu allowing it to expand entirely.
+    val spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+    containerView.measure(spec, spec)
+
+    val recyclerView = containerView.findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
+    val recyclerViewAdapter = recyclerView.adapter ?: run {
+        // We might want to track how often and in what circumstances the menu gets called without
+        // valid parameters once we have a system for that.
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1814816
+        return null
+    }
+
+    val hasViewInitializedCorrectly = containerView.measuredHeight > 0 && containerView.measuredWidth > 0 &&
+        recyclerView.measuredHeight > 0 && recyclerViewAdapter.itemCount > 0
+    if (!hasViewInitializedCorrectly) {
+        // Same as above: https://bugzilla.mozilla.org/show_bug.cgi?id=1814816
+        return null
+    }
+
+    val menuHorizontalPadding = containerView.measuredWidth - recyclerView.measuredWidth
+    val menuVerticalPadding = containerView.measuredHeight - recyclerView.measuredHeight
+    var horizontalOffset = style?.horizontalOffset ?: 0
+    var verticalOffset = style?.verticalOffset ?: 0
+
+    // Elevation creates some padding between the menu and its container, so that the start corner
+    // of the menu doesn't match the corner of the anchor view. If the user wants the menu to hide
+    // the anchor completely, we have to adjust the position of the menu to compensate for the inner
+    // padding of the menu container.
+    if (style?.completelyOverlap == true) {
+        horizontalOffset -= menuHorizontalPadding / 2
+        verticalOffset -= menuVerticalPadding / 2
+    }
+
+    // The menu height might be adjusted: if there is not enough space to show all the items,
+    // it will crop the last visible item in half, to give the user a hint that it is scrollable.
+    val containerViewHeight = calculateContainerHeight(
+        recyclerView.measuredHeight,
+        recyclerViewAdapter.itemCount,
+        containerView.measuredHeight,
+        style?.verticalOffset ?: 0,
+        anchor,
+    )
+
+    val (availableHeightToTop, availableHeightToBottom) = getMaxAvailableHeightToTopAndBottom(anchor)
+    val (availableWidthToLeft, availableWidthToRight) = getMaxAvailableWidthToLeftAndRight(anchor)
+
+    val fitsUp = availableHeightToTop + anchor.height >= containerViewHeight
+    val fitsDown = availableHeightToBottom + anchor.height >= containerViewHeight
+    val fitsRight = availableWidthToRight + anchor.width >= containerView.measuredWidth
+    val fitsLeft = availableWidthToLeft + anchor.width >= containerView.measuredWidth
+
+    val notEnoughHorizontalSpace = !fitsRight && !fitsLeft
+    val fitsBothHorizontalDirections = fitsRight && fitsLeft
+    val drawingLeft = if (notEnoughHorizontalSpace || fitsBothHorizontalDirections) {
+        anchor.isRTL
+    } else {
+        !fitsRight
+    }
+
+    val anchorPosition = IntArray(2)
+    anchor.getLocationInWindow(anchorPosition)
+    var (anchorX, anchorY) = anchorPosition
+
+    // Position the menu above the anchor if the orientation is UP and there is enough space.
+    if (orientation == Orientation.UP && fitsUp) {
+        anchorY -= containerViewHeight - anchor.height
+        verticalOffset = -verticalOffset
+    }
+
+    if (drawingLeft) {
+        anchorX -= containerView.measuredWidth - anchor.width
+        horizontalOffset = -horizontalOffset
+    }
+
+    return MenuPositioningData(
+        x = anchorX + horizontalOffset,
+        y = anchorY + verticalOffset,
+        containerHeight = containerViewHeight,
+        animation = getAnimation(fitsUp, fitsDown, drawingLeft, orientation),
+    )
+}
+
+private fun getMaxAvailableHeightToTopAndBottom(anchor: View): Pair<Int, Int> {
+    val anchorPosition = IntArray(2)
+    val displayFrame = Rect()
+
+    val appView = anchor.rootView
+    appView.getWindowVisibleDisplayFrame(displayFrame)
+
+    anchor.getLocationOnScreen(anchorPosition)
+
+    val bottomEdge = displayFrame.bottom
+
+    val distanceToBottom = bottomEdge - (anchorPosition[1] + anchor.height)
+    val distanceToTop = anchorPosition[1] - displayFrame.top
+
+    return distanceToTop to distanceToBottom
+}
+
+private fun getMaxAvailableWidthToLeftAndRight(anchor: View): Pair<Int, Int> {
+    val anchorPosition = IntArray(2)
+    val displayFrame = Rect()
+
+    val appView = anchor.rootView
+    appView.getWindowVisibleDisplayFrame(displayFrame)
+
+    anchor.getLocationOnScreen(anchorPosition)
+
+    val distanceToLeft = anchorPosition[0] - displayFrame.left
+    val distanceToRight = displayFrame.right - (anchorPosition[0] + anchor.width)
+
+    return distanceToLeft to distanceToRight
+}
+
+/**
+ * Determine whether the container view can display all menu items (without scrolling) within
+ * the available height.
+ *
+ * @return The original container height if the container view can display all menu items
+ * (without scrolling), else calculate the maximum available container height for a scrollable
+ * view with a half menu item.
+ */
+private fun calculateContainerHeight(
+    recyclerViewHeight: Int,
+    recyclerViewItemCount: Int,
+    containerViewHeight: Int,
+    menuStylePadding: Int,
+    anchor: View,
+): Int {
+    // Get the total screen display height.
+    val totalHeight = anchor.rootView.measuredHeight
+
+    // Note: We cannot use getWindowVisibleDisplayFrame() as the height is dynamic based on whether
+    // the keyboard is open.
+    // Get any displayed system bars e.g. top status bar, bottom navigation bar or soft buttons bar.
+    val systemBars =
+        ViewCompat.getRootWindowInsets(anchor)?.getInsets(WindowInsetsCompat.Type.systemBars())
+    // Store the vertical status bars.
+    val topSystemBarHeight = systemBars?.top ?: 0
+    val bottomSystemBarHeight = systemBars?.bottom ?: 0
+
+    // Deduct any status bar heights from the total height.
+    val availableHeight = totalHeight - (bottomSystemBarHeight + topSystemBarHeight)
+
+    val menuItemHeight = recyclerViewHeight / recyclerViewItemCount
+
+    // We must take the menu container padding into account as this will be applied to the final height.
+    val containerPadding = containerViewHeight - recyclerViewHeight
+
+    val maxAvailableHeightForRecyclerView = availableHeight - containerPadding - menuStylePadding
+
+    // The number of menu items that can fit exactly (no cropping) within the max app height.
+    // Round the number of items to the closet Int value to ensure the max space available is utilized.
+    // E.g if 6.9 items fit, round to 7 so the calculation below will show 6.5 items instead of 5.5 .
+    val numberOfItemsFitExactly =
+        (maxAvailableHeightForRecyclerView.toFloat() / menuItemHeight.toFloat()).roundToInt()
+
+    val itemsAlreadyFitContainerHeight = recyclerViewItemCount <= numberOfItemsFitExactly
+
+    return if (itemsAlreadyFitContainerHeight) {
+        containerViewHeight
+    } else {
+        getCroppedMenuContainerHeight(numberOfItemsFitExactly, menuItemHeight, containerPadding)
+    }
+}
+
+private fun getAnimation(
+    fitsUp: Boolean,
+    fitsDown: Boolean,
+    drawingLeft: Boolean,
+    orientation: Orientation?,
+): Int {
+    val isUpOrientation = orientation == Orientation.UP
+    return when {
+        isUpOrientation && fitsUp -> if (drawingLeft) {
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightBottom
+        } else {
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftBottom
+        }
+        fitsDown -> if (drawingLeft) {
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightTop
+        } else {
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop
+        }
+        else -> if (drawingLeft) {
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRight
+        } else {
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeft
+        }
+    }
+}
+
+private fun getCroppedMenuContainerHeight(
+    numberOfItemsFitExactly: Int,
+    menuItemHeight: Int,
+    containerPadding: Int,
+): Int {
+    // The number of menu items that fit exactly, minus a half menu item (indicates more menu items exist).
+    val numberOfItemsFitWithOverflow = numberOfItemsFitExactly - HALF_MENU_ITEM
+    val updatedRecyclerViewHeight = (numberOfItemsFitWithOverflow * menuItemHeight).toInt()
+
+    return updatedRecyclerViewHeight + containerPadding
+}
+
+/**
+ * Data needed for menu positioning.
+ */
+data class MenuPositioningData(
+    /**
+     * [WindowManager#LayoutParams#x] of params the menu will be added with.
+     */
+    @Px val x: Int = 0,
+
+    /**
+     * [WindowManager#LayoutParams#y] of params the menu will be added with.
+     */
+    @Px val y: Int = 0,
+
+    /**
+     * [View#measuredHeight] of the menu.
+     */
+    @Px val containerHeight: Int = 0,
+
+    /**
+     * [PopupWindow#animationStyle] of the menu.
+     */
+    val animation: Int,
+)

--- a/android-components/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/ext/PopupWindow.kt
+++ b/android-components/components/browser/menu2/src/main/java/mozilla/components/browser/menu2/ext/PopupWindow.kt
@@ -4,21 +4,12 @@
 
 package mozilla.components.browser.menu2.ext
 
-import android.graphics.Rect
 import android.view.Gravity
 import android.view.View
 import android.widget.PopupWindow
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.PopupWindowCompat
-import androidx.recyclerview.widget.RecyclerView
-import mozilla.components.browser.menu2.R
+import mozilla.components.concept.menu.MenuStyle
 import mozilla.components.concept.menu.Orientation
-import mozilla.components.support.base.log.Log
-import mozilla.components.support.ktx.android.view.isRTL
-import kotlin.math.roundToInt
-
-const val HALF_MENU_ITEM = 0.5
 
 /**
  * If parameters passed are a valid configuration attempt to show a [PopupWindow].
@@ -29,226 +20,25 @@ internal fun PopupWindow.displayPopup(
     containerView: View,
     anchor: View,
     orientation: Orientation? = null,
+    style: MenuStyle? = null,
 ): Boolean {
-    // Measure menu.
-    val spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
-    containerView.measure(spec, spec)
+    val positioningData =
+        inferMenuPositioningData(containerView, anchor, style, orientation) ?: return false
 
-    val containerRecyclerView =
-        containerView.findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-    val recyclerViewAdapter = containerRecyclerView.adapter
-
-    if (recyclerViewAdapter == null) {
-        Log.log(
-            priority = Log.Priority.ERROR,
-            tag = "mozac-popupwindow",
-            message = "The browser menu recyclerview has no adapter set.",
-        )
-        return false
-    }
-
-    val containerViewHeight = containerView.measuredHeight
-    val recyclerViewHeight = containerRecyclerView.measuredHeight
-    val recyclerViewItemCount = recyclerViewAdapter.itemCount
-
-    val hasViewInitializedCorrectly =
-        containerViewHeight > 0 && recyclerViewHeight > 0 && recyclerViewItemCount > 0
-    if (!hasViewInitializedCorrectly) {
-        Log.log(
-            priority = Log.Priority.ERROR,
-            tag = "mozac-popupwindow",
-            message = "containerViewHeight: $containerViewHeight must be more than 0," +
-                "recyclerViewHeight: $recyclerViewHeight must be more than 0 &" +
-                "recyclerViewItemCount: $recyclerViewItemCount must be more than 0.",
-        )
-        return false
-    }
-
-    // Popup window does not need a input method. This avoids keyboard flicker when menu is opened.
     inputMethodMode = PopupWindow.INPUT_METHOD_NOT_NEEDED
 
-    showPopup(orientation, anchor, recyclerViewHeight, recyclerViewItemCount, containerViewHeight)
+    showAtAnchorLocation(anchor, positioningData)
     return true
-}
-
-/**
- * Show the [PopupWindow] with the required configuration.
- */
-private fun PopupWindow.showPopup(
-    orientation: Orientation?,
-    anchor: View,
-    recyclerViewHeight: Int,
-    recyclerViewItemCount: Int,
-    containerViewHeight: Int,
-) {
-    val calculatedContainerHeight =
-        calculateContainerHeight(recyclerViewHeight, recyclerViewItemCount, containerViewHeight, anchor)
-
-    when (orientation) {
-        Orientation.DOWN -> showPopupWithDownOrientation(anchor, calculatedContainerHeight)
-
-        Orientation.UP -> {
-            val availableHeightToTop = getMaxAvailableHeightToTopAndBottom(anchor).first
-
-            // This could include cases where the keyboard is being displayed.
-            if (calculatedContainerHeight > availableHeightToTop) {
-                showPopupWhereBestFits(anchor, calculatedContainerHeight)
-            } else {
-                showPopupWithUpOrientation(anchor, calculatedContainerHeight)
-            }
-        }
-
-        else -> showPopupWhereBestFits(anchor, calculatedContainerHeight)
-    }
-}
-
-/**
- * Determine whether the container view can display all menu items (without scrolling) within
- * the available height.
- *
- * @return The original container height if the container view can display all menu items
- * (without scrolling), else calculate the maximum available container height for a scrollable
- * view with a half menu item.
- */
-private fun calculateContainerHeight(
-    recyclerViewHeight: Int,
-    recyclerViewItemCount: Int,
-    containerViewHeight: Int,
-    anchor: View,
-): Int {
-    // Get the total screen display height.
-    val totalHeight = anchor.rootView.measuredHeight
-
-    // Note: We cannot use getWindowVisibleDisplayFrame() as the height is dynamic based on whether
-    // the keyboard is open.
-    // Get any displayed system bars e.g. top status bar, bottom navigation bar or soft buttons bar.
-    val systemBars =
-        ViewCompat.getRootWindowInsets(anchor)?.getInsets(WindowInsetsCompat.Type.systemBars())
-    // Store the vertical status bars.
-    val topSystemBarHeight = systemBars?.top ?: 0
-    val bottomSystemBarHeight = systemBars?.bottom ?: 0
-
-    // Deduct any status bar heights from the total height.
-    val availableHeight = totalHeight - (bottomSystemBarHeight + topSystemBarHeight)
-
-    val menuItemHeight = recyclerViewHeight / recyclerViewItemCount
-
-    // We must take the menu container padding into account as this will be applied to the final height.
-    val containerPadding = containerViewHeight - recyclerViewHeight
-
-    val maxAvailableHeightForRecyclerView = availableHeight - containerPadding
-
-    // The number of menu items that can fit exactly (no cropping) within the max app height.
-    // Round the number of items to the closet Int value to ensure the max space available is utilized.
-    // E.g if 6.9 items fit, round to 7 so the calculation below will show 6.5 items instead of 5.5 .
-    val numberOfItemsFitExactly =
-        (maxAvailableHeightForRecyclerView.toFloat() / menuItemHeight.toFloat()).roundToInt()
-
-    val itemsAlreadyFitContainerHeight = recyclerViewItemCount <= numberOfItemsFitExactly
-
-    return if (itemsAlreadyFitContainerHeight) {
-        containerViewHeight
-    } else {
-        getCroppedMenuContainerHeight(numberOfItemsFitExactly, menuItemHeight, containerPadding)
-    }
-}
-
-private fun getCroppedMenuContainerHeight(
-    numberOfItemsFitExactly: Int,
-    menuItemHeight: Int,
-    containerPadding: Int,
-): Int {
-    // The number of menu items that fit exactly, minus a half menu item (indicates more menu items exist).
-    val numberOfItemsFitWithOverflow = numberOfItemsFitExactly - HALF_MENU_ITEM
-    val updatedRecyclerViewHeight = (numberOfItemsFitWithOverflow * menuItemHeight).toInt()
-
-    return updatedRecyclerViewHeight + containerPadding
-}
-
-private fun PopupWindow.showPopupWhereBestFits(
-    anchor: View,
-    containerHeight: Int,
-) {
-    val (availableHeightToTop, availableHeightToBottom) = getMaxAvailableHeightToTopAndBottom(anchor)
-    val fitsUp = availableHeightToTop >= containerHeight
-    val fitsDown = availableHeightToBottom >= containerHeight
-
-    when {
-        // Not enough space to show the menu UP neither DOWN.
-        // Let's just show the popup at the location of the anchor.
-        !fitsUp && !fitsDown -> showAtAnchorLocation(anchor, containerHeight)
-        // Enough space to show menu down
-        fitsDown -> showPopupWithDownOrientation(anchor, containerHeight)
-        // Otherwise, show menu up
-        else -> showPopupWithUpOrientation(anchor, containerHeight)
-    }
-}
-
-private fun PopupWindow.showPopupWithUpOrientation(
-    anchor: View,
-    containerHeight: Int,
-) {
-    // Apply the best fit animation style based on positioning
-    animationStyle = if (anchor.isRTL) {
-        R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightBottom
-    } else {
-        R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftBottom
-    }
-    height = containerHeight
-
-    val yOffset = -containerHeight
-    showAsDropDown(anchor, 0, yOffset)
-}
-
-private fun PopupWindow.showPopupWithDownOrientation(
-    anchor: View,
-    containerHeight: Int,
-) {
-    // Apply the best fit animation style based on positioning
-    animationStyle = if (anchor.isRTL) {
-        R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightTop
-    } else {
-        R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop
-    }
-    height = containerHeight
-
-    PopupWindowCompat.setOverlapAnchor(this, true)
-    showAsDropDown(anchor)
 }
 
 private fun PopupWindow.showAtAnchorLocation(
     anchor: View,
-    containerHeight: Int,
+    positioningData: MenuPositioningData,
 ) {
-    val anchorPosition = IntArray(2)
-
     // Apply the best fit animation style based on positioning
-    animationStyle = if (anchor.isRTL) {
-        R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRight
-    } else {
-        R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeft
-    }
-    height = containerHeight
+    animationStyle = positioningData.animation
+    height = positioningData.containerHeight
 
-    anchor.getLocationInWindow(anchorPosition)
-    val (x, y) = anchorPosition
     PopupWindowCompat.setOverlapAnchor(this, true)
-    showAtLocation(anchor, Gravity.START or Gravity.TOP, x, y)
-}
-
-private fun getMaxAvailableHeightToTopAndBottom(anchor: View): Pair<Int, Int> {
-    val anchorPosition = IntArray(2)
-    val displayFrame = Rect()
-
-    val appView = anchor.rootView
-    appView.getWindowVisibleDisplayFrame(displayFrame)
-
-    anchor.getLocationOnScreen(anchorPosition)
-
-    val bottomEdge = displayFrame.bottom
-
-    val distanceToBottom = bottomEdge - (anchorPosition[1] + anchor.height)
-    val distanceToTop = anchorPosition[1] - displayFrame.top
-
-    return distanceToTop to distanceToBottom
+    showAtLocation(anchor, Gravity.NO_GRAVITY, positioningData.x, positioningData.y)
 }

--- a/android-components/components/browser/menu2/src/main/res/values/dimens.xml
+++ b/android-components/components/browser/menu2/src/main/res/values/dimens.xml
@@ -4,7 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <dimen name="mozac_browser_menu2_corner_radius">4dp</dimen>
-    <dimen name="mozac_browser_menu2_elevation">8dp</dimen>
+    <dimen name="mozac_browser_menu2_elevation">6dp</dimen>
     <dimen name="mozac_browser_menu2_width">250dp</dimen>
     <dimen name="mozac_browser_menu2_padding_vertical">0dp</dimen>
 

--- a/android-components/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/ext/PopupWindowTest.kt
+++ b/android-components/components/browser/menu2/src/test/java/mozilla/components/browser/menu2/ext/PopupWindowTest.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.browser.menu2.R
 import mozilla.components.browser.menu2.adapter.MenuCandidateListAdapter
+import mozilla.components.concept.menu.MenuStyle
 import mozilla.components.concept.menu.Orientation
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -40,293 +41,683 @@ private const val HALF_MENU_ITEM = 0.5
 /**
  * [PopupWindow] UI components.
  */
-private const val ANCHOR_ROOT_VIEW_HEIGHT = 1000
-private const val ANCHOR_ROOT_VIEW_WIDTH = 400
-private const val ITEM_HEIGHT = 50
-private const val CONTAINER_PADDING = 10
+private const val SCREEN_ROOT_VIEW_HEIGHT = 1000
+private const val SCREEN_ROOT_VIEW_WIDTH = 400
+private const val MENU_ITEM_HEIGHT = 50
+private const val DEFAULT_ITEM_COUNT = 10
+private const val MENU_CONTAINER_WIDTH = 100
+private const val MENU_CONTAINER_PADDING = 10
 
 @RunWith(AndroidJUnit4::class)
 class PopupWindowTest {
-
-    private lateinit var containerView: View
-    private lateinit var anchor: View
     private lateinit var popupWindow: PopupWindow
+    private lateinit var overlapStyle: MenuStyle
+    private lateinit var offsetStyle: MenuStyle
+    private lateinit var offsetOverlapStyle: MenuStyle
 
     @Before
     fun setUp() {
-        containerView = mock(View::class.java)
-        doReturn(createContainerRecyclerView()).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
+        overlapStyle = MenuStyle(completelyOverlap = true)
+        offsetStyle = MenuStyle(horizontalOffset = 10, verticalOffset = 10)
+        offsetOverlapStyle =
+            MenuStyle(completelyOverlap = true, horizontalOffset = 10, verticalOffset = 10)
 
         popupWindow = spy(PopupWindow())
     }
 
     @Test
     fun `WHEN recycler view has no adapter THEN show is never called`() {
-        val containerRecyclerView = createContainerRecyclerView(hasAdapter = false)
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-
-        anchor = mock(View::class.java)
+        val containerView = createContainerView(hasAdapter = false)
+        val anchor = mock(View::class.java)
 
         assertFalse(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
 
-        verify(popupWindow, never()).showAsDropDown(any())
-        verify(popupWindow, never()).showAsDropDown(any(), anyInt(), anyInt())
         verify(popupWindow, never()).showAtLocation(any(), anyInt(), anyInt(), anyInt())
     }
 
     @Test
     fun `WHEN container view has no measured height THEN show is never called`() {
-        val containerRecyclerView = createContainerRecyclerView()
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-        `when`(containerView.measuredHeight).thenReturn(0)
+        val containerView = createContainerView()
+        val anchor = mock(View::class.java)
 
-        anchor = mock(View::class.java)
+        `when`(containerView.measuredHeight).thenReturn(0)
 
         assertFalse(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
 
-        verify(popupWindow, never()).showAsDropDown(any())
-        verify(popupWindow, never()).showAsDropDown(any(), anyInt(), anyInt())
+        verify(popupWindow, never()).showAtLocation(any(), anyInt(), anyInt(), anyInt())
+    }
+
+    @Test
+    fun `WHEN container view has no measured width THEN show is never called`() {
+        val containerView = createContainerView()
+        val anchor = mock(View::class.java)
+
+        `when`(containerView.measuredWidth).thenReturn(0)
+
+        assertFalse(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
+
         verify(popupWindow, never()).showAtLocation(any(), anyInt(), anyInt(), anyInt())
     }
 
     @Test
     fun `WHEN recycler view has no measured height THEN show is never called`() {
-        val containerRecyclerView = createContainerRecyclerView(recyclerViewHeight = 0)
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
-
-        anchor = mock(View::class.java)
+        val containerView = createContainerView(recyclerViewHeight = 0)
+        val anchor = mock(View::class.java)
 
         assertFalse(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
 
-        verify(popupWindow, never()).showAsDropDown(any())
-        verify(popupWindow, never()).showAsDropDown(any(), anyInt(), anyInt())
         verify(popupWindow, never()).showAtLocation(any(), anyInt(), anyInt(), anyInt())
     }
 
     @Test
     fun `WHEN recycler view has no items THEN show is never called`() {
-        val containerRecyclerView =
-            createContainerRecyclerView(recyclerViewHeight = 100, itemCount = 0)
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
-
-        anchor = mock(View::class.java)
+        val containerView = createContainerView(recyclerViewHeight = 100, itemCount = 0)
+        val anchor = mock(View::class.java)
 
         assertFalse(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
 
-        verify(popupWindow, never()).showAsDropDown(any())
-        verify(popupWindow, never()).showAsDropDown(any(), anyInt(), anyInt())
         verify(popupWindow, never()).showAtLocation(any(), anyInt(), anyInt(), anyInt())
     }
 
     @Test
-    fun `WHEN orientation up & fits available height THEN showAsDropDown with original height & positioned from the bottom of the anchor with leftBottomAnimation`() {
-        val containerRecyclerView = createContainerRecyclerView()
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
+    fun `WHEN orientation up & fits available height THEN showAtLocation with original height & positioned from the bottom of the anchor with leftBottomAnimation`() {
+        val containerView = createContainerView()
 
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
-
-        anchor = createAnchor(20, ANCHOR_ROOT_VIEW_HEIGHT - 20)
+        val (x, y) = 20 to SCREEN_ROOT_VIEW_HEIGHT - 20
+        val anchor = createAnchor(x, y)
 
         assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
 
-        assertEquals(containerHeight, popupWindow.height)
+        assertEquals(containerView.measuredHeight, popupWindow.height)
         assertEquals(
             R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftBottom,
             popupWindow.animationStyle,
         )
-        verify(popupWindow).showAsDropDown(anchor, 0, -containerHeight)
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
     }
 
     @Test
-    fun `WHEN orientation up & fits available height & is RTL THEN showAsDropDown with original height & positioned from the bottom of the anchor with rightBottomAnimation`() {
-        val containerRecyclerView = createContainerRecyclerView()
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
+    fun `WHEN orientation up & fits available height & is RTL THEN showAtLocation with original height & positioned from the bottom right of the anchor with rightBottomAnimation`() {
+        val containerView = createContainerView()
 
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
-
-        anchor = createAnchor(ANCHOR_ROOT_VIEW_WIDTH - 20, ANCHOR_ROOT_VIEW_HEIGHT - 20, true)
+        val (x, y) = SCREEN_ROOT_VIEW_WIDTH - 20 to SCREEN_ROOT_VIEW_HEIGHT - 20
+        val anchor = createAnchor(x, y, true)
 
         assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
 
-        assertEquals(containerHeight, popupWindow.height)
+        assertEquals(containerView.measuredHeight, popupWindow.height)
         assertEquals(
             R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightBottom,
             popupWindow.animationStyle,
         )
-        verify(popupWindow).showAsDropDown(anchor, 0, -containerHeight)
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, directionRight = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
     }
 
     @Test
-    fun `WHEN orientation up & does not fit available height THEN showAtLocation with original height & positioned from the bottom of the anchor with leftAnimation`() {
-        val containerRecyclerView = createContainerRecyclerView()
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
+    fun `WHEN orientation up & does not fit available height & fits down THEN showAtLocation with original height & positioned from the top left of the anchor with leftTopAnimation`() {
+        val containerView = createContainerView()
 
         val (x, y) = 20 to 25
-        anchor = createAnchor(x, y)
+        val anchor = createAnchor(x, y)
 
         assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
 
-        assertEquals(containerHeight, popupWindow.height)
-        assertEquals(
-            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeft,
-            popupWindow.animationStyle,
-        )
-        verify(popupWindow).showAtLocation(anchor, Gravity.START or Gravity.TOP, x, y)
-    }
-
-    @Test
-    fun `WHEN orientation up & does not fit available height & is RTL THEN showAtLocation with original height & positioned from the bottom of the anchor with rightAnimation`() {
-        val containerRecyclerView = createContainerRecyclerView()
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
-
-        val (x, y) = ANCHOR_ROOT_VIEW_HEIGHT - 20 to 25
-        anchor = createAnchor(x, y, true)
-
-        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
-
-        assertEquals(containerHeight, popupWindow.height)
-        assertEquals(
-            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRight,
-            popupWindow.animationStyle,
-        )
-        verify(popupWindow).showAtLocation(anchor, Gravity.START or Gravity.TOP, x, y)
-    }
-
-    @Test
-    fun `WHEN orientation down & fits available height THEN showAsDropDown with original height & positioned from the top of the anchor with leftTopAnimation`() {
-        val containerRecyclerView = createContainerRecyclerView()
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
-
-        anchor = createAnchor(20, 25)
-
-        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.DOWN))
-
-        assertEquals(containerHeight, popupWindow.height)
+        assertEquals(containerView.measuredHeight, popupWindow.height)
         assertEquals(
             R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop,
             popupWindow.animationStyle,
         )
-        verify(popupWindow).showAsDropDown(anchor)
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
     }
 
     @Test
-    fun `WHEN orientation down & fits available height & is RTL THEN showAsDropDown with original height & positioned from the top of the anchor with rightTopAnimation`() {
-        val containerRecyclerView = createContainerRecyclerView()
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
+    fun `WHEN orientation up & does not fit up or down THEN showAtLocation with original height & positioned from the top left of the anchor with leftAnimation`() {
+        val containerView = createContainerView()
 
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
+        val notEnoughHeight = containerView.measuredHeight.minus(MENU_CONTAINER_PADDING).minus(1)
+        val (x, y) = 20 to notEnoughHeight
+        val anchor = createAnchor(x, y)
 
-        anchor = createAnchor(ANCHOR_ROOT_VIEW_WIDTH - 20, 25, true)
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeft,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN orientation up & does not fit up or down & is RTL THEN showAtLocation with original height & positioned from the bottom right of the anchor with rightAnimation`() {
+        val containerView = createContainerView()
+
+        val notEnoughHeight = containerView.measuredHeight.minus(MENU_CONTAINER_PADDING).minus(1)
+        val (x, y) = SCREEN_ROOT_VIEW_HEIGHT - 20 to notEnoughHeight
+        val anchor = createAnchor(x, y, true)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRight,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, directionRight = false, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN orientation down & fits available height THEN showAtLocation with original height & positioned from the top left of the anchor with leftTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to 25
+        val anchor = createAnchor(x, y)
 
         assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.DOWN))
 
-        assertEquals(containerHeight, popupWindow.height)
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN orientation down & fits available height & is RTL THEN showAtLocation with original height & positioned from the top right of the anchor with rightTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = SCREEN_ROOT_VIEW_WIDTH - 20 to 25
+        val anchor = createAnchor(x, y, true)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.DOWN))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
         assertEquals(
             R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightTop,
             popupWindow.animationStyle,
         )
-        verify(popupWindow).showAsDropDown(anchor)
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, directionRight = false, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
     }
 
     @Test
     fun `WHEN number of menu items don't fit available height THEN set popup with calculated height`() {
-        val containerRecyclerView = createContainerRecyclerView(itemCount = 22)
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
-
-        anchor = createAnchor(20, 25)
+        val containerView = createContainerView(itemCount = 22)
+        val anchor = createAnchor(20, 25)
 
         assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP))
 
         val availableHeight = anchor.rootView.measuredHeight
-        val maxAvailableHeightForRecyclerView = availableHeight - CONTAINER_PADDING
+        val maxAvailableHeightForRecyclerView = availableHeight - MENU_CONTAINER_PADDING
         val numberOfItemsFitExactly =
-            (maxAvailableHeightForRecyclerView.toFloat() / ITEM_HEIGHT.toFloat()).roundToInt()
+            (maxAvailableHeightForRecyclerView.toFloat() / MENU_ITEM_HEIGHT.toFloat()).roundToInt()
         val numberOfItemsFitWithOverFlow = numberOfItemsFitExactly - HALF_MENU_ITEM
-        val updatedRecyclerViewHeight = (numberOfItemsFitWithOverFlow * ITEM_HEIGHT).toInt()
-        val calculatedHeight = updatedRecyclerViewHeight + CONTAINER_PADDING
+        val updatedRecyclerViewHeight = (numberOfItemsFitWithOverFlow * MENU_ITEM_HEIGHT).toInt()
+        val calculatedHeight = updatedRecyclerViewHeight + MENU_CONTAINER_PADDING
 
         assertEquals(calculatedHeight, popupWindow.height)
     }
 
     @Test
-    fun `WHEN orientation is null THEN showAtAnchorLocation is called with the anchor info & default gravity`() {
-        val containerRecyclerView = createContainerRecyclerView()
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
-
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
+    fun `WHEN orientation is null & menu fits down THEN showAtLocation with original height & positioned from the top left of the anchor with leftTopAnimation`() {
+        val containerView = createContainerView()
 
         val (x, y) = 20 to 25
-        anchor = createAnchor(x, y)
+        val anchor = createAnchor(x, y)
 
         assertTrue(popupWindow.displayPopup(containerView, anchor))
 
-        assertEquals(containerHeight, popupWindow.height)
+        assertEquals(containerView.measuredHeight, popupWindow.height)
         assertEquals(
-            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeft,
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop,
             popupWindow.animationStyle,
         )
-        verify(popupWindow).showAtLocation(anchor, Gravity.START or Gravity.TOP, x, y)
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
     }
 
     @Test
-    fun `WHEN orientation is null & is RTL THEN showAtAnchorLocation is called with the anchor info & default gravity`() {
-        val containerRecyclerView = createContainerRecyclerView(itemCount = 20)
-        doReturn(containerRecyclerView).`when`(containerView)
-            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
+    fun `WHEN orientation is null & menu does not fit & is RTL THEN showAtLocation with original height & positioned from the top right of the anchor with rightAnimation`() {
+        val containerView = createContainerView(itemCount = 20)
 
-        val containerHeight = containerRecyclerView.measuredHeight.plus(CONTAINER_PADDING)
-        `when`(containerView.measuredHeight).thenReturn(containerHeight)
-
-        val (x, y) = ANCHOR_ROOT_VIEW_WIDTH - 20 to 25
-        anchor = createAnchor(x, y, true)
+        val (x, y) = SCREEN_ROOT_VIEW_WIDTH - 20 to 25
+        val anchor = createAnchor(x, y, true)
 
         assertTrue(popupWindow.displayPopup(containerView, anchor))
 
-        assertEquals(containerHeight, popupWindow.height)
+        assertEquals(containerView.measuredHeight, popupWindow.height)
         assertEquals(
             R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRight,
             popupWindow.animationStyle,
         )
-        verify(popupWindow).showAtLocation(anchor, Gravity.START or Gravity.TOP, x, y)
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, directionRight = false, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
     }
 
-    private fun createContainerRecyclerView(
-        itemCount: Int = 10,
+    @Test
+    fun `WHEN should completely overlap & orientation up & fits up THEN showAtLocation with original height & bottom of the menu positioned exactly to the bottom of the anchor with leftBottomAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to SCREEN_ROOT_VIEW_HEIGHT - 20
+        val anchor = createAnchor(x, y)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, overlapStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftBottom,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, overlapStyle)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should completely overlap & orientation up & fits up & is RTL THEN showAtLocation with original height & bottom right of the menu positioned exactly to the bottom right of the anchor with rightBottomAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = SCREEN_ROOT_VIEW_WIDTH - 20 to SCREEN_ROOT_VIEW_HEIGHT - 20
+        val anchor = createAnchor(x, y, true)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, overlapStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightBottom,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, overlapStyle, directionRight = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should completely overlap & orientation down & fits down THEN showAtLocation with original height & positioned exactly from the top of the anchor with leftTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to 25
+        val anchor = createAnchor(x, y)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.DOWN, overlapStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, overlapStyle, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should completely overlap & orientation down & fits down & is RTL THEN showAtLocation with original height & positioned exactly from the top of the anchor with rightTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = SCREEN_ROOT_VIEW_WIDTH - 20 to 25
+        val anchor = createAnchor(x, y, true)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.DOWN, overlapStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, overlapStyle, directionUp = false, directionRight = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should completely overlap & orientation up & does not fit up & fits down THEN showAtLocation with original height & positioned exactly from the top left of the anchor with leftTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to 25
+        val anchor = createAnchor(x, y)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, overlapStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, overlapStyle, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should completely overlap & orientation up & does not fit up or down THEN showAtLocation with original height & positioned exactly from the top left of the anchor with leftAnimation`() {
+        val containerView = createContainerView()
+
+        val notEnoughHeight = containerView.measuredHeight.minus(MENU_CONTAINER_PADDING).minus(1)
+        val (x, y) = 20 to notEnoughHeight
+        val anchor = createAnchor(x, y)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, overlapStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeft,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, overlapStyle, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN has style offsets & orientation up & fits up THEN showAtLocation with original height & positioned from the bottom left of the anchor with applied offsets and leftBottomAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to SCREEN_ROOT_VIEW_HEIGHT - 20
+        val anchor = createAnchor(x, y)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, offsetStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftBottom,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetStyle)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN has style offsets & orientation up & fits up & is RTL THEN showAtLocation with original height & positioned from the bottom right of the anchor with applied offsets and rightBottomAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = SCREEN_ROOT_VIEW_WIDTH - 20 to SCREEN_ROOT_VIEW_HEIGHT - 20
+        val anchor = createAnchor(x, y, true)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, offsetStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightBottom,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetStyle, directionRight = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN has style offsets & orientation down & fits down THEN showAtLocation with original height & positioned from the top left of the anchor with applied offsets and leftTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to 25
+        val anchor = createAnchor(x, y)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, offsetStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetStyle, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN has style offsets & orientation down & fits down & is RTL THEN showAtLocation with original height & positioned from the top right of the anchor with applied offsets and rightTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = SCREEN_ROOT_VIEW_WIDTH - 20 to 25
+        val anchor = createAnchor(x, y, true)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, offsetStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetStyle, directionUp = false, directionRight = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN has style offsets & orientation up & does not fit up & fits down THEN showAtLocation with original height & positioned from the top left of the anchor with applied offsets and leftAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to 25
+        val anchor = createAnchor(x, y)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, offsetStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetStyle, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN has style offsets & orientation up & does not fit up or down THEN showAtLocation with original height & positioned from the top left of the anchor with applied offsets leftAnimation`() {
+        val containerView = createContainerView()
+
+        val notEnoughHeight = containerView.measuredHeight.minus(MENU_CONTAINER_PADDING).minus(1)
+        val (x, y) = 20 to notEnoughHeight
+        val anchor = createAnchor(x, y)
+
+        assertTrue(popupWindow.displayPopup(containerView, anchor, Orientation.UP, offsetStyle))
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeft,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetStyle, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should overlap & has style offsets & orientation up & fits up THEN showAtLocation with original height & positioned exactly from the bottom left of the anchor with applied offsets leftBottomAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to SCREEN_ROOT_VIEW_HEIGHT - 20
+        val anchor = createAnchor(x, y)
+
+        assertTrue(
+            popupWindow.displayPopup(
+                containerView,
+                anchor,
+                Orientation.UP,
+                offsetOverlapStyle,
+            ),
+        )
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftBottom,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetOverlapStyle)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should overlap & has style offsets & orientation up & fits up & is RTL THEN showAtLocation with original height & positioned exactly to the bottom right of the anchor with applied offsets rightBottomAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = SCREEN_ROOT_VIEW_WIDTH - 20 to SCREEN_ROOT_VIEW_HEIGHT - 20
+        val anchor = createAnchor(x, y, true)
+
+        assertTrue(
+            popupWindow.displayPopup(
+                containerView,
+                anchor,
+                Orientation.UP,
+                offsetOverlapStyle,
+            ),
+        )
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightBottom,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetOverlapStyle, directionRight = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should overlap & has style offsets & orientation down & fits down THEN showAsDropDown with original height & positioned exactly from the top of the anchor with applied offsets leftTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to 25
+        val anchor = createAnchor(x, y)
+
+        assertTrue(
+            popupWindow.displayPopup(
+                containerView,
+                anchor,
+                Orientation.UP,
+                offsetOverlapStyle,
+            ),
+        )
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetOverlapStyle, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should overlap & has style offsets & orientation down & fits down & is RTL THEN showAsDropDown with original height & positioned exactly from the top of the anchor with applied offsets and rightTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = SCREEN_ROOT_VIEW_WIDTH - 20 to 25
+        val anchor = createAnchor(x, y, true)
+
+        assertTrue(
+            popupWindow.displayPopup(
+                containerView,
+                anchor,
+                Orientation.UP,
+                offsetOverlapStyle,
+            ),
+        )
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuRightTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetOverlapStyle, directionUp = false, directionRight = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should overlap & has style offsets & orientation up & fits down only THEN showAtLocation with original height & positioned exactly from the top left of the anchor with applied offsets and leftTopAnimation`() {
+        val containerView = createContainerView()
+
+        val (x, y) = 20 to 25
+        val anchor = createAnchor(x, y)
+
+        assertTrue(
+            popupWindow.displayPopup(
+                containerView,
+                anchor,
+                Orientation.UP,
+                offsetOverlapStyle,
+            ),
+        )
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeftTop,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetOverlapStyle, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    @Test
+    fun `WHEN should overlap & has style offsets & orientation up & does not fit up or down THEN showAtLocation with original height & positioned exactly from the top left of the anchor with applied offsets and leftAnimation`() {
+        val containerView = createContainerView()
+
+        val notEnoughHeight = containerView.measuredHeight.minus(MENU_CONTAINER_PADDING).minus(1)
+        val (x, y) = 20 to notEnoughHeight
+        val anchor = createAnchor(x, y)
+
+        assertTrue(
+            popupWindow.displayPopup(
+                containerView,
+                anchor,
+                Orientation.UP,
+                offsetOverlapStyle,
+            ),
+        )
+
+        assertEquals(containerView.measuredHeight, popupWindow.height)
+        assertEquals(
+            R.style.Mozac_Browser_Menu2_Animation_OverflowMenuLeft,
+            popupWindow.animationStyle,
+        )
+
+        val (targetX, targetY) = getTargetCoordinates(x, y, containerView, anchor, offsetOverlapStyle, directionUp = false)
+        verify(popupWindow).showAtLocation(anchor, Gravity.NO_GRAVITY, targetX, targetY)
+    }
+
+    private fun createContainerView(
+        itemCount: Int = DEFAULT_ITEM_COUNT,
+        hasAdapter: Boolean = true,
+        recyclerViewHeight: Int? = null,
+    ): View {
+        val containerView = mock(View::class.java)
+
+        // Mimicking elevation added spacing.
+        val recyclerView = createRecyclerView(itemCount, hasAdapter, recyclerViewHeight)
+        val containerHeight = recyclerView.measuredHeight.plus(MENU_CONTAINER_PADDING)
+        val containerWidth = recyclerView.measuredWidth.plus(MENU_CONTAINER_PADDING)
+        `when`(containerView.measuredHeight).thenReturn(containerHeight)
+        `when`(containerView.measuredWidth).thenReturn(containerWidth)
+
+        doReturn(recyclerView).`when`(containerView)
+            .findViewById<RecyclerView>(R.id.mozac_browser_menu_recyclerView)
+        return containerView
+    }
+
+    private fun createRecyclerView(
+        itemCount: Int = DEFAULT_ITEM_COUNT,
         hasAdapter: Boolean = true,
         recyclerViewHeight: Int? = null,
     ): RecyclerView {
@@ -340,8 +731,10 @@ class PopupWindowTest {
 
         `when`(recyclerView.measuredHeight).thenReturn(
             recyclerViewHeight
-                ?: (itemCount * ITEM_HEIGHT),
+                ?: (itemCount * MENU_ITEM_HEIGHT),
         )
+
+        `when`(recyclerView.measuredWidth).thenReturn(MENU_CONTAINER_WIDTH)
 
         return recyclerView
     }
@@ -382,12 +775,85 @@ class PopupWindowTest {
         doAnswer { invocation ->
             val displayFrame = (invocation.getArgument(0) as Rect)
             displayFrame.left = 0
-            displayFrame.right = ANCHOR_ROOT_VIEW_WIDTH
+            displayFrame.right = SCREEN_ROOT_VIEW_WIDTH
+            displayFrame.bottom = SCREEN_ROOT_VIEW_HEIGHT
             displayFrame
         }.`when`(view).getWindowVisibleDisplayFrame(any())
 
-        `when`(view.measuredHeight).thenReturn(ANCHOR_ROOT_VIEW_HEIGHT)
+        `when`(view.measuredHeight).thenReturn(SCREEN_ROOT_VIEW_HEIGHT)
 
         return view
+    }
+
+    private fun getTargetCoordinates(
+        anchorX: Int,
+        anchorY: Int,
+        containerView: View,
+        anchor: View,
+        style: MenuStyle? = null,
+        directionUp: Boolean = true,
+        directionRight: Boolean = true,
+    ): Pair<Int, Int> {
+        val targetX = getTargetX(
+            anchorX,
+            containerView,
+            anchor,
+            directionRight,
+            style?.completelyOverlap ?: false,
+            style?.horizontalOffset ?: 0,
+        )
+        val targetY = getTargetY(
+            anchorY,
+            containerView,
+            anchor,
+            directionUp,
+            style?.completelyOverlap ?: false,
+            style?.verticalOffset ?: 0,
+        )
+        return targetX to targetY
+    }
+
+    private fun getTargetX(
+        anchorX: Int,
+        containerView: View,
+        anchor: View,
+        directionRight: Boolean,
+        shouldOverlap: Boolean,
+        horizontalOffset: Int,
+    ): Int {
+        val targetX = when {
+            directionRight && shouldOverlap -> anchorX - (MENU_CONTAINER_PADDING / 2)
+            directionRight && !shouldOverlap -> anchorX
+            !directionRight && shouldOverlap -> anchorX - (containerView.measuredWidth - anchor.width) + (MENU_CONTAINER_PADDING / 2)
+            else -> anchorX - (containerView.measuredWidth - anchor.width)
+        }
+
+        return if (directionRight) {
+            targetX + horizontalOffset
+        } else {
+            targetX - horizontalOffset
+        }
+    }
+
+    private fun getTargetY(
+        anchorY: Int,
+        containerView: View,
+        anchor: View,
+        directionUp: Boolean,
+        shouldOverlap: Boolean,
+        verticalOffset: Int,
+    ): Int {
+        val targetY = when {
+            directionUp && shouldOverlap -> anchorY - (containerView.measuredHeight - anchor.height) + (MENU_CONTAINER_PADDING / 2)
+            directionUp && !shouldOverlap -> anchorY - (containerView.measuredHeight - anchor.height)
+            !directionUp && shouldOverlap -> anchorY - (MENU_CONTAINER_PADDING / 2)
+            else -> anchorY
+        }
+
+        return if (directionUp) {
+            targetY - verticalOffset
+        } else {
+            targetY + verticalOffset
+        }
     }
 }

--- a/android-components/components/concept/menu/src/main/java/mozilla/components/concept/menu/MenuStyle.kt
+++ b/android-components/components/concept/menu/src/main/java/mozilla/components/concept/menu/MenuStyle.kt
@@ -14,19 +14,31 @@ import androidx.annotation.Px
  * @property backgroundColor Custom background color for the menu.
  * @property minWidth Custom minimum width for the menu.
  * @property maxWidth Custom maximum width for the menu.
+ * @property horizontalOffset Custom horizontal offset for the menu.
+ * @property verticalOffset Custom vertical offset for the menu.
+ * @property completelyOverlap Forces menu to overlap the anchor completely.
  */
 data class MenuStyle(
     val backgroundColor: ColorStateList? = null,
     @Px val minWidth: Int? = null,
     @Px val maxWidth: Int? = null,
+    @Px val horizontalOffset: Int? = null,
+    @Px val verticalOffset: Int? = null,
+    val completelyOverlap: Boolean = false,
 ) {
     constructor(
         @ColorInt backgroundColor: Int,
         @Px minWidth: Int? = null,
         @Px maxWidth: Int? = null,
+        @Px horizontalOffset: Int? = null,
+        @Px verticalOffset: Int? = null,
+        completelyOverlap: Boolean = false,
     ) : this(
         backgroundColor = ColorStateList.valueOf(backgroundColor),
         minWidth = minWidth,
         maxWidth = maxWidth,
+        horizontalOffset = horizontalOffset,
+        verticalOffset = verticalOffset,
+        completelyOverlap = completelyOverlap,
     )
 }


### PR DESCRIPTION
Adds settings to account for spacing between the menu view and the list (created by `elevation` + `cardUseCompatPadding`) and setting extra offset to shift the item even further. 

I followed the approach that was implemented in the `BrowserMenu.v1` with calculating parameters separately and storing them in `MenuPositioningData` class.

NB: in order it work, we have to pass the [search_selector](https://searchfox.org/mozilla-mobile/source/fenix/app/src/main/res/layout/search_selector.xml#12), not the view with the same icon from the `HomeFragment` as it has a different size (added margins).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



























### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=27998