### PR TITLE
Bug 1816892 - Update the Private Browsing Mode CFR text

### DIFF
--- a/fenix/app/src/main/res/layout/pbm_shortcut_popup.xml
+++ b/fenix/app/src/main/res/layout/pbm_shortcut_popup.xml
@@ -31,7 +31,7 @@
             android:layout_marginTop="8dp"
             android:layout_marginEnd="32dp"
             android:lineSpacingExtra="2dp"
-            android:text="@string/private_mode_cfr_message"
+            android:text="@string/private_mode_cfr_message_2"
             android:textColor="@color/fx_mobile_text_color_oncolor_primary"
             app:layout_constraintBottom_toTopOf="@id/cfr_pos_button"
             app:layout_constraintEnd_toEndOf="parent"

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -67,7 +67,9 @@
     <!-- Text for the main message -->
     <string name="cfr_message" moz:removedIn="109" tools:ignore="UnusedResources">Add a shortcut to open private tabs from your Home screen.</string>
     <!-- Text for the Private mode shortcut CFR message for adding a private mode shortcut to open private tabs from the Home screen -->
-    <string name="private_mode_cfr_message">Launch next private tab in one tap.</string>
+    <string name="private_mode_cfr_message" moz:removedIn="111" tools:ignore="UnusedResources">Launch next private tab in one tap.</string>
+    <!-- Text for the Private mode shortcut CFR message for adding a private mode shortcut to open private tabs from the Home screen -->
+    <string name="private_mode_cfr_message_2">Launch your next private tab in one tap.</string>
     <!-- Text for the positive button -->
     <string name="cfr_pos_button_text" moz:removedIn="109" tools:ignore="UnusedResources">Add shortcut</string>
     <!-- Text for the positive button to accept adding a Private Browsing shortcut to the Home screen -->


### PR DESCRIPTION
Update the Private Browsing Mode CFR text that currently says, “Launch next private tab in one tap.” to say “Launch your next private tab in one tap" [as per the original issue](https://github.com/mozilla-mobile/fenix/issues/28114)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816892