### PR TITLE
Bug 1815628 - Refactored Navigation Graph to show `Saved Login Page` after new Credentials added. 

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
@@ -353,7 +353,7 @@ class AddLoginFragment : Fragment(R.layout.fragment_add_login), MenuProvider {
 
     override fun onPause() {
         redirectToReAuth(
-            listOf(R.id.savedLoginsFragment),
+            listOf(R.id.loginDetailFragment, R.id.savedLoginsFragment),
             findNavController().currentDestination?.id,
             R.id.addLoginFragment,
         )

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
@@ -14,6 +14,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle
@@ -122,6 +123,13 @@ class LoginDetailFragment : SecureFragment(R.layout.fragment_login_detail), Menu
             R.id.loginDetailFragment,
         )
         super.onPause()
+    }
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requireActivity().onBackPressedDispatcher.addCallback(this) {
+            val directions = LoginDetailFragmentDirections.actionLoginDetailFragmentToSavedLoginsFragment()
+            findNavController().navigate(directions)
+        }
     }
 
     private fun setUpPasswordReveal() {

--- a/fenix/app/src/main/res/navigation/nav_graph.xml
+++ b/fenix/app/src/main/res/navigation/nav_graph.xml
@@ -473,6 +473,12 @@
             app:popUpTo="@id/editLoginFragment"
             app:popUpToInclusive="true" />
     </fragment>
+    
+    <action
+            android:id="@+id/action_loginDetailFragment_to_savedLoginsFragment"
+            app:destination="@id/savedLoginsFragment"
+            app:popUpTo="@id/savedLoginsFragment"
+            app:popUpToInclusive="true"/>
 
     <fragment
         android:id="@+id/editLoginFragment"
@@ -496,10 +502,10 @@
         android:label="@string/add_login"
         tools:layout="@layout/fragment_add_login">
         <action
-            android:id="@+id/action_addLoginFragment_to_savedLoginsFragment"
-            app:destination="@id/savedLoginsFragment"
+            android:id="@+id/action_addLoginFragment_to_loginDetailFragment"
+            app:destination="@id/loginDetailFragment"
             app:popUpTo="@id/savedLoginsFragment"
-            app:popUpToInclusive="true" />
+            app:popUpToInclusive="false" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
The PR fixes the issue where `saved Login Page` is shown after a new `login` is added

### Issue Screenshots
https://www.loom.com/share/3b5cc33e7a7a4ae79282531292666c52

### Fix Screenshots
[fnx-15-fix.webm](https://user-images.githubusercontent.com/93866435/214651093-fc6a787e-5456-4aa5-878c-1354a6820782.webm)

### Pull Request checklist
- [x] **Quality:** This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog:** This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
 - Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
 - Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.

**GitHub Automation**
Fixes https://github.com/mozilla-mobile/fenix/issues/27855
https://bugzilla.mozilla.org/show_bug.cgi?id=1815628
https://bugzilla.mozilla.org/show_bug.cgi?id=1815628
https://bugzilla.mozilla.org/show_bug.cgi?id=1815628
https://bugzilla.mozilla.org/show_bug.cgi?id=1815628