### PR TITLE
Bug 1814140 - Added fixed height to the elements in the edit login page

### DIFF
--- a/fenix/app/src/main/res/layout/fragment_credit_card_editor.xml
+++ b/fenix/app/src/main/res/layout/fragment_credit_card_editor.xml
@@ -7,7 +7,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="16dp">
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginTop="16dp"
+    android:layout_marginBottom="8dp"
+    >
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -31,7 +34,7 @@
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/card_number_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="50dp"
             android:textColor="?attr/textPrimary"
             app:errorEnabled="true"
             app:hintEnabled="false">
@@ -60,7 +63,7 @@
             style="@style/CaptionTextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="8dp"
             android:gravity="center_vertical"
             android:letterSpacing="0.05"
             android:paddingStart="3dp"
@@ -72,8 +75,7 @@
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/name_on_card_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="11dp"
+            android:layout_height="50dp"
             android:textColor="?attr/textPrimary"
             app:hintEnabled="false">
 
@@ -99,7 +101,7 @@
             style="@style/CaptionTextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="8dp"
             android:gravity="center_vertical"
             android:letterSpacing="0.05"
             android:paddingStart="3dp"
@@ -129,7 +131,7 @@
                 <androidx.appcompat.widget.AppCompatSpinner
                     android:id="@+id/expiry_month_drop_down"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="50dp"
                     tools:listitem="@android:layout/simple_list_item_1" />
 
                 <View
@@ -154,7 +156,7 @@
                 <androidx.appcompat.widget.AppCompatSpinner
                     android:id="@+id/expiry_year_drop_down"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="50dp"
                     tools:listitem="@android:layout/simple_list_item_1" />
 
                 <View
@@ -168,7 +170,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="16dp">
+            android:paddingTop="8dp">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/delete_button"


### PR DESCRIPTION
### What
"Cancel" and "Save" buttons that are cut off the screen in the landscape when adding a new card   

### Screenshots
### Issue video
[bug.webm](https://user-images.githubusercontent.com/39338964/215788354-3db52024-19c0-465c-939c-c952efcd657c.webm)

### Demo video after fix
[fix.webm](https://user-images.githubusercontent.com/39338964/215786403-797eb806-c31a-4fce-bb31-8abc47a3cce6.webm)

### Pull Request checklist
 - [ ] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
### GitHub Automation


