### PR TITLE
Bug 1808605 - part 29: Run `startup-test` from the fenix folder

### DIFF
--- a/taskcluster/ci/startup-test/kind.yml
+++ b/taskcluster/ci/startup-test/kind.yml
@@ -47,6 +47,8 @@ task-defaults:
 tasks:
     nightly-arm:
         run:
+            pre-commands:
+                - ["cd", "fenix"]
             commands:
                 - [wget, {artifact-reference: '<signing/public/build/fenix/arm64-v8a/target.apk>'}, '-O', app.apk]
                 - [wget, {artifact-reference: '<signing-android-test/public/build/fenix/noarch/target.apk>'}, '-O', android-test.apk]


### PR DESCRIPTION
Fixes[1]:

```
[task 2023-02-14T11:35:10.857Z] executing ['bash', '-cx', "../taskcluster/scripts/get-secret.py -s project/mobile/fenix/firebase -k firebaseToken -f .firebase_token.json --json && wget 'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/LlnFRTvsRfCa7Aoql_kxXw/artifacts/public/build/fenix/arm64-v8a/target.apk' -O app.apk && wget 'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/fzUBQlSiQi2fkWpfjpdDUg/artifacts/public/build/fenix/noarch/target.apk' -O android-test.apk && automation/taskcluster/androidTest/ui-test.sh arm-start-test app.apk android-test.apk 1"]
[task 2023-02-14T11:35:10.859Z] + ../taskcluster/scripts/get-secret.py -s project/mobile/fenix/firebase -k firebaseToken -f .firebase_token.json --json
[task 2023-02-14T11:35:10.859Z] bash: ../taskcluster/scripts/get-secret.py: No such file or directory
```

[1] https://firefox-ci-tc.services.mozilla.com/tasks/BfoYEG4jSpKtm0Pk9QCzfg/runs/0/logs/public/logs/live.log#L38
https://bugzilla.mozilla.org/show_bug.cgi?id=1808605