### PR TITLE
Bug 1806066 - Finish onboarding when Focus is set as default browser from OS settings.

### DIFF
--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingController.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingController.kt
@@ -12,7 +12,6 @@ import android.content.Intent
 import android.os.Build
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
-import mozilla.components.feature.search.widget.BaseVoiceSearchActivity
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.utils.Browsers
 import mozilla.components.support.utils.ext.navigateToDefaultBrowserAppsSettings
@@ -78,7 +77,7 @@ class DefaultOnboardingController(
                         try {
                             activityResultLauncher.launch(it.createRequestRoleIntent(RoleManager.ROLE_BROWSER))
                         } catch (e: ActivityNotFoundException) {
-                            Logger(BaseVoiceSearchActivity.TAG).error(
+                            Logger(TAG).error(
                                 "ActivityNotFoundException " +
                                     e.message.toString(),
                             )
@@ -93,5 +92,9 @@ class DefaultOnboardingController(
                 context.navigateToDefaultBrowserAppsSettings()
             }
         }
+    }
+
+    companion object {
+        const val TAG = "OnboardingController"
     }
 }

--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingController.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingController.kt
@@ -15,12 +15,10 @@ import androidx.activity.result.ActivityResultLauncher
 import mozilla.components.feature.search.widget.BaseVoiceSearchActivity
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.utils.Browsers
-import mozilla.components.support.utils.ManufacturerCodes
 import mozilla.components.support.utils.ext.navigateToDefaultBrowserAppsSettings
 import org.mozilla.focus.ext.settings
 import org.mozilla.focus.state.AppAction
 import org.mozilla.focus.state.AppStore
-import org.mozilla.focus.utils.SupportUtils
 
 interface OnboardingController {
     fun handleFinishOnBoarding()
@@ -50,11 +48,6 @@ class DefaultOnboardingController(
     }
 
     override fun handleMakeFocusDefaultBrowserButtonClicked(activityResultLauncher: ActivityResultLauncher<Intent>) {
-        if (ManufacturerCodes.isHuawei) {
-            SupportUtils.openDefaultBrowserSumoPage(context)
-            handleFinishOnBoarding()
-            return
-        }
         val isDefault = Browsers.all(context).isDefaultBrowser
         if (isDefault) {
             handleFinishOnBoarding()

--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingSecondFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/onboarding/OnboardingSecondFragment.kt
@@ -6,6 +6,7 @@ package org.mozilla.focus.fragment.onboarding
 
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.transition.TransitionInflater
 import android.view.LayoutInflater
@@ -15,6 +16,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
+import mozilla.components.support.utils.Browsers
 import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.focus.GleanMetrics.Onboarding
 import org.mozilla.focus.R
@@ -70,6 +72,17 @@ class OnboardingSecondFragment : Fragment() {
                 }
             }
             isTransitionGroup = true
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // check if the default browser was changed from OS settings for devices with Android 7,8 and 9.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.Q &&
+            Browsers.all(requireContext()).isDefaultBrowser
+        ) {
+            onboardingInteractor.onFinishOnBoarding()
         }
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.





















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1806066