### PR TITLE
Bug 1817398 - Run `external-gradle-dependencies-lint-fenix` when `Dep…

### DIFF
--- a/taskcluster/ci/external-gradle-dependencies/kind.yml
+++ b/taskcluster/ci/external-gradle-dependencies/kind.yml
@@ -30,7 +30,6 @@ task-defaults:
             - android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
             - android-components/build.gradle
             - android-components/gradle/wrapper/gradle-wrapper.properties
-            - focus-android/buildSrc/src/main/java/FocusDependencies.kt
         toolchain-artifact: public/build/external-gradle-dependencies.tar.xz
         using: toolchain-script
     treeherder:
@@ -62,6 +61,9 @@ tasks:
                 - ktlint
                 - detekt
                 - githubLintDetektDetails
+            resources:
+                # TODO: Make focus lint tasks use their own gradle deps tasks
+                - focus-android/buildSrc/src/main/java/FocusDependencies.kt
 
     lint-fenix:
         treeherder:
@@ -76,6 +78,8 @@ tasks:
                 - githubLintDetektDetails
                 - mozilla-detekt-rules:test
                 - mozilla-lint-rules:test
+            resources:
+                - fenix/buildSrc/src/main/java/Dependencies.kt
 
     test-components:
         attributes:


### PR DESCRIPTION
…endencies.kt` changes

Blocks https://github.com/mozilla-mobile/firefox-android/pull/842. More details in [bug 1817398 comment 0](https://bugzilla.mozilla.org/show_bug.cgi?id=1817398#c0).
https://bugzilla.mozilla.org/show_bug.cgi?id=1817398