### PR TITLE
Bug 1816058 - Fix error pages strings for https and expired certificate.

### DIFF
--- a/focus-android/app/src/main/res/values/strings.xml
+++ b/focus-android/app/src/main/res/values/strings.xml
@@ -979,19 +979,19 @@
     <!-- The text of the error page for websites that do not support HTTPS when HTTPS-Only is turned on. %1$s will get replaced with the name of the app (e.g. "Firefox Focus").
         Contains a button that will redirect the user to Privacy & Security Screen-->
     <string name="errorpage_httpsonly_message2"><![CDATA[%1$s tries to use an HTTPS connection whenever possible for more security.
-     <a style="color:white;" href="%2$s">Learn more</a> <br/><br/>
+     <a href="%2$s">Learn more</a> <br/><br/>
      Change this setting in Settings > Privacy &amp; Security > Security.]]></string>
 
-    <!-- The document title and heading of the error page shown when a website sends has an invalid or expired SSL certificate. -->
+    <!-- The document title and heading of the error page shown when a website has an invalid or expired SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_title">Connection not secure</string>
 
-    <!-- The error message shown when a website sends has an invalid or expired SSL certificate. -->
+    <!-- The error message shown when a website has an invalid or expired SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_message" ><![CDATA[
     This could be a problem with the server’s configuration, or it could be someone trying to impersonate the server. <br/><br/>
     If you’ve connected to this server successfully in the past, the error may be temporary.
     ]]></string>
 
-    <!-- The advanced certificate information shown when a website sends has an invalid SSL certificate. The %1$s will be replaced by the app name and %2$s will be replaced by website URL. It's only shown when a website has an invalid SSL certificate. -->
+    <!-- The advanced certificate information shown when a website has an invalid SSL certificate. The %1$s will be replaced by the app name and %2$s will be replaced by website URL. It's only shown when a website has an invalid SSL certificate. -->
     <string name="mozac_browser_errorpages_security_bad_cert_techInfo"><![CDATA[
         <label>Someone could be trying to impersonate the site and continuing could be risky.</label>
         <br><br>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816058