### PR TITLE
Bug 1810531 - Re-enable Fenix UI test: saveAndOpenPdfTest

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -8,7 +8,6 @@ import androidx.core.net.toUri
 import mozilla.components.concept.engine.utils.EngineReleaseChannel
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -210,7 +209,6 @@ class DownloadTest {
         }
     }
 
-    @Ignore("Failing because of https://bugzilla.mozilla.org/show_bug.cgi?id=1810132")
     @SmokeTest
     @Test
     fun saveAndOpenPdfTest() {
@@ -226,7 +224,6 @@ class DownloadTest {
             }.openThreeDotMenu {
             }.clickShareButton {
             }.clickSaveAsPDF {
-                // change back to simple filename
                 verifyDownloadPrompt(pdfFileName)
             }.clickDownload {
             }.clickOpen("application/pdf") {


### PR DESCRIPTION
The bug blocking the test was fixed. Re-enabled the test now and ran it on Firebase for 50 times to check for flakiness, all green:  https://github.com/mozilla-mobile/firefox-android/pull/841/checks?check_run_id=11385569028

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1810531