### PR TITLE
Bug 1809447 - Add issue and data review links to ads telemetry.

### DIFF
--- a/focus-android/app/metrics.yaml
+++ b/focus-android/app/metrics.yaml
@@ -276,10 +276,12 @@ browser.search:
       - https://github.com/mozilla-mobile/fenix/issues/4967
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1804057
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1799049
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1809447
     data_reviews:
       - https://github.com/mozilla-mobile/focus-android/pull/4968#issuecomment-879256443
       - https://github.com/mozilla-mobile/focus-android/pull/7418#issuecomment-1195518264
       - https://github.com/mozilla-mobile/focus-android/pull/8109#issuecomment-1337394286
+      - https://github.com/mozilla-mobile/firefox-android/pull/523#issuecomment-1377494482
     data_sensitivity:
       - interaction
     notification_emails:
@@ -306,10 +308,12 @@ browser.search:
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/4967
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1804057
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1809447
     data_reviews:
       - https://github.com/mozilla-mobile/focus-android/pull/4968#issuecomment-879256443
       - https://github.com/mozilla-mobile/focus-android/pull/7418#issuecomment-1195518264
       - https://github.com/mozilla-mobile/focus-android/pull/8109#issuecomment-1337394286
+      - https://github.com/mozilla-mobile/firefox-android/pull/523#issuecomment-1377494482
     data_sensitivity:
       - interaction
     notification_emails:
@@ -327,9 +331,11 @@ browser.search:
       - BASELINE_PING
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/4967
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1809447
     data_reviews:
       - https://github.com/mozilla-mobile/focus-android/pull/4968#issuecomment-879256443
       - https://github.com/mozilla-mobile/focus-android/pull/7418#issuecomment-1195518264
+      - https://github.com/mozilla-mobile/firefox-android/pull/523#issuecomment-1377494482
     data_sensitivity:
       - interaction
     notification_emails:


### PR DESCRIPTION
The links point to the recent change of setting this metrics to never expire.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
