### PR TITLE
Bug 1806444 - Do not run tasks for mergify branches on git-push

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -127,28 +127,28 @@ tasks:
                   then: ${event.action}
                   else: 'UNDEFINED'
           in:
-              $if: >
-                  tasks_for in ["action", "cron"]
-                  || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
-                  || (tasks_for == "github-push" && head_ref[:10] != "refs/tags/" && head_ref != "staging.tmp" && head_ref != "trying.tmp") && (head_ref[:8] != "mergify/")
-              then:
-                  $let:
-                      level:
-                          $if: >
-                              tasks_for in ["github-push", "action", "cron"] && repoUrl == canonicalRepo
-                          then: '3'
-                          else: '1'
+              $let:
+                  level:
+                      $if: >
+                          tasks_for in ["github-push", "action", "cron"] && repoUrl == canonicalRepo
+                      then: '3'
+                      else: '1'
 
-                      short_base_ref:
-                          $if: 'base_ref[:11] == "refs/heads/"'
-                          then: {$eval: 'base_ref[11:]'}
-                          else: ${base_ref}
+                  short_base_ref:
+                      $if: 'base_ref[:11] == "refs/heads/"'
+                      then: {$eval: 'base_ref[11:]'}
+                      else: ${base_ref}
 
-                      short_head_ref:
-                          $if: 'head_ref[:11] == "refs/heads/"'
-                          then: {$eval: 'head_ref[11:]'}
-                          else: ${head_ref}
-                  in:
+                  short_head_ref:
+                      $if: 'head_ref[:11] == "refs/heads/"'
+                      then: {$eval: 'head_ref[11:]'}
+                      else: ${head_ref}
+              in:
+                  $if: >
+                      tasks_for in ["action", "cron"]
+                      || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
+                      || (tasks_for == "github-push" && head_ref[:10] != "refs/tags/" && head_ref != "staging.tmp" && head_ref != "trying.tmp") && (head_ref[:8] != "mergify/")
+                  then:
                       $mergeDeep:
                           - $if: 'tasks_for != "action"'
                             then:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -147,7 +147,7 @@ tasks:
                   $if: >
                       tasks_for in ["action", "cron"]
                       || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
-                      || (tasks_for == "github-push" && head_ref[:10] != "refs/tags/" && head_ref != "staging.tmp" && head_ref != "trying.tmp") && (head_ref[:8] != "mergify/")
+                      || (tasks_for == "github-push" && head_ref[:10] != "refs/tags/" && short_head_ref != "staging.tmp" && short_head_ref != "trying.tmp" && short_head_ref[:8] != "mergify/")
                   then:
                       $mergeDeep:
                           - $if: 'tasks_for != "action"'


### PR DESCRIPTION
I don't know when we regressed https://github.com/mozilla-mobile/fenix/pull/17489 and https://github.com/mozilla-mobile/android-components/pull/9421. 

This patch was tested in staging. 

Pushes on main still work:

<img width="1288" alt="image" src="https://user-images.githubusercontent.com/5907366/208625863-258b10be-4d1f-4136-abd9-8af052c634db.png">


Pushes to a release branch too: 

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/5907366/208625977-919586dc-ddd5-4073-ac25-a6fd63065e1e.png">


Mergify PRs don't run `push` graphs (tested in https://github.com/mozilla-releng/staging-firefox-android/pull/22):

<img width="953" alt="image" src="https://user-images.githubusercontent.com/5907366/208626054-f63bf574-3e06-436f-a774-4ea388295387.png">


But they used to (tested in https://github.com/mozilla-releng/staging-firefox-android/pull/20): 

<img width="924" alt="Screenshot 2022-12-20 at 09 46 14" src="https://user-images.githubusercontent.com/5907366/208626187-95d3adaf-4133-4ce5-ad14-eb0ae5843739.png">


More info on why this is important to fix this today in [bug 1806444](https://bugzilla.mozilla.org/show_bug.cgi?id=1806444#c0)