### PR TITLE
Bug 1813877 - Announce page title with talkback when swiping on navbar

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -143,6 +143,7 @@ import org.mozilla.fenix.onboarding.FenixOnboarding
 import org.mozilla.fenix.perf.MarkersFragmentLifecycleCallbacks
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.settings.biometric.BiometricPromptFeature
+import org.mozilla.fenix.tabstray.ext.toDisplayTitle
 import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.allowUndo
 import org.mozilla.fenix.wifi.SitePermissionsWifiIntegration
@@ -1134,6 +1135,8 @@ abstract class BaseBrowserFragment :
         if (!this.isRemoving) {
             updateThemeForSession(selectedTab)
         }
+
+        binding.engineView.asView().contentDescription = selectedTab.toDisplayTitle()
 
         if (browserInitialized) {
             view?.let {

--- a/fenix/app/src/main/res/layout/fragment_browser.xml
+++ b/fenix/app/src/main/res/layout/fragment_browser.xml
@@ -32,6 +32,7 @@
                     android:id="@+id/engineView"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    android:accessibilityLiveRegion="polite"
                     android:visibility="gone" />
             </mozilla.components.ui.widgets.VerticalSwipeRefreshLayout>
 


### PR DESCRIPTION
Talkback now announces the title of the tab switched to using swipe left or right gestures on the navbar.


https://user-images.githubusercontent.com/32488956/218774755-0680500f-657c-4b08-94e1-2ef3bd7ab62c.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1813877