### PR TITLE
Bug 1811183 - Handle non-digit step values passed for time input

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -399,10 +399,12 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
             onConfirm("")
         }
         val initialDateString = prompt.defaultValue ?: ""
-        val stepValue = if (prompt.stepValue.isNullOrBlank()) {
-            null
-        } else {
-            prompt.stepValue
+        val stepValue = with(prompt.stepValue) {
+            if (this?.toDoubleOrNull() == null) {
+                null
+            } else {
+                this
+            }
         }
 
         val format = when (prompt.type) {

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -31,6 +31,7 @@ import mozilla.components.test.ReflectionUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -573,6 +574,31 @@ class GeckoPromptDelegateTest {
         (timeSelectionRequest as PromptRequest.TimeSelection).onConfirm(selectedTime.toDate("HH:mm:ss.SSS"))
         verify(millisecondsGeckoPrompt).confirm(confirmCaptor.capture())
         assertEquals(selectedTime, confirmCaptor.value)
+    }
+
+    @Test
+    fun `WHEN DateTimePrompt request with invalid stepValue parameter is triggered THEN stepValue is passed as null`() {
+        val mockSession = GeckoEngineSession(runtime)
+        var timeSelectionRequest: PromptRequest.TimeSelection? = null
+        val promptDelegate = GeckoPromptDelegate(mockSession)
+        mockSession.register(
+            object : EngineSession.Observer {
+                override fun onPromptRequest(promptRequest: PromptRequest) {
+                    timeSelectionRequest = promptRequest as PromptRequest.TimeSelection
+                }
+            },
+        )
+        val geckoPrompt = geckoDateTimePrompt(
+            type = TIME,
+            defaultValue = "17:00",
+            stepValue = "Time",
+        )
+
+        promptDelegate.onDateTimePrompt(mock(), geckoPrompt)
+
+        assertNotNull(timeSelectionRequest)
+        assertEquals(PromptRequest.TimeSelection.Type.TIME, timeSelectionRequest?.type)
+        assertNull(timeSelectionRequest?.stepValue)
     }
 
     @Test

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **browser-engine-gecko**
+  * 🚒 Bug fixed [bug 1811183](https://bugzilla.mozilla.org/show_bug.cgi?id=1811183). Handles non-digit values for `DateTimePrompt.stepValue`.
+
 * **concept-engine**
   * 🆕 Added `Settings.cookieBannerHandlingDetectOnlyMode` which helps to detect cookie banner events without handle the banners + indicating the mode of the events, see [bug 1810743](https://bugzilla.mozilla.org/show_bug.cgi?id=1810743)
   * ⚠️ **This is a breaking change**: Removed `CookieBannerMode.MODE_DETECT_ONLY` use `Settings.cookieBannerHandlingDetectOnlyMode` instead.


### PR DESCRIPTION
Added method to handle non-digit step values passed with `DateTimePrompt.stepValue`. Can be tested using https://codepen.io/alexp7777/pen/YzavNYg.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1811183