### PR TITLE
Bug 1816186 - Use detect-only just when we can show the re-engagement dialog

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -132,6 +132,7 @@ import org.mozilla.fenix.settings.TrackingProtectionFragmentDirections
 import org.mozilla.fenix.settings.about.AboutFragmentDirections
 import org.mozilla.fenix.settings.logins.fragment.LoginDetailFragmentDirections
 import org.mozilla.fenix.settings.logins.fragment.SavedLoginsAuthFragmentDirections
+import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.dialog.CookieBannerReEngagementDialogUtils
 import org.mozilla.fenix.settings.search.AddSearchEngineFragmentDirections
 import org.mozilla.fenix.settings.search.EditCustomSearchEngineFragmentDirections
 import org.mozilla.fenix.settings.studies.StudiesFragmentDirections
@@ -445,6 +446,10 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         // and the user changes the system language
         // More details here: https://github.com/mozilla-mobile/fenix/pull/27793#discussion_r1029892536
         components.core.store.dispatch(SearchAction.RefreshSearchEnginesAction)
+        CookieBannerReEngagementDialogUtils.tryToEnableDetectOnlyModeIfNeeded(
+            components.settings,
+            components.core.engine.settings,
+        )
     }
 
     override fun onStart() {

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -140,7 +140,7 @@ class Core(
             cookieBannerHandlingModePrivateBrowsing = context.settings().getCookieBannerHandling(),
             cookieBannerHandlingMode = context.settings().getCookieBannerHandling(),
             cookieBannerHandlingDetectOnlyMode = context.settings()
-                .shouldEnabledCookieBannerDetectOnlyMode(),
+                .shouldShowCookieBannerReEngagementDialog(),
         )
 
         GeckoEngine(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/CookieBannersFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/CookieBannersFragment.kt
@@ -53,7 +53,7 @@ class CookieBannersFragment : PreferenceFragmentCompat() {
                     getEngineSettings().cookieBannerHandlingModePrivateBrowsing = mode
                     getEngineSettings().cookieBannerHandlingMode = mode
                     getEngineSettings().cookieBannerHandlingDetectOnlyMode =
-                        requireContext().settings().shouldEnabledCookieBannerDetectOnlyMode()
+                        requireContext().settings().shouldShowCookieBannerReEngagementDialog()
                     CookieBanners.settingChanged.record(CookieBanners.SettingChangedExtra(metricTag))
                     requireContext().components.useCases.sessionUseCases.reload()
                     return super.onPreferenceChange(preference, newValue)

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/dialog/CookieBannerReEngagementDialog.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/dialog/CookieBannerReEngagementDialog.kt
@@ -62,13 +62,12 @@ class CookieBannerReEngagementDialog : DialogFragment() {
                         dismiss()
                     },
                     onNotNowButtonClicked = {
+                        disabledCookieBannerHandlingDetectOnlyMode()
                         CookieBanners.notNowReEngagementDialog.record(NoExtras())
                         dismiss()
                     },
                     onCloseButtonClicked = {
-                        getEngineSettings().cookieBannerHandlingDetectOnlyMode = false
-                        getEngineSettings().cookieBannerHandlingModePrivateBrowsing = DISABLED
-                        getEngineSettings().cookieBannerHandlingMode = DISABLED
+                        disabledCookieBannerHandlingDetectOnlyMode()
                         requireContext().settings().userOptOutOfReEngageCookieBannerDialog = true
                         CookieBanners.optOutReEngagementDialog.record(NoExtras())
                         dismiss()
@@ -76,6 +75,12 @@ class CookieBannerReEngagementDialog : DialogFragment() {
                 )
             }
         }
+    }
+
+    private fun disabledCookieBannerHandlingDetectOnlyMode() {
+        getEngineSettings().cookieBannerHandlingDetectOnlyMode = false
+        getEngineSettings().cookieBannerHandlingModePrivateBrowsing = DISABLED
+        getEngineSettings().cookieBannerHandlingMode = DISABLED
     }
 
     private fun getEngineSettings(): Settings {

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -586,10 +586,10 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      * Indicates if we should should show the cookie banner dialog that invites the user to turn-on
      * the setting.
      */
-    fun shouldCookieBannerReEngagementDialog(): Boolean {
+    fun shouldShowCookieBannerReEngagementDialog(): Boolean {
         val shouldShowDialog =
             shouldShowCookieBannerUI && !userOptOutOfReEngageCookieBannerDialog && !shouldUseCookieBanner
-        return if (!shouldShowTotalCookieProtectionCFR && shouldShowDialog) {
+        return if (shouldShowDialog) {
             !cookieBannerDetectedPreviously ||
                 timeNowInMillis() - lastInteractionWithReEngageCookieBannerDialogInMs >= timerForCookieBannerDialog
         } else {
@@ -704,7 +704,10 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     val enabledTotalCookieProtection: Boolean
         get() = Config.channel.isNightlyOrDebug || mr2022Sections[Mr2022Section.TCP_FEATURE] == true
 
-    private val enabledTotalCookieProtectionCFR: Boolean
+    /**
+     * Indicates if the total cookie protection CRF feature is enabled.
+     */
+    val enabledTotalCookieProtectionCFR: Boolean
         get() = Config.channel.isNightlyOrDebug || mr2022Sections[Mr2022Section.TCP_CFR] == true
 
     /**
@@ -1557,24 +1560,12 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     fun getCookieBannerHandling(): CookieBannerHandlingMode {
         return when (shouldUseCookieBanner) {
             true -> CookieBannerHandlingMode.REJECT_ALL
-            false -> if (shouldEnabledCookieBannerDetectOnlyMode()) {
+            false -> if (shouldShowCookieBannerReEngagementDialog()) {
                 CookieBannerHandlingMode.REJECT_ALL
             } else {
                 CookieBannerHandlingMode.DISABLED
             }
         }
-    }
-
-    /**
-     * Indicates if the cookie banner detect only mode should be enabled.
-     */
-    fun shouldEnabledCookieBannerDetectOnlyMode(): Boolean {
-        val tcpCFRAlreadyShown = if (enabledTotalCookieProtectionCFR) {
-            !userOptOutOfReEngageCookieBannerDialog
-        } else {
-            true
-        }
-        return shouldShowCookieBannerUI && tcpCFRAlreadyShown && !shouldUseCookieBanner
     }
 
     var setAsDefaultGrowthSent by booleanPreference(


### PR DESCRIPTION

Re-open as https://github.com/mozilla-mobile/fenix/pull/28824 was closed because of the monorepo migration.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816186