### PR TITLE
Bug 1819927 - Remove DEFAULT_BROWSER_NOTIFICATION_ID from MarketingNotificationHelper 

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/MarketingNotificationHelper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/MarketingNotificationHelper.kt
@@ -15,7 +15,6 @@ import org.mozilla.fenix.R
 const val MARKETING_CHANNEL_ID = "org.mozilla.fenix.default.browser.channel"
 
 // For notification that uses the marketing notification channel, IDs should be unique.
-const val DEFAULT_BROWSER_NOTIFICATION_ID = 1
 const val RE_ENGAGEMENT_NOTIFICATION_ID = 2
 
 /**


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819927