### PR TITLE
Bug 1811280 - Add worker retry on Firebase infrastructure error

### DIFF
--- a/taskcluster/ci/ui-test-focus/kind.yml
+++ b/taskcluster/ci/ui-test-focus/kind.yml
@@ -35,6 +35,8 @@ task-defaults:
             - name: public
               path: /builds/worker/artifacts
               type: directory
+        retry-exit-status: [20]
+
     treeherder:
         kind: test
         platform: 'focus-ui-test/opt'


### PR DESCRIPTION
For [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1811280)

Under the Focus worker (Fenix has this), we should retry on exit 20 for if a Firebase Test Lab infrastructure error occurs (e.g, [here](https://github.com/mozilla-mobile/firefox-android/runs/10740656576)

https://firebase.google.com/docs/test-lab/ios/command-line#script-exit-codes

See: https://github.com/mozilla-mobile/fenix/blob/main/taskcluster/ci/ui-test/kind.yml#L100

For worker in https://github.com/mozilla-mobile/firefox-android/blob/main/taskcluster/ci/ui-test-focus/kind.yml#L28
https://bugzilla.mozilla.org/show_bug.cgi?id=1811280
https://bugzilla.mozilla.org/show_bug.cgi?id=1811280