### PR TITLE
Bug 1820552 - Increase Site's field x button in Add new login

### DIFF
--- a/fenix/app/src/main/res/layout/fragment_add_login.xml
+++ b/fenix/app/src/main/res/layout/fragment_add_login.xml
@@ -75,7 +75,7 @@
     <ImageButton
         android:id="@+id/clearHostnameTextButton"
         android:layout_width="48dp"
-        android:layout_height="30dp"
+        android:layout_height="48dp"
         android:layout_marginTop="3dp"
         android:layout_marginBottom="10dp"
         android:background="@null"


### PR DESCRIPTION
For having the minimum of target size for the delete button,
 following the other examples in code, i modified it's height to 48dp.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1820552