### PR TITLE
Bug 1817726 - Add Recents url sharing

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -4,11 +4,13 @@
 
 package org.mozilla.fenix
 
+import android.app.assist.AssistContent
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.ACTION_MAIN
 import android.content.Intent.FLAG_ACTIVITY_REORDER_TO_FRONT
 import android.content.res.Configuration
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.StrictMode
@@ -25,6 +27,7 @@ import android.view.ViewConfiguration
 import android.view.WindowManager.LayoutParams.FLAG_SECURE
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
+import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.Companion.PROTECTED
 import androidx.appcompat.app.ActionBar
@@ -46,6 +49,7 @@ import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.SearchAction
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
+import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.concept.engine.EngineSession
@@ -521,6 +525,13 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         //
         // NB: There are ways for the user to install new products without leaving the browser.
         BrowsersCache.resetAll()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    override fun onProvideAssistContent(outContent: AssistContent?) {
+        super.onProvideAssistContent(outContent)
+        val currentTabUrl = components.core.store.state.selectedTab?.content?.url
+        outContent?.webUri = currentTabUrl?.let { Uri.parse(it) }
     }
 
     private fun getBookmarkCount(node: BookmarkNode): Int {


### PR DESCRIPTION
Enables [Recents URL sharing](https://developer.android.com/guide/components/activities/recents#url-sharing) so users can share links to recently viewed web content directly from the Recents screen.

### Video
https://user-images.githubusercontent.com/38040960/220072399-6fafcdfa-d6c3-4d68-b11d-3c603c249ab6.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817726