### PR TITLE
Bug 1816945 - Ensure Focus/Fenix builds and unit tests run on (untrusted) PRs

### DIFF
--- a/taskcluster/ci/build-apk/kind.yml
+++ b/taskcluster/ci/build-apk/kind.yml
@@ -51,6 +51,7 @@ tasks:
     focus-debug:
         attributes:
             code-review: true
+            shipping-product: focus
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
         description: 'Focus debug build from source code'
@@ -69,6 +70,7 @@ tasks:
     klar-debug:
         attributes:
             code-review: true
+            shipping-product: focus
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
         description: 'Klar debug build from source code'
@@ -87,6 +89,7 @@ tasks:
     fenix-debug:
         attributes:
             code-review: true
+            shipping-product: fenix
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
         description: 'Fenix debug build from source code'
@@ -109,6 +112,7 @@ tasks:
             # inherit this attribute via the multi_dep loader
         attributes:
             release-type: release
+            shipping-product: focus
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
         run-on-tasks-for: []
@@ -127,6 +131,7 @@ tasks:
         description: 'Release Klar build'
         attributes:
             release-type: release
+            shipping-product: focus
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
         run-on-tasks-for: []
@@ -145,6 +150,7 @@ tasks:
         description: 'Release Fenix build'
         attributes:
             release-type: release
+            shipping-product: fenix
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
         run-on-tasks-for: []
@@ -166,6 +172,7 @@ tasks:
             # any tasks that have this as a primary dependency will
             # inherit this attribute via the multi_dep loader
             nightly-task: true
+            shipping-product: focus
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
         run-on-tasks-for: []
@@ -184,6 +191,7 @@ tasks:
             # any tasks that have this as a primary dependency will
             # inherit this attribute via the multi_dep loader
             nightly-task: true
+            shipping-product: fenix
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
         run-on-tasks-for: []
@@ -201,6 +209,7 @@ tasks:
         description: 'Beta focus build'
         attributes:
             release-type: beta
+            shipping-product: focus
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
         run-on-tasks-for: []
@@ -219,6 +228,7 @@ tasks:
         description: 'Beta fenix build'
         attributes:
             release-type: beta
+            shipping-product: fenix
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
         run-on-tasks-for: []
@@ -235,6 +245,8 @@ tasks:
             platform: fenix-android-all/opt
 
     focus-nightly-firebase:
+        attributes:
+            shipping-product: focus
         description: 'Focus Nightly build for UI tests'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
@@ -251,6 +263,8 @@ tasks:
             symbol: focus-nightly(Bf)
 
     fenix-nightly-firebase:
+        attributes:
+            shipping-product: fenix
         description: 'Fenix Nightly build for UI tests'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
@@ -268,6 +282,8 @@ tasks:
             platform: fenix-android-all/opt
 
     focus-beta-firebase:
+        attributes:
+            shipping-product: focus
         description: 'Focus Beta build for UI tests'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
@@ -284,6 +300,8 @@ tasks:
             symbol: focus-beta(Bf)
 
     fenix-beta-firebase:
+        attributes:
+            shipping-product: fenix
         description: 'Fenix Beta build for UI tests'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
@@ -301,6 +319,8 @@ tasks:
             platform: fenix-android-all/opt
 
     focus-android-test-debug:
+        attributes:
+            shipping-product: focus
         description: 'Focus Android Test for debugging'
         attributes:
             code-review: true
@@ -324,6 +344,8 @@ tasks:
             symbol: focus-debug(Bat)
 
     fenix-android-test-debug:
+        attributes:
+            shipping-product: focus
         description: 'Fenix Debug Android Test for debugging'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
@@ -354,6 +376,8 @@ tasks:
     # nightly means we need an androidTest APK with the same signature.
 
     focus-android-test-nightly:
+        attributes:
+            shipping-product: focus
         description: 'Focus Nightly Android Test for debugging'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
@@ -379,6 +403,8 @@ tasks:
     # TODO: See if we can tweak the signing kind to make 2 signing jobs out of a single `android-test`
     # job.
     fenix-android-test-nightly:
+        attributes:
+            shipping-product: fenix
         description: 'Fenix Nightly Android Test for debugging'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
@@ -403,6 +429,8 @@ tasks:
             platform: fenix-android-all/opt
 
     focus-android-test-beta:
+        attributes:
+            shipping-product: focus
         description: 'Focus Beta Android Test for debugging'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
@@ -421,6 +449,8 @@ tasks:
             symbol: focus-beta(Bat)
 
     fenix-android-test-beta:
+        attributes:
+            shipping-product: fenix
         description: 'Fenix Beta Android Test for debugging'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
@@ -443,6 +473,8 @@ tasks:
             platform: fenix-android-all/opt
 
     fenix-android-test-mozillaonline:
+        attributes:
+            shipping-product: fenix
         description: 'Fenix Android Test mozillaonline'
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
@@ -472,6 +504,7 @@ tasks:
             external-gradle-dependencies: external-gradle-dependencies-fenix
         attributes:
             nightly: false
+            shipping-product: fenix
         run-on-tasks-for: [github-push]
         include-nightly-version: true
         include-shippable-secrets: true
@@ -493,6 +526,7 @@ tasks:
         attributes:
             release-type: beta
             shipping_phase: promote
+            shipping-product: fenix
         include-release-version: true
         include-shippable-secrets: true
         filter-incomplete-translations: true
@@ -516,6 +550,7 @@ tasks:
         attributes:
             release-type: release
             shipping_phase: promote
+            shipping-product: fenix
         include-release-version: true
         include-shippable-secrets: true
         filter-incomplete-translations: true

--- a/taskcluster/ci/build-apk/kind.yml
+++ b/taskcluster/ci/build-apk/kind.yml
@@ -54,7 +54,10 @@ tasks:
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
         description: 'Focus debug build from source code'
-        run-on-tasks-for: [github-pull-request, github-push]
+        run-on-tasks-for:
+            - github-pull-request
+            - github-pull-request-untrusted
+            - github-push
         run:
             gradle-build-type: debug
             gradle-build-name: focusDebug
@@ -69,7 +72,10 @@ tasks:
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
         description: 'Klar debug build from source code'
-        run-on-tasks-for: [github-pull-request, github-push]
+        run-on-tasks-for:
+            - github-pull-request
+            - github-pull-request-untrusted
+            - github-push
         run:
             gradle-build-type: debug
             gradle-build-name: klarDebug
@@ -84,7 +90,10 @@ tasks:
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
         description: 'Fenix debug build from source code'
-        run-on-tasks-for: [github-pull-request, github-push]
+        run-on-tasks-for:
+            - github-pull-request
+            - github-pull-request-untrusted
+            - github-push
         run:
             gradle-build-type: debug
             gradle-build-name: fenixDebug
@@ -297,7 +306,10 @@ tasks:
             code-review: true
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-focus
-        run-on-tasks-for: [github-pull-request, github-push]
+        run-on-tasks-for:
+            - github-pull-request
+            - github-pull-request-untrusted
+            - github-push
         run:
             gradle-build-type: androidTest
             gradle-build-name: androidTest
@@ -317,7 +329,10 @@ tasks:
             external-gradle-dependencies: external-gradle-dependencies-fenix
         attributes:
             code-review: true
-        run-on-tasks-for: [github-pull-request, github-push]
+        run-on-tasks-for:
+            - github-pull-request
+            - github-pull-request-untrusted
+            - github-push
         run:
             gradle-build-type: androidTest
             gradle-build-name: androidTest

--- a/taskcluster/ci/test-apk/kind.yml
+++ b/taskcluster/ci/test-apk/kind.yml
@@ -44,6 +44,7 @@ tasks:
         description: Focus unit tests
         attributes:
             code-review: true
+            shipping-product: focus
         run:
             pre-gradlew:
                 - ["cd", "focus-android"]
@@ -74,6 +75,7 @@ tasks:
         attributes:
             build-type: debug
             code-review: true
+            shipping-product: fenix
         run:
             pre-gradlew:
                 - ["cd", "fenix"]

--- a/taskcluster/ci/test-components/kind.yml
+++ b/taskcluster/ci/test-components/kind.yml
@@ -41,6 +41,7 @@ task-defaults:
         use-caches: false
     run-on-tasks-for:
         - github-pull-request
+        - github-pull-request-untrusted
         - github-push
     treeherder:
             kind: test


### PR DESCRIPTION
Regression from the Fenix repo migration. By moving the repo to firefox-android we now have 2 `github-pull-request` events. We need to explicitly call out `github-pull-request-untrusted` if we want jobs to run there. 

There was another bug along the way: these jobs got optimized away for the same reason as https://github.com/mozilla-mobile/firefox-android/pull/793. 

Here's taskgraph-diff run against the `parameters.yml` file in  https://github.com/mozilla-mobile/firefox-android/pull/800: 

```diff
--- optimized_task_graph@494d69711963
+++ optimized_task_graph@bug-1816945
@@ -1,20 +1,21 @@
+build-apk-fenix-debug
 build-docker-image-android-build
 build-docker-image-base
 build-docker-image-ui-tests
 complete-pr
 complete-pr-1
 complete-pr-2
 complete-pr-3
 external-gradle-dependencies-browser-domains
 external-gradle-dependencies-browser-engine-gecko
 external-gradle-dependencies-browser-engine-system
 external-gradle-dependencies-browser-errorpages
 external-gradle-dependencies-browser-icons
 external-gradle-dependencies-browser-menu
 external-gradle-dependencies-browser-menu2
 external-gradle-dependencies-browser-session-storage
 external-gradle-dependencies-browser-state
 external-gradle-dependencies-browser-storage-sync
 external-gradle-dependencies-browser-tabstray
 external-gradle-dependencies-browser-thumbnails
 external-gradle-dependencies-browser-toolbar
@@ -117,22 +118,23 @@
 external-gradle-dependencies-support-test-libstate
 external-gradle-dependencies-support-utils
 external-gradle-dependencies-support-webextensions
 external-gradle-dependencies-test-components
 external-gradle-dependencies-tooling-detekt
 external-gradle-dependencies-tooling-fetch-tests
 external-gradle-dependencies-tooling-glean-gradle
 external-gradle-dependencies-tooling-lint
 external-gradle-dependencies-tooling-nimbus-gradle
 external-gradle-dependencies-ui-autocomplete
 external-gradle-dependencies-ui-colors
 external-gradle-dependencies-ui-fonts
 external-gradle-dependencies-ui-icons
 external-gradle-dependencies-ui-tabcounter
 external-gradle-dependencies-ui-widgets
 fetch-android-sdk-3859397
 lint-compare-locales-fenix
 lint-detekt-fenix
 lint-ktlint-fenix
 lint-lint-fenix
+test-apk-fenix-debug
 toolchain-linux64-android-sdk-linux-repack
```
https://bugzilla.mozilla.org/show_bug.cgi?id=1816945
https://bugzilla.mozilla.org/show_bug.cgi?id=1816945