### PR TITLE
Bug 1813582  - Added checks for TelemetryWrapper.startSession() and TelemetryWrapper.stopSession() not to be called multiple times.

### DIFF
--- a/focus-android/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -198,8 +198,9 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-
-        TelemetryWrapper.startSession()
+        if (TelemetryWrapper.isTelemetryEnabled(this)) {
+            TelemetryWrapper.startSession()
+        }
         checkBiometricStillValid()
     }
 
@@ -214,8 +215,9 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
         urlInputFragment?.cancelAnimation()
 
         super.onPause()
-
-        TelemetryWrapper.stopSession()
+        if (TelemetryWrapper.isTelemetryEnabled(this)) {
+            TelemetryWrapper.stopSession()
+        }
     }
 
     override fun onStop() {

--- a/focus-android/app/src/main/java/org/mozilla/focus/widget/TelemetrySwitchPreference.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/widget/TelemetrySwitchPreference.kt
@@ -28,12 +28,14 @@ internal class TelemetrySwitchPreference(context: Context, attrs: AttributeSet?)
     override fun onClick() {
         super.onClick()
         TelemetryHolder.get()
-            .configuration
-            .setUploadEnabled(isChecked).isCollectionEnabled = isChecked
+            .configuration.isUploadEnabled = isChecked
 
         Glean.setUploadEnabled(isChecked)
+
         if (isChecked) {
-            TelemetryHolder.get().recordSessionStart()
+            TelemetryWrapper.startSession()
+        } else {
+            TelemetryWrapper.stopSession()
         }
     }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1813582