### PR TITLE
Bug 1809972 - Part 2: Use the correct moz:RemovedIn version for cookie banner CFR strings

### DIFF
--- a/focus-android/app/src/main/res/values/strings.xml
+++ b/focus-android/app/src/main/res/values/strings.xml
@@ -696,11 +696,11 @@
     <string name="cookie_banner_exception_panel_description_state_off_for_site">%1$s can try to automatically reject cookie requests.</string>
 
     <!-- Contextual Feature Recommendation Popups -->
-    <string name="cfr_for_cookie_banner" moz:RemovedIn="110" tools:ignore="UnusedResources">%1$s tries to reject cookie requests to dismiss annoying cookie banners.\n\nManage cookie banner preferences in settings.</string>
+    <string name="cfr_for_cookie_banner" moz:RemovedIn="111" tools:ignore="UnusedResources">%1$s tries to reject cookie requests to dismiss annoying cookie banners.\n\nManage cookie banner preferences in settings.</string>
     <!-- CFR for Cookie Banner (Banner Info Message). %1$s will be replaced by the app name, %2$s will be an active link using the string cfr_cookie_banner_link as text. -->
     <string name="cfr_cookie_banner">%1$s tries to reject cookie requests to dismiss annoying cookie banners.\n\nManage cookie banner preferences in %2$s.</string>
 
-    <string name="cfr_for_cookie_banner_underline_settings" moz:RemovedIn="110" tools:ignore="UnusedResources">settings</string>
+    <string name="cfr_for_cookie_banner_underline_settings" moz:RemovedIn="111" tools:ignore="UnusedResources">settings</string>
     <!-- CFR for Cookie Banner (Banner Info Message). This string is used as text for a link in cfr_cookie_banner and takes the user to the app settings. -->
     <string name="cfr_cookie_banner_link">settings</string>
 


### PR DESCRIPTION
Adjusting the moz:RemovedIn version to 111 in https://github.com/mozilla-mobile/firefox-android/commit/d07784c0b3827561394768b601bf6592319b3ba1 which landed today. Current Nightly is 111 https://whattrainisitnow.com/


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1809972