### PR TITLE
Bug 1802975 - Allow crash dumps to be shared using Talkback

### DIFF
--- a/android-components/components/lib/crash/src/main/java/mozilla/components/lib/crash/ui/CrashListAdapter.kt
+++ b/android-components/components/lib/crash/src/main/java/mozilla/components/lib/crash/ui/CrashListAdapter.kt
@@ -16,6 +16,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.view.ViewCompat
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.R
@@ -80,6 +81,7 @@ internal class CrashListAdapter(
                 append(crashReporter, crashWithReports.reports, onSelection)
             }
         }
+        ViewCompat.enableAccessibleClickableSpanSupport(holder.footerView)
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **lib-crash**
+  * 🚒 Bug fixed [bug 1802975](https://bugzilla.mozilla.org/show_bug.cgi?id=1802975). Allow crash dumps to be shared using a11y services.
+
 * **concept-engine**
   * 🌟️️ Add `CookieBannerHandlingStatus` to `SessionState` instance to indicate the status of the given session state see more on [bug #1797568](https://bugzilla.mozilla.org/show_bug.cgi?id=1797568).
 


### PR DESCRIPTION
Allow share links from crash dumps to be accessible using Talkback.

https://user-images.githubusercontent.com/35462038/209953453-69f6304f-1e58-4ceb-9605-4dd8a60f8eaa.mp4

It is worth noting that the chime sound is also played before every link, as explained [here](https://support.google.com/accessibility/android/answer/6378148?hl=en).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
