### PR TITLE
Bug 1817611 - Revert using live region for talkback on navbar swipe

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1136,8 +1136,6 @@ abstract class BaseBrowserFragment :
             updateThemeForSession(selectedTab)
         }
 
-        binding.engineView.asView().contentDescription = selectedTab.toDisplayTitle()
-
         if (browserInitialized) {
             view?.let {
                 fullScreenChanged(false)
@@ -1146,6 +1144,7 @@ abstract class BaseBrowserFragment :
                 val toolbarHeight = resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
                 val context = requireContext()
                 resumeDownloadDialogState(selectedTab.id, context.components.core.store, context, toolbarHeight)
+                it.announceForAccessibility(selectedTab.toDisplayTitle())
             }
         } else {
             view?.let { view -> initializeUI(view) }

--- a/fenix/app/src/main/res/layout/fragment_browser.xml
+++ b/fenix/app/src/main/res/layout/fragment_browser.xml
@@ -32,7 +32,6 @@
                     android:id="@+id/engineView"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:accessibilityLiveRegion="polite"
                     android:visibility="gone" />
             </mozilla.components.ui.widgets.VerticalSwipeRefreshLayout>
 


### PR DESCRIPTION
A previous PR (https://github.com/mozilla-mobile/firefox-android/pull/790) introduced accessibilityLiveRegion for EngineView in order for talkback to dictate when swiping to another tab on navbar. This change lead to talkback dictating the title/url of the current page even when tapping empty spaces or when certain elements lose focus (see videos below). Changing the implementation from using live regions to the announceForAccessibility method seems to fix this issue.

| Previous implementation with live region  | Current implementation with announceForAccessibility |
| ------------- | ------------- |
|  <video src="https://user-images.githubusercontent.com/32488956/221524352-ce66a20a-85ea-445a-a734-24d7d454366e.mp4"> |  <video src="https://user-images.githubusercontent.com/32488956/221524444-2a7a8a1b-0345-438c-b9d2-66618cc7802d.mp4"> |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817611