### PR TITLE
Bug 1817250 - Add/Enable Robo Test on Firebase Test Lab

### DIFF
--- a/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
@@ -1,0 +1,39 @@
+# Google Cloud Documentation: https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
+# Flank Documentation: https://flank.github.io/flank/
+gcloud:
+  results-bucket: fenix_test_artifacts
+  record-video: true
+  timeout: 10m
+  async: false
+
+  app: /app/path
+
+  auto-google-login: false
+  use-orchestrator: true
+  environment-variables:
+    clearPackageData: true
+
+  device:
+    - model: Pixel2.arm
+      version: 26
+      locale: en_US
+    - model: walleye
+      version: 27
+      locale: en_US
+    - model: dreamlte
+      version: 28
+      locale: en_US
+    - model: HWCOR
+      version: 27
+      locale: en_US
+    - model: blueline
+      version: 28
+      locale: en_US
+
+  type: robo
+
+flank:
+  project: GOOGLE_PROJECT
+  num-test-runs: 1
+  output-style: compact
+  full-junit-result: true

--- a/fenix/automation/taskcluster/androidTest/robo-test.sh
+++ b/fenix/automation/taskcluster/androidTest/robo-test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This script does the following:
+# 1. Retrieves gcloud service account token
+# 2. Activates gcloud service account
+# 3. Connects to Google's Firebase Test Lab (using Flank)
+# 4. Executes Robo test
+# 5. Puts any artifacts into the test_artifacts folder
+
+# If a command fails then do not proceed and fail this script too.
+set -e
+
+get_abs_filename() {
+  relative_filename="$1"
+  echo "$(cd "$(dirname "$relative_filename")" && pwd)/$(basename "$relative_filename")"
+}
+
+# Basic parameter check
+if [[ $# -lt 1 ]]; then
+    echo "Error: please provide a Flank configuration"
+    display_help
+    exit 1
+fi
+
+device_type="$1" # flank-arm-robo-test.yml | flank-x86-robo-test.yml
+APK_APP="$2"
+JAVA_BIN="/usr/bin/java"
+PATH_TEST="./automation/taskcluster/androidTest"
+FLANK_BIN="/builds/worker/test-tools/flank.jar"
+ARTIFACT_DIR="/builds/worker/artifacts"
+RESULTS_DIR="${ARTIFACT_DIR}/results"
+
+echo
+echo "ACTIVATE SERVICE ACCT"
+echo
+gcloud config set project "$GOOGLE_PROJECT"
+gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+echo
+echo
+echo
+
+set +e
+
+flank_template="${PATH_TEST}/flank-${device_type}.yml"
+if [ -f "$flank_template" ]; then
+    echo "Using Flank template: $flank_template"
+else
+    echo "Error: Flank template not found: $flank_template"
+    exit 1
+fi
+
+APK_APP="$(get_abs_filename $APK_APP)"
+
+function failure_check() {
+    echo
+    echo
+    if [[ $exitcode -ne 0 ]]; then
+        echo "FAILURE: Robo test run failed, please check above URL"
+    else
+	    echo "Robo test was successful!"
+    fi
+
+    echo
+    echo "RESULTS"
+    echo
+
+    mkdir -p /builds/worker/artifacts/github
+    chmod +x $PATH_TEST/parse-ui-test.py
+    $PATH_TEST/parse-ui-test.py \
+        --exit-code "${exitcode}" \
+        --log flank.log \
+        --results "${RESULTS_DIR}" \
+        --output-md "${ARTIFACT_DIR}/github/customCheckRunText.md" \
+	    --device-type "${device_type}"
+}
+
+echo
+echo "FLANK VERSION"
+echo
+$JAVA_BIN -jar $FLANK_BIN --version
+echo
+echo
+
+echo
+echo "EXECUTE ROBO TEST"
+echo
+set -o pipefail && $JAVA_BIN -jar $FLANK_BIN android run \
+	--config=$flank_template \
+	--app=$APK_APP \
+	--local-result-dir="${RESULTS_DIR}" \
+	--project=$GOOGLE_PROJECT \
+	--client-details=commit=${MOBILE_HEAD_REV:-None},pullRequest=${PULL_REQUEST_NUMBER:-None} \
+	| tee flank.log
+
+exitcode=$?
+failure_check
+
+exit $exitcode

--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -322,3 +322,30 @@ tasks:
         worker:
             env:
                 GOOGLE_PROJECT: moz-fenix
+
+    fenix-robo-arm-debug:
+        attributes:
+            shipping-product: fenix
+            code-review: false
+        description: Run Robo test on ARM devices
+        run-on-tasks-for: [github-push]
+        run-on-git-branches: [main]
+        dependencies:
+            signed-apk-debug-apk: signing-apk-fenix-debug
+        run:
+            secrets:
+                - name: project/mobile/fenix/firebase
+                  key: firebaseToken
+                  path: .firebase_token.json
+                  json: true
+            pre-commands:
+                - ["cd", "fenix"]
+            commands:
+                - [wget, {artifact-reference: '<signed-apk-debug-apk/public/build/fenix/arm64-v8a/target.apk>'}, '-O', app.apk]
+                - [automation/taskcluster/androidTest/robo-test.sh, arm-robo-test, app.apk]
+        treeherder:
+            platform: 'fenix-ui-test/opt'
+            symbol: fenix-debug(robo-arm)
+        worker:
+            env:
+                GOOGLE_PROJECT: moz-fenix


### PR DESCRIPTION
[Bug 1817250 - Add/Enable Robo Test on Firebase Test Lab](https://github.com/mozilla-mobile/firefox-android/commit/60fd1ecb68f42412de603faf5f0c198c4b51f9d0)

To assist with finding client-side crashes in Firefox for Android, we can run Robo test on Firebase Test Lab to target a device pool and API target and run the testing tool crawler. Robo test analyzes the structure of an app's user interface and then explores it methodically, automatically simulating user activities. This can be helpful in finding crashes.

PR adds:

* New `ui-test-apk` `task` for Robo Test for `fenix` (`code-review` off, push only)
* New script (clone of `ui-test.sh`) with adjustments in calls for Robo test
* New Flank config for targeting Robo test specifics

Of note: Robo test does not require a test app APK
https://bugzilla.mozilla.org/show_bug.cgi?id=1817250
https://bugzilla.mozilla.org/show_bug.cgi?id=1817250
https://bugzilla.mozilla.org/show_bug.cgi?id=1817250