### PR TITLE
Bug 1812517 - Update error pages for https and expired certificate. Modified the texts and added a link.

### DIFF
--- a/focus-android/app/src/main/assets/error_style.css
+++ b/focus-android/app/src/main/assets/error_style.css
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* Below styling is mirroring the Android Components styling from
+https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/browser/errorpages/src/main/assets/error_style.css */
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  --moz-vertical-spacing: 10px;
+  --moz-background-height: 32px;
+}
+
+body {
+  background-size: 64px var(--moz-background-height);
+  /* background-size: 64px 32px; */
+  background-repeat: repeat-x;
+
+  background-color: #363B40;
+  color: #FFFFFF;
+  padding: 0 20px;
+
+  font-weight: 300;
+  font-size: 13px;
+  -moz-text-size-adjust: none;
+  font-family: sans-serif;
+}
+
+ul {
+  /* Shove the list indicator so that its left aligned, but use outside so that text
+   * doesn't don't wrap the text around it */
+  padding: 0 1em;
+  margin: 0;
+  list-style: round outside none;
+}
+
+#errorShortDesc,
+li:not(:last-of-type) {
+  /* Margins between the li and buttons below it won't be collapsed. Remove the bottom margin here. */
+  margin: var(--moz-vertical-spacing) 0;
+}
+
+h1 {
+  margin: 0;
+  /* Since this has an underline, use padding for vertical spacing rather than margin */
+  padding: var(--moz-vertical-spacing) 0;
+  font-weight: 300;
+  border-bottom: 1px solid #e0e2e5;
+}
+
+h2 {
+  font-size: small;
+  padding: 0;
+  margin: var(--moz-vertical-spacing) 0;
+}
+
+p {
+  margin: var(--moz-vertical-spacing) 0;
+}
+
+button {
+  /* Force buttons to display: block here to try and enfoce collapsing margins */
+  display: block;
+  width: 100%;
+  border: none;
+  padding: 1rem;
+  font-family: sans-serif;
+  background-color: #00A4DC;
+  color: #FFFFFF;
+  font-weight: 300;
+  border-radius: 2px;
+  background-image: none;
+  margin: var(--moz-vertical-spacing) 0 0;
+}
+
+.buttonSecondary{
+  /* Force buttons to display: block here to try and enforce collapsing margins */
+  display: block;
+  width: 100%;
+  border: none;
+  padding: 1rem;
+  font-family: sans-serif;
+  background-color: rgba(249, 249, 250, 0.1);
+  color: #FFFFFF;
+  font-weight: 300;
+  border-radius: 2px;
+  background-image: none;
+  margin: var(--moz-vertical-spacing) 0 0;
+}
+
+#errorPageContainer {
+  /* If the page is greater than 550px center the content.
+   * This number should be kept in sync with the media query for tablets below */
+  max-width: 550px;
+  margin: 0 auto;
+  transform: translateY(var(--moz-background-height));
+  padding-bottom: var(--moz-vertical-spacing);
+
+  min-height: calc(100% - var(--moz-background-height) - var(--moz-vertical-spacing));
+  display: flex;
+  flex-direction: column;
+}
+
+/* On large screen devices (hopefully a 7+ inch tablet, we already center content (see #errorPageContainer above).
+   Apply tablet specific styles here */
+@media (min-width: 550px) {
+  button {
+    min-width: 160px;
+    width: auto;
+  }
+
+  /* If the tablet is tall as well, add some padding to make content feel a bit more centered */
+  @media (min-height: 550px) {
+    #errorPageContainer {
+      padding-top: 64px;
+      min-height: calc(100% - 64px);
+    }
+  }
+}
+
+.advancedPanelButtonContainer {
+  background-color: rgba(128, 128, 147, 0.1);
+  display: flex;
+  justify-content: center;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  padding-bottom: 0.5em;
+}
+
+#advancedPanelBackButtonContainer {
+  padding-bottom: 0;
+}
+
+#advancedPanelContainer {
+  width: 100%;
+  left: 0;
+}
+
+.advanced-panel {
+  display: none;
+  background-color: #202023;
+  border: 1px solid rgba(249, 249, 250, 0.2);
+  margin: 48px auto;
+  min-width: 13em;
+  max-width: 52em;
+}
+
+.button-container {
+  display: flex;
+  flex-flow: row;
+}
+
+#badCertTechnicalInfo {
+  margin: 0em 1em 1em;
+  overflow: auto;
+  white-space: pre-line;
+}
+
+#advancedButton {
+  display: none;
+}
+
+#badCertAdvancedPanel {
+  display: none;
+}
+
+/* Below styling is Focus specific */
+a {
+  color: white;
+}

--- a/focus-android/app/src/main/java/org/mozilla/focus/engine/AppContentInterceptor.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/engine/AppContentInterceptor.kt
@@ -15,6 +15,7 @@ import org.mozilla.focus.R
 import org.mozilla.focus.activity.CrashListActivity
 import org.mozilla.focus.browser.LocalizedContent
 import org.mozilla.focus.ext.components
+import org.mozilla.focus.utils.SupportUtils
 
 class AppContentInterceptor(
     private val context: Context,
@@ -91,7 +92,7 @@ class AppContentInterceptor(
 
 private fun getErrorPageTitle(context: Context, type: ErrorType): String? {
     if (type == ErrorType.ERROR_HTTPS_ONLY) {
-        return context.getString(R.string.errorpage_httpsonly_title)
+        return context.getString(R.string.errorpage_httpsonly_title2)
     }
     // Returning `null` here will let the component use its default title for this error type
     return null
@@ -100,8 +101,9 @@ private fun getErrorPageTitle(context: Context, type: ErrorType): String? {
 private fun getErrorPageDescription(context: Context, type: ErrorType): String? {
     if (type == ErrorType.ERROR_HTTPS_ONLY) {
         return context.getString(
-            R.string.errorpage_httpsonly_message,
+            R.string.errorpage_httpsonly_message2,
             context.getString(R.string.app_name),
+            SupportUtils.getGenericSumoURLForTopic(SupportUtils.SumoTopic.HTTPS_ONLY),
         )
     }
     // Returning `null` here will let the component use its default description for this error type

--- a/focus-android/app/src/main/res/values/strings.xml
+++ b/focus-android/app/src/main/res/values/strings.xml
@@ -968,11 +968,37 @@
     <string name="preference_follow_device_theme">Follow device theme</string>
 
     <!-- The title of the error page for websites that do not support HTTPS when HTTPS-Only is turned on  -->
-    <string name="errorpage_httpsonly_title">The site you requested does not support HTTPS</string>
-    <!-- The text of the error page for websites that do not support HTTPS when HTTPS-Only is turned on. %1$s will get replaced with the name of the app (e.g. "Firefox Focus") -->
-    <string name="errorpage_httpsonly_message">By default, %1$s attempts to connect using HTTPS for increased security. To change this setting or to learn more, go to Settings > Privacy &amp; Security > Security.</string>
+    <string name="errorpage_httpsonly_title" moz:RemovedIn="111" tools:ignore="UnusedResources">The site you requested does not support HTTPS</string>
 
-    <!-- Sessions List -->
+    <!-- The title of the error page for websites that do not support HTTPS when HTTPS-Only is turned on  -->
+    <string name="errorpage_httpsonly_title2">This site doesn’t support HTTPS</string>
+
+    <!-- The text of the error page for websites that do not support HTTPS when HTTPS-Only is turned on. %1$s will get replaced with the name of the app (e.g. "Firefox Focus") -->
+    <string name="errorpage_httpsonly_message" moz:RemovedIn="111" tools:ignore="UnusedResources">By default, %1$s attempts to connect using HTTPS for increased security. To change this setting or to learn more, go to Settings > Privacy &amp; Security > Security.</string>
+
+    <!-- The text of the error page for websites that do not support HTTPS when HTTPS-Only is turned on. %1$s will get replaced with the name of the app (e.g. "Firefox Focus").
+        Contains a button that will redirect the user to Privacy & Security Screen-->
+    <string name="errorpage_httpsonly_message2"><![CDATA[%1$s tries to use an HTTPS connection whenever possible for more security.
+     <a style="color:white;" href="%2$s">Learn more</a> <br/><br/>
+     Change this setting in Settings > Privacy &amp; Security > Security.]]></string>
+
+    <!-- The document title and heading of the error page shown when a website sends has an invalid or expired SSL certificate. -->
+    <string name="mozac_browser_errorpages_security_bad_cert_title">Connection not secure</string>
+
+    <!-- The error message shown when a website sends has an invalid or expired SSL certificate. -->
+    <string name="mozac_browser_errorpages_security_bad_cert_message" ><![CDATA[
+    This could be a problem with the server’s configuration, or it could be someone trying to impersonate the server. <br/><br/>
+    If you’ve connected to this server successfully in the past, the error may be temporary.
+    ]]></string>
+
+    <!-- The advanced certificate information shown when a website sends has an invalid SSL certificate. The %1$s will be replaced by the app name and %2$s will be replaced by website URL. It's only shown when a website has an invalid SSL certificate. -->
+    <string name="mozac_browser_errorpages_security_bad_cert_techInfo"><![CDATA[
+        <label>Someone could be trying to impersonate the site and continuing could be risky.</label>
+        <br><br>
+        <label>%1$s does not trust <b>%2$s</b> because its certificate issuer is unknown, the certificate is self-signed, or the server is not sending the correct intermediate certificates.</label>
+    ]]></string>
+
+     <!-- Sessions List -->
     <!-- Content description (not visible, for screen readers etc.): Button that closes a tab n the sessions list -->
     <string name="close_tab">Close tab</string>
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1812517