### PR TITLE
Bug 1815551 - Update Sentry to version 6.13.1

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -34,7 +34,7 @@ object Versions {
     const val detekt = "1.19.0"
 
     const val sentry_legacy = "1.7.30"
-    const val sentry_latest = "6.11.0"
+    const val sentry_latest = "6.13.1"
 
     // zxing 3.4+ requires a minimum API of 24 or higher
     const val zxing = "3.3.3"

--- a/focus-android/buildSrc/src/main/java/FocusDependencies.kt
+++ b/focus-android/buildSrc/src/main/java/FocusDependencies.kt
@@ -65,7 +65,7 @@ object FocusVersions {
     object ThirdParty {
         const val jna = "5.12.1"
         const val leakcanary = "2.10"
-        const val sentry = "6.11.0"
+        const val sentry = "6.13.1"
     }
 
     // Workaround for a Gradle parsing bug that prevents using nested objects directly in Gradle files.


### PR DESCRIPTION
See the bug for changelog links.
https://bugzilla.mozilla.org/show_bug.cgi?id=1815551