### PR TITLE
Bug 1815195 - Avoid a redundant file extension when saving a real pdf file

### DIFF
--- a/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
+++ b/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
@@ -235,10 +235,14 @@ object DownloadUtils {
      * This is primarily useful for connecting the "Save to PDF" feature response to downloads.
      */
     fun makePdfContentDisposition(filename: String): String {
-        return filename
-            .take(MAX_FILE_NAME_LENGTH)
+        val pdfExtension = ".pdf"
+        return if (filename.endsWith(pdfExtension)) {
+            filename.substringBeforeLast('.')
+        } else {
+            filename
+        }.take(MAX_FILE_NAME_LENGTH - pdfExtension.length)
             .run {
-                "attachment; filename=$this.pdf;"
+                "attachment; filename=$this$pdfExtension;"
             }
     }
 

--- a/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
+++ b/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
@@ -137,6 +137,15 @@ class DownloadUtilsTest {
         assertEquals(null, DownloadUtils.sanitizeMimeType(null))
     }
 
+    @Test
+    fun makePdfContentDisposition() {
+        assertEquals("attachment; filename=foo.pdf;", DownloadUtils.makePdfContentDisposition("foo"))
+        assertEquals("attachment; filename=foo.html.pdf;", DownloadUtils.makePdfContentDisposition("foo.html"))
+        assertEquals("attachment; filename=foo.pdf;", DownloadUtils.makePdfContentDisposition("foo.pdf"))
+        assertEquals("attachment; filename=${"a".repeat(251)}.pdf;", DownloadUtils.makePdfContentDisposition("a".repeat(260)))
+        assertEquals("attachment; filename=${"a".repeat(251)}.pdf;", DownloadUtils.makePdfContentDisposition("a".repeat(260) + ".pdf"))
+    }
+
     companion object {
         private val CONTENT_DISPOSITION_TYPES = listOf("attachment", "inline")
 


### PR DESCRIPTION
and avoid to have a too long filename.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815195