### PR TITLE
Bug 1817058 - add github log link to release promotion notification email

### DIFF
--- a/taskcluster/android_taskgraph/transforms/release_started.py
+++ b/taskcluster/android_taskgraph/transforms/release_started.py
@@ -1,0 +1,58 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Add github links for release notifications
+"""
+import os
+
+from mozilla_version.mobile import MobileVersion
+from taskgraph.util.vcs import get_repository
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+CHANGESET_URL_TEMPLATE = "{repo}/compare/{from_version}...{to_version}"
+TAG_PREFIX = "focus-v"
+
+
+def get_previous_tag_version(current_version, tags):
+    prefixlen = len(TAG_PREFIX)
+    versions = [MobileVersion.parse(t[prefixlen:]) for t in tags]
+    return max(v for v in versions if v < current_version)
+
+
+@transforms.add
+def add_github_link(config, tasks):
+    version = MobileVersion.parse(config.params["version"])
+    repo = get_repository(".")
+    git_tags = repo.run("tag", "-l", TAG_PREFIX + "*").splitlines()
+    previous_version = get_previous_tag_version(version, git_tags)
+    current_revision = config.params["head_rev"]
+    repo_url = config.params["base_repository"]
+    compare_url = CHANGESET_URL_TEMPLATE.format(
+        repo=repo_url,
+        from_version=f"{TAG_PREFIX}{previous_version}",
+        to_version=current_revision,
+    )
+    for task in tasks:
+        task["notifications"][
+            "message"
+        ] = """\
+Commit: [{revision}]({repo}/commit/{revision})
+Task group: [{task_group_id}]({root_url}/tasks/groups/{task_group_id})
+
+Comparing git changes from {from_version} to {to_version}:
+{compare_url}
+""".format(
+            repo=repo_url,
+            revision=current_revision,
+            # TASK_ID isn't set when e.g. using taskgraph locally
+            task_group_id=os.getenv("TASK_ID", "<decision>"),
+            root_url=os.getenv("TASKCLUSTER_ROOT_URL"),
+            from_version=previous_version,
+            to_version=version,
+            compare_url=compare_url,
+        )
+        yield task

--- a/taskcluster/android_taskgraph/transforms/release_started.py
+++ b/taskcluster/android_taskgraph/transforms/release_started.py
@@ -4,10 +4,13 @@
 """
 Add github links for release notifications
 """
+from datetime import datetime
 import os
+import re
 
 from mozilla_version.mobile import MobileVersion
 from taskgraph.util.vcs import get_repository
+from taskgraph.util.taskcluster import find_task_id, get_task_definition
 from taskgraph.transforms.base import TransformSequence
 
 transforms = TransformSequence()
@@ -15,6 +18,43 @@ transforms = TransformSequence()
 
 CHANGESET_URL_TEMPLATE = "{repo}/compare/{from_version}...{to_version}"
 TAG_PREFIX = "focus-v"
+# XXX is there a better index we can use to get from buildid to revision?
+GECKO_INDEX = "gecko.v2.{repo}.pushdate.{build_date}.{build_timestamp}.mobile-l10n.android-geckoview-fat-aar-opt.multi"
+GECKO_KT = "android-components/plugins/dependencies/src/main/java/Gecko.kt"
+BUILDID_RE = re.compile(r'version = "[0-9]*\.[0-9]*\.([0-9]*)"', re.MULTILINE)
+CHANNEL_RE = re.compile(
+    r"val channel = GeckoChannel.(NIGHTLY|BETA|RELEASE)", re.MULTILINE
+)
+HG_CHANGESET_URL_TEMPLATE = (
+    "{repo}/{logtype}?rev={to_version}+%25+{from_version}&revcount=1000"
+)
+
+REPO_FROM_CHANNEL = {
+    "NIGHTLY": "mozilla-central",
+    "BETA": "mozilla-beta",
+    "RELEASE": "mozilla-release",
+}
+
+
+def get_gecko_revision(channel, buildid):
+    repo = REPO_FROM_CHANNEL[channel]
+    build_date = datetime.strptime(buildid, "%Y%m%d%H%M%S").strftime("%Y.%m.%d")
+    index_path = GECKO_INDEX.format(
+        repo=repo, build_date=build_date, build_timestamp=buildid
+    )
+    task_id = find_task_id(index_path)
+    task_definition = get_task_definition(task_id)
+    rev = task_definition["payload"]["env"]["GECKO_HEAD_REV"]
+    return rev
+
+
+def get_gecko_channel_and_buildid(repo, commit):
+    gecko_kt = repo.run("show", f"{commit}:{GECKO_KT}")
+    buildid_match = BUILDID_RE.search(gecko_kt)
+    channel_match = CHANNEL_RE.search(gecko_kt)
+    if not buildid_match or not channel_match:
+        return
+    return channel_match[1], buildid_match[1]
 
 
 def get_previous_tag_version(current_version, tags):
@@ -36,6 +76,28 @@ def add_github_link(config, tasks):
         from_version=f"{TAG_PREFIX}{previous_version}",
         to_version=current_revision,
     )
+    try:
+        previous_gecko_revision = get_gecko_revision(
+            *get_gecko_channel_and_buildid(repo, f"{TAG_PREFIX}{previous_version}")
+        )
+        gecko_channel, gecko_buildid = get_gecko_channel_and_buildid(
+            repo, current_revision
+        )
+        assert gecko_channel in ("BETA", "RELEASE")
+        current_gecko_revision = get_gecko_revision(gecko_channel, gecko_buildid)
+        gecko_url = (
+            f"https://hg.mozilla.org/releases/{REPO_FROM_CHANNEL[gecko_channel]}"
+        )
+        gecko_changelog_url = HG_CHANGESET_URL_TEMPLATE.format(
+            repo=gecko_url,
+            logtype="log",
+            from_version=previous_gecko_revision,
+            to_version=current_gecko_revision,
+        )
+        gecko_changelog = f"[Full Gecko mercurial changelog]({gecko_changelog_url})"
+    except Exception:
+        gecko_changelog = ""
+
     for task in tasks:
         task["notifications"][
             "message"
@@ -44,7 +106,8 @@ Commit: [{revision}]({repo}/commit/{revision})
 Task group: [{task_group_id}]({root_url}/tasks/groups/{task_group_id})
 
 Comparing git changes from {from_version} to {to_version}:
-{compare_url}
+[Full Git changelog]({compare_url})
+{gecko_changelog}
 """.format(
             repo=repo_url,
             revision=current_revision,
@@ -54,5 +117,6 @@ Comparing git changes from {from_version} to {to_version}:
             from_version=previous_version,
             to_version=version,
             compare_url=compare_url,
+            gecko_changelog=gecko_changelog,
         )
         yield task

--- a/taskcluster/ci/release-notify-started/kind.yml
+++ b/taskcluster/ci/release-notify-started/kind.yml
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - android_taskgraph.transforms.release_started:transforms
+    - taskgraph.transforms.notify:transforms
+    - taskgraph.transforms.task:transforms
+
+task-defaults:
+    description: Sends email to release-signoff telling release was started.
+    run-on-projects: []
+    shipping-phase: promote
+    worker-type: succeed
+    worker:
+        implementation: succeed
+    notifications:
+        emails:
+            by-level:
+                '3': ["release-signoff@mozilla.org"]
+                default: ["{config[params][owner]}"]
+        subject: "[mobile] Build of {config[params][project]} {config[params][version]} build{config[params][build_number]}"
+        # email body added by the release_started transform
+
+tasks:
+    beta:
+        attributes:
+            release-type: beta
+    release:
+        attributes:
+            release-type: release


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817058