### PR TITLE
Bug 1815185 - Remove fixed height from `RecentSyncedTab`

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
@@ -86,7 +86,6 @@ fun RecentSyncedTab(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .height(180.dp)
             .combinedClickable(
                 onClick = { tab?.let { onRecentSyncedTabClick(tab) } },
                 onLongClick = { isDropdownExpanded = true },


### PR DESCRIPTION
This content originally had a fixed height of 180, but it does not actually need this to be set as a `Modifier` property, since the card's contents will naturally make this larger than 180.

The text cut-off manifested after [replacing the fixed height of 36 from the top-level `Button` Composable](https://bugzilla.mozilla.org/show_bug.cgi?id=1813905) with the up-to-date padding values. The padding increase (in order to match the figma) caused the button to be bigger than what was allowed by the card's fixed height, causing the text to be vertically truncated. The [figma](https://www.figma.com/file/hJfV1KGZuOK7OYr29pooL5/Synced-tabs?node-id=334%3A14730&t=aKEEiisG4lp6r04a-0) for this homescreen component does not have the accurate padding represented, making the value of 180 misleading and unrepresentative of what the height of this default state should be.

The size discrepancy noted below is due to the button growing to its proper size but also the `Button` Composable adding some invisible tap area above and below the button. It obtains this via `Button` (ours) -> `Button` (Material) -> `Surface` -> `Modifier.minimumTouchTargetSize()`.

Removing the `Modifier.height(180)` resolves this issue, but this could also open the discussion for what we need to consider when translating figmas to Compose while incorporating `Modifier.minimumTouchTargetSize()`.

<img width="853" alt="image" src="https://user-images.githubusercontent.com/87384386/220436092-a29e647a-1bd5-4b11-bd1f-58e7d4a09f6a.png">



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815185