### PR TITLE
Bug 1807558 - TalkBack mentions activate actions for read only items in ETP settings info panels

### DIFF
--- a/fenix/app/src/main/res/layout/fragment_tracking_protection_blocking.xml
+++ b/fenix/app/src/main/res/layout/fragment_tracking_protection_blocking.xml
@@ -28,7 +28,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
-            android:clickable="true"
+            android:clickable="false"
             android:focusable="true"
             app:categoryItemDescription="@string/etp_social_media_trackers_description"
             app:categoryItemTitle="@string/etp_social_media_trackers_title" />
@@ -38,7 +38,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
-            android:clickable="true"
+            android:clickable="false"
             android:focusable="true"
             app:categoryItemDescription="@string/etp_cookies_description"
             app:categoryItemTitle="@string/etp_cookies_title" />
@@ -48,7 +48,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
-            android:clickable="true"
+            android:clickable="false"
             android:focusable="true"
             app:categoryItemDescription="@string/etp_cryptominers_description"
             app:categoryItemTitle="@string/etp_cryptominers_title" />
@@ -58,7 +58,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
-            android:clickable="true"
+            android:clickable="false"
             android:focusable="true"
             app:categoryItemDescription="@string/etp_fingerprinters_description"
             app:categoryItemTitle="@string/etp_fingerprinters_title" />
@@ -68,7 +68,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
-            android:clickable="true"
+            android:clickable="false"
             android:focusable="true"
             app:categoryItemDescription="@string/etp_tracking_content_description"
             app:categoryItemTitle="@string/etp_tracking_content_title" />
@@ -78,7 +78,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
-            android:clickable="true"
+            android:clickable="false"
             android:focusable="true"
             app:categoryItemDescription="@string/etp_redirect_trackers_description"
             app:categoryItemTitle="@string/etp_redirect_trackers_title" />


### PR DESCRIPTION
### What
TalkBack mentions activate actions for read only items in ETP settings info panels

### Screenshots
### Issue video

https://user-images.githubusercontent.com/39338964/222073399-c77e19d0-cdf9-451a-b811-24609c408dae.mp4
### Demo video after fix

https://user-images.githubusercontent.com/39338964/222073590-931bde99-d23d-4788-951b-c4cc43ab8099.mp4

### Pull Request checklist
 - [ ] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807558