### PR TITLE
Bug 1808606 - part 9: Sign fenix-nightly with the nightly key

### DIFF
--- a/taskcluster/android_taskgraph/transforms/signing_apk.py
+++ b/taskcluster/android_taskgraph/transforms/signing_apk.py
@@ -18,7 +18,7 @@ PRODUCTION_SIGNING_BUILD_TYPES = [
     "focus-release",
     "klar-release",
     "android-test-nightly",
-    "android-test-beta"
+    "android-test-beta",
     "fenix-nightly",
     "fenix-beta",
     "fenix-release",


### PR DESCRIPTION
Fixes[1]:

```
2023-02-14T10:22:19    DEBUG -  404 downloading https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/TY5A-Ed0RrCuIg025WJeKA/artifacts/public%2Fchain-of-trust.json.sig: 404; body={
  "code": "ResourceNotFound",
  "message": "Artifact not found\n\n---\n\n* method:     getLatestArtifact\n* errorCode:  ResourceNotFound\n* statusCode: 404\n* time:       2023-02-14T10:22:19.921Z",
  "requestInfo": {
    "method": "getLatestArtifact",
    "params": {
      "0": "public/chain-of-trust.json.sig",
      "taskId": "TY5A-Ed0RrCuIg025WJeKA",
      "name": "public/chain-of-trust.json.sig"
    },
    "payload": {},
    "time": "2023-02-14T10:22:19.921Z"
  }
}
[...]
2023-02-14T10:22:20 CRITICAL - Chain of Trust verification error!
Traceback (most recent call last):
  File "/app/lib/python3.9/site-packages/scriptworker/cot/verify.py", line 2019, in verify_chain_of_trust
    await download_cot(chain)
  File "/app/lib/python3.9/site-packages/scriptworker/cot/verify.py", line 683, in download_cot
    artifacts_paths = await raise_future_exceptions(artifact_tasks)
  File "/app/lib/python3.9/site-packages/scriptworker/utils.py", line 409, in raise_future_exceptions
    succeeded_results, _ = await _process_future_exceptions(tasks, raise_at_first_error=True)
  File "/app/lib/python3.9/site-packages/scriptworker/utils.py", line 443, in _process_future_exceptions
    raise exc
  File "/app/lib/python3.9/site-packages/scriptworker/artifacts.py", line 294, in download_artifacts
    await raise_future_exceptions(tasks)
  File "/app/lib/python3.9/site-packages/scriptworker/utils.py", line 409, in raise_future_exceptions
    succeeded_results, _ = await _process_future_exceptions(tasks, raise_at_first_error=True)
  File "/app/lib/python3.9/site-packages/scriptworker/utils.py", line 443, in _process_future_exceptions
    raise exc
  File "/app/lib/python3.9/site-packages/scriptworker/utils.py", line 955, in semaphore_wrapper
    return await coro
  File "/app/lib/python3.9/site-packages/scriptworker/utils.py", line 268, in retry_async
    return await func(*args, **kwargs)
  File "/app/lib/python3.9/site-packages/scriptworker/utils.py", line 670, in download_file
    raise Download404("{} status {}!".format(loggable_url, resp.status))
scriptworker.exceptions.Download404: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/TY5A-Ed0RrCuIg025WJeKA/artifacts/public%2Fchain-of-trust.json.sig status 404!
```

It turns out we were using the level-1 workers instead of the level-3 ones because of this small nit 😅 Here's the taskgraph diff:

```diff
--- target_task_graph@bb0d9a2d1cb1
+++ target_task_graph@bug-1808606-8
@@ -70603,55 +70603,71 @@
           {
             "formats": [
               "autograph_apk"
             ],
             "paths": [
               "public/build/fenix/arm64-v8a/target.apk",
               "public/build/fenix/armeabi-v7a/target.apk",
               "public/build/fenix/x86/target.apk",
               "public/build/fenix/x86_64/target.apk"
             ],
             "taskId": {
               "task-reference": "<build-apk>"
             },
             "taskType": "build"
           }
         ]
       },
       "priority": "highest",
       "provisionerId": "scriptworker-k8s",
       "routes": [
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.latest.arm64-v8a",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.2022.10.31.revision.aad2e6db380c05b565a5af8f21bc3af3ffb43117.arm64-v8a",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.2022.10.31.latest.arm64-v8a",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.revision.aad2e6db380c05b565a5af8f21bc3af3ffb43117.arm64-v8a",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.latest.armeabi-v7a",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.2022.10.31.revision.aad2e6db380c05b565a5af8f21bc3af3ffb43117.armeabi-v7a",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.2022.10.31.latest.armeabi-v7a",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.revision.aad2e6db380c05b565a5af8f21bc3af3ffb43117.armeabi-v7a",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.latest.x86",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.2022.10.31.revision.aad2e6db380c05b565a5af8f21bc3af3ffb43117.x86",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.2022.10.31.latest.x86",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.revision.aad2e6db380c05b565a5af8f21bc3af3ffb43117.x86",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.latest.x86_64",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.2022.10.31.revision.aad2e6db380c05b565a5af8f21bc3af3ffb43117.x86_64",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.2022.10.31.latest.x86_64",
+        "index.mobile.v3.firefox-android.apks.fenix-nightly.revision.aad2e6db380c05b565a5af8f21bc3af3ffb43117.x86_64",
         "tc-treeherder.v2.firefox-android.aad2e6db380c05b565a5af8f21bc3af3ffb43117.0",
         "checks"
       ],
       "scopes": [
-        "project:mobile:firefox-android:releng:signing:cert:dep-signing",
+        "project:mobile:firefox-android:releng:signing:cert:production-signing",
         "project:mobile:firefox-android:releng:signing:format:autograph_apk"
       ],
       "tags": {
         "createdForUser": "cron@noreply.mozilla.org",
         "kind": "signing-apk",
         "label": "signing-apk-fenix-nightly",
         "os": "scriptworker",
         "worker-implementation": "scriptworker"
       },
-      "workerType": "mobile-t-signing"
+      "workerType": "mobile-3-signing"
     }
   },
   "signing-apk-focus-nightly": {
     "attributes": {
       "always_target": false,
       "apks": {
         "arm64-v8a": {
           "github-name": "focus-108.0.0-arm64-v8a.apk",
           "name": "public/build/focus/arm64-v8a/target.apk"
         },
         "armeabi-v7a": {
           "github-name": "focus-108.0.0-armeabi-v7a.apk",
           "name": "public/build/focus/armeabi-v7a/target.apk"
         },
         "x86": {
           "github-name": "focus-108.0.0-x86.apk",
           "name": "public/build/focus/x86/target.apk"
         },
         "x86_64": {
           "github-name": "focus-108.0.0-x86_64.apk",
```

[1] https://firefox-ci-tc.services.mozilla.com/tasks/TzrDMK98SSaZ_R2uGdySZQ/runs/0/logs/public/logs/chain_of_trust.log#L51
https://bugzilla.mozilla.org/show_bug.cgi?id=1808606