### PR TITLE
Bug 1812247 - Increase tap area for history item's delete button

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/library/LibrarySiteItemView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/LibrarySiteItemView.kt
@@ -16,7 +16,6 @@ import mozilla.components.concept.menu.MenuController
 import mozilla.components.concept.menu.Orientation
 import org.mozilla.fenix.databinding.LibrarySiteItemBinding
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.selection.SelectionHolder
 import org.mozilla.fenix.selection.SelectionInteractor
@@ -41,11 +40,6 @@ class LibrarySiteItemView @JvmOverloads constructor(
     val iconView: ImageView get() = binding.favicon
 
     val overflowView: ImageButton get() = binding.overflowMenu
-
-    init {
-
-        overflowView.increaseTapArea(OVERFLOW_EXTRA_DIPS)
-    }
 
     /**
      * Change visibility of parts of this view based on what type of item is being represented.
@@ -104,9 +98,5 @@ class LibrarySiteItemView @JvmOverloads constructor(
 
     enum class ItemType {
         SITE, FOLDER
-    }
-
-    companion object {
-        private const val OVERFLOW_EXTRA_DIPS = 16
     }
 }

--- a/fenix/app/src/main/res/layout/library_site_item.xml
+++ b/fenix/app/src/main/res/layout/library_site_item.xml
@@ -42,7 +42,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="24dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginEnd="4dp"
             android:ellipsize="end"
             android:singleLine="true"
             android:textAlignment="viewStart"
@@ -61,7 +61,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="24dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginEnd="4dp"
             android:ellipsize="end"
             android:singleLine="true"
             android:textAlignment="viewStart"
@@ -80,10 +80,11 @@
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/content_description_menu"
+            android:padding="12dp"
             app:srcCompat="@drawable/ic_menu"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:layout_marginEnd="16dp"/>
+            android:layout_marginEnd="4dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
For having the minimum of target size for x buttons from history page, it was added extra padding for devices with Android 9 or older. IncreaseTapArea was not used because it didn't work for these android versions.

Resolved:
<img width="371" alt="after" src="https://user-images.githubusercontent.com/122524342/223058605-9314ad69-1d3f-492e-8e70-3ef893392705.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
