### PR TITLE
Bug 1819746 - Fix for possible NullPointerException on a potential nullable object reference in DisplayOrientationListener

### DIFF
--- a/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/helper/DisplayOrientationListener.kt
+++ b/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/helper/DisplayOrientationListener.kt
@@ -49,7 +49,7 @@ internal class DisplayOrientationListener(
     override fun onDisplayRemoved(displayId: Int) = Unit
 
     override fun onDisplayChanged(displayId: Int) {
-        val display = displayManager.getDisplay(displayId)
+        val display = displayManager.getDisplay(displayId) ?: return // getDisplay may return null
 
         if (display.rotation != currentOrientation) {
             currentOrientation = display.rotation

--- a/android-components/components/compose/cfr/src/test/java/mozilla/components/compose/cfr/helper/DisplayOrientationListenerTest.kt
+++ b/android-components/components/compose/cfr/src/test/java/mozilla/components/compose/cfr/helper/DisplayOrientationListenerTest.kt
@@ -16,6 +16,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 
 class DisplayOrientationListenerTest {
     private val context: Context = mock()
@@ -66,6 +67,17 @@ class DisplayOrientationListenerTest {
         listener.onDisplayRemoved(1)
 
         assertFalse(hasRotationChanged)
+    }
+
+    @Test
+    fun `GIVEN display is null WHEN a display is changed THEN don't inform the client`() {
+        val onDisplayRotationChanged = mock<() -> Unit>()
+        val listener = DisplayOrientationListener(context, onDisplayRotationChanged)
+        doReturn(null).`when`(displayManager).getDisplay(1)
+
+        listener.onDisplayChanged(1)
+
+        verifyNoInteractions(onDisplayRotationChanged)
     }
 
     @Test


### PR DESCRIPTION



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819746