### PR TITLE
Bug 1817245 - new Nimbus feature for controlling client-deduplication ping

### DIFF
--- a/fenix/.experimenter.yaml
+++ b/fenix/.experimenter.yaml
@@ -1,4 +1,12 @@
 ---
+client-deduplication:
+  description: A feature to control the sending of the client-deduplication ping.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the ping will be sent on a similar schedule as the baseline ping."
 cookie-banners:
   description: Features for cookie banner handling.
   hasExposure: true

--- a/fenix/nimbus.fml.yaml
+++ b/fenix/nimbus.fml.yaml
@@ -138,6 +138,21 @@ features:
       - channel: nightly
         value:
           enabled: false
+  
+  client-deduplication:
+    description: A feature to control the sending of the client-deduplication ping.
+    variables:
+      enabled:
+        description: If true, the ping will be sent on a similar schedule as the baseline ping.
+        type: Boolean
+        default: false
+    defaults:
+      - channel: nightly
+        value:
+          enabled: false
+      - channel: developer
+        value:
+          enabled: false
 
   growth-data:
     description: A feature measuring campaign growth data


### PR DESCRIPTION
This feature will enable/disable the sending of the `client-deduplication` ping that will be added in a later PR.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817245