### PR TITLE
Bug 1821088 - Update notify block in test-apk CI task

### DIFF
--- a/taskcluster/ci/test-apk/kind.yml
+++ b/taskcluster/ci/test-apk/kind.yml
@@ -109,7 +109,7 @@ tasks:
                         "type": "header",
                         "text": {
                           "type": "plain_text",
-                          "text": "Fenix :firefox: ${task.metadata.name} :x:\n "
+                          "text": "firefox-android :firefox: ${task.metadata.name} :x:\n "
                         }
                       },
                       {
@@ -140,7 +140,7 @@ tasks:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": "*Test Summary*: <https://firefoxci.taskcluster-artifacts.net/${status.taskId}/0/public/reports/test/testFenixDebugUnitTest/index.html|Results> :debug:"
+                          "text": "*Test Summary*: <https://firefoxci.taskcluster-artifacts.net/${status.taskId}/0/public/reports/index.html|Results> :debug:"
                         }
                       },
                       {


### PR DESCRIPTION
Forgot to update the `notify` route in `test-apk` CI task for the mono-repo. Just need to update some headers and links.

https://bugzilla.mozilla.org/show_bug.cgi?id=1821088
https://bugzilla.mozilla.org/show_bug.cgi?id=1821088