### PR TITLE
Bug 1811448 - Expose the GeckoView release channel in EngineVersion utils

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -577,8 +577,10 @@ class GeckoEngine(
 
     override fun name(): String = "Gecko"
 
-    override val version: EngineVersion = EngineVersion.parse(org.mozilla.geckoview.BuildConfig.MOZILLA_VERSION)
-        ?: throw IllegalStateException("Could not determine engine version")
+    override val version: EngineVersion = EngineVersion.parse(
+        org.mozilla.geckoview.BuildConfig.MOZILLA_VERSION,
+        org.mozilla.geckoview.BuildConfig.MOZ_UPDATE_CHANNEL,
+    ) ?: throw IllegalStateException("Could not determine engine version")
 
     /**
      * See [Engine.settings]

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -27,6 +27,7 @@ import mozilla.components.concept.engine.UnsupportedSettingException
 import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.serviceworker.ServiceWorkerDelegate
+import mozilla.components.concept.engine.utils.EngineReleaseChannel
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
@@ -1906,6 +1907,7 @@ class GeckoEngineTest {
 
         assertTrue(version.major >= 69)
         assertTrue(version.isAtLeast(69, 0, 0))
+        assertTrue(version.releaseChannel != EngineReleaseChannel.UNKNOWN)
     }
 
     @Test

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/utils/EngineVersion.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/utils/EngineVersion.kt
@@ -5,6 +5,16 @@
 package mozilla.components.concept.engine.utils
 
 /**
+ * Release type - as compiled - of the engine.
+ */
+enum class EngineReleaseChannel {
+    UNKNOWN,
+    NIGHTLY,
+    BETA,
+    RELEASE,
+}
+
+/**
  * Data class for engine versions using semantic versioning (major.minor.patch).
  *
  * @param major Major version number
@@ -12,12 +22,14 @@ package mozilla.components.concept.engine.utils
  * @param patch Patch version number
  * @param metadata Additional and optional metadata appended to the version number, e.g. for a version number of
  * "68.0a1" [metadata] will contain "a1".
+ * @param releaseChannel Additional property indicating the release channel of this version.
  */
 data class EngineVersion(
     val major: Int,
     val minor: Int,
     val patch: Long,
     val metadata: String? = null,
+    val releaseChannel: EngineReleaseChannel = EngineReleaseChannel.UNKNOWN,
 ) {
     operator fun compareTo(other: EngineVersion): Int {
         return when {
@@ -29,6 +41,7 @@ data class EngineVersion(
                 other.metadata == null -> 1
                 else -> metadata.compareTo(other.metadata)
             }
+            releaseChannel != other.releaseChannel -> releaseChannel.compareTo(other.releaseChannel)
             else -> 0
         }
     }
@@ -67,7 +80,7 @@ data class EngineVersion(
          * not be parsed successfully.
          */
         @Suppress("MagicNumber", "ReturnCount")
-        fun parse(version: String): EngineVersion? {
+        fun parse(version: String, releaseChannel: String? = null): EngineVersion? {
             val majorRegex = "([0-9]+)"
             val minorRegex = "\\.([0-9]+)"
             val patchRegex = "(?:\\.([0-9]+))?"
@@ -79,6 +92,12 @@ data class EngineVersion(
             val minor = result.groups[2]?.value ?: return null
             val patch = result.groups[3]?.value ?: "0"
             val metadata = result.groups[4]?.value
+            val engineReleaseChannel = when (releaseChannel) {
+                "nightly" -> EngineReleaseChannel.NIGHTLY
+                "beta" -> EngineReleaseChannel.BETA
+                "release" -> EngineReleaseChannel.RELEASE
+                else -> EngineReleaseChannel.UNKNOWN
+            }
 
             return try {
                 EngineVersion(
@@ -86,6 +105,7 @@ data class EngineVersion(
                     minor.toInt(),
                     patch.toLong(),
                     metadata,
+                    engineReleaseChannel,
                 )
             } catch (e: NumberFormatException) {
                 null

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/utils/EngineVersionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/utils/EngineVersionTest.kt
@@ -68,6 +68,100 @@ class EngineVersionTest {
         assertEquals("68.3.0esr", "68.3esr".toVersion().toString())
         assertEquals("68.0.0", "68.0".toVersion().toString())
     }
+
+    @Test
+    fun `GIVEN a nightly build of the engine WHEN parsing the version THEN add the correct release channel`() {
+        val result = EngineVersion.parse("0.0.1", "nightly")?.releaseChannel
+
+        assertEquals(EngineReleaseChannel.NIGHTLY, result)
+    }
+
+    @Test
+    fun `GIVEN a beta build of the engine WHEN parsing the version THEN add the correct release channel`() {
+        val result = EngineVersion.parse("0.0.1", "beta")?.releaseChannel
+
+        assertEquals(EngineReleaseChannel.BETA, result)
+    }
+
+    @Test
+    fun `GIVEN a release build of the engine WHEN parsing the version THEN add the correct release channel`() {
+        val result = EngineVersion.parse("0.0.1", "release")?.releaseChannel
+
+        assertEquals(EngineReleaseChannel.RELEASE, result)
+    }
+
+    @Test
+    fun `GIVEN a different build of the engine WHEN parsing the version THEN add the correct release channel`() {
+        val result = EngineVersion.parse("0.0.1", "aurora")?.releaseChannel
+
+        assertEquals(EngineReleaseChannel.UNKNOWN, result)
+    }
+
+    @Test
+    fun `GIVEN an unknown release type WHEN comparing to other versions THEN return a negative value`() {
+        val version = "0.0.1"
+        val unknown = EngineVersion.parse(version, "canary")
+
+        assertEquals(0, unknown!!.compareTo(unknown))
+        assertTrue(unknown < EngineVersion.parse(version, "nightly")!!)
+        assertTrue(unknown < EngineVersion.parse(version, "beta")!!)
+        assertTrue(unknown < EngineVersion.parse(version, "release")!!)
+    }
+
+    @Test
+    fun `GIVEN an nightly release type WHEN comparing to other versions THEN return the expected result`() {
+        val version = "0.0.1"
+        val nightly = EngineVersion.parse(version, "nightly")
+
+        assertEquals(0, nightly!!.compareTo(nightly))
+        assertTrue(nightly > EngineVersion.parse(version, "unknown")!!)
+        assertTrue(nightly < EngineVersion.parse(version, "beta")!!)
+        assertTrue(nightly < EngineVersion.parse(version, "release")!!)
+    }
+
+    @Test
+    fun `GIVEN an beta release type WHEN comparing to other versions THEN return the expected result`() {
+        val version = "0.0.1"
+        val beta = EngineVersion.parse(version, "beta")
+
+        assertEquals(0, beta!!.compareTo(beta))
+        assertTrue(beta > EngineVersion.parse(version, "unknown")!!)
+        assertTrue(beta > EngineVersion.parse(version, "nightly")!!)
+        assertTrue(beta < EngineVersion.parse(version, "release")!!)
+    }
+
+    @Test
+    fun `GIVEN a release type WHEN comparing to other versions THEN return the expected result`() {
+        val version = "0.0.1"
+        val release = EngineVersion.parse(version, "release")
+
+        assertEquals(0, release!!.compareTo(release))
+        assertTrue(release > EngineVersion.parse(version, "unknown")!!)
+        assertTrue(release > EngineVersion.parse(version, "nightly")!!)
+        assertTrue(release > EngineVersion.parse(version, "beta")!!)
+    }
+
+    @Test
+    fun `GIVEN a newer version of a less stable release WHEN comparing to other versions THEN return the expected result`() {
+        val debug = EngineVersion.parse("103.4567890", "test")
+        val nightly = EngineVersion.parse("102.1.0", "nightly")
+        val beta = EngineVersion.parse("101.0.0", "nightly")
+        val release = EngineVersion.parse("100.1.2", "release")
+
+        assertEquals(0, debug!!.compareTo(debug))
+        assertTrue(debug > nightly!!)
+        assertTrue(debug > beta!!)
+        assertTrue(debug > release!!)
+
+        assertEquals(0, nightly.compareTo(nightly))
+        assertTrue(nightly > beta)
+        assertTrue(nightly > release)
+
+        assertEquals(0, beta.compareTo(beta))
+        assertTrue(beta > release)
+
+        assertEquals(0, release.compareTo(release))
+    }
 }
 
 private fun String.toVersion() = EngineVersion.parse(this)!!

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
 * **concept-engine**
+  * 🌟 Expose the release channel of GeckoView through a new `releaseChannel` property of `EngineVersion`. [bug #1811448](https://bugzilla.mozilla.org/show_bug.cgi?id=1811448).
+
+* **concept-engine**
   * 🆕 Added `Settings.cookieBannerHandlingDetectOnlyMode` which helps to detect cookie banner events without handle the banners + indicating the mode of the events, see [bug 1810743](https://bugzilla.mozilla.org/show_bug.cgi?id=1810743)
   * ⚠️ **This is a breaking change**: Removed `CookieBannerMode.MODE_DETECT_ONLY` use `Settings.cookieBannerHandlingDetectOnlyMode` instead.
 


### PR DESCRIPTION
This will help conditionally execute code depending on the GeckoView release channel which may have different functionalities enabled at compile time.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1811448