### PR TITLE
Bug 1815011 - Create a top-level FAB Composable

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/button/FloatingActionButton.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/button/FloatingActionButton.kt
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.compose.button
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.R
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Floating action button.
+ *
+ * @param icon [Painter] icon to be displayed inside the action button.
+ * @param modifier [Modifier] to be applied to the action button.
+ * @param label Text to be displayed next to the icon.
+ * @param onClick Invoked when the button is clicked.
+ */
+@Composable
+fun FloatingActionButton(
+    icon: Painter,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    label: String? = null,
+    onClick: () -> Unit,
+) {
+    FloatingActionButton(
+        onClick = onClick,
+        modifier = Modifier.testTag("button.fab").then(modifier),
+        backgroundColor = FirefoxTheme.colors.actionPrimary,
+        contentColor = FirefoxTheme.colors.textActionPrimary,
+    ) {
+        Row(
+            modifier = Modifier
+                .wrapContentSize()
+                .padding(16.dp)
+                .animateContentSize(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                painter = icon,
+                contentDescription = contentDescription,
+                tint = FirefoxTheme.colors.iconOnColor,
+            )
+
+            if (!label.isNullOrBlank()) {
+                Spacer(Modifier.width(12.dp))
+
+                Text(
+                    text = label,
+                    style = FirefoxTheme.typography.button,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun FloatingActionButtonPreview() {
+    var label by remember { mutableStateOf<String?>("LABEL") }
+
+    FirefoxTheme {
+        Box(Modifier.wrapContentSize()) {
+            FloatingActionButton(
+                label = label,
+                icon = painterResource(R.drawable.ic_new),
+                onClick = {
+                    label = if (label == null) "LABEL" else null
+                },
+            )
+        }
+    }
+}


### PR DESCRIPTION
Added Composable FAB, which supports animations similar to the existing new tab/sync FAB.

https://user-images.githubusercontent.com/35462038/222423705-a5e6b1b0-17ac-4ac8-94ff-c65146a42666.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815011