### PR TITLE
Bug 1808605 - part 28: Do not include non-existing secrets on Focus

### DIFF
--- a/taskcluster/android_taskgraph/transforms/build_apk.py
+++ b/taskcluster/android_taskgraph/transforms/build_apk.py
@@ -50,7 +50,6 @@ def add_shippable_secrets(config, tasks):
             task.pop("include-shippable-secrets", False)
             and config.params["level"] == "3"
         ):
-            gradle_build_type = task["run"]["gradle-build-type"]
             secrets.extend(
                 [
                     {
@@ -58,20 +57,7 @@ def add_shippable_secrets(config, tasks):
                         "name": _get_secret_index(task["name"]),
                         "path": target_file,
                     }
-                    for key, target_file in (
-                        ("adjust", ".adjust_token"),
-                        (
-                            "firebase",
-                            "app/src/{}/res/values/firebase.xml".format(
-                                gradle_build_type
-                            ),
-                        ),
-                        ("sentry_dsn", ".sentry_token"),
-                        ("mls", ".mls_token"),
-                        ("nimbus_url", ".nimbus"),
-                        ("wallpaper_url", ".wallpaper_url"),
-                        ("pocket_consumer_key", ".pocket_consumer_key"),
-                    )
+                    for key, target_file in _get_secrets_keys_and_target_files(task)
                 ]
             )
         else:
@@ -90,6 +76,30 @@ def add_shippable_secrets(config, tasks):
             )
 
         yield task
+
+
+def _get_secrets_keys_and_target_files(task):
+    secrets = [
+        ('adjust', '.adjust_token'),
+        ('sentry_dsn', '.sentry_token'),
+        ('mls', '.mls_token'),
+        ('nimbus_url', '.nimbus'),
+    ]
+
+    if task["name"].startswith("fenix-"):
+        gradle_build_type = task["run"]["gradle-build-type"]
+        secrets.extend([
+            (
+                "firebase",
+                "app/src/{}/res/values/firebase.xml".format(
+                    gradle_build_type
+                ),
+            ),
+            ("wallpaper_url", ".wallpaper_url"),
+            ("pocket_consumer_key", ".pocket_consumer_key"),
+        ])
+
+    return secrets
 
 
 def _get_secret_index(task_name):


### PR DESCRIPTION
https://github.com/mozilla-mobile/firefox-android/pull/720#pullrequestreview-1289628557 turned out to be a valid concern. 

Fixes[1]:

```
[task 2023-02-14T10:07:18.792Z] + ../taskcluster/scripts/get-secret.py -s project/mobile/focus-android/nightly -k firebase -f app/src/nightly/res/values/firebase.xml
[task 2023-02-14T10:07:18.996Z] Outputting secret to: /builds/worker/checkouts/vcs/focus-android/app/src/nightly/res/values/firebase.xml
[task 2023-02-14T10:07:18.996Z] Traceback (most recent call last):
[task 2023-02-14T10:07:18.996Z]   File "../taskcluster/scripts/get-secret.py", line 71, in <module>
[task 2023-02-14T10:07:18.996Z]     main()
[task 2023-02-14T10:07:18.996Z]   File "../taskcluster/scripts/get-secret.py", line 67, in main
[task 2023-02-14T10:07:18.996Z]     write_secret_to_file(result.path, secret, result.key, result.decode, result.json, result.append, result.prefix)
[task 2023-02-14T10:07:18.996Z]   File "../taskcluster/scripts/get-secret.py", line 26, in write_secret_to_file
[task 2023-02-14T10:07:18.996Z]     value = data['secret'][key]
[task 2023-02-14T10:07:18.996Z] KeyError: 'firebase'
```

[1] https://firefox-ci-tc.services.mozilla.com/tasks/JTpbV5W3RJaY1AiUhGpEuw/runs/0/logs/public/logs/live.log#L52
https://bugzilla.mozilla.org/show_bug.cgi?id=1808605