### PR TITLE
Bug 1803130 - Update README to reflect Fenix migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,51 @@
 
-This repository currently hosts the [Mozilla Android Components](android-components/README.md) and [Focus (Android)](focus-android/README.md) projects. It is also the future home of [Fenix](https://github.com/mozilla-mobile/fenix), which will be [migrated in the coming weeks](https://github.com/mozilla-mobile/fenix/issues/26855).
+This repository hosts the Firefox for Android (Fenix), Focus on Android, and Mozilla Android Components projects.
 
-Please file issues for Android Components in [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Fenix), selecting the corresponding component. Firefox Focus (Android) issues should now also be filed in [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Focus) under the Focus product.
+# Firefox for Android
 
+[![Task Status](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/firefox-android/main/badge.svg)](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/firefox-android/main/latest)
+[![chat.mozilla.org](https://img.shields.io/badge/chat-on%20matrix-51bb9c)](https://chat.mozilla.org/#/room/#fenix:mozilla.org)
+
+_Get the people-first browser that’s backed by a non-profit._
+
+_It’s a new era in tech. Don’t settle for a browser produced by giant, profit-driven, data-hoarding tech companies. Firefox is the obvious choice for independent, ethical tech that respects your privacy and gives you more ways than ever before to tailor your internet experience exactly the way you want it._
+
+Fenix (internal codename) is the all-new Firefox for Android browser, based on [GeckoView](https://mozilla.github.io/geckoview/) and [Mozilla Android Components](https://mozac.org/).
+
+<a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox" target="_blank"><img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="90"/></a>
+
+Please file issues for Fenix (Firefox for Android) in [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Fenix), selecting the corresponding component. 
+
+[Learn more about Firefox for Android](fenix/README.md)
+
+# Firefox Focus for Android
+
+[![Task Status](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/firefox-android/main/badge.svg)](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/firefox-android/main/latest)
+[![chat.mozilla.org](https://img.shields.io/badge/chat-on%20matrix-51bb9c)](https://chat.mozilla.org/#/room/#focus-android:mozilla.org)
+
+_Browse like no one’s watching. The new Firefox Focus automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it. Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads._ 
+
+Firefox Focus provides automatic ad blocking and tracking protection on an easy-to-use private browser.
+
+<a href="https://play.google.com/store/apps/details?id=org.mozilla.focus" target="_blank"><img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="90"/></a>
+
+* [Google Play: Firefox Focus (Global)](https://play.google.com/store/apps/details?id=org.mozilla.focus)
+* [Google Play: Firefox Klar (Germany, Austria & Switzerland)](https://play.google.com/store/apps/details?id=org.mozilla.klar)
+* [Download APKs](https://github.com/mozilla-mobile/focus-android/releases)
+
+Firefox Focus (Android) issues should now also be filed in [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Focus) under the Focus product.
+
+[Learn more about Focus for Android](focus-android/README.md)
+
+# Android components
+
+[![Task Status](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/firefox-android/main/badge.svg)](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/firefox-android/main/latest)
+[![chat.mozilla.org](https://img.shields.io/badge/chat-on%20matrix-51bb9c)](https://chat.mozilla.org/#/room/#android-components:mozilla.org)
+
+_A collection of Android libraries to build browsers or browser-like applications._
+
+A fully-featured reference browser implementation based on the components can be found in the [reference-browser repository](https://github.com/mozilla-mobile/reference-browser).
+
+Please file issues for Android Components in the Fenix [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Fenix), selecting the corresponding component. 
+
+[Learn more about Android Components](android-components/README.md)


### PR DESCRIPTION
POST FENIX MIGRATION:

@gabrielluong and I cleaned up the Monorepo README by providing some first information, and linking to the project-specific README files. This isn't perfect yet, but much better than the placeholder we have now.


https://bugzilla.mozilla.org/show_bug.cgi?id=1803130
https://bugzilla.mozilla.org/show_bug.cgi?id=1803130
https://bugzilla.mozilla.org/show_bug.cgi?id=1803130