### PR TITLE
Bug 1809447 - Set ads telemetry in Focus to never expire.

### DIFF
--- a/focus-android/app/metrics.yaml
+++ b/focus-android/app/metrics.yaml
@@ -285,7 +285,7 @@ browser.search:
     notification_emails:
       - android-probes@mozilla.com
       - rtestard@mozilla.com
-    expires: 119
+    expires: never
   ad_clicks:
     type: labeled_counter
     description: |
@@ -315,7 +315,7 @@ browser.search:
     notification_emails:
       - android-probes@mozilla.com
       - rtestard@mozilla.com
-    expires: 119
+    expires: never
   in_content:
     type: labeled_counter
     description: |
@@ -334,7 +334,8 @@ browser.search:
       - interaction
     notification_emails:
       - android-probes@mozilla.com
-    expires: 119
+      - rtestard@mozilla.com
+    expires: never
 
   search_count:
     type: labeled_counter


### PR DESCRIPTION
This ensures parity with Fenix's corresponding telemetry. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1809447