### PR TITLE
Bug 1817524 - Do not show homepage if last tab of section is closed while not in view

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -274,7 +274,8 @@ class DefaultTabsTrayController(
 
         tab?.let {
             val isLastTab = browserStore.state.getNormalOrPrivateTabs(it.content.private).size == 1
-            if (!isLastTab) {
+            val isCurrentTab = browserStore.state.selectedTabId.equals(tabId)
+            if (!isLastTab || !isCurrentTab) {
                 tabsUseCases.removeTab(tabId)
                 showUndoSnackbarForTab(it.content.private)
             } else {


### PR DESCRIPTION
Resubmitting this PR after fixing some of the tests that it broke.

Original PR: https://github.com/mozilla-mobile/firefox-android/pull/876

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817524