### PR TITLE
Bug 1809814 - Increased `Search engine` button height from home screen.

### DIFF
--- a/fenix/app/src/main/res/drawable/search_pill_background.xml
+++ b/fenix/app/src/main/res/drawable/search_pill_background.xml
@@ -12,7 +12,7 @@
                 android:width="1dp"
                 android:color="?accentBright" />
 
-            <corners android:radius="16dp" />
+            <corners android:radius="24dp" />
         </shape>
     </item>
 </layer-list>

--- a/fenix/app/src/main/res/values/dimens.xml
+++ b/fenix/app/src/main/res/values/dimens.xml
@@ -93,7 +93,7 @@
     <dimen name="search_fragment_clipboard_item_height">56dp</dimen>
     <dimen name="search_fragment_clipboard_item_horizontal_margin">8dp</dimen>
     <dimen name="search_fragment_clipboard_item_title_margin_start">8dp</dimen>
-    <dimen name="search_fragment_pill_height">40dp</dimen>
+    <dimen name="search_fragment_pill_height">48dp</dimen>
     <dimen name="search_fragment_pill_padding_start">20dp</dimen>
     <dimen name="search_fragment_pill_padding_end">16dp</dimen>
     <dimen name="search_fragment_pill_padding_vertical">4dp</dimen>

--- a/fenix/app/src/main/res/values/styles.xml
+++ b/fenix/app/src/main/res/values/styles.xml
@@ -380,7 +380,7 @@
 
     <style name="search_pill" parent="Widget.AppCompat.Button.Borderless">
         <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">40dp</item>
+        <item name="android:layout_height">48dp</item>
         <item name="android:paddingTop">4dp</item>
         <item name="android:paddingBottom">4dp</item>
         <item name="android:textAllCaps">false</item>


### PR DESCRIPTION
The PR fixes the issue of Accessibility scanner app suggesting the height of the `search engine` item be increased

### Issue Screenshots
![fnx-issue](https://user-images.githubusercontent.com/93866435/213650322-2e51674c-cbd1-4c66-8de4-9a6a2e0db273.png)
### Fix Screenshots
![fnx-fix](https://user-images.githubusercontent.com/93866435/213650372-0cfe20fc-c2f7-43cc-ab41-5f815e7a0f53.png)

### Pull Request checklist
- [x] **Quality:** This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog:** This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
 - Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
 - Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

**GitHub Automation**
Fixes https://github.com/mozilla-mobile/fenix/issues/27169
https://bugzilla.mozilla.org/show_bug.cgi?id=1809814
https://bugzilla.mozilla.org/show_bug.cgi?id=1809814
https://bugzilla.mozilla.org/show_bug.cgi?id=1809814
https://bugzilla.mozilla.org/show_bug.cgi?id=1809814