### PR TITLE
Bug 1820746 - Remove running conditions for UI tests related to the "PDF reader" feature and for youControlYourDataCardTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -5,18 +5,15 @@
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
-import mozilla.components.concept.engine.utils.EngineReleaseChannel
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestHelper.assertExternalAppOpens
 import org.mozilla.fenix.helpers.TestHelper.deleteDownloadedFileOnStorage
 import org.mozilla.fenix.helpers.TestHelper.mDevice
-import org.mozilla.fenix.helpers.TestHelper.runWithCondition
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.downloadRobot
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -195,40 +192,28 @@ class DownloadTest {
     @SmokeTest
     @Test
     fun openPDFInBrowserTest() {
-        runWithCondition(
-            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly.
-            // Once this feature lands in Beta/RC we should remove the wrapper.
-            activityTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY,
-        ) {
-            navigationToolbar {
-            }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
-                clickLinkMatchingText(pdfFileName)
-                verifyUrl(pdfFileURL)
-                verifyPageContent(pdfFileContent)
-            }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
+            clickLinkMatchingText(pdfFileName)
+            verifyUrl(pdfFileURL)
+            verifyPageContent(pdfFileContent)
         }
     }
 
     @SmokeTest
     @Test
     fun saveAndOpenPdfTest() {
-        runWithCondition(
-            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly.
-            // Once this feature lands in Beta/RC we should remove the wrapper.
-            activityTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY,
-        ) {
-            navigationToolbar {
-            }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
-                clickLinkMatchingText(pdfFileName)
-                verifyPageContent(pdfFileContent)
-            }.openThreeDotMenu {
-            }.clickShareButton {
-            }.clickSaveAsPDF {
-                verifyDownloadPrompt(pdfFileName)
-            }.clickDownload {
-            }.clickOpen("application/pdf") {
-                assertExternalAppOpens("com.google.android.apps.docs")
-            }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
+            clickLinkMatchingText(pdfFileName)
+            verifyPageContent(pdfFileContent)
+        }.openThreeDotMenu {
+        }.clickShareButton {
+        }.clickSaveAsPDF {
+            verifyDownloadPrompt(pdfFileName)
+        }.clickDownload {
+        }.clickOpen("application/pdf") {
+            assertExternalAppOpens("com.google.android.apps.docs")
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
@@ -3,18 +3,15 @@ package org.mozilla.fenix.ui
 import android.content.res.Configuration
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import mozilla.components.concept.engine.utils.EngineReleaseChannel
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper.runWithCondition
 import org.mozilla.fenix.helpers.TestHelper.verifyDarkThemeApplied
 import org.mozilla.fenix.helpers.TestHelper.verifyLightThemeApplied
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -231,19 +228,12 @@ class OnboardingTest {
 
     @Test
     fun youControlYourDataCardTest() {
-        runWithCondition(
-            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly.
-            // Once this feature lands in Beta/RC we should remove the wrapper.
-            activityTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
-                activityTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
-        ) {
-            homeScreen {
-                verifyPrivacyNoticeCard()
-            }.clickPrivacyNoticeButton {
-                verifyCustomTabToolbarTitle("Firefox Privacy Notice")
-            }.goBackToOnboardingScreen {
-                verifyPrivacyNoticeCard()
-            }
+        homeScreen {
+            verifyPrivacyNoticeCard()
+        }.clickPrivacyNoticeButton {
+            verifyCustomTabToolbarTitle("Firefox Privacy Notice")
+        }.goBackToOnboardingScreen {
+            verifyPrivacyNoticeCard()
         }
     }
 }


### PR DESCRIPTION
Summary:
Removed running conditions for UI tests related to the "PDF reader" feature and for youControlYourDataCardTest UI test, both are now available on all current releases.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1820746