### PR TITLE
Bug 1807283 - re-enable verifyJumpBackInSectionTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -127,7 +127,6 @@ class HomeScreenTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807283")
     @Test
     fun verifyJumpBackInSectionTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 4)
@@ -135,27 +134,39 @@ class HomeScreenTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            verifyPageContent(firstWebPage.content)
+            verifyUrl(firstWebPage.url.toString())
         }.goToHomescreen {
             verifyJumpBackInSectionIsDisplayed()
-            verifyJumpBackInItemTitle(firstWebPage.title)
-            verifyJumpBackInItemWithUrl(firstWebPage.url.toString())
+            verifyJumpBackInItemTitle(activityTestRule, firstWebPage.title)
+            verifyJumpBackInItemWithUrl(activityTestRule, firstWebPage.url.toString())
             verifyJumpBackInShowAllButton()
         }.clickJumpBackInShowAllButton {
             verifyExistingOpenTabs(firstWebPage.title)
         }.closeTabDrawer {
         }
-        homeScreen {
-        }.clickJumpBackInItemWithTitle(firstWebPage.title) {
-            verifyUrl(firstWebPage.url.toString())
-            clickLinkMatchingText("Link 1")
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(secondWebPage.url) {
             verifyPageContent(secondWebPage.content)
+            verifyUrl(secondWebPage.url.toString())
         }.goToHomescreen {
             verifyJumpBackInSectionIsDisplayed()
-            verifyJumpBackInItemTitle(secondWebPage.title)
-            verifyJumpBackInItemWithUrl(secondWebPage.url.toString())
+            verifyJumpBackInItemTitle(activityTestRule, secondWebPage.title)
+            verifyJumpBackInItemWithUrl(activityTestRule, secondWebPage.url.toString())
+        }.openTabDrawer {
+            closeTabWithTitle(secondWebPage.title)
+        }.closeTabDrawer {
+        }
+
+        homeScreen {
+            verifyJumpBackInSectionIsDisplayed()
+            verifyJumpBackInItemTitle(activityTestRule, firstWebPage.title)
+            verifyJumpBackInItemWithUrl(activityTestRule, firstWebPage.url.toString())
         }.openTabDrawer {
             closeTab()
         }
+
         homeScreen {
             verifyJumpBackInSectionIsNotDisplayed()
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -295,8 +295,10 @@ class HomeScreenRobot {
         assertTrue(jumpBackInSection().waitForExists(waitingTime))
     }
     fun verifyJumpBackInSectionIsNotDisplayed() = assertJumpBackInSectionIsNotDisplayed()
-    fun verifyJumpBackInItemTitle(itemTitle: String) = assertJumpBackInItemTitle(itemTitle)
-    fun verifyJumpBackInItemWithUrl(itemUrl: String) = assertJumpBackInItemWithUrl(itemUrl)
+    fun verifyJumpBackInItemTitle(testRule: ComposeTestRule, itemTitle: String) =
+        assertJumpBackInItemTitle(testRule, itemTitle)
+    fun verifyJumpBackInItemWithUrl(testRule: ComposeTestRule, itemUrl: String) =
+        assertJumpBackInItemWithUrl(testRule, itemUrl)
     fun verifyJumpBackInShowAllButton() = assertJumpBackInShowAllButton()
     fun verifyRecentlyVisitedSectionIsDisplayed() = assertRecentlyVisitedSectionIsDisplayed()
     fun verifyRecentlyVisitedSectionIsNotDisplayed() = assertRecentlyVisitedSectionIsNotDisplayed()
@@ -990,25 +992,11 @@ private fun assertTopSiteContextMenuItems() {
 
 private fun assertJumpBackInSectionIsNotDisplayed() = assertFalse(jumpBackInSection().waitForExists(waitingTimeShort))
 
-private fun assertJumpBackInItemTitle(itemTitle: String) =
-    assertTrue(
-        mDevice
-            .findObject(
-                UiSelector()
-                    .resourceId("recent.tab.title")
-                    .textContains(itemTitle),
-            ).waitForExists(waitingTime),
-    )
+private fun assertJumpBackInItemTitle(testRule: ComposeTestRule, itemTitle: String) =
+    testRule.onNodeWithTag("recent.tab.title", useUnmergedTree = true).assert(hasText(itemTitle))
 
-private fun assertJumpBackInItemWithUrl(itemUrl: String) =
-    assertTrue(
-        mDevice
-            .findObject(
-                UiSelector()
-                    .resourceId("recent.tab.url")
-                    .textContains(itemUrl),
-            ).waitForExists(waitingTime),
-    )
+private fun assertJumpBackInItemWithUrl(testRule: ComposeTestRule, itemUrl: String) =
+    testRule.onNodeWithTag("recent.tab.url", useUnmergedTree = true).assert(hasText(itemUrl))
 
 private fun assertJumpBackInShowAllButton() =
     assertTrue(

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -37,6 +37,7 @@ import org.hamcrest.CoreMatchers.anyOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matcher
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndDescription
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
@@ -107,6 +108,15 @@ class TabDrawerRobot {
             retries++
         } while (closeTabButton().exists() && retries < 3)
     }
+
+    fun closeTabWithTitle(title: String) =
+        itemWithResIdAndDescription(
+            "$packageName:id/mozac_browser_tabstray_close",
+            "Close tab $title",
+        ).also {
+            it.waitForExists(waitingTime)
+            it.click()
+        }
 
     fun swipeTabRight(title: String) {
         var retries = 0 // number of retries before failing, will stop at 2


### PR DESCRIPTION
Bug 1807283 - re-enable `verifyJumpBackInSectionTest` UI test 

Summary:

- Switched to compose when verifying the "Jump back in" item details on the home screen
- Also refactored the test a bit to match the manual test from TestRail

✅ Successfully passed 100x **without the retry rule**.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807283