### PR TITLE
Bug 1819989 - Remove JDK8 from base docker image

### DIFF
--- a/focus-android/tools/docker/Dockerfile
+++ b/focus-android/tools/docker/Dockerfile
@@ -14,14 +14,13 @@ MAINTAINER Sebastian Kaspari "skaspari@mozilla.com"
 ENV GRADLE_OPTS='-Xmx4096m -Dorg.gradle.daemon=false' \
     LANG='en_US.UTF-8' \
     TERM='dumb' \
-    JAVA8PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/:$PATH"
+    JAVA11PATH="/usr/lib/jvm/java-11-openjdk-amd64/bin/:$PATH"
 
 RUN apt-get update -qq \
     # We need to install tzdata before all of the other packages. Otherwise it will show an interactive dialog
     # which we cannot navigate while building the Docker image.
     && apt-get install -y tzdata \
-    && apt-get install -y openjdk-8-jdk \
-                          openjdk-11-jdk \
+    && apt-get install -y openjdk-11-jdk \
                           git \
                           curl \
                           python \
@@ -47,7 +46,7 @@ RUN cd /opt && curl --location --retry 5 --output android-sdk.zip https://dl.goo
 ENV ANDROID_SDK_HOME /opt/android-sdk-linux
 ENV ANDROID_HOME /opt/android-sdk-linux
 
-RUN yes | PATH=$JAVA8PATH "${ANDROID_SDK_HOME}/tools/bin/sdkmanager" --licenses
+RUN yes | PATH=$JAVA11PATH "${ANDROID_SDK_HOME}/cmdline-tools/bin/sdkmanager" --licenses
 
 # -- Project setup ----------------------------------------------------------------------
 

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -13,13 +13,13 @@ task-defaults:
     docker-image: {in-tree: base}
 
 tasks:
-    android-sdk-3859397:
+    android-sdk-9477386:
         description: Android SDK
         fetch:
             type: static-url
-            url: https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
+            url: https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip
             artifact-name: sdk-tools-linux.zip
-            sha256: 444e22ce8ca0f67353bda4b85175ed3731cae3ffa695ca18119cbacef1c1bea0
-            size: 136964098
+            sha256: bd1aa17c7ef10066949c88dc6c9c8d536be27f992a1f3b5a584f9bd2ba5646a0
+            size: 133507477
         artifact-prefix: mobile/android-sdk
         fetch-alias: android-sdk

--- a/taskcluster/docker/android-build/Dockerfile
+++ b/taskcluster/docker/android-build/Dockerfile
@@ -7,13 +7,18 @@ FROM $DOCKER_IMAGE_PARENT
 
 VOLUME /builds/worker/checkouts
 
+# Install Java 8 needed for Nexus
+RUN apt-get update -qq \
+    && apt-get install -y openjdk-8-jdk \
+    && apt-get clean
+
 # Install Sonatype Nexus.  Cribbed directly from
-# https://github.com/sonatype/docker-nexus/blob/fffd2c61b2368292040910c055cf690c8e76a272/oss/Dockerfile.
+# https://github.com/sonatype/docker-nexus/blob/0415e54b6c824d510f883e5a75c4008b936eca62/oss/Dockerfile.
 
 ENV NEXUS_ARCHIVE='nexus-bundle.tar.gz' \
     NEXUS_ROOT='/opt/sonatype/nexus' \
-    NEXUS_SHA1SUM=1a9aaad8414baffe0a2fd46eed1f41b85f4049e6 \
-    NEXUS_VERSION=2.12.0-01 \
+    NEXUS_SHA1SUM=0fcb4f002eec0cbad6b421b90a8fe99959d78e93 \
+    NEXUS_VERSION=2.15.1-02 \
     NEXUS_WORK=/builds/worker/workspace/nexus
 
 RUN mkdir -p "$NEXUS_ROOT" \

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -30,8 +30,7 @@ RUN apt-get update -qq \
     # We need to install tzdata before all of the other packages. Otherwise it will show an interactive dialog
     # which we cannot navigate while building the Docker image.
     && apt-get install -y tzdata \
-    && apt-get install -y openjdk-8-jdk \
-                          openjdk-11-jdk \
+    && apt-get install -y openjdk-11-jdk \
                           wget \
                           expect \
                           git \

--- a/taskcluster/scripts/toolchain/repack-android-sdk-linux.sh
+++ b/taskcluster/scripts/toolchain/repack-android-sdk-linux.sh
@@ -2,12 +2,11 @@
 
 export ANDROID_SDK_ROOT=$MOZ_FETCHES_DIR
 
-# For the Android build system we want Java 11. However this version of sdkmanager requires Java 8.
-JAVA8PATH="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/:$PATH"
+JAVA11PATH="/usr/lib/jvm/java-11-openjdk-amd64/bin/:$PATH"
 
-yes | PATH=$JAVA8PATH "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" --licenses
+yes | PATH=$JAVA11PATH "${ANDROID_SDK_ROOT}/cmdline-tools/bin/sdkmanager" --licenses --sdk_root="${ANDROID_SDK_ROOT}"
 
 # It's nice to have the build logs include the state of the world upon completion.
-PATH=$JAVA8PATH "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" --list
+PATH=$JAVA11PATH "${ANDROID_SDK_ROOT}/cmdline-tools/bin/sdkmanager" --list --sdk_root="${ANDROID_SDK_ROOT}"
 
 tar cf - -C "$ANDROID_SDK_ROOT" . --transform 's,^\./,android-sdk-linux/,' | xz > "$UPLOAD_DIR/android-sdk-linux.tar.xz"


### PR DESCRIPTION
As we landed the latest Gradle upgrades and also target Java 11 now, we should be able to remove JDK8 from our docker images. 🙏 





















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819989