### PR TITLE
Bug 1819776 - Remove unused test dependencies from support-rusthttp

### DIFF
--- a/android-components/components/support/rusthttp/build.gradle
+++ b/android-components/components/support/rusthttp/build.gradle
@@ -36,10 +36,6 @@ dependencies {
     api project(':concept-fetch')
 
     implementation Dependencies.kotlin_stdlib
-
-    testImplementation Dependencies.testing_junit
-    testImplementation Dependencies.testing_robolectric
-    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../android-lint.gradle'

--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -6,7 +6,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
 
 // If you ever need to force a toolchain rebuild (taskcluster) then edit the following comment.
-// FORCE REBUILD 2022-11-14
+// FORCE REBUILD 2023-03-01
 
 class DependenciesPlugin : Plugin<Settings> {
     override fun apply(settings: Settings) = Unit

--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -46,7 +46,7 @@ object Versions {
     const val mozilla_appservices = "97.1.0"
 
     // DO NOT MODIFY MANUALLY. This is auto-updated along with GeckoView.
-    const val mozilla_glean = "52.2.0"
+    const val mozilla_glean = "52.3.0"
 
     const val material = "1.2.1"
 

--- a/android-components/plugins/dependencies/src/main/java/Gecko.kt
+++ b/android-components/plugins/dependencies/src/main/java/Gecko.kt
@@ -9,7 +9,7 @@ object Gecko {
     /**
      * GeckoView Version.
      */
-    const val version = "112.0.20230228085339"
+    const val version = "112.0.20230301093735"
 
     /**
      * GeckoView channel


### PR DESCRIPTION
A ~test~ patch to see if removing the failing dependencies from the support-rusthttp has any effect. 

Forcing the build as well for added safety, but this shouldn't change with the cherry-picked GV and Glean bumps.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819776