### PR TITLE
Bug 1807232 - Revert GeckoView to previous version to fix startup crash

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/Gecko.kt
+++ b/android-components/plugins/dependencies/src/main/java/Gecko.kt
@@ -9,7 +9,7 @@ object Gecko {
     /**
      * GeckoView Version.
      */
-    const val version = "110.0.20221222094520"
+    const val version = "110.0.20221220214632"
 
     /**
      * GeckoView channel


### PR DESCRIPTION
@amocirean helped confirm that this backout fixes the startup crash seen on Fenix - https://github.com/mozilla-mobile/fenix/issues/28297.
Also confirmed that with the current (newer) version of GV sample-browser crashes also but latest Nightly of Focus and latest GeckoView-example apps are not crashing so for a deeper fix we need to investigate what Fenix does that trigger the crash.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
