### PR TITLE
Bug 1808179 - mergify: remove rebase_fallback option from queue action config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -22,7 +22,6 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none
   - name: L10N - Auto Merge
     conditions:
       - author~=(mozilla-l10n-automation-bot|github-actions\[bot\])
@@ -36,7 +35,6 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none
   - name: Release automation
     conditions:
       - author=github-actions[bot]
@@ -50,7 +48,6 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none
       delete_head_branch:
         force: false
   - name: Needs landing - Rebase
@@ -65,7 +62,6 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none
   - name: Needs landing - Squash
     conditions:
       - status-success=complete-pr
@@ -78,4 +74,3 @@ pull_request_rules:
       queue:
         method: squash
         name: default
-        rebase_fallback: none


### PR DESCRIPTION
Per https://docs.mergify.com/actions/queue/#queue-action, this option is deprecated and due to be removed in a couple of months.  Besides, we were setting it to `none` which was the default.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
