### PR TITLE
Bug 1817519 – force search for not default engines

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -109,12 +109,14 @@ class SearchDialogController(
         clearToolbarFocus()
 
         val searchEngine = fragmentStore.state.searchEngineSource.searchEngine
+        val isDefaultEngine = searchEngine == fragmentStore.state.defaultEngine
 
         activity.openToBrowserAndLoad(
             searchTermOrURL = url,
             newTab = fragmentStore.state.tabId == null,
             from = BrowserDirection.FromSearchDialog,
             engine = searchEngine,
+            forceSearch = !isDefaultEngine,
             requestDesktopMode = fromHomeScreen && activity.settings().openNextTabInDesktopMode,
         )
 
@@ -128,7 +130,7 @@ class SearchDialogController(
 
             MetricsUtils.recordSearchMetrics(
                 searchEngine,
-                searchEngine == store.state.search.selectedOrDefaultSearchEngine,
+                isDefaultEngine,
                 searchAccessPoint,
             )
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -161,6 +161,7 @@ class ToolbarView(
         val searchEngine = searchState.searchEngineSource.searchEngine
 
         view.edit.hint = when (searchEngine?.type) {
+            null -> context.getString(R.string.search_hint)
             SearchEngine.Type.APPLICATION ->
                 when (searchEngine.id) {
                     Core.HISTORY_SEARCH_ENGINE_ID -> context.getString(R.string.history_search_hint)
@@ -168,15 +169,17 @@ class ToolbarView(
                     Core.TABS_SEARCH_ENGINE_ID -> context.getString(R.string.tab_search_hint)
                     else -> context.getString(R.string.application_search_hint)
                 }
-            SearchEngine.Type.BUNDLED -> {
+            else -> {
                 if (!searchEngine.isGeneral) {
                     context.getString(R.string.application_search_hint)
                 } else {
-                    context.getString(R.string.search_hint)
+                    if (searchEngine == searchState.defaultEngine) {
+                        context.getString(R.string.search_hint)
+                    } else {
+                        context.getString(R.string.search_hint_general_engine)
+                    }
                 }
             }
-            else ->
-                context.getString(R.string.search_hint)
         }
 
         if (!settings.showUnifiedSearchFeature && searchEngine != null) {

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -14,8 +14,10 @@
     <string name="content_description_private_browsing_button">Enable private browsing</string>
     <!-- Content description (not visible, for screen readers etc.): "Private Browsing" menu button. -->
     <string name="content_description_disable_private_browsing_button">Disable private browsing</string>
-    <!-- Placeholder text shown in the search bar before a user enters text -->
+    <!-- Placeholder text shown in the search bar before a user enters text for the default engine -->
     <string name="search_hint">Search or enter address</string>
+    <!-- Placeholder text shown in the search bar before a user enters text for a general engine -->
+    <string name="search_hint_general_engine">Search the web</string>
     <!-- Placeholder text shown in search bar when using history search -->
     <string name="history_search_hint">Search history</string>
     <!-- Placeholder text shown in search bar when using bookmarks search -->

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -101,9 +101,11 @@ class SearchDialogControllerTest {
     }
 
     @Test
-    fun handleUrlCommitted() {
+    fun `GIVEN default search engine is selected WHEN url is committed THEN load the url`() {
         val url = "https://www.google.com/"
         assertNull(Events.enteredUrl.testGetValue())
+
+        every { store.state.defaultEngine } returns searchEngine
 
         createController().handleUrlCommitted(url)
 
@@ -113,6 +115,32 @@ class SearchDialogControllerTest {
                 newTab = false,
                 from = BrowserDirection.FromSearchDialog,
                 engine = searchEngine,
+                forceSearch = false,
+            )
+        }
+
+        assertNotNull(Events.enteredUrl.testGetValue())
+        val snapshot = Events.enteredUrl.testGetValue()!!
+        assertEquals(1, snapshot.size)
+        assertEquals("false", snapshot.single().extra?.getValue("autocomplete"))
+    }
+
+    @Test
+    fun `GIVEN a general search engine is selected WHEN url is committed THEN perform search`() {
+        val url = "https://www.google.com/"
+        assertNull(Events.enteredUrl.testGetValue())
+
+        every { store.state.defaultEngine } returns mockk(relaxed = true)
+
+        createController().handleUrlCommitted(url)
+
+        verify {
+            activity.openToBrowserAndLoad(
+                searchTermOrURL = url,
+                newTab = false,
+                from = BrowserDirection.FromSearchDialog,
+                engine = searchEngine,
+                forceSearch = true,
             )
         }
 
@@ -148,6 +176,7 @@ class SearchDialogControllerTest {
                 newTab = false,
                 from = BrowserDirection.FromSearchDialog,
                 engine = searchEngine,
+                forceSearch = true,
             )
         }
     }
@@ -203,6 +232,8 @@ class SearchDialogControllerTest {
     fun handleMozillaUrlCommitted() {
         val url = "moz://a"
         assertNull(Events.enteredUrl.testGetValue())
+
+        every { store.state.defaultEngine } returns searchEngine
 
         createController().handleUrlCommitted(url)
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
@@ -39,6 +39,7 @@ import org.junit.runner.RunWith
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.components.Core
 import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -209,64 +210,145 @@ class ToolbarViewTest {
     }
 
     @Test
-    fun `GIVEN a general search engine is default WHEN a topic specific engine is selected THEN the hint changes`() {
-        val topicSpecificEngine = buildSearchEngine(SearchEngine.Type.BUNDLED, false)
+    fun `WHEN the default general search engine is selected THEN show text for default engine`() {
         val toolbarView = buildToolbarView(false)
-        toolbarView.update(defaultState)
-        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+        val defaultEngine = buildSearchEngine(SearchEngine.Type.BUNDLED, true)
 
-        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(topicSpecificEngine)))
+        toolbarView.update(
+            defaultState.copy(
+                defaultEngine = defaultEngine,
+                searchEngineSource = SearchEngineSource.Default(defaultEngine),
+            ),
+        )
+
+        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+    }
+
+    @Test
+    fun `WHEN a general search engine is selected THEN show text for general engine`() {
+        val toolbarView = buildToolbarView(false)
+        val generalEngine = buildSearchEngine(SearchEngine.Type.BUNDLED, true)
+
+        toolbarView.update(
+            defaultState.copy(
+                searchEngineSource = SearchEngineSource.Shortcut(generalEngine),
+            ),
+        )
+
+        assertEquals(context.getString(R.string.search_hint_general_engine), toolbarView.view.edit.hint)
+    }
+
+    @Test
+    fun `WHEN a topic specific search engine is selected THEN show text for topic specific engine`() {
+        val toolbarView = buildToolbarView(false)
+        val topicSpecificEngine = buildSearchEngine(SearchEngine.Type.BUNDLED, false)
+
+        toolbarView.update(
+            defaultState.copy(
+                searchEngineSource = SearchEngineSource.Shortcut(topicSpecificEngine),
+            ),
+        )
 
         assertEquals(context.getString(R.string.application_search_hint), toolbarView.view.edit.hint)
     }
 
     @Test
-    fun `GIVEN a topic specific engine is default WHEN a general engine is selected THEN the hint changes`() {
-        val topicSpecificEngine = buildSearchEngine(SearchEngine.Type.BUNDLED, false)
+    fun `WHEN the default additional general search engine is selected THEN show text for default engine`() {
         val toolbarView = buildToolbarView(false)
-        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(topicSpecificEngine)))
-        assertEquals(context.getString(R.string.application_search_hint), toolbarView.view.edit.hint)
+        val defaultEngine = buildSearchEngine(SearchEngine.Type.BUNDLED_ADDITIONAL, true)
 
-        toolbarView.update(defaultState)
+        toolbarView.update(
+            defaultState.copy(
+                defaultEngine = defaultEngine,
+                searchEngineSource = SearchEngineSource.Default(defaultEngine),
+            ),
+        )
 
         assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
     }
 
     @Test
-    fun `GIVEN a topic specific engine is default WHEN a custom engine is selected THEN the hint changes`() {
-        val topicSpecificEngine = buildSearchEngine(SearchEngine.Type.BUNDLED, false)
-        val customEngine = buildSearchEngine(SearchEngine.Type.CUSTOM, true)
+    fun `WHEN a general additional search engine is selected THEN show text for general engine`() {
         val toolbarView = buildToolbarView(false)
-        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(topicSpecificEngine)))
-        assertEquals(context.getString(R.string.application_search_hint), toolbarView.view.edit.hint)
+        val generalEngine = buildSearchEngine(SearchEngine.Type.BUNDLED_ADDITIONAL, true)
 
-        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(customEngine)))
+        toolbarView.update(
+            defaultState.copy(
+                searchEngineSource = SearchEngineSource.Shortcut(generalEngine),
+            ),
+        )
+
+        assertEquals(context.getString(R.string.search_hint_general_engine), toolbarView.view.edit.hint)
+    }
+
+    @Test
+    fun `WHEN the default custom search engine is selected THEN show text for default engine`() {
+        val toolbarView = buildToolbarView(false)
+        val customEngine = buildSearchEngine(SearchEngine.Type.CUSTOM, true)
+
+        toolbarView.update(
+            defaultState.copy(
+                defaultEngine = customEngine,
+                searchEngineSource = SearchEngineSource.Default(customEngine),
+            ),
+        )
 
         assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
     }
 
     @Test
-    fun `GIVEN a general engine is default WHEN a custom engine is selected THEN the hint does not change`() {
-        val customEngine = buildSearchEngine(SearchEngine.Type.CUSTOM, true)
+    fun `WHEN a custom search engine is selected THEN show text for general engine`() {
         val toolbarView = buildToolbarView(false)
-        toolbarView.update(defaultState)
-        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+        val customEngine = buildSearchEngine(SearchEngine.Type.CUSTOM, true)
 
-        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(customEngine)))
+        toolbarView.update(
+            defaultState.copy(
+                searchEngineSource = SearchEngineSource.Shortcut(customEngine),
+            ),
+        )
 
-        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+        assertEquals(context.getString(R.string.search_hint_general_engine), toolbarView.view.edit.hint)
     }
 
     @Test
-    fun `GIVEN a custom engine is default WHEN a general engine is selected THEN the hint does not change`() {
-        val customEngine = buildSearchEngine(SearchEngine.Type.CUSTOM, true)
+    fun `WHEN history is selected as engine THEN show text specific for history`() {
         val toolbarView = buildToolbarView(false)
-        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(customEngine)))
-        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+        val historyEngine = buildSearchEngine(SearchEngine.Type.APPLICATION, false, Core.HISTORY_SEARCH_ENGINE_ID)
 
-        toolbarView.update(defaultState)
+        toolbarView.update(
+            defaultState.copy(
+                searchEngineSource = SearchEngineSource.Shortcut(historyEngine),
+            ),
+        )
 
-        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+        assertEquals(context.getString(R.string.history_search_hint), toolbarView.view.edit.hint)
+    }
+
+    @Test
+    fun `WHEN bookmarks is selected as engine THEN show text specific for bookmarks`() {
+        val toolbarView = buildToolbarView(false)
+        val bookmarksEngine = buildSearchEngine(SearchEngine.Type.APPLICATION, false, Core.BOOKMARKS_SEARCH_ENGINE_ID)
+
+        toolbarView.update(
+            defaultState.copy(
+                searchEngineSource = SearchEngineSource.Shortcut(bookmarksEngine),
+            ),
+        )
+
+        assertEquals(context.getString(R.string.bookmark_search_hint), toolbarView.view.edit.hint)
+    }
+
+    @Test
+    fun `WHEN tabs is selected as engine THEN show text specific for tabs`() {
+        val toolbarView = buildToolbarView(false)
+        val tabsEngine = buildSearchEngine(SearchEngine.Type.APPLICATION, false, Core.TABS_SEARCH_ENGINE_ID)
+
+        toolbarView.update(
+            defaultState.copy(
+                searchEngineSource = SearchEngineSource.Shortcut(tabsEngine),
+            ),
+        )
+        assertEquals(context.getString(R.string.tab_search_hint), toolbarView.view.edit.hint)
     }
 
     @Test
@@ -637,9 +719,13 @@ class ToolbarViewTest {
         fromHomeFragment = false,
     )
 
-    private fun buildSearchEngine(type: SearchEngine.Type, isGeneral: Boolean) = SearchEngine(
-        id = UUID.randomUUID().toString(),
-        name = "General",
+    private fun buildSearchEngine(
+        type: SearchEngine.Type,
+        isGeneral: Boolean,
+        id: String = UUID.randomUUID().toString(),
+    ) = SearchEngine(
+        id = id,
+        name = UUID.randomUUID().toString(),
         icon = testContext.getDrawable(R.drawable.ic_search)!!.toBitmap(),
         type = type,
         isGeneral = isGeneral,


### PR DESCRIPTION
Verdi [reviewed](https://docs.google.com/document/d/1Byj50kRrg8fVRqEDQ06DuYnBeN0eH1tKZiU95i9CSD0/edit) unified search feature, and one of follow up [requirements](https://www.figma.com/file/epu0Sj6mCPk7K282sNpHgI/Site?node-id=3754%3A51165&t=O5Yn6gDdSKHYkGwO-4) was to search for an url instead of loading it for non default search engines. We had a call after that, and agreed on the final requirements. From the ticket:

_Not just topic specific, but non default general search engines also should search for an url instead of loading it. Also should change the prompt for those as well: in case the general search engine is selected, the text should be changed from Search or enter address to "Enter search terms"._

### How it works now?
https://user-images.githubusercontent.com/92760693/221651584-41956842-a351-4ed4-b27b-59555ccfc639.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.














### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817519