### PR TITLE
Bug 1811531 - Add 'country' and 'city' query parameter to Pocket sponsored stories request

### DIFF
--- a/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketStoriesConfig.kt
+++ b/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/PocketStoriesConfig.kt
@@ -48,8 +48,16 @@ class PocketStoriesConfig(
  *
  * @property siteId Optional - ID of the site parameter, should be used with care as it changes the
  * set of sponsored stories fetched from the server.
+ * @property country Optional - Value of the country parameter, shall be used with care as it allows
+ * overriding the IP location and receiving a set of sponsored stories not suited for the real location.
+ * @property city Optional - Value of the city parameter, shall be used with care as it allows
+ * overriding the IP location and receiving a set of sponsored stories not suited for the real location.
  */
-class PocketStoriesRequestConfig(val siteId: String = DEFAULT_SPONSORED_STORIES_SITE_ID)
+class PocketStoriesRequestConfig(
+    val siteId: String = DEFAULT_SPONSORED_STORIES_SITE_ID,
+    val country: String = "",
+    val city: String = "",
+)
 
 /**
  * Sponsored stories configuration data.

--- a/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/spocs/api/SpocsEndpointRaw.kt
+++ b/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/spocs/api/SpocsEndpointRaw.kt
@@ -33,6 +33,8 @@ private const val SPOCS_PROXY_VERSION_VALUE = 2
 private const val SPOCS_PROXY_PROFILE_KEY = "pocket_id"
 private const val SPOCS_PROXY_APP_KEY = "consumer_key"
 private const val SPOCS_PROXY_SITE_KEY = "site"
+private const val SPOCS_PROXY_COUNTRY_KEY = "country"
+private const val SPOCS_PROXY_CITY_KEY = "city"
 
 /**
  * Makes requests to the Pocket endpoint and returns the raw JSON data.
@@ -58,6 +60,12 @@ internal class SpocsEndpointRaw internal constructor(
         if (sponsoredStoriesParams.siteId.isNotBlank()) {
             url.appendQueryParameter(SPOCS_PROXY_SITE_KEY, sponsoredStoriesParams.siteId)
         }
+        if (sponsoredStoriesParams.country.isNotBlank()) {
+            url.appendQueryParameter(SPOCS_PROXY_COUNTRY_KEY, sponsoredStoriesParams.country)
+        }
+        if (sponsoredStoriesParams.city.isNotBlank()) {
+            url.appendQueryParameter(SPOCS_PROXY_CITY_KEY, sponsoredStoriesParams.city)
+        }
         url.build()
 
         val request = Request(
@@ -80,6 +88,12 @@ internal class SpocsEndpointRaw internal constructor(
             .encodedPath(baseUrl + SPOCS_ENDPOINT_DELETE_PROFILE_PATH)
         if (sponsoredStoriesParams.siteId.isNotBlank()) {
             url.appendQueryParameter(SPOCS_PROXY_SITE_KEY, sponsoredStoriesParams.siteId)
+        }
+        if (sponsoredStoriesParams.country.isNotBlank()) {
+            url.appendQueryParameter(SPOCS_PROXY_COUNTRY_KEY, sponsoredStoriesParams.country)
+        }
+        if (sponsoredStoriesParams.city.isNotBlank()) {
+            url.appendQueryParameter(SPOCS_PROXY_CITY_KEY, sponsoredStoriesParams.city)
         }
         url.build()
 

--- a/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesConfigTest.kt
+++ b/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesConfigTest.kt
@@ -59,5 +59,7 @@ class PocketStoriesConfigTest {
         val config = PocketStoriesConfig(mock())
 
         assertEquals(DEFAULT_SPONSORED_STORIES_SITE_ID, config.sponsoredStoriesParams.siteId)
+        assertEquals("", config.sponsoredStoriesParams.country)
+        assertEquals("", config.sponsoredStoriesParams.city)
     }
 }

--- a/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/SpocsUseCasesTest.kt
+++ b/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/SpocsUseCasesTest.kt
@@ -42,7 +42,7 @@ class SpocsUseCasesTest {
     private val fetchClient: Client = mock()
     private val profileId = UUID.randomUUID()
     private val appId = "test"
-    private val sponsoredStoriesParams = PocketStoriesRequestConfig("123")
+    private val sponsoredStoriesParams = PocketStoriesRequestConfig("123", "US", "NY")
     private val useCases = spy(SpocsUseCases(testContext, fetchClient, profileId, appId, sponsoredStoriesParams))
     private val spocsProvider: SpocsEndpoint = mock()
     private val spocsRepo: SpocsRepository = mock()
@@ -101,7 +101,7 @@ class SpocsUseCasesTest {
         val fetchClient2: Client = mock()
         val profileId2 = UUID.randomUUID()
         val appId2 = "test"
-        val sponsoredStoriesParams2 = PocketStoriesRequestConfig("1")
+        val sponsoredStoriesParams2 = PocketStoriesRequestConfig("1", "CA", "OW")
 
         val refreshUseCase = useCases.RefreshSponsoredStories(context2, fetchClient2, profileId2, appId2, sponsoredStoriesParams2)
 
@@ -250,7 +250,7 @@ class SpocsUseCasesTest {
         val fetchClient2: Client = mock()
         val profileId2 = UUID.randomUUID()
         val appId2 = "test"
-        val sponsoredStoriesParams2 = PocketStoriesRequestConfig("1")
+        val sponsoredStoriesParams2 = PocketStoriesRequestConfig("1", "CA", "OW")
 
         val deleteProfileUseCase = useCases.DeleteProfile(context2, fetchClient2, profileId2, appId2, sponsoredStoriesParams2)
 

--- a/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/api/SpocsEndpointRawTest.kt
+++ b/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/api/SpocsEndpointRawTest.kt
@@ -58,6 +58,8 @@ class SpocsEndpointRawTest {
         }
 
         whenever(sponsoredStoriesParams.siteId).thenReturn("")
+        whenever(sponsoredStoriesParams.country).thenReturn("")
+        whenever(sponsoredStoriesParams.city).thenReturn("")
 
         endpoint = SpocsEndpointRaw(client, profileId, appId, sponsoredStoriesParams)
     }
@@ -100,8 +102,10 @@ class SpocsEndpointRawTest {
     @Test
     fun `GIVEN a debug build AND a request configuration WHEN requesting spocs THEN the appropriate pocket proxy url is used`() {
         SpocsEndpointRaw.isDebugBuild = true
-        val expectedUrl = "https://spocs.getpocket.dev/spocs?site=123"
+        val expectedUrl = "https://spocs.getpocket.dev/spocs?site=123&country=US&city=NY"
         whenever(sponsoredStoriesParams.siteId).thenReturn("123")
+        whenever(sponsoredStoriesParams.country).thenReturn("US")
+        whenever(sponsoredStoriesParams.city).thenReturn("NY")
 
         assertRequestParams(
             client,
@@ -161,8 +165,10 @@ class SpocsEndpointRawTest {
     @Test
     fun `GIVEN a release build AND a request configuration WHEN requesting spocs THEN the appropriate pocket proxy url is used`() {
         SpocsEndpointRaw.isDebugBuild = false
-        val expectedUrl = "https://spocs.getpocket.com/spocs?site=123"
+        val expectedUrl = "https://spocs.getpocket.com/spocs?site=123&country=US&city=NY"
         whenever(sponsoredStoriesParams.siteId).thenReturn("123")
+        whenever(sponsoredStoriesParams.country).thenReturn("US")
+        whenever(sponsoredStoriesParams.city).thenReturn("NY")
 
         assertRequestParams(
             client,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
 * **service-pocket**
+  * 🌟 Added `country` and `city` parameters to Pocket sponsored stories fetch request. These can be overwritten using `PocketStoriesConfig`, allowing clients to specify a location and receive sponsored stories when outside countries where Pocket is enabled based on IP location. [Bug 1811537](https://bugzilla.mozilla.org/show_bug.cgi?id=1811537).
+
+* **service-pocket**
   * 🌟 Added `site` parameter to Pocket sponsored stories requests. It can be overwritten using `PocketStoriesConfig`, allowing clients to customize spoc content. [Bug 1811531](https://bugzilla.mozilla.org/show_bug.cgi?id=1811531).
 
 * **browser-storage-sync**:


### PR DESCRIPTION
Added `country` and `city` query parameters to Pocket sponsored stories request. These can be overridden 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1811537