### PR TITLE
Bug 1807369 - Improve accessibility for 'Learn more' hyperlink from the Pocket homepage header

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -45,6 +45,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.semantics.testTagsAsResourceId
@@ -512,7 +515,18 @@ fun PoweredByPocketHeader(
 
             Spacer(modifier = Modifier.width(16.dp))
 
-            Column {
+            val onClickLabel = stringResource(id = R.string.a11y_action_label_pocket_learn_more)
+            Column(
+                Modifier.semantics(mergeDescendants = true) {
+                    role = Role.Button
+                    onClick(label = onClickLabel) {
+                        onLearnMoreClicked(
+                            "https://www.mozilla.org/en-US/firefox/pocket/?$POCKET_FEATURE_UTM_KEY_VALUE",
+                        )
+                        false
+                    }
+                },
+            ) {
                 Text(
                     text = stringResource(
                         R.string.pocket_stories_feature_title_2,

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -1964,4 +1964,6 @@
     <string name="a11y_action_label_wallpaper_collection_learn_more">open link to learn more about this collection</string>
     <!-- Action label for links that point to an article. Talkback will append this to say "Double tap to read the article". -->
     <string name="a11y_action_label_read_article">read the article</string>
+    <!-- Action label for links to the Firefox Pocket website. Talkback will append this to say "Double tap to open link to learn more". -->
+    <string name="a11y_action_label_pocket_learn_more">open link to learn more</string>
 </resources>


### PR DESCRIPTION
Allowed Pocket homepage header `Learn more` link to be mentioned as clickable to a11y services, similar to what we did for the [wallpaper collection `Learn more` button](https://github.com/mozilla-mobile/fenix/pull/27277). Changes from this PR only affect the header when accessed from a11y services, otherwise only the `Learn more` link is clickable.

https://user-images.githubusercontent.com/35462038/219621552-0b9134db-aa26-43eb-90d2-3cfd95ab957c.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807369