### PR TITLE
Bug 1816932 - Add Maps to app links common sub domains

### DIFF
--- a/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
+++ b/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
@@ -18,6 +18,7 @@ import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 private const val WWW = "www."
 private const val M = "m."
 private const val MOBILE = "mobile."
+private const val MAPS = "maps."
 
 /**
  * This feature implements use cases for detecting and handling redirects to external apps. The user
@@ -144,18 +145,21 @@ class AppLinksInterceptor(
         return null
     }
 
-    // for app links interceptor any domains such as example.com, www.example.com and m.example.com
-    // are considered as the same domain
-    private fun isSameDomain(url1: String?, url2: String?): Boolean {
+    // Determines if the transition between the two URLs is related.  If the two URLs
+    // are from the same website then the app links interceptor will not try to find an application to open it.
+    @VisibleForTesting
+    internal fun isSameDomain(url1: String?, url2: String?): Boolean {
         return stripCommonSubDomains(url1?.tryGetHostFromUrl()) == stripCommonSubDomains(url2?.tryGetHostFromUrl())
     }
 
+    // Remove subdomains that are ignored when determining if two URLs are from the same website.
     private fun stripCommonSubDomains(url: String?): String? {
         return when {
             url == null -> return null
             url.startsWith(WWW) -> url.replaceFirst(WWW, "")
             url.startsWith(M) -> url.replaceFirst(M, "")
             url.startsWith(MOBILE) -> url.replaceFirst(MOBILE, "")
+            url.startsWith(MAPS) -> url.replaceFirst(MAPS, "")
             else -> url
         }
     }

--- a/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
+++ b/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -499,5 +500,24 @@ class AppLinksInterceptorTest {
         val testRedirect = AppLinkRedirect(null, fallbackUrl, null)
         val response = appLinksInterceptor.handleRedirect(testRedirect, webUrl)
         assert(response is RequestInterceptor.InterceptionResponse.Url)
+    }
+
+    @Test
+    fun `WHEN url have same domain THEN is same domain returns true ELSE false`() {
+        appLinksInterceptor = AppLinksInterceptor(
+            context = mockContext,
+            interceptLinkClicks = true,
+            launchInApp = { true },
+            useCases = mockUseCases,
+            launchFromInterceptor = true,
+        )
+
+        assert(appLinksInterceptor.isSameDomain("maps.google.com", "www.google.com"))
+        assert(appLinksInterceptor.isSameDomain("mobile.mozilla.com", "www.mozilla.com"))
+        assert(appLinksInterceptor.isSameDomain("m.mozilla.com", "maps.mozilla.com"))
+
+        assertFalse(appLinksInterceptor.isSameDomain("www.google.ca", "www.google.com"))
+        assertFalse(appLinksInterceptor.isSameDomain("maps.google.ca", "m.google.com"))
+        assertFalse(appLinksInterceptor.isSameDomain("accounts.google.com", "www.google.com"))
     }
 }


### PR DESCRIPTION
Add "maps" as part of the domain that we strip when deciding if two domains are the same.  (example: maps.google.com is the same as www.google.com)

The reason here is that we do not want to trigger the prompt to the user twice when the redirect from maps.google.com to www.google.com/maps happened.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816932