### PR TITLE
Bug 1818572 - Document versioning for Fenix and Focus

### DIFF
--- a/docs/shared/versioning.md
+++ b/docs/shared/versioning.md
@@ -1,0 +1,25 @@
+# Android Versioning
+
+This repository uses the same `version.txt` to define the version for Android Components, Focus, and Fenix. The following formatting corresonds to release branches 
+on the release track.
+
+## Format
+
+XXX.0 (where XXX is defined as the current desktop release #)
+
+*Please note: the initial release is `major.minor`, but the following releases will be `major.minor.patch`*
+
+* Levaraging semantic versioning, the first and second digit will be directly tied to the associated desktop release 
+* The third digit will be reserved for Android-only patch releases
+
+### Example
+|                                | Desktop               | Android                        |
+| ------------------------------ | --------------------- | ------------------------------ |
+| Fx XXX initial release         | XXX.0                 | XXX.0                          |
+| Desktop + Android dot release  | XXX.0.1               | XXX.1.0                        |
+| Android-only patch             | <sub>No change</sub>  | XXX.1.1                        |
+| Desktop-only dot release       | XXX.0.2               | <sub>XXX.2.0 is skipped </sub> |
+| Android-only dot release       | <sub>No change </sub> | XXX.2.1                        |
+| Desktop + Android dot release  | XXX.0.3               | XXX.3.0                        |
+| Desktop-only dot release       | XXX.0.4               | <sub>XXX.4.0 is skipped </sub> |
+| Desktop + Android dot release  | XXX.0.5               | XXX.5.0                        |

--- a/docs/shared/versioning.md
+++ b/docs/shared/versioning.md
@@ -1,6 +1,6 @@
 # Android Versioning
 
-This repository uses the same `version.txt` to define the version for Android Components, Focus, and Fenix. The following formatting corresonds to release branches 
+This repository uses the same `version.txt` to define the version for Android Components, Focus, and Fenix. The following formatting corresponds to release branches
 on the release track.
 
 ## Format
@@ -9,7 +9,7 @@ XXX.0 (where XXX is defined as the current desktop release #)
 
 *Please note: the initial release is `major.minor`, but the following releases will be `major.minor.patch`*
 
-* Levaraging semantic versioning, the first and second digit will be directly tied to the associated desktop release 
+* The first and second digit will be directly tied to the associated desktop release
 * The third digit will be reserved for Android-only patch releases
 
 ### Example
@@ -19,7 +19,7 @@ XXX.0 (where XXX is defined as the current desktop release #)
 | Desktop + Android dot release  | XXX.0.1               | XXX.1.0                        |
 | Android-only patch             | <sub>No change</sub>  | XXX.1.1                        |
 | Desktop-only dot release       | XXX.0.2               | <sub>XXX.2.0 is skipped </sub> |
-| Android-only dot release       | <sub>No change </sub> | XXX.2.1                        |
+| Android-only dot release       | <sub>No change</sub>  | XXX.2.1                        |
 | Desktop + Android dot release  | XXX.0.3               | XXX.3.0                        |
 | Desktop-only dot release       | XXX.0.4               | <sub>XXX.4.0 is skipped </sub> |
 | Desktop + Android dot release  | XXX.0.5               | XXX.5.0                        |


### PR DESCRIPTION
Bug 1818572 - Adds new versioning doc
Create new shared doc that describes versioning best practices for Fenix and Focus in the new monorepo

https://bugzilla.mozilla.org/show_bug.cgi?id=1818572
https://bugzilla.mozilla.org/show_bug.cgi?id=1818572