### PR TITLE
Bug 1815504 - Convert existing legacy-arm Task to soft dependency

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -30,8 +30,4 @@ jobs:
           type: decision-task
           treeherder-symbol: legacy-api-ui
           target-tasks-method: legacy_api_ui_tests
-      when:
-          - {hour: 9, minute: 0}
-          - {hour: 12, minute: 0}
-          - {hour: 18, minute: 0}
-          - {hour: 22, minute: 0}
+      when: [] # unscheduled

--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -464,8 +464,9 @@ tasks:
         attributes:
             legacy: true
             shipping-product: fenix
-        description: Run select UI tests on older Android API on cron
-        run-on-tasks-for: []
+            code-review: false
+        description: Run select UI tests on legacy Android devices and API levels
+        run-on-tasks-for: [github-push]
         run-on-git-branches: [main]
         dependencies:
             signed-apk-debug-apk: signing-apk-fenix-debug


### PR DESCRIPTION
We would like to run our current test `Task` `legacy-arm` on `github-push` but not be blocking the `complete` `task` as these are not required for PR and Push. We can try setting the `code-review: false` attribute on the `Task`. From then, we can turn off the `Cron` for this `Task`. This is for running a smaller assortment of UI tests on legacy APIs and older Android devices on Firebase Test Lab (for crash and compatibility testing)

This will introduce some time (20min or so) on spinning the task on Github until finish on push (the target [devices](https://github.com/mozilla-mobile/firefox-android/blob/289b44804e7750d0dbc44fe46061e41e344e2768/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml#L39) are medium/high availability until finish (currently 6 devices in parallel) 

@csadilek / @JohanLorenzo - head's up on `Task` time if no objection, otherwise we can keep this on Cron
https://bugzilla.mozilla.org/show_bug.cgi?id=1815504
https://bugzilla.mozilla.org/show_bug.cgi?id=1815504