### PR TITLE
Bug 1811531 - Add 'site' query parameter to Pocket sponsored stories request

### DIFF
--- a/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketStoriesConfig.kt
+++ b/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketStoriesConfig.kt
@@ -9,6 +9,7 @@ import mozilla.components.support.base.worker.Frequency
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
+internal const val DEFAULT_SPONSORED_STORIES_SITE_ID = "1240699"
 internal const val DEFAULT_REFRESH_INTERVAL = 4L
 internal const val DEFAULT_SPONSORED_STORIES_REFRESH_INTERVAL = 4L
 
@@ -26,6 +27,7 @@ internal val DEFAULT_SPONSORED_STORIES_REFRESH_TIMEUNIT = TimeUnit.HOURS
  * @param profile Optional - The profile used for downloading sponsored Pocket stories.
  * @param sponsoredStoriesRefreshFrequency Optional - The interval at which to try and refresh sponsored stories.
  * Defaults to 4 hours.
+ * @param sponsoredStoriesParams Optional - Configuration containing parameters used to get the spoc content.
  */
 class PocketStoriesConfig(
     val client: Client,
@@ -38,7 +40,16 @@ class PocketStoriesConfig(
         DEFAULT_SPONSORED_STORIES_REFRESH_INTERVAL,
         DEFAULT_SPONSORED_STORIES_REFRESH_TIMEUNIT,
     ),
+    val sponsoredStoriesParams: PocketStoriesRequestConfig = PocketStoriesRequestConfig(),
 )
+
+/**
+ * Configuration for sponsored stories request indicating parameters used to get spoc content.
+ *
+ * @property siteId Optional - ID of the site parameter, should be used with care as it changes the
+ * set of sponsored stories fetched from the server.
+ */
+class PocketStoriesRequestConfig(val siteId: String = DEFAULT_SPONSORED_STORIES_SITE_ID)
 
 /**
  * Sponsored stories configuration data.

--- a/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketStoriesService.kt
+++ b/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketStoriesService.kt
@@ -46,6 +46,7 @@ class PocketStoriesService(
             fetchClient = pocketStoriesConfig.client,
             profileId = pocketStoriesConfig.profile.profileId,
             appId = pocketStoriesConfig.profile.appId,
+            sponsoredStoriesParams = pocketStoriesConfig.sponsoredStoriesParams,
         )
     }
 
@@ -118,6 +119,13 @@ class PocketStoriesService(
      */
     fun stopPeriodicSponsoredStoriesRefresh() {
         spocsRefreshscheduler.stopPeriodicRefreshes(context)
+    }
+
+    /**
+     * Fetch sponsored Pocket stories and refresh the locally persisted list.
+     */
+    suspend fun refreshSponsoredStories() {
+        spocsUseCases?.refreshStories?.invoke()
     }
 
     /**

--- a/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/spocs/api/SpocsEndpoint.kt
+++ b/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/spocs/api/SpocsEndpoint.kt
@@ -7,6 +7,7 @@ package mozilla.components.service.pocket.spocs.api
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import mozilla.components.concept.fetch.Client
+import mozilla.components.service.pocket.PocketStoriesRequestConfig
 import mozilla.components.service.pocket.spocs.api.SpocsEndpoint.Companion.newInstance
 import mozilla.components.service.pocket.stories.api.PocketEndpoint.Companion.newInstance
 import mozilla.components.service.pocket.stories.api.PocketResponse
@@ -51,9 +52,15 @@ internal class SpocsEndpoint internal constructor(
          * @param client the HTTP client to use for network requests.
          * @param profileId Unique profile identifier which will be presented with sponsored stories.
          * @param appId Unique identifier of the application using this feature.
+         * @param sponsoredStoriesParams Configuration containing parameters used to get the spoc content.
          */
-        fun newInstance(client: Client, profileId: UUID, appId: String): SpocsEndpoint {
-            val rawEndpoint = SpocsEndpointRaw.newInstance(client, profileId, appId)
+        fun newInstance(
+            client: Client,
+            profileId: UUID,
+            appId: String,
+            sponsoredStoriesParams: PocketStoriesRequestConfig,
+        ): SpocsEndpoint {
+            val rawEndpoint = SpocsEndpointRaw.newInstance(client, profileId, appId, sponsoredStoriesParams)
             return SpocsEndpoint(rawEndpoint, SpocsJSONParser)
         }
     }

--- a/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesConfigTest.kt
+++ b/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesConfigTest.kt
@@ -53,4 +53,11 @@ class PocketStoriesConfigTest {
     fun `GIVEN a Frequency THEN its visibility is internal`() {
         assertClassVisibility(Frequency::class, KVisibility.PUBLIC)
     }
+
+    @Test
+    fun `WHEN instantiating a PocketStoriesConfig THEN sponsoredStoriesParams default value is used`() {
+        val config = PocketStoriesConfig(mock())
+
+        assertEquals(DEFAULT_SPONSORED_STORIES_SITE_ID, config.sponsoredStoriesParams.siteId)
+    }
 }

--- a/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesServiceTest.kt
+++ b/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesServiceTest.kt
@@ -128,6 +128,16 @@ class PocketStoriesServiceTest {
     }
 
     @Test
+    fun `WHEN called to refresh locally saved sponsored stories THEN refresh usecase is invoked`() = runTest {
+        val refreshStories: SpocsUseCases.RefreshSponsoredStories = mock()
+        doReturn(refreshStories).`when`(spocsUseCases).refreshStories
+
+        service.refreshSponsoredStories()
+
+        verify(refreshStories).invoke()
+    }
+
+    @Test
     fun `GIVEN PocketStoriesService WHEN getStories THEN stories useCases should return`() = runTest {
         val stories = listOf(mock<PocketRecommendedStory>())
         val getStoriesUseCase: GetPocketStories = mock()

--- a/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/SpocsUseCasesTest.kt
+++ b/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/SpocsUseCasesTest.kt
@@ -9,6 +9,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.fetch.Client
+import mozilla.components.service.pocket.PocketStoriesRequestConfig
 import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import mozilla.components.service.pocket.helpers.PocketTestResources
 import mozilla.components.service.pocket.helpers.assertClassVisibility
@@ -41,13 +42,14 @@ class SpocsUseCasesTest {
     private val fetchClient: Client = mock()
     private val profileId = UUID.randomUUID()
     private val appId = "test"
-    private val useCases = spy(SpocsUseCases(testContext, fetchClient, profileId, appId))
+    private val sponsoredStoriesParams = PocketStoriesRequestConfig("123")
+    private val useCases = spy(SpocsUseCases(testContext, fetchClient, profileId, appId, sponsoredStoriesParams))
     private val spocsProvider: SpocsEndpoint = mock()
     private val spocsRepo: SpocsRepository = mock()
 
     @Before
     fun setup() {
-        doReturn(spocsProvider).`when`(useCases).getSpocsProvider(any(), any(), any())
+        doReturn(spocsProvider).`when`(useCases).getSpocsProvider(any(), any(), any(), any())
         doReturn(spocsRepo).`when`(useCases).getSpocsRepository(any())
     }
 
@@ -79,6 +81,7 @@ class SpocsUseCasesTest {
         assertSame(fetchClient, refreshUseCase.fetchClient)
         assertSame(profileId, refreshUseCase.profileId)
         assertSame(appId, refreshUseCase.appId)
+        assertSame(sponsoredStoriesParams, refreshUseCase.sponsoredStoriesParams)
     }
 
     @Test
@@ -89,6 +92,7 @@ class SpocsUseCasesTest {
         assertSame(fetchClient, refreshUseCase.fetchClient)
         assertSame(profileId, refreshUseCase.profileId)
         assertSame(appId, refreshUseCase.appId)
+        assertSame(sponsoredStoriesParams, refreshUseCase.sponsoredStoriesParams)
     }
 
     @Test
@@ -97,13 +101,15 @@ class SpocsUseCasesTest {
         val fetchClient2: Client = mock()
         val profileId2 = UUID.randomUUID()
         val appId2 = "test"
+        val sponsoredStoriesParams2 = PocketStoriesRequestConfig("1")
 
-        val refreshUseCase = useCases.RefreshSponsoredStories(context2, fetchClient2, profileId2, appId2)
+        val refreshUseCase = useCases.RefreshSponsoredStories(context2, fetchClient2, profileId2, appId2, sponsoredStoriesParams2)
 
         assertSame(context2, refreshUseCase.appContext)
         assertSame(fetchClient2, refreshUseCase.fetchClient)
         assertSame(profileId2, refreshUseCase.profileId)
         assertSame(appId2, refreshUseCase.appId)
+        assertSame(sponsoredStoriesParams2, refreshUseCase.sponsoredStoriesParams)
     }
 
     @Test
@@ -224,6 +230,7 @@ class SpocsUseCasesTest {
         assertSame(fetchClient, deleteProfileUseCase.fetchClient)
         assertSame(profileId, deleteProfileUseCase.profileId)
         assertSame(appId, deleteProfileUseCase.appId)
+        assertSame(sponsoredStoriesParams, deleteProfileUseCase.sponsoredStoriesParams)
     }
 
     @Test
@@ -234,6 +241,7 @@ class SpocsUseCasesTest {
         assertSame(fetchClient, deleteProfileUseCase.fetchClient)
         assertSame(profileId, deleteProfileUseCase.profileId)
         assertSame(appId, deleteProfileUseCase.appId)
+        assertSame(sponsoredStoriesParams, deleteProfileUseCase.sponsoredStoriesParams)
     }
 
     @Test
@@ -242,13 +250,15 @@ class SpocsUseCasesTest {
         val fetchClient2: Client = mock()
         val profileId2 = UUID.randomUUID()
         val appId2 = "test"
+        val sponsoredStoriesParams2 = PocketStoriesRequestConfig("1")
 
-        val deleteProfileUseCase = useCases.DeleteProfile(context2, fetchClient2, profileId2, appId2)
+        val deleteProfileUseCase = useCases.DeleteProfile(context2, fetchClient2, profileId2, appId2, sponsoredStoriesParams2)
 
         assertSame(context2, deleteProfileUseCase.context)
         assertSame(fetchClient2, deleteProfileUseCase.fetchClient)
         assertSame(profileId2, deleteProfileUseCase.profileId)
         assertSame(appId2, deleteProfileUseCase.appId)
+        assertSame(sponsoredStoriesParams2, deleteProfileUseCase.sponsoredStoriesParams)
     }
 
     @Test

--- a/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/api/SpocsEndpointTest.kt
+++ b/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/api/SpocsEndpointTest.kt
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.fetch.Client
+import mozilla.components.service.pocket.PocketStoriesRequestConfig
 import mozilla.components.service.pocket.helpers.PocketTestResources
 import mozilla.components.service.pocket.helpers.assertClassVisibility
 import mozilla.components.service.pocket.helpers.assertResponseIsFailure
@@ -148,11 +149,13 @@ class SpocsEndpointTest {
     fun `WHEN newInstance is called THEN a new SpocsEndpoint is returned as a wrapper over a configured SpocsEndpointRaw`() {
         val profileId = UUID.randomUUID()
         val appId = "test"
+        val sponsoredStoriesParams = PocketStoriesRequestConfig("123")
 
-        val result = SpocsEndpoint.Companion.newInstance(client, profileId, appId)
+        val result = SpocsEndpoint.Companion.newInstance(client, profileId, appId, sponsoredStoriesParams)
 
         assertSame(client, result.rawEndpoint.client)
         assertSame(profileId, result.rawEndpoint.profileId)
         assertSame(appId, result.rawEndpoint.appId)
+        assertSame(sponsoredStoriesParams, result.rawEndpoint.sponsoredStoriesParams)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **service-pocket**
+  * 🌟 Added `site` parameter to Pocket sponsored stories requests. It can be overwritten using `PocketStoriesConfig`, allowing clients to customize spoc content. [Bug 1811531](https://bugzilla.mozilla.org/show_bug.cgi?id=1811531).
+
 * **browser-storage-sync**:
 * **feature-awesomebar**
 * **feature-syncedtabs**


### PR DESCRIPTION
Added `site` parameter to Pocket sponsored stories request, can be overridden by clients using `PocketStoriesConfig`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1811531