### PR TITLE
Bug 1646242 - Avoid crashes when requireContext is called and fragment is no longer attached.

### DIFF
--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -926,7 +926,7 @@ class BrowserFragment :
             },
             showConnectionInfo = ::showConnectionInfo,
             showCookieBannerExceptionsDetailsPanel = ::showCookieBannerExceptionDetailsPanel,
-        ).also { currentEtp -> currentEtp.show() }
+        ).also { currentEtp -> context?.let { currentEtp.show() } }
     }
 
     private fun reloadCurrentTab() {

--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -654,9 +654,9 @@ class BrowserFragment :
             ),
         )
 
-        snackbar.setAction(getString(R.string.download_snackbar_open)) {
+        snackbar.setAction(getString(R.string.download_snackbar_open)) { context ->
             val opened = AbstractFetchDownloadService.openFile(
-                applicationContext = requireContext().applicationContext,
+                applicationContext = context.applicationContext,
                 download = state,
             )
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/UrlInputFragment.kt
@@ -35,6 +35,7 @@ import org.mozilla.focus.GleanMetrics.SearchWidget
 import org.mozilla.focus.R
 import org.mozilla.focus.activity.MainActivity
 import org.mozilla.focus.databinding.FragmentUrlinputBinding
+import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.defaultSearchEngineName
 import org.mozilla.focus.ext.hasSearchTerms
 import org.mozilla.focus.ext.requireComponents
@@ -533,7 +534,7 @@ class UrlInputFragment :
         // this transaction is committed. To avoid this we commit while allowing a state loss here.
         // We do not save any state in this fragment (It's getting destroyed) so this should not be a problem.
 
-        requireComponents.appStore.dispatch(AppAction.FinishEdit(tab!!.id))
+        context?.components?.appStore?.dispatch(AppAction.FinishEdit(tab!!.id))
     }
 
     internal fun onCommit(input: String) {

--- a/focus-android/app/src/main/java/org/mozilla/focus/utils/FocusSnackbar.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/utils/FocusSnackbar.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.focus.utils
 
+import android.content.Context
 import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
@@ -33,12 +34,15 @@ class FocusSnackbar private constructor(
         binding.snackbarText.text = text
     }
 
-    fun setAction(text: String, action: () -> Unit) = apply {
+    /**
+     * Sets an action to be performed on clicking [FocusSnackbar]'s action button.
+     */
+    fun setAction(text: String, action: (Context) -> Unit) = apply {
         binding.snackbarAction.apply {
             setText(text)
             isVisible = true
             setOnClickListener {
-                action.invoke()
+                action.invoke(it.context)
                 dismiss()
             }
         }

--- a/focus-android/quality/detekt-baseline.xml
+++ b/focus-android/quality/detekt-baseline.xml
@@ -306,7 +306,6 @@
     <ID>UndocumentedPublicFunction:FocusDialog.kt$@Composable fun FocusDialogSample()</ID>
     <ID>UndocumentedPublicFunction:FocusDialog.kt$@Preview( name = "dark theme", showBackground = true, backgroundColor = 0xFF393473, uiMode = Configuration.UI_MODE_NIGHT_MASK, ) @Composable fun DialogTitlePreviewDark()</ID>
     <ID>UndocumentedPublicFunction:FocusDialog.kt$@Preview( name = "light theme", showBackground = true, backgroundColor = 0xFFFBFBFE, uiMode = Configuration.UI_MODE_NIGHT_NO, ) @Composable fun DialogTitlePreviewLight()</ID>
-    <ID>UndocumentedPublicFunction:FocusSnackbar.kt$FocusSnackbar$fun setAction(text: String, action: () -&gt; Unit)</ID>
     <ID>UndocumentedPublicFunction:FocusSnackbar.kt$FocusSnackbar$fun setText(text: String)</ID>
     <ID>UndocumentedPublicFunction:FocusTheme.kt$fun phoneDimensions()</ID>
     <ID>UndocumentedPublicFunction:FocusTheme.kt$fun tabletDimensions()</ID>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.
















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1646242