### PR TITLE
Revert "Bug 1810150 - don't run pull-request task graphs when we already have a push graph"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,7 @@
 queue_rules:
   - name: default
     conditions:
-      - or:
-        - status-success=complete-pr
-        - status-success=complete-push
+      - status-success=complete-pr
 pull_request_rules:
   - name: Resolve conflict
     conditions:
@@ -14,7 +12,7 @@ pull_request_rules:
   - name: MickeyMoz - Auto Merge
     conditions:
       - author=MickeyMoz
-      - status-success=complete-push
+      - status-success=complete-pr
       - files~=^android-components/(Gecko\.kt|components/lib/publicsuffixlist/src/main/assets/publicsuffixes)
       - -files~=^(?!android-components/(Gecko\.kt|components/lib/publicsuffixlist/src/main/assets/publicsuffixes)).+$
     actions:
@@ -27,7 +25,7 @@ pull_request_rules:
   - name: L10N - Auto Merge
     conditions:
       - author~=(mozilla-l10n-automation-bot|github-actions\[bot\])
-      - status-success=complete-push
+      - status-success=complete-pr
       - files~=^(android-components|focus-android)/(.+/strings\.xml|l10n\.toml)
       - -files~=^(?!(android-components|focus-android)/(.+/strings\.xml|l10n\.toml)).+$
     actions:
@@ -40,7 +38,7 @@ pull_request_rules:
   - name: Release automation
     conditions:
       - author=github-actions[bot]
-      - status-success=complete-push
+      - status-success=complete-pr
       - files~=^android-components/(\.buildconfig\.yml|.+/NimbusGradlePlugin\.groovy|plugins/dependencies/src/main/java/(Gecko|DependenciesPlugin)\.kt|buildSrc/src/main/java/Gecko\.kt)
       - -files~=^(?!android-components/(\.buildconfig\.yml|.+/NimbusGradlePlugin\.groovy|plugins/dependencies/src/main/java/(Gecko|DependenciesPlugin)\.kt|buildSrc/src/main/java/Gecko\.kt)).+$
     actions:
@@ -54,9 +52,7 @@ pull_request_rules:
         force: false
   - name: Needs landing - Rebase
     conditions:
-      - or:
-        - status-success=complete-pr
-        - status-success=complete-push
+      - status-success=complete-pr
       - label=🛬 needs landing
       - "#approved-reviews-by>=1"
       - -draft
@@ -68,9 +64,7 @@ pull_request_rules:
         name: default
   - name: Needs landing - Squash
     conditions:
-      - or:
-        - status-success=complete-pr
-        - status-success=complete-push
+      - status-success=complete-pr
       - label=🛬 needs landing (squash)
       - "#approved-reviews-by>=1"
       - -draft

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -146,8 +146,8 @@ tasks:
               in:
                   $if: >
                       tasks_for in ["action", "cron"]
-                      || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"] && baseRepoUrl != repoUrl)
-                      || (tasks_for == "github-push" && head_ref[:10] != "refs/tags/" && short_head_ref != "staging.tmp" && short_head_ref != "trying.tmp")
+                      || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
+                      || (tasks_for == "github-push" && head_ref[:10] != "refs/tags/" && short_head_ref != "staging.tmp" && short_head_ref != "trying.tmp" && short_head_ref[:8] != "mergify/")
                   then:
                       $mergeDeep:
                           - $if: 'tasks_for != "action"'

--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -38,8 +38,8 @@ task-defaults:
     notifications:
         by-geckoview-bump:
             nightly:
-                subject: "[Firefox-Android] Failed CI for {commit_message}"
-                message: "Please check {repository}/commit/{commit}"
+                subject: "[Android-Components] Failed to update geckoview nightly PR#{pull_request_number}"
+                message: "Please check {repository}/pull/{pull_request_number}"
                 emails:
                     - fenix-eng-notifications@mozilla.com
                     - geckoview-core@mozilla.com


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-android#542

The branch protection rule requires complete-pr on main, so we need to coordinate a change to that rule before we can re-land this.
https://bugzilla.mozilla.org/show_bug.cgi?id=1810150