### PR TITLE
Bug 1814130 - Add prompt to "open in app" in normal tabs

### DIFF
--- a/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/RedirectDialogFragment.kt
+++ b/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/RedirectDialogFragment.kt
@@ -4,7 +4,6 @@
 
 package mozilla.components.feature.app.links
 
-import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 
 /**
@@ -29,23 +28,7 @@ abstract class RedirectDialogFragment : DialogFragment() {
      */
     var onCancelRedirect: () -> Unit? = {}
 
-    /**
-     * add the metadata of this download object to the arguments of this fragment.
-     */
-    fun setAppLinkRedirectUrl(url: String) {
-        val args = arguments ?: Bundle()
-        with(args) {
-            putString(KEY_INTENT_URL, url)
-        }
-        arguments = args
-    }
-
     companion object {
-        /**
-         * Key for finding the app link.
-         */
-        const val KEY_INTENT_URL = "KEY_INTENT_URL"
-
         const val FRAGMENT_TAG = "SHOULD_OPEN_APP_LINK_PROMPT_DIALOG"
     }
 }

--- a/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/SimpleRedirectDialogFragment.kt
+++ b/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/SimpleRedirectDialogFragment.kt
@@ -32,8 +32,8 @@ class SimpleRedirectDialogFragment : RedirectDialogFragment() {
         }
 
         return with(requireBundle()) {
-            val fileName = getString(KEY_INTENT_URL, "")
-            val dialogTitleText = getInt(KEY_TITLE_TEXT, R.string.mozac_feature_applinks_confirm_dialog_title)
+            val dialogTitleText = getInt(KEY_TITLE_TEXT, R.string.mozac_feature_applinks_normal_confirm_dialog_title)
+            val dialogMessageString = getString(KEY_MESSAGE_STRING, "")
             val positiveButtonText = getInt(KEY_POSITIVE_TEXT, R.string.mozac_feature_applinks_confirm_dialog_confirm)
             val negativeButtonText = getInt(KEY_NEGATIVE_TEXT, R.string.mozac_feature_applinks_confirm_dialog_deny)
             val themeResId = getInt(KEY_THEME_ID, 0)
@@ -41,7 +41,7 @@ class SimpleRedirectDialogFragment : RedirectDialogFragment() {
 
             getBuilder(themeResId)
                 .setTitle(dialogTitleText)
-                .setMessage(fileName)
+                .setMessage(dialogMessageString)
                 .setPositiveButton(positiveButtonText) { _, _ ->
                     onConfirmRedirect()
                 }
@@ -58,7 +58,8 @@ class SimpleRedirectDialogFragment : RedirectDialogFragment() {
          * A builder method for creating a [SimpleRedirectDialogFragment]
          */
         fun newInstance(
-            @StringRes dialogTitleText: Int = R.string.mozac_feature_applinks_confirm_dialog_title,
+            @StringRes dialogTitleText: Int = R.string.mozac_feature_applinks_normal_confirm_dialog_title,
+            dialogMessageString: String = "",
             @StringRes positiveButtonText: Int = R.string.mozac_feature_applinks_confirm_dialog_confirm,
             @StringRes negativeButtonText: Int = R.string.mozac_feature_applinks_confirm_dialog_deny,
             @StyleRes themeResId: Int = 0,
@@ -69,6 +70,8 @@ class SimpleRedirectDialogFragment : RedirectDialogFragment() {
 
             with(arguments) {
                 putInt(KEY_TITLE_TEXT, dialogTitleText)
+
+                putString(KEY_MESSAGE_STRING, dialogMessageString)
 
                 putInt(KEY_POSITIVE_TEXT, positiveButtonText)
 
@@ -90,6 +93,8 @@ class SimpleRedirectDialogFragment : RedirectDialogFragment() {
         const val KEY_NEGATIVE_TEXT = "KEY_NEGATIVE_TEXT"
 
         const val KEY_TITLE_TEXT = "KEY_TITLE_TEXT"
+
+        const val KEY_MESSAGE_STRING = "KEY_MESSAGE_STRING"
 
         const val KEY_THEME_ID = "KEY_THEME_ID"
 

--- a/android-components/components/feature/app-links/src/main/res/values/strings.xml
+++ b/android-components/components/feature/app-links/src/main/res/values/strings.xml
@@ -10,6 +10,11 @@
     <string name="mozac_feature_applinks_open_in">Open in…</string>
     <!-- The description to warn users that their private browsing session changes  -->
     <string name="mozac_feature_applinks_confirm_dialog_title">Open in app? Your activity may no longer be private.</string>
+    <!-- The title of the prompt that warns users their normal browsing session is trying to open another app  -->
+    <string name="mozac_feature_applinks_normal_confirm_dialog_title">Open in another app</string>
+    <!-- The message of the prompt to confirm with users that they want to open the link in another app
+    %s is a placeholder that will be replaced by the app name -->
+    <string name="mozac_feature_applinks_normal_confirm_dialog_message">Would you like to leave %s to view this content?</string>
     <!-- Opens the selected time -->
     <string name="mozac_feature_applinks_confirm_dialog_confirm">Open</string>
     <!-- Cancels the prompt -->

--- a/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
+++ b/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksFeatureTest.kt
@@ -22,7 +22,6 @@ import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -37,7 +36,6 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.Mockito.`when`
 
 @RunWith(AndroidJUnit4::class)
@@ -142,12 +140,12 @@ class AppLinksFeatureTest {
     }
 
     @Test
-    fun `in non-private mode an external app is opened without a dialog`() {
+    fun `in non-private mode an external app dialog is shown`() {
         val tab = createTab(webUrl)
         feature.handleAppIntent(tab, intentUrl, mock())
 
-        verifyNoMoreInteractions(mockDialog)
-        verify(mockOpenRedirect).invoke(any(), anyBoolean(), any())
+        verify(mockDialog).showNow(eq(mockFragmentManager), anyString())
+        verify(mockOpenRedirect, never()).invoke(any(), anyBoolean(), any())
     }
 
     @Test
@@ -160,22 +158,13 @@ class AppLinksFeatureTest {
     }
 
     @Test
-    fun `reused redirect dialog if exists`() {
-        val tab = createTab(webUrl, private = true)
-        feature.handleAppIntent(tab, intentUrl, mock())
-
-        val dialog = feature.getOrCreateDialog()
-        assertEquals(dialog, feature.getOrCreateDialog())
-    }
-
-    @Test
     fun `redirect dialog is only added once`() {
         val tab = createTab(webUrl, private = true)
         feature.handleAppIntent(tab, intentUrl, mock())
 
         verify(mockDialog).showNow(eq(mockFragmentManager), anyString())
 
-        doReturn(mockDialog).`when`(feature).getOrCreateDialog()
+        doReturn(mockDialog).`when`(feature).getOrCreateDialog(false, "")
         doReturn(mockDialog).`when`(mockFragmentManager).findFragmentByTag(RedirectDialogFragment.FRAGMENT_TAG)
         feature.handleAppIntent(tab, intentUrl, mock())
         verify(mockDialog, times(1)).showNow(mockFragmentManager, RedirectDialogFragment.FRAGMENT_TAG)

--- a/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/SimpleRedirectDialogFragmentTest.kt
+++ b/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/SimpleRedirectDialogFragmentTest.kt
@@ -41,7 +41,6 @@ class SimpleRedirectDialogFragmentTest {
         @Suppress("DEPRECATION")
         doReturn(mockFragmentManager()).`when`(fragment).requireFragmentManager()
 
-        fragment.setAppLinkRedirectUrl(webUrl)
         fragment.onConfirmRedirect = onConfirm
         fragment.onCancelRedirect = onCancel
 
@@ -71,7 +70,6 @@ class SimpleRedirectDialogFragmentTest {
         @Suppress("DEPRECATION")
         doReturn(mockFragmentManager()).`when`(fragment).requireFragmentManager()
 
-        fragment.setAppLinkRedirectUrl(webUrl)
         fragment.onConfirmRedirect = onConfirm
         fragment.onCancelRedirect = onCancel
 
@@ -101,7 +99,6 @@ class SimpleRedirectDialogFragmentTest {
         @Suppress("DEPRECATION")
         doReturn(mockFragmentManager()).`when`(fragment).requireFragmentManager()
 
-        fragment.setAppLinkRedirectUrl(webUrl)
         fragment.onConfirmRedirect = onConfirm
         fragment.onCancelRedirect = onCancel
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1814130