### PR TITLE
Bug 1819094 - Fix ApkSizeTask to work for new variant names

### DIFF
--- a/fenix/buildSrc/src/main/java/org/mozilla/fenix/gradle/tasks/ApkSizeTask.kt
+++ b/fenix/buildSrc/src/main/java/org/mozilla/fenix/gradle/tasks/ApkSizeTask.kt
@@ -44,8 +44,9 @@ open class ApkSizeTask : DefaultTask() {
     }
 
     private fun determineApkSizes(): Map<String, Long> {
+        val variantOutputPath = variantName?.removePrefix("fenix")?.toLowerCase()
         val basePath = listOf(
-            "${project.projectDir}", "build", "outputs", "apk", variantName
+            "${project.projectDir}", "build", "outputs", "apk", "fenix", variantOutputPath
         ).joinToString(File.separator)
 
         return requireNotNull(apks).associateWith { apk ->


### PR DESCRIPTION
Our `ApkSizeTask` regressed by https://github.com/mozilla-mobile/firefox-android/commit/07ee3642ad1b959ac55c946228cf5dd97e147af0, which changed the variant names to include `fenix` as a prefix. The task basically just looked at the wrong output folder, based on this change.

Before: `../debug/app-fenix-x86-debug.apk`
After: `../fenix/fenixDebug/app-fenix-x86-debug.apk`
https://bugzilla.mozilla.org/show_bug.cgi?id=1819094
https://bugzilla.mozilla.org/show_bug.cgi?id=1819094