### PR TITLE
Bug 1807531 - Honor private_browsing_mode value from external intents

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -58,7 +58,12 @@ class IntentReceiverActivity : Activity() {
 
     fun processIntent(intent: Intent) {
         // Call process for side effects, short on the first that returns true
-        val private = settings().openLinksInAPrivateTab
+
+        var private = settings().openLinksInAPrivateTab
+        if (!private) {
+            // if PRIVATE_BROWSING_MODE is already set to true, honor that
+            private = intent.getBooleanExtra(PRIVATE_BROWSING_MODE, false)
+        }
         intent.putExtra(PRIVATE_BROWSING_MODE, private)
         if (private) {
             Events.openedLink.record(Events.OpenedLinkExtra("PRIVATE"))


### PR DESCRIPTION
Change IntentReceiverActivity so that if the incoming intent has the private_browsing_mode extra set to true, it overrides the openLinksInAPrivateTab setting. This allows external apps to set this flag for sites they want opened in a private app explicitly.

External apps cannot force the link to open in a non-private tab if openLinksInAPrivateTab is enabled, in that case the extra will be ignored.

This is similar to an old fennec feature ( https://bugzilla.mozilla.org/show_bug.cgi?id=1347583 ), however I used the "private_browsing_mode" extra name since it already appears in the code, instead of the "private_tab" extra that fennec used.

Bugzilla bug is 1807531, GitHub bug is https://github.com/mozilla-mobile/fenix/issues/26158

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807531