### PR TITLE
Bug 1806924 - Add the API to allow to persist cookie banner handling exceptions in private

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/cookiebanners/GeckoCookieBannersStorage.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/cookiebanners/GeckoCookieBannersStorage.kt
@@ -32,6 +32,10 @@ class GeckoCookieBannersStorage(
         setGeckoException(uri, DISABLED, privateBrowsing)
     }
 
+    override suspend fun addPersistentExceptionInPrivateMode(uri: String) {
+        setPersistentPrivateGeckoException(uri, DISABLED)
+    }
+
     override suspend fun findExceptionFor(
         uri: String,
         privateBrowsing: Boolean,
@@ -62,6 +66,17 @@ class GeckoCookieBannersStorage(
             uri,
             mode.mode,
             privateBrowsing,
+        )
+    }
+
+    @VisibleForTesting
+    internal fun setPersistentPrivateGeckoException(
+        uri: String,
+        mode: CookieBannerHandlingMode,
+    ) {
+        geckoStorage.setCookieBannerModeAndPersistInPrivateBrowsingForDomain(
+            uri,
+            mode.mode,
         )
     }
 

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/cookiebanners/GeckoCookieBannersStorageTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/cookiebanners/GeckoCookieBannersStorageTest.kt
@@ -100,4 +100,17 @@ class GeckoCookieBannersStorageTest {
 
             assertTrue(result)
         }
+
+    @Test
+    fun `GIVEN a cookie banner mode WHEN adding a persistent exception in private mode THEN add a persistent exception for the given uri in private browsing mode`() =
+        runTest {
+            val uri = "https://www.mozilla.org"
+
+            doNothing().`when`(geckoStorage)
+                .setPersistentPrivateGeckoException(uri = uri, mode = DISABLED)
+
+            geckoStorage.addPersistentExceptionInPrivateMode(uri = uri)
+
+            verify(geckoStorage).setPersistentPrivateGeckoException(uri, DISABLED)
+        }
 }

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/cookiehandling/CookieBannersStorage.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/cookiehandling/CookieBannersStorage.kt
@@ -21,6 +21,13 @@ interface CookieBannersStorage {
     )
 
     /**
+     * Set persistently the [CookieBannerHandlingMode.DISABLED] mode for the given [uri] in
+     * private browsing.
+     * @param uri the [uri] for the site to be updated.
+     */
+    suspend fun addPersistentExceptionInPrivateMode(uri: String)
+
+    /**
      * Find a [CookieBannerHandlingMode] that matches the given [uri] and browsing mode.
      * @param uri the [uri] to be used as filter in the search.
      * @param privateBrowsing Indicates if given [uri] should be in private browsing or not.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,9 @@ permalink: /changelog/
 * **feature-toolbar**
   * 🆕 Added a new parameter `shouldDisplaySearchTerms` to `ToolbarFeature` which allows clients to specify if the search terms should be shown instead of the URL when the toolbar is in display mode. [Bug 1805164](https://bugzilla.mozilla.org/show_bug.cgi?id=1805164)
 
+* **browser-engine-gecko**
+  * 🆕 Added `GeckoCookieBannersStorage.addPersistentExceptionInPrivateMode` to allow to add persistent cookie banner exceptions in private browsing [bug #1797605](https://bugzilla.mozilla.org/show_bug.cgi?id=1806924).
+
 # 109.0.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/v108.0.0...v109.0.0)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/v109.0.0/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)


### PR DESCRIPTION



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
