### PR TITLE
Bug 1809609 - adds UI test page content assertion and retries

### DIFF
--- a/focus-android/app/src/androidTest/assets/etpPages/adsTrackers.html
+++ b/focus-android/app/src/androidTest/assets/etpPages/adsTrackers.html
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html dir="ltr" xml:lang="en-US" lang="en-US">
+<meta name="viewport" content="width=device-width">
 <head>
     <meta charset="UTF-8">
     <title>adsTrackers</title>

--- a/focus-android/app/src/androidTest/assets/etpPages/analyticsTrackers.html
+++ b/focus-android/app/src/androidTest/assets/etpPages/analyticsTrackers.html
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html dir="ltr" xml:lang="en-US" lang="en-US">
+<meta name="viewport" content="width=device-width">
 <head>
     <meta charset="UTF-8">
     <title>analyticsTrackers</title>

--- a/focus-android/app/src/androidTest/assets/etpPages/otherTrackers.html
+++ b/focus-android/app/src/androidTest/assets/etpPages/otherTrackers.html
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html dir="ltr" xml:lang="en-US" lang="en-US">
+<meta name="viewport" content="width=device-width">
 <head>
     <meta charset="UTF-8">
     <title>otherTrackers</title>

--- a/focus-android/app/src/androidTest/assets/etpPages/socialTrackers.html
+++ b/focus-android/app/src/androidTest/assets/etpPages/socialTrackers.html
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html dir="ltr" xml:lang="en-US" lang="en-US">
+<meta name="viewport" content="width=device-width">
 <head>
     <meta charset="UTF-8">
     <title>socialTrackers</title>

--- a/focus-android/app/src/androidTest/assets/storage_check.html
+++ b/focus-android/app/src/androidTest/assets/storage_check.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+<meta name="viewport" content="width=device-width">
 <body>
 
 <h1>Storage check</h1>

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
@@ -50,7 +50,24 @@ class BrowserRobot {
         )
 
     fun verifyPageContent(expectedText: String) {
-        mDevice.wait(Until.findObject(By.textContains(expectedText)), waitingTime)
+        sessionLoadedIdlingResource = SessionLoadedIdlingResource()
+
+        runWithIdleRes(sessionLoadedIdlingResource) {
+            for (i in 1..RETRY_COUNT) {
+                try {
+                    assertTrue(
+                        webPageItemContainingText(expectedText).waitForExists(pageLoadingTime),
+                    )
+                    break
+                } catch (e: AssertionError) {
+                    if (i == RETRY_COUNT) {
+                        throw e
+                    } else {
+                        refreshPageIfStillLoading(expectedText)
+                    }
+                }
+            }
+        }
     }
 
     fun verifyTrackingProtectionAlert(expectedText: String) {
@@ -59,7 +76,7 @@ class BrowserRobot {
         for (i in 1..RETRY_COUNT) {
             try {
                 assertTrue(
-                    mDevice.findObject(UiSelector().textContains(expectedText))
+                    webPageItemContainingText(expectedText)
                         .waitForExists(pageLoadingTime),
                 )
                 // close the JavaScript alert


### PR DESCRIPTION
For https://mozilla-hub.atlassian.net/browse/MTE-453
The BrowserRobot verifyPageContent() method was changed during the API 30 updates, but an assertion was omitted, which is needed to validate the test result. Since this method is widely used in our tests, it is important to have it return the correct results.

Added the assertion and the retries in case of failure, to ensure the stability is not affected.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1809609