### PR TITLE
Bug 1815634 - Set weight and fill to text to display collection expand / collapse chevron for any length of title

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/list/ExpandableListHeader.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/list/ExpandableListHeader.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
@@ -68,6 +69,8 @@ fun ExpandableListHeader(
                 color = FirefoxTheme.colors.textPrimary,
                 style = headerTextStyle,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
             )
 
             expanded?.let {


### PR DESCRIPTION
### What
The PR fixes the bug `Collection expand/collapse chevron not displayed from a certain length of title`

### Screenshots
| Issue  | Fix |
| ------------- | ------------- |
| https://user-images.githubusercontent.com/48829350/204004973-edce88a1-f94d-40d5-bb47-716f0c983110.mp4 | https://www.loom.com/share/0599cfadc63348c29caf06257760e498 |

### Pull Request checklist
 - [ ] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815634