### PR TITLE
Bug 1796766 - Add support for silent web notifications

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webnotifications/GeckoWebNotificationDelegate.kt
@@ -33,6 +33,7 @@ internal class GeckoWebNotificationDelegate(
             triggeredByWebExtension = source == null,
             privateBrowsing = privateBrowsing,
             engineNotification = this@toWebNotification,
+            silent = silent,
         )
     }
 }

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webnotifications/WebNotification.kt
@@ -25,6 +25,7 @@ import mozilla.components.concept.engine.Engine
  * @property triggeredByWebExtension True if this notification was triggered by a
  * web extension, otherwise false.
  * @property privateBrowsing indicates if the [WebNotification] belongs to a private session.
+ * @property silent Whether or not the notification should be silent.
  */
 data class WebNotification(
     val title: String?,
@@ -39,4 +40,5 @@ data class WebNotification(
     val timestamp: Long = System.currentTimeMillis(),
     val triggeredByWebExtension: Boolean = false,
     val privateBrowsing: Boolean,
+    val silent: Boolean = true,
 )

--- a/android-components/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/NativeNotificationBridge.kt
+++ b/android-components/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/NativeNotificationBridge.kt
@@ -13,6 +13,7 @@ import android.graphics.Bitmap
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import androidx.annotation.DrawableRes
+import androidx.core.app.NotificationCompat
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.Icon.Source
 import mozilla.components.browser.icons.IconRequest
@@ -41,10 +42,10 @@ internal class NativeNotificationBridge(
         requestId: Int,
     ): Notification {
         val builder = if (SDK_INT >= Build.VERSION_CODES.O) {
-            Notification.Builder(context, channelId)
+            NotificationCompat.Builder(context, channelId)
         } else {
             @Suppress("Deprecation")
-            Notification.Builder(context)
+            NotificationCompat.Builder(context)
         }
 
         with(notification) {
@@ -63,6 +64,7 @@ internal class NativeNotificationBridge(
                 .setShowWhen(true)
                 .setWhen(timestamp)
                 .setAutoCancel(true)
+                .setSilent(notification.silent)
 
             sourceUrl?.let {
                 builder.setSubText(it.tryGetHostFromUrl())
@@ -70,7 +72,7 @@ internal class NativeNotificationBridge(
 
             body?.let {
                 builder.setContentText(body)
-                    .setStyle(Notification.BigTextStyle().bigText(body))
+                    .setStyle(NotificationCompat.BigTextStyle().bigText(body))
             }
 
             loadIcon(sourceUrl, iconUrl, Size.DEFAULT, true)?.let { iconBitmap ->

--- a/android-components/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/WebNotificationFeature.kt
+++ b/android-components/components/feature/webnotifications/src/main/java/mozilla/components/feature/webnotifications/WebNotificationFeature.kt
@@ -111,7 +111,7 @@ class WebNotificationFeature(
             val channel = NotificationChannel(
                 NOTIFICATION_CHANNEL_ID,
                 context.getString(R.string.mozac_feature_notification_channel_name),
-                NotificationManager.IMPORTANCE_LOW,
+                NotificationManager.IMPORTANCE_DEFAULT,
             )
             channel.setShowBadge(true)
             channel.lockscreenVisibility = NotificationCompat.VISIBILITY_PRIVATE

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **feature-webnotifications**
+  * 🌟 Added support for silent web notifications.[bug #1796766](https://bugzilla.mozilla.org/show_bug.cgi?id=1796766).
+
 * **lib-crash**
   * 🚒 Bug fixed [bug 1802975](https://bugzilla.mozilla.org/show_bug.cgi?id=1802975). Allow crash dumps to be shared using a11y services.
 


### PR DESCRIPTION
Added support for silent web notifications. This change makes all the web notifications play a sound, apart from the ones specified as silent.

https://user-images.githubusercontent.com/35462038/211504368-7a0f821b-02ec-46bc-9965-3d0c80ea2101.mp4

Both notifications from the video work as intended (Silent notification is silent and Web Push notification plays the default notification sound)

Because this changes all web push notifications to play a sound, we should check with UX. See [ticket](https://mozilla-hub.atlassian.net/browse/FNXV2-9801) for more details.
cc @topotropic 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
