### PR TITLE
Bug 1811928 - Android Components: get metrics/pings.yaml for crash pi…

### DIFF
--- a/android-components/components/lib/crash/build.gradle
+++ b/android-components/components/lib/crash/build.gradle
@@ -8,8 +8,11 @@ buildscript {
             url "https://maven.mozilla.org/maven2"
         }
 
+        gradlePluginPortal()
+
         dependencies {
             classpath "org.mozilla.telemetry:glean-gradle-plugin:${Versions.mozilla_glean}"
+            classpath Dependencies.plugin_ksp
         }
     }
 }
@@ -19,9 +22,8 @@ plugins {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'kotlin-android'
-
-apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion config.compileSdkVersion
@@ -39,10 +41,8 @@ android {
         }
     }
 
-    kapt {
-        arguments {
-            arg("room.schemaLocation", "$projectDir/schemas".toString())
-        }
+    ksp {
+        arg("room.schemaLocation", "$projectDir/schemas".toString())
     }
 
     buildTypes {
@@ -70,7 +70,7 @@ dependencies {
     implementation project(':support-utils')
 
     implementation Dependencies.androidx_room_runtime
-    kapt Dependencies.androidx_room_compiler
+    ksp Dependencies.androidx_room_compiler
 
     // We only compile against GeckoView and Glean. It's up to the app to add those dependencies if it wants to
     // send crash reports to Socorro (GV).

--- a/android-components/components/lib/crash/docs/metrics.md
+++ b/android-components/components/lib/crash/docs/metrics.md
@@ -8,7 +8,41 @@ This means you might have to go searching through the dependency tree to get a f
 
 # Pings
 
+- [crash](#crash)
 - [metrics](#metrics)
+
+## crash
+
+A ping to report crash information. This information is sent as soon as possible after a crash occurs (whether the crash is a background/content process or the main process). It is expected to be used for crash report analysis and to reduce blind spots in crash reporting.
+
+
+This ping includes the [client id](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section).
+
+**Data reviews for this ping:**
+
+- <https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12>
+
+**Bugs related to this ping:**
+
+- <https://bugzilla.mozilla.org/show_bug.cgi?id=1790569>
+
+**Reasons this ping may be sent:**
+
+- `crash`: A process crashed and a ping was immediately sent.
+
+- `event_found`: A process crashed and produced a crash event, which was later found and sent in a ping.
+
+
+All Glean pings contain built-in metrics in the [`ping_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-ping_info-section) and [`client_info`](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section) sections.
+
+In addition to those built-in metrics, the following metrics are added to the ping:
+
+| Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
+| --- | --- | --- | --- | --- | --- | --- |
+| crash.process_type |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |The type of process that experienced a crash. See the full list of options [here](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/crash-ping.html#process-types).  |[Bug 1790569](https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12)||never |1 |
+| crash.startup |[boolean](https://mozilla.github.io/glean/book/user/metrics/boolean.html) |If true, the crash occurred during process startup.  |[Bug 1790569](https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12)||never |1 |
+| crash.time |[datetime](https://mozilla.github.io/glean/book/user/metrics/datetime.html) |The time at which the crash occurred.  |[Bug 1790569](https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12)||never |1 |
+| crash.uptime |[timespan](https://mozilla.github.io/glean/book/user/metrics/timespan.html) |The application uptime. This is equivalent to the legacy crash ping's `UptimeTS` field.  |[Bug 1790569](https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12)||never |1 |
 
 ## metrics
 

--- a/android-components/components/lib/crash/metrics.yaml
+++ b/android-components/components/lib/crash/metrics.yaml
@@ -43,3 +43,78 @@ crash_metrics:
       - android-probes@mozilla.com
       - jnicol@mozilla.com
     expires: never
+
+crash:
+  uptime:
+    type: timespan
+    description: >
+      The application uptime. This is equivalent to the legacy crash ping's
+      `UptimeTS` field.
+    notification_emails:
+      - crash-reporting-wg@mozilla.org
+      - stability@mozilla.org
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12
+    data_sensitivity:
+      - technical
+    expires: never
+    send_in_pings:
+      - crash
+
+  process_type:
+    type: string
+    # yamllint disable
+    description: >
+      The type of process that experienced a crash. See the full list of
+      options
+      [here](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/crash-ping.html#process-types).
+    # yamllint enable
+    notification_emails:
+      - crash-reporting-wg@mozilla.org
+      - stability@mozilla.org
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12
+    data_sensitivity:
+      - technical
+    expires: never
+    send_in_pings:
+      - crash
+
+  time:
+    type: datetime
+    time_unit: minute
+    description: >
+      The time at which the crash occurred.
+    notification_emails:
+      - crash-reporting-wg@mozilla.org
+      - stability@mozilla.org
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12
+    data_sensitivity:
+      - technical
+    expires: never
+    send_in_pings:
+      - crash
+
+  startup:
+    type: boolean
+    description: >
+      If true, the crash occurred during process startup.
+    notification_emails:
+      - crash-reporting-wg@mozilla.org
+      - stability@mozilla.org
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12
+    data_sensitivity:
+      - technical
+    expires: never
+    send_in_pings:
+      - crash

--- a/android-components/components/lib/crash/pings.yaml
+++ b/android-components/components/lib/crash/pings.yaml
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+---
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+crash:
+  description: >
+    A ping to report crash information. This information is sent as soon as
+    possible after a crash occurs (whether the crash is a background/content
+    process or the main process). It is expected to be used for crash report
+    analysis and to reduce blind spots in crash reporting.
+  include_client_id: true
+  send_if_empty: false
+  notification_emails:
+    - crash-reporting-wg@mozilla.org
+    - stability@mozilla.org
+  bugs:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1790569#c12
+  reasons:
+    crash: >
+      A process crashed and a ping was immediately sent.
+    event_found: >
+      A process crashed and produced a crash event, which was later found and
+      sent in a ping.

--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -49,6 +49,7 @@ object Versions {
     const val mozilla_glean = "52.2.0"
 
     const val material = "1.2.1"
+    const val ksp = "1.0.8"
 
     // see https://android-developers.googleblog.com/2022/06/independent-versioning-of-Jetpack-Compose-libraries.html
     // for Jetpack Compose libraries versioning
@@ -158,6 +159,8 @@ object Dependencies {
     const val androidx_swiperefreshlayout = "androidx.swiperefreshlayout:swiperefreshlayout:${Versions.AndroidX.swiperefreshlayout}"
 
     const val google_material = "com.google.android.material:material:${Versions.material}"
+
+    const val plugin_ksp = "com.google.devtools.ksp:symbol-processing-gradle-plugin:${Versions.kotlin}-${Versions.ksp}"
 
     const val leakcanary = "com.squareup.leakcanary:leakcanary-android:${Versions.leakcanary}"
 


### PR DESCRIPTION
…ngs from mozilla-central

This also pulls tags.yaml since those tags may be used in metrics.yaml.

The use of kapt is replaced by ksp as the kapt produces java stubs from the glean generated code which are invalid java (ksp does not generate stubs).



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1811928