### PR TITLE
Bug 1812196 - Sets height of `Learn more about Sync` in Logins and passwords- Saved logins

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/view/SavedLoginsListView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/view/SavedLoginsListView.kt
@@ -4,11 +4,13 @@
 
 package org.mozilla.fenix.settings.logins.view
 
+import android.content.res.Resources
 import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
+import mozilla.components.support.ktx.android.util.dpToPx
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.ComponentSavedLoginsBinding
 import org.mozilla.fenix.ext.addUnderline
@@ -38,6 +40,7 @@ class SavedLoginsListView(
         }
 
         with(binding.savedPasswordsEmptyLearnMore) {
+            height = 48.dpToPx(Resources.getSystem().displayMetrics)
             movementMethod = LinkMovementMethod.getInstance()
             addUnderline()
             setOnClickListener { interactor.onLearnMoreClicked() }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/view/SavedLoginsListView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/view/SavedLoginsListView.kt
@@ -4,16 +4,15 @@
 
 package org.mozilla.fenix.settings.logins.view
 
-import android.content.res.Resources
 import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
-import mozilla.components.support.ktx.android.util.dpToPx
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.ComponentSavedLoginsBinding
 import org.mozilla.fenix.ext.addUnderline
+import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.settings.logins.LoginsListState
 import org.mozilla.fenix.settings.logins.interactor.SavedLoginsInteractor
 
@@ -40,7 +39,7 @@ class SavedLoginsListView(
         }
 
         with(binding.savedPasswordsEmptyLearnMore) {
-            height = 48.dpToPx(Resources.getSystem().displayMetrics)
+            increaseTapArea(LEARN_MORE_EXTRA_DIPS)
             movementMethod = LinkMovementMethod.getInstance()
             addUnderline()
             setOnClickListener { interactor.onLearnMoreClicked() }
@@ -71,5 +70,9 @@ class SavedLoginsListView(
             // Reset scroll position to the first item after submitted list was committed.
             binding.savedLoginsList.scrollToPosition(0)
         }
+    }
+
+    companion object {
+        private const val LEARN_MORE_EXTRA_DIPS = 24
     }
 }


### PR DESCRIPTION
The PR increases the clickable area of the `Learn more about Sync` in the Logins and passwords- Saved logins page

### Screenshots
| Issue | Fix |
| ----- | --- |
| ![FNXOSS-58](https://user-images.githubusercontent.com/2725300/216322497-9281abd3-c1c6-46d7-afd9-1c11cd51adbe.gif) | [FNXOSS-56 FIX.webm](https://user-images.githubusercontent.com/2725300/216570647-86dac6d5-d6f0-4c04-9af3-f61e832b9252.webm) |

### Pull Request checklist
 - [ ] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1812196