### PR TITLE
Bug 1809820 - For Recent bookmarks, always display them instead of just for 10 days

### DIFF
--- a/fenix/app/src/test/java/org/mozilla/fenix/components/bookmarks/BookmarksUseCaseTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/bookmarks/BookmarksUseCaseTest.kt
@@ -21,7 +21,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
-import java.util.concurrent.TimeUnit
 
 class BookmarksUseCaseTest {
 
@@ -94,7 +93,7 @@ class BookmarksUseCaseTest {
             )
         }.coAnswers { listOf(bookmarkNode) }
 
-        val result = useCase.retrieveRecentBookmarks(BookmarksUseCase.DEFAULT_BOOKMARKS_TO_RETRIEVE, 22)
+        val result = useCase.retrieveRecentBookmarks(BookmarksUseCase.DEFAULT_BOOKMARKS_TO_RETRIEVE)
 
         assertEquals(
             listOf(
@@ -110,7 +109,7 @@ class BookmarksUseCaseTest {
         coVerify {
             bookmarksStorage.getRecentBookmarks(
                 BookmarksUseCase.DEFAULT_BOOKMARKS_TO_RETRIEVE,
-                22,
+                null,
                 any(),
             )
         }
@@ -131,7 +130,7 @@ class BookmarksUseCaseTest {
         coVerify {
             bookmarksStorage.getRecentBookmarks(
                 BookmarksUseCase.DEFAULT_BOOKMARKS_TO_RETRIEVE,
-                TimeUnit.DAYS.toMillis(BookmarksUseCase.DEFAULT_BOOKMARKS_DAYS_AGE_TO_RETRIEVE),
+                null,
                 any(),
             )
         }


### PR DESCRIPTION
### Screenshots
| Issue | Fix |
| ----- | --- |
| ![new issue](https://user-images.githubusercontent.com/2725300/218064250-1895c34e-e9f7-4429-8ed2-e759624b4346.gif) | https://user-images.githubusercontent.com/2725300/218425559-bfe55259-2c86-4d2d-a987-a97758965661.mp4 |


### Pull Request checklist
 - [ ] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1809820