### PR TITLE
Bug 1814338 - Improve l10n GitHub Workflows

### DIFF
--- a/.github/workflows/ac-sync-strings.yml
+++ b/.github/workflows/ac-sync-strings.yml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-name: "AC - Sync Strings"
+name: AC - Uplift Strings
 
 permissions:
   contents: write
@@ -10,38 +10,42 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
 jobs:
   main:
-    name: "Sync Strings"
-    runs-on: ubuntu-20.04
+    name: Uplift strings
+    runs-on: ubuntu-latest
     steps:
-      - name: "Discover A-C Version"
-        id: ac-version-for-fenix-beta
+      - name: Discover A-C version
+        id: discover-version
         uses: mozilla-mobile/ac-version-for-fenix-beta@1.3.0
-      - name: "Checkout Main Branch"
-        uses: actions/checkout@v2
+      - name: Store ENV variables
+        id: env-variables
+        run: |
+          echo "beta_branch=releases_v${{ steps.discover-version.outputs.major-ac-version }}" >> $GITHUB_OUTPUT
+      - name: Checkout main branch
+        uses: actions/checkout@v3
         with:
           path: main
           ref: main
-      - name: "Checkout Beta Branch"
-        uses: actions/checkout@v2
+      - name: Checkout beta branch
+        uses: actions/checkout@v3
         with:
           path: beta
-          ref: "releases_v${{ steps.ac-version-for-fenix-beta.outputs.major-ac-version }}"
-      - name: "Sync Strings"
+          ref: ${{ steps.env-variables.outputs.beta_branch }}
+      - name: Sync strings
         uses: mozilla-mobile/sync-strings-action@2.0.0
         with:
           project: android-components
           src: main
           dst: beta
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: beta
-          branch: automation/sync-ac-strings-${{ steps.ac-version-for-fenix-beta.outputs.major-ac-version }}
-          title: "Uplift AC Strings from main to releases_v${{steps.ac-version-for-fenix-beta.outputs.major-ac-version}}"
-          body: "This (automated) PR sync strings from `main` to `releases_v${{steps.ac-version-for-fenix-beta.outputs.major-ac-version}}`"
+          branch: automation/uplift-ac-strings-${{ steps.discover-version.outputs.major-ac-version }}
+          title: "Uplift AC strings from ${{ github.ref_name }} to ${{ steps.env-variables.outputs.beta_branch }}"
+          body: "This (automated) PR uplifts strings from `${{ github.ref_name }}` to `${{ steps.env-variables.outputs.beta_branch }}`"

--- a/.github/workflows/focus-sync-strings.yml
+++ b/.github/workflows/focus-sync-strings.yml
@@ -2,45 +2,49 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-name: "Focus - Sync Strings"
+name: Focus - Uplift Strings
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
 jobs:
   main:
-    name: "Sync Strings"
-    runs-on: ubuntu-20.04
+    name: Uplift strings
+    runs-on: ubuntu-latest
     steps:
-      - name: "Discover Focus Beta Version"
-        id: focus-android-beta-version
+      - name: Discover Focus beta version
+        id: discover-beta-version
         uses: mozilla-mobile/fenix-beta-version@4.2.2
-      - name: "Skip non-beta versions"
+      - name: Skip non-beta versions
         uses: andymckay/cancel-action@0.2
-        if: ${{ steps.focus-android-beta-version.outputs.beta_version == '' }}
-      - name: "Checkout Main Branch"
-        uses: actions/checkout@v2
+        if: ${{ steps.discover-beta-version.outputs.beta_version == '' }}
+      - name: Store ENV variables
+        id: env-variables
+        run: |
+          echo "beta_branch=releases_v${{ steps.discover-beta-version.outputs.beta_version }}" >> $GITHUB_OUTPUT
+      - name: Checkout main branch
+        uses: actions/checkout@v3
         with:
           path: main
           ref: main
-      - name: "Checkout Beta Branch"
-        uses: actions/checkout@v2
+      - name: Checkout beta branch
+        uses: actions/checkout@v3
         with:
           path: beta
-          ref: "releases_v${{ steps.focus-android-beta-version.outputs.beta_version }}"
-      - name: "Sync Strings"
+          ref: ${{ steps.env-variables.outputs.beta_branch }}
+      - name: Sync strings
         uses: mozilla-mobile/sync-strings-action@2.0.0
         with:
           project: focus-android
           src: main
           dst: beta
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: beta
-          branch: automation/sync-focus-strings-${{ steps.focus-android-beta-version.outputs.beta_version }}
-          title: "Uplift Focus Strings from main to releases_v${{ steps.focus-android-beta-version.outputs.beta_version }}"
-          body: "This (automated) PR syncs strings from `main` to `releases_v${{ steps.focus-android-beta-version.outputs.beta_version }}`"
+          branch: automation/uplift-focus-strings-${{ steps.discover-beta-version.outputs.beta_version }}
+          title: "Uplift Focus strings from ${{ github.ref_name }} to ${{ steps.env-variables.outputs.beta_branch }}"
+          body: "This (automated) PR uplifts strings from `${{ github.ref_name }}` to `${{ steps.env-variables.outputs.beta_branch }}`"

--- a/.github/workflows/import-l10n.yml
+++ b/.github/workflows/import-l10n.yml
@@ -10,7 +10,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 20 * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:
@@ -57,7 +57,7 @@ jobs:
 
             git checkout -B "$branch"
             git add .
-            git commit -m "Import l10n."
+            git commit -m "Import translations from android-l10n"
             git push -f origin "$branch"
 
             # Create pull request if there isn't one open yet, use the last


### PR DESCRIPTION
CC @gabrielluong 

This pull request restores the original cronjob time for the "import l10n" workflow, and improve the commit message for clarity.

Changes to the sync workflows are mostly for clarity:
* Use of env variables to avoid repetitions, and simplify reuse for other products (e.g. Fenix)
* Use latest versions of ubuntu and actions (most use a deprecated version of node at this point)

There should be no practical changes to the workflow, I've only used `uplift` instead of `sync` in the branch name. Both actions have been tested on my fork.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1814338