### PR TITLE
Bug 1816683 - Fix AC version not displayed in verifyAboutFirefoxPreview UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
@@ -100,17 +100,13 @@ private fun assertVersionNumber() {
 
     val packageInfo = context.packageManager.getPackageInfoCompat(context.packageName, 0)
     val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo).toString()
-
     val buildNVersion = "${packageInfo.versionName} (Build #$versionCode)\n"
-    val componentsVersion =
-        "${mozilla.components.Build.version}, ${mozilla.components.Build.gitHash}"
     val geckoVersion =
         org.mozilla.geckoview.BuildConfig.MOZ_APP_VERSION + "-" + org.mozilla.geckoview.BuildConfig.MOZ_APP_BUILDID
     val asVersion = mozilla.components.Build.applicationServicesVersion
 
     onView(withId(R.id.about_text))
         .check(matches(withText(containsString(buildNVersion))))
-        .check(matches(withText(containsString(componentsVersion))))
         .check(matches(withText(containsString(geckoVersion))))
         .check(matches(withText(containsString(asVersion))))
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816683