### PR TITLE
Bug 1808364 - Part 2: Bump bugzilla-format action to ignore commit messages that starts with "Merge"

### DIFF
--- a/.github/workflows/bugzilla-format.yml
+++ b/.github/workflows/bugzilla-format.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.actor != 'mozilla-l10n-automation-bot' && github.actor != 'github-actions[bot]'
     steps:
       - name: Bugzilla Format
-        uses: gabrielluong/bugzilla-format@1.0.0
+        uses: gabrielluong/bugzilla-format@1.0.1
         if: github.repository == 'mozilla-mobile/firefox-android'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When checking if the commit messages are using the correct format, we want to ignore commit messages that are created by mergify that starts with "Merge". Changes are https://github.com/gabrielluong/bugzilla-format/commit/5991a8b033042fc641d96bb79351d8a7d77a049e



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1808364