### PR TITLE
Bug 1809859 - Let focus UI tests run when A-C dependencies and gradle…

### DIFF
--- a/taskcluster/android_taskgraph/transforms/gradle_optimization.py
+++ b/taskcluster/android_taskgraph/transforms/gradle_optimization.py
@@ -9,25 +9,33 @@ transforms = TransformSequence()
 @transforms.add
 def add_components_optimization(config, tasks):
     for task in tasks:
-        if _is_task_related_to_android_components(task):
-            build_type = task["attributes"]["build-type"]
-            if build_type not in ("nightly", "release"):
-                optimization = task.setdefault("optimization", {})
-                skip_unless_changed = optimization.setdefault("skip-unless-changed", [])
-                skip_unless_changed.extend([
-                    "android-components/build.gradle",
-                    "android-components/settings.gradle",
-                    "android-components/buildSrc.*",
-                    "android-components/gradle.properties",
-                    "android-components/gradle/wrapper/gradle-wrapper.properties",
-                    "android-components/plugins/dependencies/**",
-                ])
+        attributes = task.get("attributes", {})
+        # TODO bug 1806454 - Use a single attribute instead of 2. This is an historical
+        # discrepancy where A-C are labeled by build-types but APKs by release ones.
+        #
+        # The monorepo migration made this discrepancy more obvious compared to when
+        # A-C and APKs lived in different repos
+        build_type = attributes.get("build-type", "")
+        release_type = attributes.get("release-type", "")
+
+        # We want to optimize away tasks on all android-components and APKs as long as
+        # these tasks are not labeled nightly, beta, or releases.
+        #
+        # Any change in that impact all a-c (e.g. a change in the a-c gradle config)
+        # should trigger also APKs builds and tests.
+        if all(type_ not in ("nightly", "beta", "release") for type_ in (build_type, release_type)):
+            optimization = task.setdefault("optimization", {})
+            skip_unless_changed = optimization.setdefault("skip-unless-changed", [])
+            skip_unless_changed.extend([
+                "android-components/build.gradle",
+                "android-components/settings.gradle",
+                "android-components/buildSrc.*",
+                "android-components/gradle.properties",
+                "android-components/gradle/wrapper/gradle-wrapper.properties",
+                "android-components/plugins/dependencies/**",
+            ])
 
         yield task
-
-
-def _is_task_related_to_android_components(task):
-    return bool(task.get("attributes", {}).get("component", ""))
 
 
 @transforms.add

--- a/taskcluster/android_taskgraph/transforms/gradle_optimization.py
+++ b/taskcluster/android_taskgraph/transforms/gradle_optimization.py
@@ -10,7 +10,7 @@ transforms = TransformSequence()
 def add_components_optimization(config, tasks):
     for task in tasks:
         attributes = task.get("attributes", {})
-        # TODO bug 1806454 - Use a single attribute instead of 2. This is an historical
+        # TODO bug 1806454 - Use a single attribute instead of 2. This is a historical
         # discrepancy where A-C are labeled by build-types but APKs by release ones.
         #
         # The monorepo migration made this discrepancy more obvious compared to when
@@ -19,10 +19,10 @@ def add_components_optimization(config, tasks):
         release_type = attributes.get("release-type", "")
 
         # We want to optimize away tasks on all android-components and APKs as long as
-        # these tasks are not labeled nightly, beta, or releases.
+        # these tasks are not labeled nightly, beta, or release.
         #
-        # Any change in that impact all a-c (e.g. a change in the a-c gradle config)
-        # should trigger also APKs builds and tests.
+        # Any change that impacts all a-c (e.g. a change in the a-c gradle config)
+        # should also trigger APK builds and tests.
         if all(type_ not in ("nightly", "beta", "release") for type_ in (build_type, release_type)):
             optimization = task.setdefault("optimization", {})
             skip_unless_changed = optimization.setdefault("skip-unless-changed", [])


### PR DESCRIPTION
… config are changed

`taskgraph optimized -p parameters.yml --diff main` with this [params file](https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/JDIE5X59Qa2HL6R-a2pV-Q/runs/0/artifacts/public/parameters.yml) returns:

```diff
--- optimized_task_graph@main
+++ optimized_task_graph@bug-1809859
@@ -1,21 +1,27 @@
+build-apk-focus-android-test-beta
+build-apk-focus-android-test-debug
+build-apk-focus-android-test-nightly
+build-apk-focus-beta-firebase
 build-apk-focus-debug
+build-apk-focus-nightly-firebase
+build-apk-klar-debug
 build-components-browser-domains
 build-components-browser-engine-gecko
 build-components-browser-engine-system
 build-components-browser-errorpages
 build-components-browser-icons
 build-components-browser-menu
 build-components-browser-menu2
 build-components-browser-session-storage
 build-components-browser-state
 build-components-browser-storage-sync
 build-components-browser-tabstray
 build-components-browser-thumbnails
 build-components-browser-toolbar
 build-components-compose-awesomebar
 build-components-compose-browser-toolbar
 build-components-compose-cfr
 build-components-compose-engine
 build-components-compose-tabstray
 build-components-concept-awesomebar
 build-components-concept-base
@@ -242,36 +248,45 @@
 external-gradle-dependencies-tooling-glean-gradle
 external-gradle-dependencies-tooling-lint
 external-gradle-dependencies-tooling-nimbus-gradle
 external-gradle-dependencies-ui-autocomplete
 external-gradle-dependencies-ui-colors
 external-gradle-dependencies-ui-fonts
 external-gradle-dependencies-ui-icons
 external-gradle-dependencies-ui-tabcounter
 external-gradle-dependencies-ui-widgets
 fetch-android-sdk-3859397
 lint-buildconfig-android-components
 lint-buildconfig-focus
 lint-compare-locales-android-components
 lint-compare-locales-focus
 lint-detekt-android-components
 lint-detekt-focus
 lint-ktlint-android-components
 lint-ktlint-focus
 lint-lint-android-components
 lint-lint-focus
+signing-apk-focus-android-test-beta
+signing-apk-focus-android-test-debug
+signing-apk-focus-android-test-nightly
+signing-apk-focus-beta-firebase
 signing-apk-focus-debug
+signing-apk-focus-nightly-firebase
 test-components-android-feature-containers
 test-components-android-feature-downloads
 test-components-android-feature-logins
 test-components-android-feature-prompts
 test-components-android-feature-pwa
 test-components-android-feature-recentlyclosed
 test-components-android-feature-share
 test-components-android-feature-sitepermissions
 test-components-android-feature-top-sites
 test-components-android-support-ktx
 test-components-ui-browser
 test-components-ui-glean
 test-components-unit-browser-engine-gecko-nightly
+test-focus-debug
 toolchain-linux64-android-sdk-linux-repack
+ui-test-focus-arm-beta
+ui-test-focus-arm-debug
+ui-test-focus-arm-nightly
```

Having `...-android-test-beta` and `...-nightly` makes sense because we run these flavors on pushes to the `main` branch.
https://bugzilla.mozilla.org/show_bug.cgi?id=1809859
https://bugzilla.mozilla.org/show_bug.cgi?id=1809859
https://bugzilla.mozilla.org/show_bug.cgi?id=1809859
https://bugzilla.mozilla.org/show_bug.cgi?id=1809859