### PR TITLE
Bug 1815638 - disable permission prompt pre checking

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -70,6 +70,7 @@ class SearchDialogController(
     private val navController: NavController,
     private val settings: Settings,
     private val dismissDialog: () -> Unit,
+    private val onPermissionDialogClosure: () -> Unit,
     private val clearToolbarFocus: () -> Unit,
     private val focusToolbar: () -> Unit,
     private val clearToolbar: () -> Unit,
@@ -326,7 +327,7 @@ class SearchDialogController(
             )
             setMessage(spannableText)
             setNegativeButton(R.string.camera_permissions_needed_negative_button_text) { _, _ ->
-                dismissDialog()
+                onPermissionDialogClosure()
             }
             setPositiveButton(R.string.camera_permissions_needed_positive_button_text) {
                     dialog: DialogInterface, _ ->
@@ -345,6 +346,9 @@ class SearchDialogController(
                 intent.data = uri
                 dialog.cancel()
                 activity.startActivity(intent)
+            }
+            setOnCancelListener { _ ->
+                onPermissionDialogClosure()
             }
             create().withCenterAlignedButtons()
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -4,13 +4,12 @@
 
 package org.mozilla.fenix.search
 
-import android.Manifest
+import android.Manifest.permission.CAMERA
 import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
@@ -63,7 +62,6 @@ import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.android.content.hasCamera
-import mozilla.components.support.ktx.android.content.isPermissionGranted
 import mozilla.components.support.ktx.android.content.res.getSpanned
 import mozilla.components.support.ktx.android.net.isHttpOrHttps
 import mozilla.components.support.ktx.android.view.findViewInHierarchy
@@ -98,11 +96,18 @@ import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
 import org.mozilla.fenix.search.toolbar.SearchSelectorToolbarAction
 import org.mozilla.fenix.search.toolbar.ToolbarView
 import org.mozilla.fenix.settings.SupportUtils
+import org.mozilla.fenix.utils.CameraPermissionHandler
 
 typealias SearchDialogFragmentStore = SearchFragmentStore
 
+/**
+ * Let the user :
+ *  - Open an URL read using the QR code scanner
+ *  - Copy and paste to the url bar
+ *  - Open the search selector menu
+ */
 @SuppressWarnings("LargeClass", "TooManyFunctions")
-class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
+class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler, CameraPermissionHandler {
     private var _binding: FragmentSearchDialogBinding? = null
     private val binding get() = _binding!!
 
@@ -130,6 +135,17 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
     private var searchSelectorAlreadyAdded = false
     private var qrButtonAction: Toolbar.Action? = null
     private var voiceSearchButtonAction: Toolbar.Action? = null
+
+    private val cameraPermissionLauncher = registerCameraLauncher(
+        permissionGranted = { qrFeature.get()?.onPermissionsResult(arrayOf(CAMERA), intArrayOf(0)) },
+        permissionDenied = { forever: Boolean ->
+            if (forever) {
+                interactor.onCameraPermissionsNeeded()
+            } else {
+                resetFocus()
+            }
+        },
+    )
 
     override fun onStart() {
         super.onStart()
@@ -218,6 +234,9 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 dismissDialog = {
                     dialogHandledAction = true
                     dismissAllowingStateLoss()
+                },
+                onPermissionDialogClosure = {
+                    resetFocus()
                 },
                 clearToolbarFocus = {
                     dialogHandledAction = true
@@ -398,19 +417,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
             view.hideKeyboard()
             toolbarView.view.clearFocus()
 
-            if (requireContext().settings().shouldShowCameraPermissionPrompt) {
-                qrFeature.get()?.scan(binding.searchWrapper.id)
-            } else {
-                if (requireContext().isPermissionGranted(Manifest.permission.CAMERA)) {
-                    qrFeature.get()?.scan(binding.searchWrapper.id)
-                } else {
-                    interactor.onCameraPermissionsNeeded()
-                    resetFocus()
-                    view.hideKeyboard()
-                    toolbarView.view.requestFocus()
-                }
-            }
-            requireContext().settings().setCameraPermissionNeededState = false
+            qrFeature.get()?.scan(binding.searchWrapper.id)
         }
 
         binding.fillLinkFromClipboard.setOnClickListener {
@@ -677,7 +684,8 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
             requireContext(),
             fragmentManager = childFragmentManager,
             onNeedToRequestPermissions = { permissions ->
-                requestPermissions(permissions, REQUEST_CODE_CAMERA_PERMISSIONS)
+                assert(permissions.size == 1 && permissions[0] == CAMERA)
+                cameraPermissionLauncher.launch(CAMERA)
             },
             onScanResult = { result ->
                 val normalizedUrl = result.toNormalizedUrl()
@@ -719,25 +727,6 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 }
             },
         )
-    }
-
-    @Suppress("DEPRECATION")
-    // https://github.com/mozilla-mobile/fenix/issues/19920
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<String>,
-        grantResults: IntArray,
-    ) {
-        when (requestCode) {
-            REQUEST_CODE_CAMERA_PERMISSIONS -> qrFeature.withFeature {
-                it.onPermissionsResult(permissions, grantResults)
-                if (grantResults.contains(PackageManager.PERMISSION_DENIED)) {
-                    resetFocus()
-                }
-                requireContext().settings().setCameraPermissionNeededState = false
-            }
-            else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        }
     }
 
     private fun resetFocus() {
@@ -912,21 +901,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
 
         view?.hideKeyboard()
         toolbarView.view.clearFocus()
-
-        when {
-            requireContext().settings().shouldShowCameraPermissionPrompt ->
-                qrFeature.get()?.scan(binding.searchWrapper.id)
-            requireContext().isPermissionGranted(Manifest.permission.CAMERA) ->
-                qrFeature.get()?.scan(binding.searchWrapper.id)
-            else -> {
-                interactor.onCameraPermissionsNeeded()
-                resetFocus()
-                view?.hideKeyboard()
-                toolbarView.view.requestFocus()
-            }
-        }
-
-        requireContext().settings().setCameraPermissionNeededState = false
+        qrFeature.get()?.scan(binding.searchWrapper.id)
     }
 
     private fun isSpeechAvailable(): Boolean = speechIntent.resolveActivity(requireContext().packageManager) != null
@@ -1046,6 +1021,5 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         private const val TAP_INCREASE_DPS = 8
         private const val TAP_INCREASE_DPS_4 = 4
         private const val QR_FRAGMENT_TAG = "MOZAC_QR_FRAGMENT"
-        private const val REQUEST_CODE_CAMERA_PERMISSIONS = 1
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
@@ -4,13 +4,12 @@
 
 package org.mozilla.fenix.settings
 
-import android.content.pm.PackageManager
+import android.Manifest.permission.CAMERA
 import android.os.Build
 import android.os.Bundle
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.view.View
-import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
@@ -18,27 +17,45 @@ import androidx.navigation.fragment.navArgs
 import mozilla.components.feature.qr.QrFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
+import org.mozilla.fenix.settings.account.DefaultSyncController
+import org.mozilla.fenix.settings.account.DefaultSyncInteractor
+import org.mozilla.fenix.utils.CameraPermissionHandler
 
-class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
+/**
+ * Let the user scan a QRCode to associate a Firefox Account and sync devices
+ */
+class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler, CameraPermissionHandler {
     private val args by navArgs<PairFragmentArgs>()
-
     private val qrFeature = ViewBoundFeatureWrapper<QrFeature>()
+    private lateinit var interactor: DefaultSyncInteractor
 
-    @Suppress("DEPRECATION")
-    // https://github.com/mozilla-mobile/fenix/issues/19920
+    private val cameraPermissionLauncher = registerCameraLauncher(
+        permissionGranted = { qrFeature.get()?.onPermissionsResult(arrayOf(CAMERA), intArrayOf(0)) },
+        permissionDenied = { forever: Boolean ->
+            if (forever) interactor.onCameraPermissionsNeeded()
+            findNavController().popBackStack(R.id.turnOnSyncFragment, false)
+        },
+    )
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        interactor = DefaultSyncInteractor(
+            DefaultSyncController(activity = activity as HomeActivity),
+        )
 
         qrFeature.set(
             QrFeature(
                 requireContext(),
                 fragmentManager = parentFragmentManager,
                 onNeedToRequestPermissions = { permissions ->
-                    requestPermissions(permissions, REQUEST_CODE_CAMERA_PERMISSIONS)
+                    assert(permissions.size == 1 && permissions[0] == CAMERA)
+                    cameraPermissionLauncher.launch(CAMERA)
                 },
                 onScanResult = { pairingUrl ->
                     // By the time we get a scan result, we may not be attached to the context anymore.
@@ -102,29 +119,6 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
     }
 
     companion object {
-        private const val REQUEST_CODE_CAMERA_PERMISSIONS = 1
         private const val VIBRATE_LENGTH = 200L
-    }
-
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<String>,
-        grantResults: IntArray,
-    ) {
-        when (requestCode) {
-            REQUEST_CODE_CAMERA_PERMISSIONS -> {
-                if (ContextCompat.checkSelfPermission(
-                        requireContext(),
-                        android.Manifest.permission.CAMERA,
-                    ) == PackageManager.PERMISSION_GRANTED
-                ) {
-                    qrFeature.withFeature {
-                        it.onPermissionsResult(permissions, grantResults)
-                    }
-                } else {
-                    findNavController().popBackStack(R.id.turnOnSyncFragment, false)
-                }
-            }
-        }
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.settings.account
 
-import android.Manifest
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -18,12 +17,10 @@ import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.support.ktx.android.content.hasCamera
-import mozilla.components.support.ktx.android.content.isPermissionGranted
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.SyncAuth
-import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.databinding.FragmentTurnOnSyncBinding
@@ -37,7 +34,6 @@ import org.mozilla.fenix.ext.showToolbar
 class TurnOnSyncFragment : Fragment(), AccountObserver {
 
     private val args by navArgs<TurnOnSyncFragmentArgs>()
-    private lateinit var interactor: DefaultSyncInteractor
 
     private var shouldLoginJustWithEmail = false
     private var pairWithEmailStarted = false
@@ -47,18 +43,8 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
     }
 
     private val paringClickListener = View.OnClickListener {
-        if (requireContext().settings().shouldShowCameraPermissionPrompt) {
-            navigateToPairFragment()
-        } else {
-            if (requireContext().isPermissionGranted(Manifest.permission.CAMERA)) {
-                navigateToPairFragment()
-            } else {
-                interactor.onCameraPermissionsNeeded()
-                view?.hideKeyboard()
-            }
-        }
+        navigateToPairFragment()
         view?.hideKeyboard()
-        requireContext().settings().setCameraPermissionNeededState = false
     }
 
     private var _binding: FragmentTurnOnSyncBinding? = null
@@ -137,10 +123,6 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
                 getString(R.string.sign_in_instructions)
             },
             HtmlCompat.FROM_HTML_MODE_LEGACY,
-        )
-
-        interactor = DefaultSyncInteractor(
-            DefaultSyncController(activity = activity as HomeActivity),
         )
 
         binding.createAccount.increaseTapArea(CREATE_ACCOUNT_EXTRA_DIPS)

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/CameraPermissionHandler.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/CameraPermissionHandler.kt
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.utils
+
+import android.Manifest
+import android.content.Context
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
+import org.mozilla.fenix.ext.settings
+
+/**
+ * Helper to handle the logic around the camera permission
+ * The logic is to always prompt the user to grant the permission.
+ * But the permission can reach a state of Denied Forever (the user won't be prompted anymore)
+ *      - On android 11+: if the user deny twice the permission in a row
+ *      - On android <= 10 : if the user select the `Deny Forever` option
+ * We use a setting to memorize when we reach this state in order to display the permission dialog
+ */
+interface CameraPermissionHandler {
+
+    /**
+     *  Implementation should be provided by Fragment
+     */
+    fun <I, O> registerForActivityResult(
+        contract: ActivityResultContract<I, O>,
+        callback: ActivityResultCallback<O>,
+    ): ActivityResultLauncher<I>
+
+    /**
+     * Implementation should be provided by Fragment
+     */
+    fun requireContext(): Context
+
+    /**
+     * Implementation should be provided by Fragment
+     */
+    fun shouldShowRequestPermissionRationale(permission: String): Boolean
+
+    /**
+     * Create an `ActivityResultLauncher<String>` used to request the camera permission.
+     * Add the common logic around handling the result to track if we are denied forever.
+     * Callbacks allow to add custom logic.
+     */
+    fun registerCameraLauncher(
+        permissionGranted: () -> Unit,
+        permissionDenied: (forever: Boolean) -> Unit,
+    ): ActivityResultLauncher<String> {
+        return registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (!isGranted) {
+                val wasBlocked = requireContext().settings().shouldShowCameraPermissionDialog
+                requireContext().settings().setCameraPermissionDeniedForeverState =
+                    !shouldShowRequestPermissionRationale(
+                        Manifest.permission.CAMERA,
+                    )
+
+                permissionDenied(wasBlocked && requireContext().settings().shouldShowCameraPermissionDialog)
+            } else {
+                requireContext().settings().setCameraPermissionDeniedForeverState = false
+                permissionGranted()
+            }
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1184,21 +1184,22 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
-     * Used in [SearchDialogFragment.kt], [SearchFragment.kt] (deprecated), and [PairFragment.kt]
-     * to see if we need to check for camera permissions before using the QR code scanner.
+     * Used in [SearchDialogFragment.kt] and [TurnOnSyncFragment.kt]
+     * to see if we need to display the Camera permission dialog
+     * to ask the user to change permissions in settings
      */
-    var shouldShowCameraPermissionPrompt by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_camera_permissions_needed),
-        default = true,
+    var shouldShowCameraPermissionDialog by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_camera_permission_denied_forever),
+        default = false,
     )
 
     /**
      * Sets the state of permissions that have been checked, where [false] denotes already checked
      * and [true] denotes needing to check. See [shouldShowCameraPermissionPrompt].
      */
-    var setCameraPermissionNeededState by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_camera_permissions_needed),
-        default = true,
+    var setCameraPermissionDeniedForeverState by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_camera_permission_denied_forever),
+        default = false,
     )
 
     var shouldPromptToSaveLogins by booleanPreference(

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -322,7 +322,7 @@
     <string name="pref_key_start_on_home_after_four_hours" translatable="false">pref_key_start_on_home_after_four_hours</string>
     <string name="pref_key_start_on_home_always" translatable="false">pref_key_start_on_home_always</string>
     <string name="pref_key_start_on_home_never" translatable="false">pref_key_start_on_home_never</string>
-    <string name="pref_key_camera_permissions_needed" translatable="false">pref_key_camera_permissions_needed</string>
+    <string name="pref_key_camera_permission_denied_forever" translatable="false">pref_key_camera_permission_denied_forever</string>
     <string name="pref_key_inactive_tabs_category" translatable="false">pref_key_inactive_tabs_category</string>
     <string name="pref_key_inactive_tabs" translatable="false">pref_key_inactive_tabs</string>
     <!-- Whether or not the Tabs Tray to Compose changes are shown -->

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -681,6 +681,7 @@ class SearchDialogControllerTest {
         clearToolbar: () -> Unit = { },
         dismissDialog: () -> Unit = { },
         dismissDialogAndGoBack: () -> Unit = { },
+        onPermissionDialogClosure: () -> Unit = { },
     ): SearchDialogController {
         return SearchDialogController(
             activity = activity,
@@ -690,6 +691,7 @@ class SearchDialogControllerTest {
             navController = navController,
             settings = settings,
             dismissDialog = dismissDialog,
+            onPermissionDialogClosure = onPermissionDialogClosure,
             clearToolbarFocus = clearToolbarFocus,
             focusToolbar = focusToolbar,
             clearToolbar = clearToolbar,


### PR DESCRIPTION
Ported from : https://github.com/mozilla-mobile/fenix/pull/27276

Change the camera logic to always prompt the user and only rely on a setting to memorize if we are in the `Denied Forever` state.

Note: logic could be implemented without storing a state but it would mean opening the permission dialog change when we reached the `Denied Forever` state just after the user refused to grant the permission (a bit obnoxious I believe).

Switched to using `ActivityResultLauncher` to request the permission as mentioned in (https://github.com/mozilla-mobile/fenix/issues/19920) since it made code factorization easier.

It could be made cleaner by modifying the `QrFeature` component to change the signature of the parameter `onNeedToRequestPermissions` and the function `onPermissionsResult`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815638