### PR TITLE
Bug 1820129 - Fix Fenix test result report URL

### DIFF
--- a/fenix/build.gradle
+++ b/fenix/build.gradle
@@ -257,7 +257,7 @@ tasks.register("listRepositories") {
 }
 
 tasks.register("githubTestDetails", GithubDetailsTask) {
-    text = "### [Unit Test Results Fenix]({reportsUrl}/test/testDebugUnitTest/index.html)"
+    text = "### [Unit Test Results Fenix]({reportsUrl}/test/testFenixDebugUnitTest/index.html)"
 }
 
 tasks.register("githubLintDetektDetails", GithubDetailsTask) {


### PR DESCRIPTION
Follow up to https://github.com/mozilla-mobile/firefox-android/pull/1098 to fix the link to the Fenix unit test report. Focus is already correct.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1820129