### PR TITLE
Bug 1812430 - No success pop-up or snackbar is displayed after adding manually a login

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/controller/SavedLoginsStorageController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/controller/SavedLoginsStorageController.kt
@@ -21,6 +21,7 @@ import mozilla.components.service.sync.logins.LoginsApiException
 import mozilla.components.service.sync.logins.NoSuchRecordException
 import mozilla.components.service.sync.logins.SyncableLoginsStorage
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.settings.logins.LoginsAction
 import org.mozilla.fenix.settings.logins.LoginsFragmentStore
 import org.mozilla.fenix.settings.logins.fragment.AddLoginFragmentDirections
@@ -39,6 +40,7 @@ open class SavedLoginsStorageController(
     private val loginsFragmentStore: LoginsFragmentStore,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val clipboardHandler: ClipboardHandler,
+    private val snackbar: FenixSnackbar,
 ) {
 
     fun delete(loginId: String) {
@@ -76,6 +78,11 @@ open class SavedLoginsStorageController(
             }
             saveLoginJob?.await()
             withContext(Dispatchers.Main) {
+                snackbar.apply {
+                    setText(context.getString(R.string.new_login_added))
+                    setLength(FenixSnackbar.LENGTH_LONG)
+                    show()
+                }
                 val directions =
                     AddLoginFragmentDirections.actionAddLoginFragmentToSavedLoginsFragment()
                 navController.navigate(directions)

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
@@ -25,9 +25,11 @@ import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.support.ktx.android.view.showKeyboard
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentAddLoginBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -76,6 +78,10 @@ class AddLoginFragment : Fragment(R.layout.fragment_add_login), MenuProvider {
                 navController = findNavController(),
                 loginsFragmentStore = loginsFragmentStore,
                 clipboardHandler = requireContext().components.clipboardHandler,
+                snackbar = FenixSnackbar.make(
+                    view = requireActivity().getRootView()!!,
+                    isDisplayedWithBrowserToolbar = false,
+                ),
             ),
         )
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -26,9 +26,11 @@ import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.GleanMetrics.Logins
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentEditLoginBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.toEditable
@@ -83,6 +85,10 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login), MenuProvider {
                 navController = findNavController(),
                 loginsFragmentStore = loginsFragmentStore,
                 clipboardHandler = requireContext().components.clipboardHandler,
+                snackbar = FenixSnackbar.make(
+                    view = requireActivity().getRootView()!!,
+                    isDisplayedWithBrowserToolbar = false,
+                ),
             ),
         )
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
@@ -32,6 +32,7 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentLoginDetailBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
@@ -90,6 +91,10 @@ class LoginDetailFragment : SecureFragment(R.layout.fragment_login_detail), Menu
                 navController = findNavController(),
                 loginsFragmentStore = savedLoginsStore,
                 clipboardHandler = requireContext().components.clipboardHandler,
+                snackbar = FenixSnackbar.make(
+                    view = requireActivity().getRootView()!!,
+                    isDisplayedWithBrowserToolbar = false,
+                ),
             ),
         )
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
@@ -28,9 +28,11 @@ import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.SecureFragment
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentSavedLoginsBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -89,6 +91,10 @@ class SavedLoginsFragment : SecureFragment(), MenuProvider {
                 navController = findNavController(),
                 loginsFragmentStore = savedLoginsStore,
                 clipboardHandler = requireContext().components.clipboardHandler,
+                snackbar = FenixSnackbar.make(
+                    view = requireActivity().getRootView()!!,
+                    isDisplayedWithBrowserToolbar = false,
+                ),
             )
 
         savedLoginsInteractor =

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -1830,6 +1830,8 @@
     <string name="edit">Edit</string>
     <!--  The page title for adding new login. -->
     <string name="add_login">Add new login</string>
+    <!--  Snack message for adding new login. -->
+    <string name="new_login_added">New login added</string>
     <!--  The error message in add/edit login view when password field is blank. -->
     <string name="saved_login_password_required">Password required</string>
     <!--  The error message in add login view when username field is blank. -->

--- a/fenix/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
@@ -10,6 +10,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verifyOrder
 import mozilla.components.concept.storage.EncryptedLogin
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
@@ -22,9 +23,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.ext.directionsEq
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.logins.controller.SavedLoginsStorageController
+import org.mozilla.fenix.settings.logins.fragment.AddLoginFragmentDirections
 import org.mozilla.fenix.settings.logins.fragment.EditLoginFragmentDirections
 import org.mozilla.fenix.utils.ClipboardHandler
 
@@ -41,6 +44,7 @@ class SavedLoginsStorageControllerTest {
     private val loginsFragmentStore: LoginsFragmentStore = mockk(relaxed = true)
     private val clipboardHandler: ClipboardHandler = mockk(relaxed = true)
     private val loginMock: Login = mockk(relaxed = true)
+    private val snackbar: FenixSnackbar = mockk(relaxed = true)
 
     @Before
     fun setup() {
@@ -57,6 +61,7 @@ class SavedLoginsStorageControllerTest {
             loginsFragmentStore = loginsFragmentStore,
             ioDispatcher = ioDispatcher,
             clipboardHandler = clipboardHandler,
+            snackbar = snackbar,
         )
     }
 
@@ -339,6 +344,26 @@ class SavedLoginsStorageControllerTest {
                     password = "password",
                 ),
             )
+        }
+    }
+
+    @Test
+    fun `WHEN a new login is added THEN a snackbar is shown and navigate to savedLogin`() = runTestOnMain {
+        controller.add(
+            originText = "https://www.firefox.com",
+            usernameText = "username",
+            passwordText = "password",
+        )
+
+        verifyOrder {
+            snackbar.context
+            snackbar.setText(any())
+            snackbar.setLength(FenixSnackbar.LENGTH_LONG)
+            snackbar.show()
+
+            val directions =
+                AddLoginFragmentDirections.actionAddLoginFragmentToSavedLoginsFragment()
+            navController.navigate(directions)
         }
     }
 }


### PR DESCRIPTION
The PR display an snackbar when a new login is added


### Issue video
[fnx-64-issue.webm](https://user-images.githubusercontent.com/93866435/217091674-336975c2-223d-4a57-861d-3483f291a036.webm)


### Demo video after fix
[fnx-64-fix.webm](https://user-images.githubusercontent.com/93866435/217091642-858ddf42-b213-4cdb-b135-ef459b3d743a.webm)


### Pull Request checklist
- [x] **Quality:** This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog:** This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
 - Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
 - Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


### GitHub Automation
Used by GitHub Actions.
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1812430
