### PR TITLE
Bug 1816196 - Do not fetch messaging during storage initialization

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
@@ -48,7 +48,7 @@ class NimbusMessagingStorage(
     @VisibleForTesting
     internal val malFormedMap = mutableMapOf<String, String>()
     private val logger = Logger("MessagingStorage")
-    private val nimbusFeature = messagingFeature.value()
+    private val nimbusFeature = messagingFeature
     private val customAttributes: JSONObject
         get() = attributeProvider?.getCustomAttributes(context) ?: JSONObject()
 
@@ -56,11 +56,12 @@ class NimbusMessagingStorage(
      * Returns a list of available messages descending sorted by their priority.
      */
     suspend fun getMessages(): List<Message> {
-        val nimbusTriggers = nimbusFeature.triggers
-        val nimbusStyles = nimbusFeature.styles
-        val nimbusActions = nimbusFeature.actions
+        val featureValue = messagingFeature.value()
+        val nimbusTriggers = featureValue.triggers
+        val nimbusStyles = featureValue.styles
+        val nimbusActions = featureValue.actions
 
-        val nimbusMessages = nimbusFeature.messages
+        val nimbusMessages = featureValue.messages
         val defaultStyle = StyleData()
         val storageMetadata = metadataStorage.getMetadata()
 
@@ -96,7 +97,7 @@ class NimbusMessagingStorage(
         } ?: return null
 
         // Check this isn't an experimental message. If not, we can go ahead and return it.
-        if (!isMessageUnderExperiment(message, nimbusFeature.messageUnderExperiment)) {
+        if (!isMessageUnderExperiment(message, nimbusFeature.value().messageUnderExperiment)) {
             return message
         }
         // If the message is under experiment, then we need to record the exposure
@@ -232,7 +233,7 @@ class NimbusMessagingStorage(
     }
 
     @VisibleForTesting
-    internal fun getOnControlBehavior(): ControlMessageBehavior = nimbusFeature.onControl
+    internal fun getOnControlBehavior(): ControlMessageBehavior = nimbusFeature.value().onControl
 
     private suspend fun addMetadata(id: String): Message.Metadata {
         return metadataStorage.addMetadata(


### PR DESCRIPTION
While debugging a UI test, we found that the messaging feature was being queried during the storage initialization and acting on the cached value alone. This could lead us to no longer receiving new messages during the app lifetime.

For the unit tests, we switched from mocking the entire feature to mocking just the `FeaturesInterface` as the test was providing false-positive results. It's better to create a real feature in any case for the other testing needs.

Co-authored-by: Benjamin Forehand Jr

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816196