### PR TITLE
Bug 1813416 - Clear FLAG_KEEP_SCREEN_ON when playing media is finished.

### DIFF
--- a/android-components/components/feature/media/src/main/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeature.kt
+++ b/android-components/components/feature/media/src/main/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeature.kt
@@ -73,6 +73,7 @@ class MediaSessionFullscreenFeature(
     private fun processDeviceSleepMode(sessionStates: List<SessionState>) {
         val activeTabState = sessionStates.firstOrNull()
         if (activeTabState == null || activeTabState.mediaSessionState?.fullscreen != true) {
+            activity.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
             return
         }
         activeTabState.mediaSessionState?.let {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,6 +51,7 @@ permalink: /changelog/
 
 * **feature-media**
   * 🚒 Bug fixed [Bug 1802620](https://bugzilla.mozilla.org/show_bug.cgi?id=1802620). Handles `ForegroundServiceStartNotAllowedException`.
+  * 🚒 Bug fixed [Bug 1813416](https://bugzilla.mozilla.org/show_bug.cgi?id=1813416). Clear `FLAG_KEEP_SCREEN_ON` when playing media is finished.
 
 # 110.0.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/v109.0.0...v110.0.0)


### PR DESCRIPTION
When media session is destroyed, we forget clearing ` FLAG_KEEP_SCREEN_ON`. So we should clear it when active session is nothing or not fullscreen.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1813416