### PR TITLE
Bug 1804844 - Downgrade ZXing to version 3.3.3.

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -35,7 +35,10 @@ object Versions {
 
     const val sentry_legacy = "1.7.30"
     const val sentry_latest = "6.8.0"
-    const val zxing = "3.5.0"
+
+    // zxing 3.4+ requires a minimum API of 24 or higher
+    const val zxing = "3.3.3"
+
     const val jna = "5.12.1"
     const val disklrucache = "2.0.2"
     const val leakcanary = "2.10"


### PR DESCRIPTION
Newer ZXing releases require Android 7 or higher, but we still support Android 5.