### PR TITLE
Bug 1813451 - Fix accessibility issues on History deletion screen

### DIFF
--- a/fenix/app/src/main/res/layout/delete_history_time_range_dialog.xml
+++ b/fenix/app/src/main/res/layout/delete_history_time_range_dialog.xml
@@ -49,7 +49,7 @@
         <RadioButton
             android:id="@+id/last_hour_button"
             android:layout_width="match_parent"
-            android:layout_height="48dp"
+            android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
             android:ellipsize="end"
             android:buttonTint="?attr/textSecondary"
@@ -63,7 +63,7 @@
         <RadioButton
             android:id="@+id/today_and_yesterday_button"
             android:layout_width="match_parent"
-            android:layout_height="48dp"
+            android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
             android:ellipsize="end"
             android:buttonTint="?attr/textSecondary"
@@ -77,7 +77,7 @@
         <RadioButton
             android:id="@+id/everything_button"
             android:layout_width="match_parent"
-            android:layout_height="48dp"
+            android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
             android:ellipsize="end"
             android:buttonTint="?attr/textSecondary"


### PR DESCRIPTION
The PR fixes accessibility issue on the History deletion screen. The fixes include:
- ~Increased contrast ratio on `Delete` and `Cancel` buttons (achieved by making the card background darker)~
- Dynamic height of radio buttons (achieved with `wrap_content` property)

PS: This is a minor UI change only, and thus does not require writing tests under PR checklist

### Fix description
Updated card background color to achieve the desired contrast ratio.

### Issue screenshot
<img src="https://user-images.githubusercontent.com/13991373/218087293-3103e0c0-093a-4a6e-9020-aa26d48da6ad.png" width="200"/>

### Fix screenshot/recording
<img width="381" alt="fix" src="https://user-images.githubusercontent.com/13991373/221780797-578c3cf7-40e3-40d7-b4de-316fc311a080.png">




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1813451