### PR TITLE
Bug 1819776 - Remove unused test dependencies from support-rusthttp (partial backport #1061)

### DIFF
--- a/android-components/components/support/rusthttp/build.gradle
+++ b/android-components/components/support/rusthttp/build.gradle
@@ -36,10 +36,6 @@ dependencies {
     api project(':concept-fetch')
 
     implementation Dependencies.kotlin_stdlib
-
-    testImplementation Dependencies.testing_junit
-    testImplementation Dependencies.testing_robolectric
-    testImplementation Dependencies.testing_mockito
 }
 
 apply from: '../../../android-lint.gradle'

--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -6,7 +6,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
 
 // If you ever need to force a toolchain rebuild (taskcluster) then edit the following comment.
-// FORCE REBUILD 2022-11-14
+// FORCE REBUILD 2023-03-01
 
 class DependenciesPlugin : Plugin<Settings> {
     override fun apply(settings: Settings) = Unit


### PR DESCRIPTION
These dependencies are not needed and for some reason this fixes the build failure we are seeing on CI that is expecting the artifact `androidx.test:monitor:1.4.0`.


### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
