### PR TITLE
Bug 1816724 - Show previous ETP message in onboarding if TCP is not enabled

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
@@ -64,7 +64,11 @@ class OnboardingTest {
             )
             verifyToolbarPlacementCard(isBottomChecked = true, isTopChecked = false)
             verifySignInToSyncCard()
-            verifyPrivacyProtectionCard(isStandardChecked = true, isStrictChecked = false)
+            verifyPrivacyProtectionCard(
+                settings = activityTestRule.activity.getSettings(),
+                isStandardChecked = true,
+                isStrictChecked = false,
+            )
             verifyPrivacyNoticeCard()
             verifyStartBrowsingSection()
             verifyNavigationToolbarItems("0")
@@ -193,11 +197,23 @@ class OnboardingTest {
     @Test
     fun privacyProtectionByDefaultCardTest() {
         homeScreen {
-            verifyPrivacyProtectionCard(isStandardChecked = true, isStrictChecked = false)
+            verifyPrivacyProtectionCard(
+                settings = activityTestRule.activity.getSettings(),
+                isStandardChecked = true,
+                isStrictChecked = false,
+            )
             clickStrictTrackingProtectionButton()
-            verifyPrivacyProtectionCard(isStandardChecked = false, isStrictChecked = true)
+            verifyPrivacyProtectionCard(
+                settings = activityTestRule.activity.getSettings(),
+                isStandardChecked = false,
+                isStrictChecked = true,
+            )
             clickStandardTrackingProtectionButton()
-            verifyPrivacyProtectionCard(isStandardChecked = true, isStrictChecked = false)
+            verifyPrivacyProtectionCard(
+                settings = activityTestRule.activity.getSettings(),
+                isStandardChecked = true,
+                isStrictChecked = false,
+            )
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -37,6 +37,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withHint
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
@@ -74,6 +75,7 @@ import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.helpers.withBitmapDrawable
+import org.mozilla.fenix.utils.Settings
 
 /**
  * Implementation of Robot Pattern for the home screen menu.
@@ -151,9 +153,9 @@ class HomeScreenRobot {
         assertItemWithResIdExists(signInButton)
     }
 
-    fun verifyPrivacyProtectionCard(isStandardChecked: Boolean, isStrictChecked: Boolean) {
+    fun verifyPrivacyProtectionCard(settings: Settings, isStandardChecked: Boolean, isStrictChecked: Boolean) {
         scrollToElementByText(getStringResource(R.string.onboarding_privacy_notice_header_1))
-        assertItemContainingTextExists(privacyProtectionHeader, privacyProtectionDescription)
+        assertItemContainingTextExists(privacyProtectionHeader, privacyProtectionDescription(settings))
         assertCheckedItemWithResIdExists(
             standardTrackingProtectionToggle(isStandardChecked),
             strictTrackingProtectionToggle(isStrictChecked),
@@ -1060,6 +1062,16 @@ private fun sponsoredShortcut(sponsoredShortcutTitle: String) =
 private fun storyByTopicItem(composeTestRule: ComposeTestRule, position: Int) =
     composeTestRule.onNodeWithTag("pocket.categories").onChildAt(position - 1)
 
+private fun privacyProtectionDescription(settings: Settings): UiObject {
+    val isTCPPublic = settings.enabledTotalCookieProtectionCFR
+    val descriptionText = when (isTCPPublic) {
+        true -> R.string.onboarding_tracking_protection_description
+        false -> R.string.onboarding_tracking_protection_description_old
+    }
+
+    return itemContainingText(getStringResource(descriptionText))
+}
+
 private val homeScreen =
     itemWithResId("$packageName:id/homeLayout")
 private val privateBrowsingButton =
@@ -1112,8 +1124,6 @@ private val signInButton =
     itemWithResId("$packageName:id/fxa_sign_in_button")
 private val privacyProtectionHeader =
     itemContainingText(getStringResource(R.string.onboarding_tracking_protection_header))
-private val privacyProtectionDescription =
-    itemContainingText(getStringResource(R.string.onboarding_tracking_protection_description))
 private fun standardTrackingProtectionToggle(isChecked: Boolean) =
     checkedItemWithResId("$packageName:id/tracking_protection_standard_option", isChecked)
 private fun strictTrackingProtectionToggle(isChecked: Boolean) =

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingTrackingProtectionViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingTrackingProtectionViewHolder.kt
@@ -4,7 +4,9 @@
 
 package org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding
 
+import android.content.Context
 import android.view.View
+import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import org.mozilla.fenix.GleanMetrics.Onboarding
 import org.mozilla.fenix.R
@@ -18,6 +20,7 @@ class OnboardingTrackingProtectionViewHolder(view: View) : RecyclerView.ViewHold
 
     private var standardTrackingProtection: OnboardingRadioButton
     private var strictTrackingProtection: OnboardingRadioButton
+    private var descriptionText: TextView
 
     init {
         val binding = OnboardingTrackingProtectionBinding.bind(view)
@@ -25,10 +28,24 @@ class OnboardingTrackingProtectionViewHolder(view: View) : RecyclerView.ViewHold
 
         standardTrackingProtection = binding.trackingProtectionStandardOption
         strictTrackingProtection = binding.trackingProtectionStrictDefault
+        descriptionText = binding.descriptionText
+
+        val isTCPPublic = view.context.settings().enabledTotalCookieProtectionCFR
+        setupDescriptionText(view.context, isTCPPublic)
 
         val isTrackingProtectionEnabled = view.context.settings().shouldUseTrackingProtection
         setupRadioGroup(isTrackingProtectionEnabled)
         updateRadioGroupState(isTrackingProtectionEnabled)
+    }
+
+    private fun setupDescriptionText(context: Context, shuldUseNewDescription: Boolean) {
+        if (!shuldUseNewDescription) {
+            val appName = context.getString(R.string.app_name)
+            descriptionText.text = context.getString(
+                R.string.onboarding_tracking_protection_description_old,
+                appName,
+            )
+        }
     }
 
     private fun setupRadioGroup(isChecked: Boolean) {

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -1308,6 +1308,8 @@
     <string name="onboarding_firefox_account_sync_is_on">Sync is on</string>
     <!-- Text for the tracking protection onboarding card header -->
     <string name="onboarding_tracking_protection_header">Privacy protection by default</string>
+    <!-- Text for the tracking protection card description. The first parameter is the name of the application.-->
+    <string name="onboarding_tracking_protection_description_old">%1$s automatically stops companies from secretly following you around the web.</string>
     <!-- Text for the tracking protection card description. -->
     <string name="onboarding_tracking_protection_description">Featuring Total Cookie Protection to stop trackers from using cookies to stalk you across sites.</string>
     <!-- text for tracking protection radio button option for standard level of blocking -->

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingTrackingProtectionViewHolderTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingTrackingProtectionViewHolderTest.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding
+
+import android.content.Context
+import android.view.LayoutInflater
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.OnboardingTrackingProtectionBinding
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class OnboardingTrackingProtectionViewHolderTest {
+    @Test
+    fun `GIVEN the TCP feature is public WHEN this ViewHolder is initialized THEN set an appropriate description`() {
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().settings() } returns mockk(relaxed = true) {
+                every { enabledTotalCookieProtectionCFR } returns true
+            }
+            val expectedDescription = testContext.getString(R.string.onboarding_tracking_protection_description)
+
+            val binding = OnboardingTrackingProtectionBinding.inflate(LayoutInflater.from(testContext))
+            OnboardingTrackingProtectionViewHolder(binding.root)
+
+            assertEquals(expectedDescription, binding.descriptionText.text)
+        }
+    }
+
+    @Test
+    fun `GIVEN the TCP feature is not public WHEN this ViewHolder is initialized THEN set an appropriate description`() {
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().settings() } returns mockk(relaxed = true) {
+                every { enabledTotalCookieProtectionCFR } returns false
+            }
+            val expectedDescription = testContext.getString(
+                R.string.onboarding_tracking_protection_description_old,
+                testContext.getString(R.string.app_name),
+            )
+
+            val binding = OnboardingTrackingProtectionBinding.inflate(LayoutInflater.from(testContext))
+            OnboardingTrackingProtectionViewHolder(binding.root)
+
+            assertEquals(expectedDescription, binding.descriptionText.text)
+        }
+    }
+}


### PR DESCRIPTION
Restore showing a different description of the Tracking Protection feature in application's onboarding if the Total Cookie Protection feature is not yet public.
The new description mentioning Total Cookie Protection will only be shown if the Total Cookie Protection CFR is to also be shown.

| If TCP is enabled | If TCP is disabled |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11428869/219096883-2f1ade67-c512-4973-9e0e-adeb3ef16cba.png" /> | <img src="https://user-images.githubusercontent.com/11428869/219097019-17211d59-b6be-44fa-8c3c-0d7a464e36f6.png" /> |




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816724