### PR TITLE
Bug 1807273 - Prevent keyboard blocking the login saving prompt in UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -127,6 +127,7 @@ class HomeScreenTest {
         }
     }
 
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807283")
     @Test
     fun verifyJumpBackInSectionTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 4)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
@@ -8,6 +8,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -407,6 +408,7 @@ class LoginsTest {
         }
     }
 
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1812995")
     @Test
     fun verifyLoginIsNotUpdatedTest() {
         val loginPage = "https://mozilla-mobile.github.io/testapp/v2.0/loginForm.html"

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
@@ -17,6 +17,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.restartApp
+import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -26,7 +27,8 @@ class LoginsTest {
     private lateinit var mockWebServer: MockWebServer
 
     @get:Rule
-    val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
+    val activityTestRule =
+        HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
 
     @Before
     fun setUp() {
@@ -86,6 +88,7 @@ class LoginsTest {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
             fillAndSubmitLoginCredentials(userName, password)
             saveLoginFromPrompt("Save")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -107,6 +110,7 @@ class LoginsTest {
             clickSubmitLoginButton()
             // Don't save the login, add to exceptions
             saveLoginFromPrompt("Never save")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -137,13 +141,14 @@ class LoginsTest {
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(saveLoginTest.url) {
             enterPassword("test")
+            mDevice.waitForIdle()
             clickSubmitLoginButton()
             verifyUpdateLoginPromptIsShown()
             // Click Update to change the saved password
             saveLoginFromPrompt("Update")
         }.openThreeDotMenu {
         }.openSettings {
-            TestHelper.scrollToElementByText("Logins and passwords")
+            scrollToElementByText("Logins and passwords")
         }.openLoginsAndPasswordSubMenu {
         }.openSavedLogins {
             verifySecurityPromptForLogins()
@@ -186,6 +191,7 @@ class LoginsTest {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
             fillAndSubmitLoginCredentials("mozilla", "firefox")
             saveLoginFromPrompt("Save")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -210,6 +216,7 @@ class LoginsTest {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
             fillAndSubmitLoginCredentials("mozilla", "firefox")
             saveLoginFromPrompt("Save")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -243,6 +250,7 @@ class LoginsTest {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
             fillAndSubmitLoginCredentials("mozilla", "firefox")
             saveLoginFromPrompt("Save")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -253,6 +261,7 @@ class LoginsTest {
             clickEditLoginButton()
             clickClearUserNameButton()
             saveEditedLogin()
+            verifyLoginItemUsername("")
         }
     }
 
@@ -265,6 +274,7 @@ class LoginsTest {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
             fillAndSubmitLoginCredentials("mozilla", "firefox")
             saveLoginFromPrompt("Save")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -290,6 +300,7 @@ class LoginsTest {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
             fillAndSubmitLoginCredentials("mozilla", "firefox")
             saveLoginFromPrompt("Save")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -315,6 +326,7 @@ class LoginsTest {
         }.enterURLAndEnterToBrowser(loginPage.url) {
             clickSubmitLoginButton()
             saveLoginFromPrompt("Save")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -521,6 +533,7 @@ class LoginsTest {
         }.enterURLAndEnterToBrowser(secondLoginPage.toUri()) {
             fillAndSubmitLoginCredentials("mozilla", "firefox")
             saveLoginFromPrompt("Save")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -414,6 +414,7 @@ class BrowserRobot {
             mDevice.findObject(
                 UiSelector().resourceId("$packageName:id/feature_prompt_login_fragment"),
             ),
+            waitingTime,
         )
         mDevice.findObject(text(optionToSaveLogin)).click()
     }
@@ -494,7 +495,7 @@ class BrowserRobot {
         setPageObjectText(webPageItemWithResourceId("password"), password)
         clickPageObject(webPageItemWithResourceId("submit"))
 
-        mDevice.waitForObjects(mDevice.findObject(UiSelector().resourceId("$packageName:id/save_confirm")))
+        mDevice.waitForObjects(mDevice.findObject(UiSelector().resourceId("$packageName:id/save_confirm")), waitingTime)
     }
 
     fun clearUserNameLoginCredential() {
@@ -1346,7 +1347,8 @@ private fun setPageObjectText(webPageItem: UiObject, text: String) {
         try {
             webPageItem.also {
                 it.waitForExists(waitingTime)
-                it.setText(text)
+                it.clearTextField()
+                it.text = text
             }
 
             break


### PR DESCRIPTION
This affected a lot of the logins tests, but after fixing it, there's still one bug remaining that is causing failures in these tests: https://bugzilla.mozilla.org/show_bug.cgi?id=1812426
If the tests become blocking, we'll start disabling them until the bug is fixed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807273
https://bugzilla.mozilla.org/show_bug.cgi?id=1807283
https://bugzilla.mozilla.org/show_bug.cgi?id=1812995