### PR TITLE
Bug 1813794 - When navigating back from a saved login your search results should be saved.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/controller/LoginsListController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/controller/LoginsListController.kt
@@ -33,6 +33,7 @@ class LoginsListController(
         from: BrowserDirection,
     ) -> Unit,
     private val settings: Settings,
+    private val addLoginCallback: () -> Unit,
 ) {
 
     fun handleItemClicked(item: SavedLogin) {
@@ -45,6 +46,7 @@ class LoginsListController(
     }
 
     fun handleAddLoginClicked() {
+        addLoginCallback.invoke()
         Logins.managementAddTapped.record(NoExtras())
         navController.navigate(
             SavedLoginsFragmentDirections.actionSavedLoginsFragmentToAddLoginFragment(),

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
@@ -14,8 +14,12 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
 import androidx.core.view.MenuProvider
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -108,6 +112,16 @@ class LoginDetailFragment : SecureFragment(R.layout.fragment_login_detail), Menu
             setUpPasswordReveal()
         }
         togglePasswordReveal(binding.passwordText, binding.revealPasswordButton)
+
+        setFragmentResultListener(HAS_QUERY_KEY) { _, bundle ->
+            val hasSearchQuery = bundle.getString(HAS_QUERY_BUNDLE)
+            if (hasSearchQuery == null) {
+                requireActivity().onBackPressedDispatcher.addCallback(this) {
+                    val directions = LoginDetailFragmentDirections.actionLoginDetailFragmentToSavedLogins()
+                    findNavController().navigate(directions)
+                }
+            }
+        }
     }
 
     /**
@@ -219,6 +233,10 @@ class LoginDetailFragment : SecureFragment(R.layout.fragment_login_detail), Menu
                     Logins.deleteSavedLogin.record(NoExtras())
                     Logins.deleted.add()
                     interactor.onDeleteLogin(args.savedLoginId)
+                    setFragmentResult(
+                        LOGIN_REQUEST_KEY,
+                        bundleOf(LOGIN_BUNDLE_ARGS to args.savedLoginId),
+                    )
                     dialog.dismiss()
                 }
                 create().withCenterAlignedButtons()
@@ -233,5 +251,10 @@ class LoginDetailFragment : SecureFragment(R.layout.fragment_login_detail), Menu
 
     companion object {
         private const val BUTTON_INCREASE_DPS = 24
+        const val LOGIN_REQUEST_KEY = "logins"
+        const val LOGIN_BUNDLE_ARGS = "loginsBundle"
+
+        const val HAS_QUERY_KEY = "hasSearchQueryKey"
+        const val HAS_QUERY_BUNDLE = "hasSearchQueryBundle"
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
@@ -13,11 +13,15 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.FrameLayout
+import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.os.bundleOf
 import androidx.core.view.MenuProvider
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -36,6 +40,7 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.logins.LoginsAction
 import org.mozilla.fenix.settings.logins.LoginsFragmentStore
+import org.mozilla.fenix.settings.logins.LoginsListState
 import org.mozilla.fenix.settings.logins.SavedLoginsSortingStrategyMenu
 import org.mozilla.fenix.settings.logins.SortingStrategy
 import org.mozilla.fenix.settings.logins.controller.LoginsListController
@@ -55,6 +60,10 @@ class SavedLoginsFragment : SecureFragment(), MenuProvider {
     private lateinit var sortLoginsMenuRoot: ConstraintLayout
     private lateinit var loginsListController: LoginsListController
     private lateinit var savedLoginsStorageController: SavedLoginsStorageController
+    private lateinit var loginState: LoginsListState
+    private var removedLoginGuid: String? = null
+    private var deletedGuid = mutableSetOf<String>()
+    private var searchQuery: LoginsListState? = null
 
     override fun onResume() {
         super.onResume()
@@ -82,6 +91,9 @@ class SavedLoginsFragment : SecureFragment(), MenuProvider {
                 navController = findNavController(),
                 browserNavigator = ::openToBrowserAndLoad,
                 settings = requireContext().settings(),
+                addLoginCallback = {
+                    searchQuery = null
+                },
             )
         savedLoginsStorageController =
             SavedLoginsStorageController(
@@ -107,9 +119,25 @@ class SavedLoginsFragment : SecureFragment(), MenuProvider {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        consumeFrom(savedLoginsStore) {
+        setFragmentResultListener(LoginDetailFragment.LOGIN_REQUEST_KEY) { _, bundle ->
+            removedLoginGuid = bundle.getString(LoginDetailFragment.LOGIN_BUNDLE_ARGS)
+            deletedGuid.add(removedLoginGuid.toString())
+        }
+        consumeFrom(savedLoginsStore) { loginsListState ->
             sortingStrategyMenu.updateMenu(savedLoginsStore.state.highlightedItem)
-            savedLoginsListView.update(it)
+
+            loginState = loginsListState
+            val currentList = loginState.filteredItems.toMutableList()
+
+            if (removedLoginGuid != null) {
+                val newList = currentList.filter { !deletedGuid.contains(it.guid) }
+
+                loginState = loginState.copy(
+                    loginList = newList,
+                    filteredItems = newList,
+                )
+            }
+            savedLoginsListView.update(loginState)
         }
     }
 
@@ -121,6 +149,13 @@ class SavedLoginsFragment : SecureFragment(), MenuProvider {
         searchView.queryHint = getString(R.string.preferences_passwords_saved_logins_search)
         searchView.maxWidth = Int.MAX_VALUE
 
+        if (searchQuery?.searchedForText?.isNotEmpty() == true) {
+            searchItem.expandActionView()
+            searchView.setQuery(searchQuery?.searchedForText, true)
+            searchView.clearFocus()
+            filterSavedLogins(searchQuery?.searchedForText)
+        }
+
         searchView.setOnQueryTextListener(
             object : SearchView.OnQueryTextListener {
                 override fun onQueryTextSubmit(query: String?): Boolean {
@@ -128,14 +163,31 @@ class SavedLoginsFragment : SecureFragment(), MenuProvider {
                 }
 
                 override fun onQueryTextChange(newText: String?): Boolean {
-                    savedLoginsStore.dispatch(
-                        LoginsAction.FilterLogins(
-                            newText,
-                        ),
-                    )
+                    if (newText?.isNotEmpty() == true) {
+                        searchQuery = savedLoginsStore.state.copy(
+                            searchedForText = newText,
+                        )
+                    }
+                    filterSavedLogins(newText)
                     return false
                 }
             },
+        )
+        val closeButton: ImageView = searchView.findViewById(R.id.search_close_btn) as ImageView
+
+        closeButton.setOnClickListener {
+            searchView.setQuery("", false)
+            searchQuery = savedLoginsStore.state.copy(
+                searchedForText = null,
+            )
+        }
+    }
+
+    private fun filterSavedLogins(query: String?) {
+        savedLoginsStore.dispatch(
+            LoginsAction.FilterLogins(
+                query,
+            ),
         )
     }
 
@@ -151,6 +203,11 @@ class SavedLoginsFragment : SecureFragment(), MenuProvider {
             .setDisplayShowTitleEnabled(true)
         sortingStrategyMenu.menuController.dismiss()
         sortLoginsMenuRoot.setOnClickListener(null)
+
+        setFragmentResult(
+            LoginDetailFragment.HAS_QUERY_KEY,
+            bundleOf(LoginDetailFragment.HAS_QUERY_BUNDLE to searchQuery?.searchedForText),
+        )
 
         redirectToReAuth(
             listOf(R.id.loginDetailFragment, R.id.addLoginFragment),

--- a/fenix/app/src/main/res/menu/login_list.xml
+++ b/fenix/app/src/main/res/menu/login_list.xml
@@ -10,5 +10,5 @@
         app:actionViewClass="androidx.appcompat.widget.SearchView"
         app:iconTint="?attr/textPrimary"
         android:contentDescription="@string/preferences_passwords_saved_logins_search"
-        app:showAsAction="ifRoom|collapseActionView" />
+        app:showAsAction="collapseActionView|always" />
 </menu>

--- a/fenix/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
@@ -33,12 +33,14 @@ class LoginsListControllerTest {
     private val sortingStrategy: SortingStrategy = SortingStrategy.Alphabetically
     private val navController: NavController = mockk(relaxed = true)
     private val browserNavigator: (String, Boolean, BrowserDirection) -> Unit = mockk(relaxed = true)
+    private val addLoginCallback: () -> Unit = mockk(relaxed = true)
     private val controller =
         LoginsListController(
             loginsFragmentStore = store,
             navController = navController,
             browserNavigator = browserNavigator,
             settings = settings,
+            addLoginCallback = addLoginCallback,
         )
 
     @Test


### PR DESCRIPTION
The PR keeps your search result when navigating back from savedLoginsDetail screen


### Issue video
[fnx-74-issue.webm](https://user-images.githubusercontent.com/93866435/218043622-e7cae2cf-a9c0-4713-8bc6-e35216e891db.webm)


### Demo video after fix
[fnx-17-fix.webm](https://user-images.githubusercontent.com/93866435/218042321-e056c036-d755-4b49-a905-235fc7629c1e.webm)


### Pull Request checklist
- [x] **Quality:** This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog:** This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
 - Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
 - Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1813794