### PR TITLE
Bug 1807289 - Fix collections related UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
@@ -60,9 +60,13 @@ object MatcherHelper {
         }
     }
 
-    fun assertItemWithDescriptionExists(vararg appItems: UiObject) {
+    fun assertItemWithDescriptionExists(vararg appItems: UiObject, exists: Boolean = true) {
         for (appItem in appItems) {
-            assertTrue(appItem.waitForExists(waitingTime))
+            if (exists) {
+                assertTrue(appItem.waitForExists(waitingTime))
+            } else {
+                assertFalse(appItem.waitForExists(waitingTime))
+            }
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
@@ -109,7 +109,7 @@ class CollectionTest {
 
         homeScreen {
             verifyCollectionIsDisplayed(collectionName)
-        }.expandCollection(collectionName, composeTestRule) {
+        }.expandCollection(collectionName) {
             verifyTabSavedInCollection(webPage.title)
             verifyCollectionTabUrl(true, webPageUrl)
             verifyShareCollectionButtonIsVisible(true)
@@ -126,7 +126,8 @@ class CollectionTest {
         }
 
         homeScreen {
-        }.expandCollection(collectionName, composeTestRule) {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
             verifyTabSavedInCollection(webPage.title)
             verifyCollectionTabUrl(true, webPageUrl)
             verifyShareCollectionButtonIsVisible(true)
@@ -166,7 +167,8 @@ class CollectionTest {
         }
 
         homeScreen {
-        }.expandCollection(collectionName, composeTestRule) {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
             clickCollectionThreeDotButton(composeTestRule)
             selectOpenTabs(composeTestRule)
         }
@@ -194,7 +196,8 @@ class CollectionTest {
             verifySnackBarText("Collection saved!")
         }.openTabsListThreeDotMenu {
         }.closeAllTabs {
-        }.expandCollection(collectionName, composeTestRule) {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
         }.clickShareCollectionButton {
             verifyShareTabsOverlay(firstWebsite.title, secondWebsite.title)
             verifySharingWithSelectedApp(sharingApp, urlString, collectionName)
@@ -216,7 +219,8 @@ class CollectionTest {
         }
 
         homeScreen {
-        }.expandCollection(collectionName, composeTestRule) {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
             clickCollectionThreeDotButton(composeTestRule)
             selectDeleteCollection(composeTestRule)
         }
@@ -248,7 +252,8 @@ class CollectionTest {
         }.selectExistingCollection(collectionName) {
             verifySnackBarText("Tab saved!")
         }.goToHomescreen {
-        }.expandCollection(collectionName, composeTestRule) {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
             verifyTabSavedInCollection(firstWebPage.title)
             verifyTabSavedInCollection(secondWebPage.title)
         }
@@ -270,7 +275,8 @@ class CollectionTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(secondWebPage.url) {
         }.goToHomescreen {
-        }.expandCollection(collectionName, composeTestRule) {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
             clickCollectionThreeDotButton(composeTestRule)
             selectAddTabToCollection(composeTestRule)
             verifyTabsSelectedCounterText(1)
@@ -291,10 +297,12 @@ class CollectionTest {
             verifySnackBarText("Collection saved!")
         }.closeTabDrawer {
         }.goToHomescreen {
-        }.expandCollection(firstCollectionName, composeTestRule) {
+            verifyCollectionIsDisplayed(firstCollectionName)
+        }.expandCollection(firstCollectionName) {
             clickCollectionThreeDotButton(composeTestRule)
             selectRenameCollection(composeTestRule)
         }.typeCollectionNameAndSave(secondCollectionName) {}
+
         homeScreen {
             verifyCollectionIsDisplayed(secondCollectionName)
         }
@@ -334,7 +342,8 @@ class CollectionTest {
         }
 
         homeScreen {
-        }.expandCollection(collectionName, composeTestRule) {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
             verifyTabSavedInCollection(webPage.title, true)
             removeTabFromCollection(webPage.title)
             verifyTabSavedInCollection(webPage.title, false)
@@ -360,8 +369,8 @@ class CollectionTest {
         }
 
         homeScreen {
-        }.expandCollection(collectionName, composeTestRule) {
-            swipeToBottom()
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
             swipeTabLeft(testPage.title, composeTestRule)
             verifyTabSavedInCollection(testPage.title, false)
         }
@@ -386,8 +395,8 @@ class CollectionTest {
         }
 
         homeScreen {
-        }.expandCollection(collectionName, composeTestRule) {
-            swipeToBottom()
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
             swipeTabRight(testPage.title, composeTestRule)
             verifyTabSavedInCollection(testPage.title, false)
         }
@@ -422,7 +431,7 @@ class CollectionTest {
         tabDrawer {
         }.closeTabDrawer {
         }.goToHomescreen {
-        }.expandCollection(collectionName, composeTestRule) {
+        }.expandCollection(collectionName) {
             verifyTabSavedInCollection(firstWebPage.title)
             verifyTabSavedInCollection(secondWebPage.title)
         }
@@ -473,7 +482,8 @@ class CollectionTest {
         }
 
         homeScreen {
-        }.expandCollection(collectionName, composeTestRule) {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
             clickCollectionThreeDotButton(composeTestRule)
             selectDeleteCollection(composeTestRule)
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.swipeRight
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -25,8 +24,14 @@ import androidx.test.uiautomator.Until
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
@@ -197,13 +202,9 @@ class CollectionRobot {
             title: String,
             interact: HomeScreenRobot.() -> Unit,
         ): HomeScreenRobot.Transition {
-            try {
-                collectionTitle(title).waitForExists(waitingTime)
-                collectionTitle(title).click()
-            } catch (e: NoMatchingViewException) {
-                scrollToElementByText(title)
-                collectionTitle(title).click()
-            }
+            assertItemContainingTextExists(itemContainingText(title))
+            itemContainingText(title).clickAndWaitForNewWindow(waitingTimeShort)
+            assertItemWithDescriptionExists(itemWithDescription(getStringResource(R.string.remove_tab_from_collection)), exists = false)
 
             HomeScreenRobot().interact()
             return HomeScreenRobot.Transition()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -56,11 +56,13 @@ import org.mozilla.fenix.helpers.Constants.LISTS_MAXSWIPES
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.MatcherHelper.assertCheckedItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndDescriptionExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.checkedItemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
@@ -324,10 +326,8 @@ class HomeScreenRobot {
     // Collections elements
     fun verifyCollectionIsDisplayed(title: String, collectionExists: Boolean = true) {
         if (collectionExists) {
-            scrollToElementByText(title)
             assertTrue(mDevice.findObject(UiSelector().text(title)).waitForExists(waitingTime))
         } else {
-            scrollToElementByText("Collections")
             assertTrue(mDevice.findObject(UiSelector().text(title)).waitUntilGone(waitingTime))
         }
     }
@@ -723,13 +723,10 @@ class HomeScreenRobot {
             return TabDrawerRobot.Transition()
         }
 
-        fun expandCollection(title: String, rule: ComposeTestRule, interact: CollectionRobot.() -> Unit): CollectionRobot.Transition {
-            homeScreenList().waitForExists(waitingTime)
-            homeScreenList().scrollToEnd(LISTS_MAXSWIPES)
-
-            collectionTitle(title, rule)
-                .assertIsDisplayed()
-                .performClick()
+        fun expandCollection(title: String, interact: CollectionRobot.() -> Unit): CollectionRobot.Transition {
+            assertItemContainingTextExists(itemContainingText(title))
+            itemContainingText(title).clickAndWaitForNewWindow(waitingTimeShort)
+            assertItemWithDescriptionExists(itemWithDescription(getStringResource(R.string.remove_tab_from_collection)))
 
             CollectionRobot().interact()
             return CollectionRobot.Transition()


### PR DESCRIPTION
Bug 1807289 - Fix collections related UI tests that were affected by timeouts.

Summary:

- Removed excessive scrolling when interacting with the collections
- Used UI automator instead of compose to interact with the collections
- Minor timing syncing adjustments 

Based on the results from #788, I'm confident that the problem is solved.
The most affected collections UI tests successfully passed 200x on Firebase ✅ 
`verifyExpandedCollectionItemsTest`
`renameCollectionTest`
`swipeLeftToRemoveTabFromCollectionTest`
`swipeRightToRemoveTabFromCollectionTest`
`mainMenuSaveToExistingCollection`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807289