### PR TITLE
Bug 1815633 - Set margin top to zero when address bar is set to not to hide on scroll which removes a blank space on installed pwa

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -909,7 +909,11 @@ abstract class BaseBrowserFragment :
             owner = this,
             view = view,
         )
-        initializeEngineView(toolbarHeight)
+        if (browserToolbarView.isPwaTabOrTwaTab) {
+            initializeEngineView(0)
+        } else {
+            initializeEngineView(toolbarHeight)
+        }
     }
 
     /**


### PR DESCRIPTION
The PR fixes a blank space on installed PWA when the address bar is set not to hide on scroll.

### Fix description
Remove the margin-top

### Screenshots
| Issue | Fix |
| -----  | ----- |
| ![image](https://user-images.githubusercontent.com/2725300/213976692-e1de6267-c1d1-46fc-9b51-c189e5bcd07e.png) |  ![Screenshot_20230123-122243](https://user-images.githubusercontent.com/2725300/214016903-a3e36cfa-101f-4531-9ad8-f19c05043bb5.png) |

### Pull Request checklist
 - [ ] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815633