### PR TITLE
Bug 1806601 - Don't always run `sample-browser` and tests on `focus-debug` 

### DIFF
--- a/taskcluster/android_taskgraph/transforms/build.py
+++ b/taskcluster/android_taskgraph/transforms/build.py
@@ -23,7 +23,6 @@ def resolve_keys(config, tasks):
             'attributes.code-review',
             'expose-artifacts',
             'include-coverage',
-            'optimization',
             'shipping-phase',
             'run-on-tasks-for',
             'run.gradlew',

--- a/taskcluster/android_taskgraph/transforms/gradle_optimization.py
+++ b/taskcluster/android_taskgraph/transforms/gradle_optimization.py
@@ -7,6 +7,30 @@ transforms = TransformSequence()
 
 
 @transforms.add
+def add_components_optimization(config, tasks):
+    for task in tasks:
+        if _is_task_related_to_android_components(task):
+            build_type = task["attributes"]["build-type"]
+            if build_type not in ("nightly", "release"):
+                optimization = task.setdefault("optimization", {})
+                skip_unless_changed = optimization.setdefault("skip-unless-changed", [])
+                skip_unless_changed.extend([
+                    "android-components/build.gradle",
+                    "android-components/settings.gradle",
+                    "android-components/buildSrc.*",
+                    "android-components/gradle.properties",
+                    "android-components/gradle/wrapper/gradle-wrapper.properties",
+                    "android-components/plugins/dependencies/**",
+                ])
+
+        yield task
+
+
+def _is_task_related_to_android_components(task):
+    return bool(task.get("attributes", {}).get("component", ""))
+
+
+@transforms.add
 def extend_optimization_if_one_already_exists(config, tasks):
     deps_per_component = get_upstream_deps_for_all_gradle_projects()
 

--- a/taskcluster/ci/build-components/kind.yml
+++ b/taskcluster/ci/build-components/kind.yml
@@ -59,18 +59,6 @@ task-defaults:
             release: false
             nightly: false
             default: true
-    optimization:
-        by-build-type:
-            (nightly|release): {}
-            default:
-                skip-unless-changed:
-                    - android-components/build.gradle
-                    - android-components/settings.gradle
-                    - android-components/buildSrc.*
-                    - android-components/gradle.properties
-                    - android-components/gradle/wrapper/gradle-wrapper.properties
-                    - android-components/plugins/dependencies/**
-                    # More paths are dynamically added by transforms
     run:
         gradlew:
             by-build-type:

--- a/taskcluster/ci/test-components/kind.yml
+++ b/taskcluster/ci/test-components/kind.yml
@@ -54,12 +54,6 @@ task-defaults:
         max-run-time: 2400
     optimization:
         skip-unless-changed:
-            - android-components/build.gradle
-            - android-components/settings.gradle
-            - android-components/buildSrc.*
-            - android-components/gradle.properties
-            - android-components/gradle/wrapper/gradle-wrapper.properties
-            - android-components/plugins/dependencies/**
             - android-components/automation/taskcluster/androidTest/ui-test.sh
             # More paths are dynamically added by transforms
 

--- a/taskcluster/ci/test-focus/kind.yml
+++ b/taskcluster/ci/test-focus/kind.yml
@@ -5,6 +5,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+    - android_taskgraph.transforms.gradle_optimization:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
@@ -19,6 +20,12 @@ task-defaults:
         toolchain:
             - android-sdk-linux
             - android-gradle-dependencies
+    optimization:
+        skip-unless-changed: [] # Paths are dynamically added by transforms
+    run-on-tasks-for:
+        - github-pull-request
+        - github-pull-request-untrusted
+        - github-push
     run:
         pre-gradlew:
             - ["cd", "focus-android"]

--- a/taskcluster/ci/ui-test-focus/kind.yml
+++ b/taskcluster/ci/ui-test-focus/kind.yml
@@ -5,6 +5,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+    - android_taskgraph.transforms.gradle_optimization:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
@@ -21,6 +22,8 @@ task-defaults:
         # key is arbitrary, the value corresponds to <kind name>-<build-name>
         signed-apk-debug-apk: signing-apk-focus-debug
         signed-apk-android-test: signing-apk-focus-android-test-debug
+    optimization:
+        skip-unless-changed: [] # Paths are dynamically added by transforms
     worker-type: b-android
     worker:
         docker-image: {in-tree: ui-tests}


### PR DESCRIPTION
Tested with this [parameters file](https://firefoxci.taskcluster-artifacts.net/AD67L8BPRaeqT_bqfcfTbQ/0/public/parameters.yml). `taskgraph optimized -p parameters.yml --diff upstream/main` returns this diff which is what I expected.

```diff
--- optimized_task_graph@ab473bfe7ee8
+++ optimized_task_graph@bug-1806601
@@ -1,18 +1,10 @@
-build-apk-focus-android-test-debug
-build-apk-focus-debug
 build-docker-image-android-build
 build-docker-image-base
 build-docker-image-ui-tests
-build-samples-browser-gecko
-build-samples-browser-system
 complete-pr
 complete-pr-1
 complete-pr-2
 fetch-android-sdk-3859397
-signing-apk-focus-android-test-debug
-signing-apk-focus-debug
-test-focus-debug
 toolchain-linux64-android-gradle-dependencies
 toolchain-linux64-android-sdk-linux-repack
-ui-test-focus-arm-debug
```