### PR TITLE
Bug 1817708 - Using local contile service in MozillaOnline builds

### DIFF
--- a/android-components/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSitesProvider.kt
+++ b/android-components/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSitesProvider.kt
@@ -17,4 +17,11 @@ interface TopSitesProvider {
      * @return a list of top sites from the provider.
      */
     suspend fun getTopSites(allowCache: Boolean = true): List<TopSite>
+
+    /**
+     * Provides a list of hosts of top sites that should be excluded from default top sites.
+     *
+     * @return a list of hosts from the provider.
+     */
+    fun getPinnedExclusions(): List<String>
 }

--- a/android-components/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
+++ b/android-components/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt
@@ -885,6 +885,50 @@ class DefaultTopSitesStorageTest {
     }
 
     @Test
+    fun `GIVEN exclusions in provider is set WHEN getTopSites is called THEN the corresponding pinned top sites are filtered`() = runTestOnMain {
+        val defaultTopSitesStorage = DefaultTopSitesStorage(
+            pinnedSitesStorage = pinnedSitesStorage,
+            historyStorage = historyStorage,
+            topSitesProvider = topSitesProvider,
+            coroutineContext = coroutineContext,
+        )
+
+        whenever(topSitesProvider.getPinnedExclusions()).thenReturn(listOf("mozilla.com"))
+        whenever(topSitesProvider.getTopSites()).thenReturn(listOf())
+
+        val defaultSite = TopSite.Default(
+            id = 1,
+            title = "Mozilla",
+            url = "https://mozilla.com",
+            createdAt = 1,
+        )
+        val pinnedSite = TopSite.Pinned(
+            id = 2,
+            title = "Firefox",
+            url = "https://firefox.com",
+            createdAt = 2,
+        )
+
+        whenever(pinnedSitesStorage.getPinnedSites()).thenReturn(
+            listOf(
+                defaultSite,
+                pinnedSite,
+            ),
+        )
+
+        val topSites = defaultTopSitesStorage.getTopSites(
+            totalSites = 2,
+            providerConfig = TopSitesProviderConfig(
+                showProviderTopSites = true,
+            ),
+        )
+
+        assertEquals(1, topSites.size)
+        assertEquals(pinnedSite, topSites[0])
+        assertEquals(defaultTopSitesStorage.cachedTopSites, topSites)
+    }
+
+    @Test
     fun `GIVEN frecent top sites exist as a pinned or provided site WHEN top sites are retrieved THEN filters out frecent sites that already exist in pinned or provided sites`() = runTestOnMain {
         val defaultTopSitesStorage = DefaultTopSitesStorage(
             pinnedSitesStorage = pinnedSitesStorage,

--- a/android-components/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesProviderTest.kt
+++ b/android-components/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesProviderTest.kt
@@ -274,6 +274,22 @@ class ContileTopSitesProviderTest {
         assertNull(provider.cacheState.serverCacheMaxAge)
     }
 
+    @Test
+    fun `GIVEN a json object with exclusions WHEN top sites are fetched THEN response should contain exclusions`() =
+        runTest {
+            val jsonResponse = loadResourceAsString("/contile/contile-hasExclusions.json")
+            val client = prepareClient(jsonResponse)
+            val provider = spy(
+                ContileTopSitesProvider(testContext, client, hasExclusions = true),
+            )
+            val topSites = provider.getTopSites()
+            val exclusions = provider.getPinnedExclusions()
+
+            assertEquals(0, topSites.size)
+            assertEquals(1, exclusions.size)
+            assertEquals("mozilla.com", exclusions[0])
+        }
+
     private fun prepareClient(
         jsonResponse: String = loadResourceAsString("/contile/contile.json"),
         status: Int = 200,

--- a/android-components/components/service/contile/src/test/resources/contile/contile-hasExclusions.json
+++ b/android-components/components/service/contile/src/test/resources/contile/contile-hasExclusions.json
@@ -1,0 +1,9 @@
+{
+  "tiles": [
+  ],
+  "exclusions": [
+    {
+      "host": "mozilla.com"
+    }
+  ]
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -438,11 +438,21 @@ class Core(
     val pocketStoriesService by lazyMonitored { PocketStoriesService(context, pocketStoriesConfig) }
 
     val contileTopSitesProvider by lazyMonitored {
-        ContileTopSitesProvider(
-            context = context,
-            client = client,
-            maxCacheAgeInSeconds = CONTILE_MAX_CACHE_AGE,
-        )
+        if (Config.channel.isMozillaOnline) {
+            ContileTopSitesProvider(
+                context = context,
+                client = client,
+                endPointURL = "https://download-ssl.firefox.com.cn/fenix-contile/d3.json ",
+                maxCacheAgeInSeconds = CONTILE_MAX_CACHE_AGE,
+                hasExclusions = true,
+            )
+        } else {
+            ContileTopSitesProvider(
+                context = context,
+                client = client,
+                maxCacheAgeInSeconds = CONTILE_MAX_CACHE_AGE,
+            )
+        }
     }
 
     @Suppress("MagicNumber")


### PR DESCRIPTION
We Beijing office plan to start to use Contile service in MozillaOnline builds. However, there are some unique demands for us.

Beijing office need to do some promotion during shopping festivals like 11/11 every year, using contile service can help us make it easier.
The situation now is we have already put some sponsored top sites into the pinned default top sites. While we start to using Contile service, we want to make those duplicated pinned default topsites invisible. Also, for those pinned default top sites, if they are not sponsored anymore , we want them invisible too.

For these requirements, I wrote this draft PR, trying to add some information, about the pinned default top sites which should be hidden, into the JSON. But I'm not sure if it's appropriate because it modifies the interface TopSitesProvider .











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817708