### PR TITLE
Bug 1799622 - A password deleted in the password manager, is still visible in the list afterwards

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
@@ -16,7 +16,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
 import androidx.core.view.MenuProvider
+import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -224,6 +226,10 @@ class LoginDetailFragment : SecureFragment(R.layout.fragment_login_detail), Menu
                 setPositiveButton(R.string.dialog_delete_positive) { dialog: DialogInterface, _ ->
                     Logins.deleteSavedLogin.record(NoExtras())
                     interactor.onDeleteLogin(args.savedLoginId)
+                    setFragmentResult(
+                        LOGIN_REQUEST_KEY,
+                        bundleOf(LOGIN_BUNDLE_ARGS to args.savedLoginId),
+                    )
                     dialog.dismiss()
                 }
                 create()
@@ -236,7 +242,9 @@ class LoginDetailFragment : SecureFragment(R.layout.fragment_login_detail), Menu
         _binding = null
     }
 
-    private companion object {
+    companion object {
         private const val BUTTON_INCREASE_DPS = 24
+        const val LOGIN_REQUEST_KEY = "logins"
+        const val LOGIN_BUNDLE_ARGS = "loginsBundle"
     }
 }


### PR DESCRIPTION
The PR fixes saved Logins not updating immediately a login is deleted

### Fix description
Navigate back to the saved login screen, rather than just popping back stack 

### Issue video
[fnx-58-issue.webm](https://user-images.githubusercontent.com/93866435/216845977-f84bf078-76b6-4fc9-a02b-10649605c509.webm)


### Demo video after fix
[fnx-58-fix.webm](https://user-images.githubusercontent.com/93866435/216846010-0f993584-f300-40cc-a9ff-acc418ce14b7.webm)


### Pull Request checklist
- [x] **Quality:** This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog:** This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
 - Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
 - Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1799622