### PR TITLE
Bug 1815631 - changed height and reduced padding for `Active` text from the Studies menu

### DIFF
--- a/fenix/app/src/main/res/layout/studies_section_item.xml
+++ b/fenix/app/src/main/res/layout/studies_section_item.xml
@@ -22,12 +22,12 @@
         android:layout_marginStart="@dimen/top_bar_alignment_margin_start"
         android:id="@+id/title"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/section_header_height"
+        android:layout_height="wrap_content"
         android:gravity="start|center_vertical"
         android:textColor="?preferenceSectionHeader"
         android:background="?android:attr/selectableItemBackground"
         android:orientation="horizontal"
-        android:paddingVertical="16dp"
+        android:paddingVertical="12dp"
         android:textStyle="bold"
         tools:text="Active" />
 </LinearLayout>

--- a/fenix/app/src/main/res/layout/studies_section_item.xml
+++ b/fenix/app/src/main/res/layout/studies_section_item.xml
@@ -27,7 +27,8 @@
         android:textColor="?preferenceSectionHeader"
         android:background="?android:attr/selectableItemBackground"
         android:orientation="horizontal"
-        android:paddingVertical="12dp"
-        android:textStyle="bold"
-        tools:text="Active" />
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="14dp"
+        style="@style/StudiesItemTitleTextStyle"
+        tools:text="Active"/>
 </LinearLayout>

--- a/fenix/app/src/main/res/values/integers.xml
+++ b/fenix/app/src/main/res/values/integers.xml
@@ -5,4 +5,5 @@
 <resources>
     <!-- Font weights -->
     <integer name="font_weight_medium">500</integer>
+    <integer name="font_weight_semi_bold">600</integer>
 </resources>

--- a/fenix/app/src/main/res/values/styles.xml
+++ b/fenix/app/src/main/res/values/styles.xml
@@ -591,6 +591,13 @@
         <item name="android:fontWeight" tools:ignore="NewApi">@integer/font_weight_medium</item>
     </style>
 
+    <style name="StudiesItemTitleTextStyle">
+        <item name="android:textSize">12sp</item>
+        <item name="android:textFontWeight" tools:ignore="NewApi">@integer/font_weight_semi_bold</item>
+        <item name="android:fontWeight" tools:ignore="NewApi">@integer/font_weight_semi_bold</item>
+        <item name="fontFamily">sans-serif-medium</item>
+    </style>
+
     <style name="ShareDialogStyle" parent="DialogStyleBase"/>
 
     <style name="AboutItemText" parent="TextAppearance.MaterialComponents.Body2">


### PR DESCRIPTION
The PR fixes the `Active` text truncate issue on Studies screen.

### Steps to reproduce

1. Open the app and restart it once.
2. Enable the Debug menu by tapping the Firefox icon from Settings > About Firefox 5 times.
3. Enroll in an experiment by tapping a branch from Settings > Nimbus Experiments > experiment name.
4. Go to Settings > Data collection > Studies.
5. Observe the “Active” section.

### Issue video
https://www.loom.com/share/ddda083d88a0449198eac73868969a76

### Demo video after fix
https://www.loom.com/share/6875b27b4349474aae8d34ce22ee998c

### Pull Request checklist
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots:** This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**QA**
- [x] QA Needed
### To download an APK when reviewing a PR (after all CI tasks finished running):

1. Click on Checks at the top of the PR page.
2. Click on the firefoxci-taskcluster group on the left to expand all tasks.
3. Click on the build-debug task.
4. Click on View task in Taskcluster in the new DETAILS section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815631