### PR TITLE
Bug 1809919 - Implement ActivityContextDelegate in AC

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -12,6 +12,7 @@ import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.ViewCompat
+import mozilla.components.browser.engine.gecko.activity.GeckoViewActivityContextDelegate
 import mozilla.components.browser.engine.gecko.selection.GeckoSelectionActionDelegate
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
@@ -20,6 +21,7 @@ import mozilla.components.concept.engine.selection.SelectionActionDelegate
 import org.mozilla.geckoview.BasicSelectionActionDelegate
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.GeckoSession
+import java.lang.ref.WeakReference
 
 /**
  * Gecko-based EngineView implementation.
@@ -176,6 +178,10 @@ class GeckoEngineView @JvmOverloads constructor(
 
     override fun setDynamicToolbarMaxHeight(height: Int) {
         geckoView.setDynamicToolbarMaxHeight(height)
+    }
+
+    override fun setActivityContext(context: Context?) {
+        geckoView.activityContextDelegate = GeckoViewActivityContextDelegate(WeakReference(context))
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/activity/GeckoViewActivityContextDelegate.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/activity/GeckoViewActivityContextDelegate.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.activity
+
+import android.app.Activity
+import android.content.Context
+import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.geckoview.GeckoView
+import java.lang.ref.WeakReference
+
+/**
+ * GeckoViewActivityContextDelegate provides an active Activity to GeckoView or null. Not to be confused
+ * with the runtime delegate of [GeckoActivityDelegate], which is tightly coupled to webauthn.
+ * See bug 1806191 for more information on delegate differences.
+ *
+ * @param contextRef A reference to an active Activity context or null for GeckoView to use.
+ */
+class GeckoViewActivityContextDelegate(
+    private val contextRef: WeakReference<Context?>,
+) : GeckoView.ActivityContextDelegate {
+    private val logger = Logger("GeckoViewActivityContextDelegate")
+    init {
+        if (contextRef.get() == null) {
+            logger.warn("Activity context is null.")
+        } else if (contextRef.get() !is Activity) {
+            logger.warn("A non-activity context was set.")
+        }
+    }
+
+    /**
+     * Used by GeckoView to get an Activity context for operations such as printing.
+     * @return An active Activity context or null.
+     */
+    override fun getActivityContext(): Context? {
+        val context = contextRef.get()
+        if ((context == null) || (context as Activity).isDestroyed) {
+            return null
+        }
+        return context
+    }
+}

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/activity/GeckoViewActivityContextDelegateTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/activity/GeckoViewActivityContextDelegateTest.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.engine.gecko.activity
+
+import android.app.Activity
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.doReturn
+import java.lang.ref.WeakReference
+
+class GeckoViewActivityContextDelegateTest {
+
+    @Test
+    fun `getActivityContext returns the same activity as set on the delegate`() {
+        val mockActivity = mock<Activity>()
+        val activityContextDelegate = GeckoViewActivityContextDelegate(WeakReference(mockActivity))
+        assertTrue(mockActivity == activityContextDelegate.activityContext)
+    }
+
+    @Test
+    fun `getActivityContext returns null when the activity is destroyed`() {
+        val mockActivity = mock<Activity>()
+        val activityContextDelegate = GeckoViewActivityContextDelegate(WeakReference(mockActivity))
+        doReturn(true).`when`(mockActivity).isDestroyed
+        assertNull(activityContextDelegate.activityContext)
+    }
+
+    @Test
+    fun `getActivityContext returns null when the activity reference is null`() {
+        val activityContextDelegate = GeckoViewActivityContextDelegate(WeakReference(null))
+        assertNull(activityContextDelegate.activityContext)
+    }
+}

--- a/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
+++ b/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineView.kt
@@ -701,6 +701,10 @@ class SystemEngineView @JvmOverloads constructor(
         // no-op
     }
 
+    override fun setActivityContext(context: Context?) {
+        // no-op
+    }
+
     override fun canScrollVerticallyUp() = session?.webView?.canScrollVertically(-1) ?: false
 
     override fun canScrollVerticallyDown() = session?.webView?.canScrollVertically(1) ?: false

--- a/android-components/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehaviorTest.kt
+++ b/android-components/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehaviorTest.kt
@@ -566,6 +566,7 @@ class BrowserToolbarBehaviorTest {
     open class DummyEngineView(context: Context) : FrameLayout(context), EngineView {
         override fun setVerticalClipping(clippingHeight: Int) {}
         override fun setDynamicToolbarMaxHeight(height: Int) {}
+        override fun setActivityContext(context: Context?) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
         override fun release() {}

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineView.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.concept.engine
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.view.View
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -129,6 +130,13 @@ interface EngineView {
      * @param height The maximum possible height of the toolbar.
      */
     fun setDynamicToolbarMaxHeight(height: Int)
+
+    /**
+     * Sets the Activity context for GeckoView.
+     *
+     * @param context The Activity context.
+     */
+    fun setActivityContext(context: Context?)
 
     /**
      * A delegate that will handle interactions with text selection context menus.

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineViewTest.kt
@@ -64,6 +64,7 @@ class EngineViewTest {
     open class DummyEngineView(context: Context) : FrameLayout(context), EngineView {
         override fun setVerticalClipping(clippingHeight: Int) {}
         override fun setDynamicToolbarMaxHeight(height: Int) {}
+        override fun setActivityContext(context: Context?) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
         override fun release() {}
@@ -74,6 +75,7 @@ class EngineViewTest {
     open class BrokenEngineView : EngineView {
         override fun setVerticalClipping(clippingHeight: Int) {}
         override fun setDynamicToolbarMaxHeight(height: Int) {}
+        override fun setActivityContext(context: Context?) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun render(session: EngineSession) {}
         override fun release() {}

--- a/android-components/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
+++ b/android-components/components/feature/session/src/test/java/mozilla/components/feature/session/SwipeRefreshFeatureTest.kt
@@ -123,6 +123,7 @@ class SwipeRefreshFeatureTest {
     private open class DummyEngineView(context: Context) : FrameLayout(context), EngineView {
         override fun setVerticalClipping(clippingHeight: Int) {}
         override fun setDynamicToolbarMaxHeight(height: Int) {}
+        override fun setActivityContext(context: Context?) {}
         override fun captureThumbnail(onFinish: (Bitmap?) -> Unit) = Unit
         override fun clearSelection() {}
         override fun render(session: EngineSession) {}

--- a/android-components/components/support/test-fakes/src/main/java/mozilla/components/support/test/fakes/engine/FakeEngineView.kt
+++ b/android-components/components/support/test-fakes/src/main/java/mozilla/components/support/test/fakes/engine/FakeEngineView.kt
@@ -25,6 +25,8 @@ class FakeEngineView(context: Context) : View(context), EngineView {
 
     override fun setDynamicToolbarMaxHeight(height: Int) = Unit
 
+    override fun setActivityContext(context: Context?) = Unit
+
     override fun release() = Unit
 
     override var selectionActionDelegate: SelectionActionDelegate? = null

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -74,6 +74,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         _binding = FragmentBrowserBinding.inflate(inflater, container, false)
 
         binding.toolbar.display.menuBuilder = components.menuBuilder
+        binding.engineView.setActivityContext(requireActivity())
 
         sessionFeature.set(
             feature = SessionFeature(
@@ -296,6 +297,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
     }
     override fun onDestroyView() {
         super.onDestroyView()
+        binding.engineView.setActivityContext(null)
         _binding = null
     }
 }


### PR DESCRIPTION
This bug implements the GeckoView.ActivityContextDelegate in AC. The purpose of this feature is to give GeckoView access to the containing activity to start a PrintManager (or for potential other uses). Not to be confused with the runtime delegate of GeckoActivityDelegate, which is tightly tied to webauthn.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1809919