### PR TITLE
Bug 1806741 - Expose hasRuleForBrowsingContext API

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -441,6 +441,37 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.hasCookieBannerRuleForSession]
+     */
+    override fun hasCookieBannerRuleForSession(
+        onResult: (Boolean) -> Unit,
+        onException: (Throwable) -> Unit,
+    ) {
+        geckoSession.hasCookieBannerRuleForBrowsingContextTree().then(
+            { response ->
+                if (response == null) {
+                    logger.error(
+                        "Invalid value: unable to get response from hasCookieBannerRuleForBrowsingContextTree.",
+                    )
+                    onException(
+                        java.lang.IllegalStateException(
+                            "Invalid value: unable to get response from hasCookieBannerRuleForBrowsingContextTree.",
+                        ),
+                    )
+                    return@then GeckoResult()
+                }
+                onResult(response)
+                GeckoResult<Boolean>()
+            },
+            { throwable ->
+                logger.error("Checking for cookie banner rule failed.", throwable)
+                onException(throwable)
+                GeckoResult()
+            },
+        )
+    }
+
+    /**
      * Checks and returns a non-mobile version of the url.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -405,6 +405,13 @@ class SystemEngineSession(
         }
     }
 
+    override fun hasCookieBannerRuleForSession(
+        onResult: (Boolean) -> Unit,
+        onException: (Throwable) -> Unit,
+    ) {
+        throw UnsupportedOperationException("Cookie Banner handling is not available in this engine")
+    }
+
     /**
      * See [EngineSession.exitFullScreenMode]
      */

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -68,6 +68,10 @@ class EngineObserverTest {
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {
                 notifyObservers { onDesktopModeChange(enable) }
             }
+            override fun hasCookieBannerRuleForSession(
+                onResult: (Boolean) -> Unit,
+                onException: (Throwable) -> Unit,
+            ) {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -124,6 +128,10 @@ class EngineObserverTest {
             override fun restoreState(state: EngineSessionState): Boolean { return false }
             override fun updateTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
+            override fun hasCookieBannerRuleForSession(
+                onResult: (Boolean) -> Unit,
+                onException: (Throwable) -> Unit,
+            ) {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -176,6 +184,10 @@ class EngineObserverTest {
             override fun restoreState(state: EngineSessionState): Boolean { return false }
             override fun updateTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
+            override fun hasCookieBannerRuleForSession(
+                onResult: (Boolean) -> Unit,
+                onException: (Throwable) -> Unit,
+            ) {}
             override fun loadUrl(
                 url: String,
                 parent: EngineSession?,

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -781,6 +781,16 @@ abstract class EngineSession(
     abstract fun toggleDesktopMode(enable: Boolean, reload: Boolean = false)
 
     /**
+     * Checks if there is a rule for handling a cookie banner for the current website in the session.
+     *
+     * @param onSuccess callback invoked if the engine API returned a valid response. Please note
+     * that the response can be null - which can indicate a bug, a miscommunication
+     * or other unexpected failure.
+     * @param onError callback invoked if there was an error getting the response.
+     */
+    abstract fun hasCookieBannerRuleForSession(onResult: (Boolean) -> Unit, onException: (Throwable) -> Unit)
+
+    /**
      * Finds and highlights all occurrences of the provided String and highlights them asynchronously.
      *
      * @param text the String to search for

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -959,6 +959,11 @@ open class DummyEngineSession : EngineSession() {
 
     override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
 
+    override fun hasCookieBannerRuleForSession(
+        onResult: (Boolean) -> Unit,
+        onException: (Throwable) -> Unit,
+    ) {}
+
     override fun findAll(text: String) {}
 
     override fun findNext(forward: Boolean) {}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,12 @@ permalink: /changelog/
 * **lib-crash-sentry-legacy**
   * ⚠️ **This is a breaking change**: This component has been removed. Consumers should use the newer `lib-crash-sentry` component instead.
 
+* **browser-engine-gecko**:
+  * Add support for `hasCookieBannerRuleForSession` API for checking whether a cookie banner from the current website in the session can be handled.
+
+* **concept-engine**:
+  * Add new `hasCookieBannerRuleForSession` API in `Engine`. This is currently only supported in the Gecko Engine.
+
 
 # 111.0.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/v110.0.0...v111.0.0)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1806741