### PR TITLE
Bug 1817524 - Do not show homepage if last tab of section is closed while not in view

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -274,7 +274,8 @@ class DefaultTabsTrayController(
 
         tab?.let {
             val isLastTab = browserStore.state.getNormalOrPrivateTabs(it.content.private).size == 1
-            if (!isLastTab) {
+            val isCurrentTab = browserStore.state.selectedTabId.equals(tabId)
+            if (!isLastTab || !isCurrentTab) {
                 tabsUseCases.removeTab(tabId)
                 showUndoSnackbarForTab(it.content.private)
             } else {

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
@@ -865,6 +865,36 @@ class DefaultTabsTrayControllerTest {
         verify { controller.handleNavigateToBrowser() }
     }
 
+    @Test
+    fun `GIVEN a normal tab is selected WHEN the last private tab is deleted THEN that private tab is removed and an undo snackbar is shown and original normal tab is still displayed`() {
+        val currentTab = TabSessionState(content = ContentState(url = "https://simulate.com", private = false), id = "currentTab")
+        val privateTab = TabSessionState(content = ContentState(url = "https://mozilla.com", private = true), id = "privateTab")
+        var showUndoSnackbarForTabInvoked = false
+        var navigateToHomeAndDeleteSessionInvoked = false
+        browserStore = BrowserStore(
+            initialState = BrowserState(
+                tabs = listOf(currentTab, privateTab),
+                selectedTabId = currentTab.id,
+            ),
+        )
+        val controller = spyk(
+            createController(
+                showUndoSnackbarForTab = {
+                    showUndoSnackbarForTabInvoked = true
+                },
+                navigateToHomeAndDeleteSession = {
+                    navigateToHomeAndDeleteSessionInvoked = true
+                },
+            ),
+        )
+
+        controller.handleTabSelected(currentTab, "source")
+        controller.handleTabDeletion("privateTab")
+
+        assertTrue(showUndoSnackbarForTabInvoked)
+        assertFalse(navigateToHomeAndDeleteSessionInvoked)
+    }
+
     private fun createController(
         navigateToHomeAndDeleteSession: (String) -> Unit = { },
         selectTabPosition: (Int, Boolean) -> Unit = { _, _ -> },


### PR DESCRIPTION
Discovered another scenario in which the Home Page is displayed instead of the browsing fragment that was supposed to be displayed.

[Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1817524)

##Steps to reproduce

1. Open normal browsing tab and navigate to a site (ex wikipedia)
2. Open a new private browsing tab and navigate to a site
3. Switch to the previously opened normal browsing tab.
4. Open tabs tray and close the private browsing tab.

##Expected behavior
After the tabs tray is closed, the normal browsing tab is still open.

##Actual behavior
Home page is displayed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817524