### PR TITLE
Revert "Bug 1796348 - Add post notification permission requirement for downloads."

### DIFF
--- a/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/FetchDownloadManager.kt
+++ b/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/manager/FetchDownloadManager.kt
@@ -6,7 +6,6 @@ package mozilla.components.feature.downloads.manager
 
 import android.Manifest.permission.FOREGROUND_SERVICE
 import android.Manifest.permission.INTERNET
-import android.Manifest.permission.POST_NOTIFICATIONS
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.annotation.SuppressLint
 import android.app.DownloadManager.ACTION_DOWNLOAD_COMPLETE
@@ -49,9 +48,7 @@ class FetchDownloadManager<T : AbstractFetchDownloadService>(
     // Do not require WRITE_EXTERNAL_STORAGE permission on API 29 and above (using scoped storage)
     override val permissions
         @SuppressLint("InlinedApi")
-        get() = if (getSDKVersion() >= Build.VERSION_CODES.TIRAMISU) {
-            arrayOf(INTERNET, FOREGROUND_SERVICE, POST_NOTIFICATIONS)
-        } else if (getSDKVersion() >= Build.VERSION_CODES.Q) {
+        get() = if (getSDKVersion() >= Build.VERSION_CODES.Q) {
             arrayOf(INTERNET, FOREGROUND_SERVICE)
         } else if (getSDKVersion() >= P) {
             arrayOf(INTERNET, WRITE_EXTERNAL_STORAGE, FOREGROUND_SERVICE)


### PR DESCRIPTION
This reverts commit 514baf1cce46fb8ad011f1f69dabd026d11bd5e9.

Post notifications permission should be requested but not required for downloads. Handling this will require more modifications than the initial commit introduced.

Note that the other [commit](https://github.com/mozilla-mobile/firefox-android/pull/604/commits/dc4b74953c12400d105b2f2af55aea27ac075720) included in the [PR](https://github.com/mozilla-mobile/firefox-android/pull/629) landed in fixed an existing bug in the code and does not need reverting.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1796348