### PR TITLE
Bug 1806432 - Upload android-components to maven.mozilla.org in the `push` graph

### DIFF
--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -28,8 +28,7 @@ task-template:
     description: Publish component
     maven-destination: 'maven2/org/mozilla/components/{component}/{version}/{artifact_file_name}'
     run-on-tasks-for: []
-    # TODO: Publish components during the shipping phase once Fenix is migrated to the monorepo
-    shipping-phase: promote
+    shipping-phase: push
     treeherder:
         job-symbol:
             by-build-type:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -234,5 +234,7 @@ release-promotion:
     flavors:
         promote:
             target-tasks-method: promote
+        push:
+            target-tasks-method: push
         ship:
             target-tasks-method: ship

--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -42,7 +42,7 @@ task-template:
                 '3': false
                 default: true
         product: focus-android
-    shipping-phase: promote     # APKs are sent to testing tracks
+    shipping-phase: push     # APKs are sent to testing tracks
     treeherder:
         job-symbol:
             by-build-type:

--- a/taskcluster/test/params/main-repo-push-beta.yml
+++ b/taskcluster/test/params/main-repo-push-beta.yml
@@ -1,0 +1,52 @@
+base_ref: releases_v109
+base_repository: https://github.com/mozilla-mobile/firefox-android
+base_rev: 9091c35b063e78f7718cfabc4e5027bb24476933
+build_date: 1670958313
+build_number: 3
+do_not_optimize: []
+enable_always_target: true
+existing_tasks:
+  build-apk-focus-android-test-beta: GulO8hgwR06jcUkpZzRepw
+  build-apk-focus-android-test-debug: eTW_HhAuR8SscG_1fpMCoQ
+  build-apk-focus-beta-firebase: c1aE9qDrRiG1mNiT6IWEnQ
+  build-apk-focus-debug: NHDODD5lTqmvEAX0tnEk-A
+  build-docker-image-android-build: FV4s6mdvSN-Oar7m-q1FXQ
+  build-docker-image-base: ESJNzsUUQuqpCRy9V07EwQ
+  build-docker-image-ui-tests: dmeBJHAqQ4KM_-pig0vSOw
+  build-samples-browser-gecko: FSKj2itwS3y0IYPqVuqrlg
+  build-samples-browser-system: QYI_ywAhS0mmfRcI6BwFNA
+  complete-push: Hec-pdMqRbi9HGMXxtNWpA
+  complete-push-1: bEcFsUmWRJic_gqfwwTMZw
+  complete-push-2: NORkIkoEQNWodLdH_TKcvA
+  fetch-android-sdk-3859397: cO7NDIrPRsidIL_1e0vtHg
+  signing-apk-focus-android-test-beta: fKuuYDv6SZ6EJttH_WydKA
+  signing-apk-focus-android-test-debug: OTAvF1wDRhmwXvIudH3K7A
+  signing-apk-focus-beta-firebase: MrGnD5O0Qjaf0TSKwJrAcQ
+  signing-apk-focus-debug: EH9LAwLCTxCikF-bCvzSKA
+  test-focus-debug: bd2ua6_ITsazB5vFp1Mq1g
+  toolchain-linux64-android-gradle-dependencies: JIgBEJMNRDSPlgDcoTXyqg
+  toolchain-linux64-android-sdk-linux-repack: DosXH3FyTFGjz9vH9bKVJg
+  ui-test-focus-arm-beta: RguHFzRrST6nHjL8wMihBw
+  ui-test-focus-arm-debug: A0R9EF61RqWmEGfjCXN-Rg
+filters:
+- target_tasks_method
+head_ref: releases_v109
+head_repository: https://github.com/mozilla-mobile/firefox-android
+head_rev: 643bd70bbb9a1850cfa2cc1e8b20ea2ed39d596f
+head_tag: v109.0b1
+level: '3'
+moz_build_date: '20221213190513'
+next_version: 109.0b2
+optimize_strategies: null
+optimize_target_tasks: true
+owner: ryanvm@gmail.com
+project: firefox-android
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+release_type: beta
+repository_type: git
+shipping_phase: push
+target_tasks_method: push
+tasks_for: action
+version: 109.0b1


### PR DESCRIPTION
Must be landed at the same time as https://github.com/mozilla-releng/shipit/pull/1238

`taskgraph target-graph -p taskcluster/test/params/main-repo-promote-beta.yml --diff HEAD~1` returns: 

```diff
--- target_task_graph@ba3f26b9c64c
+++ target_task_graph@bug-1806432
@@ -1,126 +1,20 @@
-beetmover-release-browser-domains
-beetmover-release-browser-engine-gecko
-beetmover-release-browser-engine-system
-beetmover-release-browser-errorpages
-beetmover-release-browser-icons
-beetmover-release-browser-menu
-beetmover-release-browser-menu2
-beetmover-release-browser-session-storage
-beetmover-release-browser-state
-beetmover-release-browser-storage-sync
-beetmover-release-browser-tabstray
-beetmover-release-browser-thumbnails
-beetmover-release-browser-toolbar
-beetmover-release-compose-awesomebar
-beetmover-release-compose-browser-toolbar
-beetmover-release-compose-cfr
-beetmover-release-compose-engine
-beetmover-release-compose-tabstray
-beetmover-release-concept-awesomebar
-beetmover-release-concept-base
-beetmover-release-concept-engine
-beetmover-release-concept-fetch
-beetmover-release-concept-menu
-beetmover-release-concept-push
-beetmover-release-concept-storage
-beetmover-release-concept-sync
-beetmover-release-concept-tabstray
-beetmover-release-concept-toolbar
-beetmover-release-feature-accounts
-beetmover-release-feature-accounts-push
-beetmover-release-feature-addons
-beetmover-release-feature-app-links
-beetmover-release-feature-autofill
-beetmover-release-feature-awesomebar
-beetmover-release-feature-containers
-beetmover-release-feature-contextmenu
-beetmover-release-feature-customtabs
-beetmover-release-feature-downloads
-beetmover-release-feature-findinpage
-beetmover-release-feature-intent
-beetmover-release-feature-logins
-beetmover-release-feature-media
-beetmover-release-feature-privatemode
-beetmover-release-feature-prompts
-beetmover-release-feature-push
-beetmover-release-feature-pwa
-beetmover-release-feature-qr
-beetmover-release-feature-readerview
-beetmover-release-feature-recentlyclosed
-beetmover-release-feature-search
-beetmover-release-feature-serviceworker
-beetmover-release-feature-session
-beetmover-release-feature-share
-beetmover-release-feature-sitepermissions
-beetmover-release-feature-syncedtabs
-beetmover-release-feature-tab-collections
-beetmover-release-feature-tabs
-beetmover-release-feature-toolbar
-beetmover-release-feature-top-sites
-beetmover-release-feature-webauthn
-beetmover-release-feature-webcompat
-beetmover-release-feature-webcompat-reporter
-beetmover-release-feature-webnotifications
-beetmover-release-lib-auth
-beetmover-release-lib-crash
-beetmover-release-lib-crash-sentry
-beetmover-release-lib-crash-sentry-legacy
-beetmover-release-lib-dataprotect
-beetmover-release-lib-fetch-httpurlconnection
-beetmover-release-lib-fetch-okhttp
-beetmover-release-lib-jexl
-beetmover-release-lib-publicsuffixlist
-beetmover-release-lib-push-firebase
-beetmover-release-lib-state
-beetmover-release-service-contile
-beetmover-release-service-digitalassetlinks
-beetmover-release-service-firefox-accounts
-beetmover-release-service-glean
-beetmover-release-service-location
-beetmover-release-service-nimbus
-beetmover-release-service-pocket
-beetmover-release-service-sync-autofill
-beetmover-release-service-sync-logins
-beetmover-release-support-android-test
-beetmover-release-support-base
-beetmover-release-support-images
-beetmover-release-support-ktx
-beetmover-release-support-locale
-beetmover-release-support-rusterrors
-beetmover-release-support-rusthttp
-beetmover-release-support-rustlog
-beetmover-release-support-sync-telemetry
-beetmover-release-support-test
-beetmover-release-support-test-appservices
-beetmover-release-support-test-fakes
-beetmover-release-support-test-libstate
-beetmover-release-support-utils
-beetmover-release-support-webextensions
-beetmover-release-tooling-glean-gradle
-beetmover-release-tooling-nimbus-gradle
-beetmover-release-ui-autocomplete
-beetmover-release-ui-colors
-beetmover-release-ui-fonts
-beetmover-release-ui-icons
-beetmover-release-ui-tabcounter
-beetmover-release-ui-widgets
 build-apk-focus-beta
 build-components-release-browser-domains
 build-components-release-browser-engine-gecko
 build-components-release-browser-engine-system
 build-components-release-browser-errorpages
 build-components-release-browser-icons
 build-components-release-browser-menu
 build-components-release-browser-menu2
 build-components-release-browser-session-storage
 build-components-release-browser-state
 build-components-release-browser-storage-sync
 build-components-release-browser-tabstray
 build-components-release-browser-thumbnails
 build-components-release-browser-toolbar
 build-components-release-compose-awesomebar
 build-components-release-compose-browser-toolbar
 build-components-release-compose-cfr
 build-components-release-compose-engine
 build-components-release-compose-tabstray
 build-components-release-concept-awesomebar
@@ -198,48 +92,43 @@
 build-components-release-support-rustlog
 build-components-release-support-sync-telemetry
 build-components-release-support-test
 build-components-release-support-test-appservices
 build-components-release-support-test-fakes
 build-components-release-support-test-libstate
 build-components-release-support-utils
 build-components-release-support-webextensions
 build-components-release-tooling-glean-gradle
 build-components-release-tooling-nimbus-gradle
 build-components-release-ui-autocomplete
 build-components-release-ui-colors
 build-components-release-ui-fonts
 build-components-release-ui-icons
 build-components-release-ui-tabcounter
 build-components-release-ui-widgets
 build-docker-image-android-build
 build-docker-image-base
 build-docker-image-ui-tests
 fetch-android-sdk-3859397
-github-release-components-release
-post-beetmover-release
-post-beetmover-release-1
-post-beetmover-release-2
 post-signing-release
 post-signing-release-1
 post-signing-release-2
-push-apk-focus-beta
 release-notify-promote-beta
 signing-apk-focus-beta
 signing-release-browser-domains
 signing-release-browser-engine-gecko
 signing-release-browser-engine-system
 signing-release-browser-errorpages
 signing-release-browser-icons
 signing-release-browser-menu
 signing-release-browser-menu2
 signing-release-browser-session-storage
 signing-release-browser-state
 signing-release-browser-storage-sync
 signing-release-browser-tabstray
 signing-release-browser-thumbnails
 signing-release-browser-toolbar
 signing-release-compose-awesomebar
 signing-release-compose-browser-toolbar
 signing-release-compose-cfr
 signing-release-compose-engine
 signing-release-compose-tabstray
```

The `ship` graph remains unchanged. The `push` graph contains the deleted tasks above. 