### PR TITLE
Bug 1814187 - Clear button should be active only when username input is not empty.

### DIFF
--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -1829,7 +1829,7 @@
     <!--  The error message in add/edit login view when password field is blank. -->
     <string name="saved_login_password_required">Password required</string>
     <!--  The error message in add login view when username field is blank. -->
-    <string name="saved_login_username_required">Username required</string>
+    <string name="saved_login_username_required" moz:removedIn="111" tools:ignore="UnusedResources">Username required</string>
     <!--  The error message in add login view when hostname field is blank. -->
     <string name="saved_login_hostname_required" tools:ignore="UnusedResources">Hostname required</string>
     <!-- Voice search button content description  -->


### PR DESCRIPTION
Based on this bug https://github.com/mozilla-mobile/fenix/issues/26736 a user should be able to manually add a login without a username. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1814187