### PR TITLE
Bug 1819094 - Set track-apk-size for fenix-debug/nightly/beta/release builds

### DIFF
--- a/taskcluster/ci/build-apk/kind.yml
+++ b/taskcluster/ci/build-apk/kind.yml
@@ -101,6 +101,7 @@ tasks:
             gradle-build-type: debug
             gradle-build-name: fenixDebug
             gradle-build: fenix
+            track-apk-size: true
         source-project-name: "fenix"
         treeherder:
             symbol: fenix-debug(Bf)
@@ -160,6 +161,7 @@ tasks:
             gradle-build-type: release
             gradle-build-name: fenixRelease
             gradle-build: fenix
+            track-apk-size: true
         shipping-phase: promote
         source-project-name: "fenix"
         treeherder:
@@ -203,6 +205,7 @@ tasks:
             gradle-build-type: nightly
             gradle-build-name: fenixNightly
             gradle-build: fenix
+            track-apk-size: true
         treeherder:
             symbol: fenix-nightly(B)
             platform: fenix-android-all/opt
@@ -240,6 +243,7 @@ tasks:
             gradle-build-type: beta
             gradle-build-name: fenixBeta
             gradle-build: fenix
+            track-apk-size: true
         shipping-phase: promote
         source-project-name: "fenix"
         treeherder:


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819094