### PR TITLE
Revert "Bug 1802214 - Remove redundant getAppLaunchCount."

### DIFF
--- a/focus-android/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -140,6 +140,12 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
             TelemetryWrapper.openFromIconEvent()
         }
 
+        val launchCount = settings.getAppLaunchCount()
+        PreferenceManager.getDefaultSharedPreferences(this)
+            .edit()
+            .putInt(getString(R.string.app_launch_count), launchCount + 1)
+            .apply()
+
         AppReviewUtils.showAppReview(this)
 
         privateNotificationFeature = PrivateNotificationFeature(
@@ -297,7 +303,7 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
     private fun handleAppNavigation(intent: SafeIntent) {
         if (components.appStore.state.screen == Screen.Locked()) {
             components.appStore.dispatch(AppAction.Lock(intent.extras))
-        } else if (settings.isFirstRun) {
+        } else if (settings.getAppLaunchCount() == 0) {
             setSplashScreenPreDrawListener(intent)
         } else {
             ExternalIntentNavigation.handleAppNavigation(

--- a/focus-android/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -349,6 +349,11 @@ class Settings(
         false,
     )
 
+    fun getAppLaunchCount() = preferences.getInt(
+        getPreferenceKey(R.string.app_launch_count),
+        0,
+    )
+
     fun getTotalBlockedTrackersCount() = preferences.getInt(
         getPreferenceKey(R.string.pref_key_privacy_total_trackers_blocked_count),
         0,

--- a/focus-android/app/src/main/res/values/preference_keys.xml
+++ b/focus-android/app/src/main/res/values/preference_keys.xml
@@ -64,6 +64,7 @@
     <string name="has_opened_new_tab" translatable="false"><xliff:g id="preference_key">has_opened_new_tab</xliff:g></string>
     <string name="has_added_to_home_screen" translatable="false"><xliff:g id="preference_key">has_added_to_home_screen</xliff:g></string>
     <string name="has_requested_desktop" translatable="false"><xliff:g id="preference_key">has_requested_desktop</xliff:g></string>
+    <string name="app_launch_count" translatable="false"><xliff:g id="preference_key">app_launch_count</xliff:g></string>
     <string name="pref_key_category_safe_browsing" translatable="false"><xliff:g id="preference_key">safe_browsing_category</xliff:g></string>
 
     <string name="pref_key_category_security" translatable="false"><xliff:g id="preference_key">security_category</xliff:g></string>

--- a/focus-android/quality/detekt-baseline.xml
+++ b/focus-android/quality/detekt-baseline.xml
@@ -382,6 +382,7 @@
     <ID>UndocumentedPublicFunction:SecretSettingsUnlocker.kt$SecretSettingsUnlocker$fun increment()</ID>
     <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun addSearchWidgetInstalled(count: Int)</ID>
     <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun createTrackingProtectionPolicy( shouldBlockCookiesValue: String = shouldBlockCookiesValue(), ): EngineSession.TrackingProtectionPolicy</ID>
+    <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun getAppLaunchCount()</ID>
     <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun getClearBrowsingSessions()</ID>
     <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun getCurrentCookieBannerOptionFromSharePref(): CookieBannerOption</ID>
     <ID>UndocumentedPublicFunction:Settings.kt$Settings$fun getHttpsOnlyMode(): Engine.HttpsOnlyMode</ID>


### PR DESCRIPTION
This reverts commit 76f9abc8b973612c7f6665bf8201e5952d9393f5.

See [bug 1814508#c10](https://bugzilla.mozilla.org/show_bug.cgi?id=1814508#c10).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1802214