### PR TITLE
Bug 1806411: Remove image link from message when sharing an image

### DIFF
--- a/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/share/ShareDownloadFeature.kt
+++ b/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/share/ShareDownloadFeature.kt
@@ -55,12 +55,6 @@ internal const val DEFAULT_IMAGE_EXTENSION = "jpg"
 private const val OPERATION_TIMEOUT_MILLIS = 1000L
 
 /**
- * At most characters to be sent for subject / message in the share to operation.
- */
-@VisibleForTesting
-internal const val CHARACTERS_IN_SHARE_TEXT_LIMIT = 200
-
-/**
  * Subdirectory of Context.getCacheDir() where the resources to be shared are stored.
  *
  * Location must be kept in sync with the paths our FileProvider can share from.
@@ -147,7 +141,6 @@ class ShareDownloadFeature(
                 share(
                     contentType = internetResource.contentType,
                     filePath = download.canonicalPath,
-                    message = sanitizeLongUrls(internetResource.url),
                 )
             }
         }
@@ -217,22 +210,5 @@ class ShareDownloadFeature(
     internal fun cleanupCache() {
         logger.debug("Deleting previous cache of shared files")
         getCacheDirectory().listFiles()?.forEach { it.delete() }
-    }
-
-    /**
-     * Ensure url is not too long to be cumbersome from a UX standpoint.
-     *
-     * @param url to check
-     * @return new [String]
-     *   - with at most [CHARACTERS_IN_SHARE_TEXT_LIMIT] characters for HTTP URLs
-     *   - empty for data URLs
-     */
-    @VisibleForTesting
-    internal fun sanitizeLongUrls(url: String): String {
-        return if (url.startsWith("data")) {
-            ""
-        } else {
-            url.take(CHARACTERS_IN_SHARE_TEXT_LIMIT)
-        }
     }
 }

--- a/android-components/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/share/ShareDownloadFeatureTest.kt
+++ b/android-components/components/feature/downloads/src/test/java/mozilla/components/feature/downloads/share/ShareDownloadFeatureTest.kt
@@ -141,39 +141,7 @@ class ShareDownloadFeatureTest {
         shareFeature.startSharing(shareState)
 
         verify(shareFeature).download(shareState)
-        verify(shareFeature).share(downloadedFile.canonicalPath, "contentType", null, "testUrl")
-        Unit
-    }
-
-    @Test
-    fun `startSharing() will not use a too long HTTP url as message`() = runTestOnMain {
-        val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
-        val maxSizeUrl = "a".repeat(CHARACTERS_IN_SHARE_TEXT_LIMIT)
-        val tooLongUrl = maxSizeUrl + 'x'
-        val shareState = ShareInternetResourceState(url = tooLongUrl, contentType = "contentType")
-        val downloadedFile = File("filePath")
-        doReturn(downloadedFile).`when`(shareFeature).download(any())
-        shareFeature.scope = scope
-
-        shareFeature.startSharing(shareState)
-
-        verify(shareFeature).download(shareState)
-        verify(shareFeature).share(downloadedFile.canonicalPath, "contentType", null, maxSizeUrl)
-        Unit
-    }
-
-    @Test
-    fun `startSharing() will use an empty String as message for data URLs`() = runTestOnMain {
-        val shareFeature = spy(ShareDownloadFeature(context, mock(), mock(), null))
-        val shareState = ShareInternetResourceState(url = "data:image/png;base64,longstring", contentType = "contentType")
-        val downloadedFile = File("filePath")
-        doReturn(downloadedFile).`when`(shareFeature).download(any())
-        shareFeature.scope = scope
-
-        shareFeature.startSharing(shareState)
-
-        verify(shareFeature).download(shareState)
-        verify(shareFeature).share(downloadedFile.canonicalPath, "contentType", null, "")
+        verify(shareFeature).share(downloadedFile.canonicalPath, "contentType", null, null)
         Unit
     }
 
@@ -331,26 +299,5 @@ class ShareDownloadFeatureTest {
         val result = shareFeature.getFileExtension(gifHeaders, mock())
 
         assertEquals("gif", result)
-    }
-
-    @Test
-    fun `sanitizeLongUrls should return an empty string for a data url`() {
-        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
-
-        val result = shareFeature.sanitizeLongUrls("data:image/png;base64,longstring")
-
-        assertEquals("", result)
-    }
-
-    @Test
-    fun `sanitizeLongUrls should return at most CHARACTERS_IN_SHARE_TEXT_LIMIT for HTTP urls`() {
-        val maxSizeUrl = "a".repeat(CHARACTERS_IN_SHARE_TEXT_LIMIT)
-        val tooLongUrl = maxSizeUrl + 'x'
-        val shareFeature = ShareDownloadFeature(context, mock(), mock(), null)
-
-        val result = shareFeature.sanitizeLongUrls(tooLongUrl)
-
-        assertEquals(CHARACTERS_IN_SHARE_TEXT_LIMIT, result.length)
-        assertEquals(maxSizeUrl, result)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **feature-share**
+  * 🚒 Bug fixed [bug #1806411](https://bugzilla.mozilla.org/show_bug.cgi?id=1806411). Remove image link from share message when sharing an image.
+
 * **concept-engine**
 * 🆕 Added `CookieBannerMode.MODE_DETECT_ONLY`, this help to dected cookie banner events without handle the banners see [bug #1806435](https://bugzilla.mozilla.org/show_bug.cgi?id=1804594)
 


### PR DESCRIPTION

https://user-images.githubusercontent.com/32488956/208445056-f8343b50-dac7-480a-9ff8-3c00f1b7d02a.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
