### PR TITLE
Bug 1807369 - Added `Modifier.clickable` for Talkback to mention `Learn more` as a hyperlink in the Pocket section

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ClickableSubstringLink.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ClickableSubstringLink.kt
@@ -5,17 +5,20 @@
 package org.mozilla.fenix.compose
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import org.mozilla.fenix.R
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -79,6 +82,12 @@ fun ClickableSubstringLink(
 
     ClickableText(
         text = annotatedText,
+        Modifier.clickable(
+            enabled = true,
+            onClickLabel = stringResource(id = R.string.a11y_action_label_read_article),
+            role = null,
+            onClick = onClick,
+        ),
         onClick = {
             annotatedText
                 .getStringAnnotations("link", it, it)


### PR DESCRIPTION
The PR fix the bug where the Talkback does not mention "Learn more" as a hyperlink in the Pocket section

### Screenshots
| Issue | Fix |
| ----- | --- |
| https://www.loom.com/share/24933216c4604ce084069ea0d793f91b | https://www.loom.com/share/afaa183cfb65444d8e9d4bf122683f2a |

### Pull Request checklist
 - [ ] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
### GitHub Automation