### PR TITLE
Bug 1819981 - parse wallpaper metadata with only a start or end date correctly

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcher.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcher.kt
@@ -70,11 +70,11 @@ class WallpaperMetadataFetcher(
     private fun JSONArray.getAvailableLocales(): List<String>? =
         (0 until length()).map { getString(it) }
 
-    private fun JSONObject.getAvailabilityRange(): Pair<Date, Date>? {
+    private fun JSONObject.getAvailabilityRange(): Pair<Date?, Date?> {
         val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-        return Result.runCatching {
-            formatter.parse(getString("start"))!! to formatter.parse(getString("end"))!!
-        }.getOrNull()
+        val start = Result.runCatching { formatter.parse(getString("start")) }.getOrNull()
+        val end = Result.runCatching { formatter.parse(getString("end")) }.getOrNull()
+        return start to end
     }
 
     private fun JSONArray.toWallpaperList(collection: Wallpaper.Collection): List<Wallpaper> =

--- a/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcherTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcherTest.kt
@@ -279,6 +279,104 @@ class WallpaperMetadataFetcherTest {
     }
 
     @Test
+    fun `GIVEN collection with specified start date but no end date WHEN parsed THEN wallpapers includes date`() = runTest {
+        val calendar = Calendar.getInstance()
+        val startDate = calendar.run {
+            set(2022, Calendar.JUNE, 27)
+            time
+        }
+        val json = """
+            {
+                "last-updated-date": "2022-01-01",
+                "collections": [
+                    {
+                        "id": "classic-firefox",
+                        "available-locales": null,
+                        "availability-range": {
+                            "start": "2022-06-27"
+                        },
+                        "wallpapers": [
+                            {
+                                "id": "beach-vibes",
+                                "text-color": "FBFBFE",
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
+                            },
+                            {
+                                "id": "sunrise",
+                                "text-color": "15141A",
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
+                            }
+                        ]
+                    }
+                ]
+            }
+        """.trimIndent()
+        every { mockResponse.body } returns Response.Body(json.byteInputStream())
+
+        val wallpapers = metadataFetcher.downloadWallpaperList()
+
+        assertTrue(wallpapers.isNotEmpty())
+        assertTrue(
+            wallpapers.all {
+                val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+                formatter.format(startDate) == formatter.format(it.collection.startDate!!) &&
+                    it.collection.endDate == null
+            },
+        )
+    }
+
+    @Test
+    fun `GIVEN collection with specified end date but no start date WHEN parsed THEN wallpapers includes date`() = runTest {
+        val calendar = Calendar.getInstance()
+        val endDate = calendar.run {
+            set(2022, Calendar.SEPTEMBER, 30)
+            time
+        }
+        val json = """
+            {
+                "last-updated-date": "2022-01-01",
+                "collections": [
+                    {
+                        "id": "classic-firefox",
+                        "available-locales": null,
+                        "availability-range": {
+                            "end": "2022-09-30"
+                        },
+                        "wallpapers": [
+                            {
+                                "id": "beach-vibes",
+                                "text-color": "FBFBFE",
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
+                            },
+                            {
+                                "id": "sunrise",
+                                "text-color": "15141A",
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
+                            }
+                        ]
+                    }
+                ]
+            }
+        """.trimIndent()
+        every { mockResponse.body } returns Response.Body(json.byteInputStream())
+
+        val wallpapers = metadataFetcher.downloadWallpaperList()
+
+        assertTrue(wallpapers.isNotEmpty())
+        assertTrue(
+            wallpapers.all {
+                val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+                it.collection.startDate == null &&
+                    formatter.format(endDate) == formatter.format(it.collection.endDate!!)
+            },
+        )
+    }
+
+    @Test
     fun `GIVEN collection with specified learn more url WHEN parsed THEN wallpapers includes url`() = runTest {
         val json = """
             {


### PR DESCRIPTION
The independent voices collection was supposed to expire on 1/16/2023 but did not. This should fix that. It can be tested by comparing the available wallpapers on current main to the available wallpapers on this branch.

The code in `WallpaperUseCases` was just to prevent some strict mode violations that I ran into while testing things. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819981