### PR TITLE
Bug 1820553 - Fix speedometer3 task naming for Fenix.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -135,6 +135,7 @@ tasks:
 
     speedometer3:
         description: "Raptor Speedometer 3 Benchmark tests on Fenix"
+        subtest-symbol: sp3
         test-name: speedometer3
         run-visual-metrics: False
         chimera: False


### PR DESCRIPTION
This patch fixes an issue with the speedometer3 task that currently has a symbol of `None` but it should be `sp3`.
https://bugzilla.mozilla.org/show_bug.cgi?id=1820553
https://bugzilla.mozilla.org/show_bug.cgi?id=1820553
https://bugzilla.mozilla.org/show_bug.cgi?id=1820553
https://bugzilla.mozilla.org/show_bug.cgi?id=1820553