### PR TITLE
Bug 1812447 - Search Logins by Username

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
@@ -171,6 +171,8 @@ private fun filterItems(
             filteredItems = sortingStrategy(state.loginList).filter {
                 it.origin.contains(
                     searchedForText,
+                ) || it.username.contains(
+                    searchedForText,
                 )
             },
         )


### PR DESCRIPTION
The PR allows users to search their logins using their username 


### Issue video
https://www.loom.com/share/c9cc5340166d4e15964f36dd17a9594f


### Demo video after fix
[fnx-39-fix.webm](https://user-images.githubusercontent.com/93866435/220068930-b00087b1-11f3-4846-b117-5e9af97fdac6.webm)




### Pull Request checklist
- [x] **Quality:** This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog:** This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
 - Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
 - Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1812447