### PR TITLE
Bug 1809815 - Talkback does not mention `Show all` as a button in the Recently visited section

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,7 +17,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -104,18 +103,20 @@ private fun HomeSectionHeaderContent(
         )
 
         onShowAllClick?.let {
-            ClickableText(
-                text = AnnotatedString(text = stringResource(id = R.string.recent_tabs_show_all)),
-                modifier = Modifier.padding(start = 16.dp)
-                    .semantics {
-                        contentDescription = description
-                    },
-                style = TextStyle(
-                    color = showAllTextColor,
-                    fontSize = 14.sp,
-                ),
-                onClick = { onShowAllClick() },
-            )
+            TextButton(onClick = { onShowAllClick() }) {
+                Text(
+                    text = stringResource(id = R.string.recent_tabs_show_all),
+                    modifier = Modifier
+                        .padding(start = 16.dp)
+                        .semantics {
+                            contentDescription = description
+                        },
+                    style = TextStyle(
+                        color = showAllTextColor,
+                        fontSize = 14.sp,
+                    ),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
### What
Talkback does not mention "Show all" as a button in the Recently visited section

### Screenshots
### Issue video
https://www.loom.com/share/78849456150c422cb6958b1f69ae0582

### Demo video after fix
https://www.loom.com/share/7470a8dd1f8c48dc89d44c9dff19819d

### Pull Request checklist
 - [ ] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1809815