### PR TITLE
Bug 1812378 - Fix cookie_banner_exception_panel_description_state_off_for_site string

### DIFF
--- a/focus-android/app/src/main/java/org/mozilla/focus/cookiebannerexception/CookieBannerExceptionDetailsPanel.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/cookiebannerexception/CookieBannerExceptionDetailsPanel.kt
@@ -95,7 +95,7 @@ class CookieBannerExceptionDetailsPanel(
     private fun bindDescription(hasException: Boolean) {
         val stringID =
             if (hasException) {
-                R.string.cookie_banner_exception_panel_description_state_off_for_site
+                R.string.cookie_banner_exception_panel_description_state_off_for_site2
             } else {
                 R.string.cookie_banner_exception_panel_description_state_on_for_site
             }

--- a/focus-android/app/src/main/res/values/strings.xml
+++ b/focus-android/app/src/main/res/values/strings.xml
@@ -693,7 +693,10 @@
     <string name="cookie_banner_exception_panel_description_state_on_for_site">%1$s will clear this site’s cookies and refresh the page. Clearing all cookies may sign you out or empty shopping carts.</string>
 
     <!-- Long text for a detail explanation indicating what will happen if cookie banner handling is off for a site, this is shown as part of the cookie banner panel in the toolbar. The placeholder will be updated with the app name. -->
-    <string name="cookie_banner_exception_panel_description_state_off_for_site">%1$s can try to automatically reject cookie requests.</string>
+    <string name="cookie_banner_exception_panel_description_state_off_for_site" moz:RemovedIn="111" tools:ignore="UnusedResources">%1$s can try to automatically reject cookie requests. If a reject option isn’t available, %1$s may accept all cookies to dismiss the banner.</string>
+
+    <!-- Long text for a detail explanation indicating what will happen if cookie banner handling is off for a site, this is shown as part of the cookie banner panel in the toolbar. The placeholder will be updated with the app name. -->
+    <string name="cookie_banner_exception_panel_description_state_off_for_site2">%1$s can try to automatically reject cookie requests.</string>
 
     <!-- Contextual Feature Recommendation Popups -->
     <!-- CFR for Cookie Banner (Banner Info Message). The placeholder will be updated with the app name. -->


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1812378