### PR TITLE
Bug 1819254 - Don't exit fullscreen for user input prompts

### DIFF
--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -66,6 +66,7 @@ import mozilla.components.feature.prompts.dialog.Prompter
 import mozilla.components.feature.prompts.dialog.SaveLoginDialogFragment
 import mozilla.components.feature.prompts.dialog.TextPromptDialogFragment
 import mozilla.components.feature.prompts.dialog.TimePickerDialogFragment
+import mozilla.components.feature.prompts.ext.executeIfWindowedPrompt
 import mozilla.components.feature.prompts.facts.emitCreditCardSaveShownFact
 import mozilla.components.feature.prompts.facts.emitSuccessfulAddressAutofillFormDetectedFact
 import mozilla.components.feature.prompts.facts.emitSuccessfulCreditCardAutofillFormDetectedFact
@@ -462,7 +463,7 @@ class PromptFeature private constructor(
         // Some requests are handle with intents
         session.content.promptRequests.lastOrNull()?.let { promptRequest ->
             store.state.findTabOrCustomTabOrSelectedTab(customTabId)?.let {
-                exitFullscreenUsecase(it.id)
+                promptRequest.executeIfWindowedPrompt { exitFullscreenUsecase(it.id) }
             }
 
             when (promptRequest) {

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ext/PromptRequest.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/ext/PromptRequest.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.ext
+
+import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.prompt.PromptRequest.Alert
+import mozilla.components.concept.engine.prompt.PromptRequest.Confirm
+import mozilla.components.concept.engine.prompt.PromptRequest.Popup
+import mozilla.components.concept.engine.prompt.PromptRequest.TextPrompt
+import kotlin.reflect.KClass
+
+/**
+ * List of all prompts who are not to be shown in fullscreen.
+ */
+@PublishedApi
+internal val PROMPTS_TO_EXIT_FULLSCREEN_FOR = listOf<KClass<out PromptRequest>>(
+    Alert::class,
+    TextPrompt::class,
+    Confirm::class,
+    Popup::class,
+)
+
+/**
+ * Convenience method for executing code if the current [PromptRequest] is one that
+ * should not be shown in fullscreen tabs.
+ */
+internal inline fun <reified T> T.executeIfWindowedPrompt(
+    block: () -> Unit,
+) where T : PromptRequest {
+    PROMPTS_TO_EXIT_FULLSCREEN_FOR
+        .firstOrNull {
+            this::class == it
+        }?.let { block.invoke() }
+}

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -1840,7 +1840,7 @@ class PromptFeatureTest {
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = exitFullScreenUseCase,
         ) { }
-        val promptRequest = SingleChoice(arrayOf(), {}, {})
+        val promptRequest: Alert = mock()
 
         store.dispatch(ContentAction.UpdatePromptRequestAction("custom-tab", promptRequest)).joinBlocking()
         feature.start()
@@ -1857,7 +1857,7 @@ class PromptFeatureTest {
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = exitFullScreenUseCase,
         ) { }
-        val promptRequest = SingleChoice(arrayOf(), {}, {})
+        val promptRequest: Alert = mock()
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, promptRequest)).joinBlocking()
         feature.start()
@@ -1884,7 +1884,7 @@ class PromptFeatureTest {
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = exitFullScreenUseCase,
         ) { }
-        val promptRequest = SingleChoice(arrayOf(), {}, {})
+        val promptRequest: Alert = mock()
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(privateTabId, promptRequest)).joinBlocking()
         feature.start()

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ext/PromptRequestTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ext/PromptRequestTest.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.ext
+
+import mozilla.components.concept.engine.prompt.PromptRequest
+import mozilla.components.concept.engine.prompt.PromptRequest.Alert
+import mozilla.components.concept.engine.prompt.PromptRequest.Confirm
+import mozilla.components.concept.engine.prompt.PromptRequest.Popup
+import mozilla.components.concept.engine.prompt.PromptRequest.SingleChoice
+import mozilla.components.concept.engine.prompt.PromptRequest.TextPrompt
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.reflect.KClass
+
+class PromptRequestTest {
+    @Test
+    fun `GIVEN only a subset of prompts should be shown in fullscreen WHEN checking which are not THEN return the expected result`() {
+        val expected = listOf<KClass<out PromptRequest>>(
+            Alert::class,
+            TextPrompt::class,
+            Confirm::class,
+            Popup::class,
+        )
+
+        assertEquals(expected, PROMPTS_TO_EXIT_FULLSCREEN_FOR)
+    }
+
+    @Test
+    fun `GIVEN a prompt which should not be shown in fullscreen WHEN trying to execute code such prompts THEN execute the code`() {
+        var invocations = 0
+        val alert: Alert = mock()
+        val text: TextPrompt = mock()
+        val confirm: Confirm = mock()
+        val popup: Popup = mock()
+        val windowedPrompts = listOf(alert, text, confirm, popup)
+
+        windowedPrompts.forEachIndexed { index, prompt ->
+            prompt.executeIfWindowedPrompt { invocations++ }
+            assertEquals(index + 1, invocations)
+        }
+    }
+
+    @Test
+    fun `GIVEN a prompt which should be shown in fullscreen WHEN trying to execute code for windowed prompts THEN don't do anything`() {
+        var invocations = 0
+        val choice: SingleChoice = mock()
+
+        choice.executeIfWindowedPrompt { invocations++ }
+
+        assertEquals(0, invocations)
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **feature-prompts**:
+  * 🚒 Bug fixed [Bug 1819254](https://bugzilla.mozilla.org/show_bug.cgi?id=1819254). Don't exit fullscreen for user input prompts.
+
 * **service-contile**
   * ⚠️ **This is a breaking change**: Added support for sponsored tiles maximum age specified by the server. `maxCacheAgeInMinutes` changed to `maxCacheAgeInSeconds`, not specifying it leads to using the value provided by the server. [Bug 1811175](https://bugzilla.mozilla.org/show_bug.cgi?id=1811175)
 


### PR DESCRIPTION
Showing the YouTube issue fixed:


https://user-images.githubusercontent.com/11428869/223170127-e7a11f1b-1729-4697-ae04-8d67f5b2fb52.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819254