### PR TITLE
No issue: Disable openPdfFileTest on releases_v110 branch

### DIFF
--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
@@ -7,6 +7,7 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -140,6 +141,7 @@ class DownloadFileTest {
 
     @SmokeTest
     @Test
+    @Ignore("Disabled: Feature not yet available on Beta")
     fun openPdfFileTest() {
         downloadFileName = "washington.pdf"
         val pdfFileURL = "https://storage.googleapis.com/mobile_test_assets/public/washington.pdf"


### PR DESCRIPTION
> [CI](https://firefox-ci-tc.services.mozilla.com/tasks/DZj0L8kiQYiw0yLE0UgLFA/runs/1#artifacts) is failing in the GeckoView Beta update [PR](https://github.com/mozilla-mobile/firefox-android/pull/548) for the firefox-android 110 release branch

`openPdfFileTest` – `PDF.js` is not yet available on Beta.