### PR TITLE
Bug 1819733 - Fix broken tests in `TabSheetBehaviorManagerTest`

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabSheetBehaviorManager.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabSheetBehaviorManager.kt
@@ -27,7 +27,7 @@ import mozilla.components.support.ktx.android.util.dpToPx
  * @param displayMetrics [DisplayMetrics] used for adapting resources to the current display.
  */
 internal class TabSheetBehaviorManager(
-    private val behavior: BottomSheetBehavior<View>,
+    private val behavior: BottomSheetBehavior<out View>,
     orientation: Int,
     private val maxNumberOfTabs: Int,
     private val numberForExpandingTray: Int,
@@ -85,7 +85,7 @@ internal class TabSheetBehaviorManager(
 
 @VisibleForTesting
 internal class TraySheetBehaviorCallback(
-    @get:VisibleForTesting internal val behavior: BottomSheetBehavior<View>,
+    @get:VisibleForTesting internal val behavior: BottomSheetBehavior<out View>,
     @get:VisibleForTesting internal val trayInteractor: NavigationInteractor,
 ) : BottomSheetBehavior.BottomSheetCallback() {
 


### PR DESCRIPTION
For some reason, the CI did not catch this when landing https://github.com/mozilla-mobile/firefox-android/pull/1013. 

This test was throwing an error about a typing mismatch. Simply allowing it to match the function signature of `BottomSheetBehavior` (allowing `View` and any of its subtypes) fixes the issue.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819733