### PR TITLE
Bug 1821266 - Refactor privateModeScreenItemsTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/AddToHomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/AddToHomeScreenTest.kt
@@ -86,7 +86,7 @@ class AddToHomeScreenTest {
         searchScreen {
             verifySearchView()
         }.dismissSearchBar {
-            verifyPrivateSessionMessage()
+            verifyCommonMythsLink()
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
@@ -130,7 +130,7 @@ class CrashReportingTest {
             verifyExistingOpenTabs(secondWebPage.title)
         }.closeTabDrawer {
         }.goToHomescreen {
-            verifyPrivateSessionMessage()
+            verifyCommonMythsLink()
         }.openThreeDotMenu {
             verifySettingsButton()
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -6,9 +6,7 @@ package org.mozilla.fenix.ui
 
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.Until
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -20,8 +18,6 @@ import org.mozilla.fenix.helpers.Constants.POCKET_RECOMMENDED_STORIES_UTM_PARAM
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
-import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -97,33 +93,9 @@ class HomeScreenTest {
         homeScreen { }.togglePrivateBrowsingMode()
 
         homeScreen {
-            verifyHomeScreen()
-            verifyNavigationToolbar()
-            verifyHomePrivateBrowsingButton()
-            verifyHomeMenuButton()
-            verifyHomeWordmark()
-            verifyTabButton()
-            verifyPrivateSessionMessage()
-            verifyNavigationToolbar()
-            verifyHomeComponent()
+            verifyPrivateBrowsingHomeScreen()
         }.openCommonMythsLink {
             verifyUrl("common-myths-about-private-browsing")
-            mDevice.pressBack()
-        }
-
-        homeScreen {
-            // To deal with the race condition where multiple "add tab" buttons are present,
-            // we need to wait until previous HomeFragment View objects are gone.
-            mDevice.waitNotNull(Until.gone(By.text(privateSessionMessage)), waitingTime)
-            verifyHomeScreen()
-            verifyNavigationToolbar()
-            verifyHomePrivateBrowsingButton()
-            verifyHomeMenuButton()
-            verifyHomeWordmark()
-            verifyTabButton()
-            verifyPrivateSessionMessage()
-            verifyNavigationToolbar()
-            verifyHomeComponent()
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -352,7 +352,7 @@ class TabbedBrowsingTest {
             verifyFocusedNavigationToolbar()
             // dismiss search dialog
             homeScreen { }.pressBack()
-            verifyPrivateSessionMessage()
+            verifyCommonMythsLink()
             verifyNavigationToolbar()
         }
         navigationToolbar {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -93,6 +93,13 @@ class HomeScreenRobot {
     fun verifyFocusedNavigationToolbar() = assertFocusedNavigationToolbar()
     fun verifyHomeScreen() = assertItemWithResIdExists(homeScreen)
 
+    fun verifyPrivateBrowsingHomeScreen() {
+        verifyHomeScreenAppBarItems()
+        assertItemContainingTextExists(itemContainingText(privateSessionMessage))
+        verifyCommonMythsLink()
+        verifyNavigationToolbarItems()
+    }
+
     fun verifyHomeScreenAppBarItems() =
         assertItemWithResIdExists(homeScreen, privateBrowsingButton, homepageWordmark)
 
@@ -182,7 +189,7 @@ class HomeScreenRobot {
         assertItemContainingTextExists(conclusionHeader)
     }
 
-    fun verifyNavigationToolbarItems(numberOfOpenTabs: String) {
+    fun verifyNavigationToolbarItems(numberOfOpenTabs: String = "0") {
         assertItemWithResIdExists(navigationToolbar, menuButton)
         assertItemWithResIdAndTextExists(tabCounter(numberOfOpenTabs))
     }
@@ -266,7 +273,8 @@ class HomeScreenRobot {
             .onNodeWithText(getStringResource(R.string.onboarding_home_skip_button))
             .performClick()
 
-    fun verifyPrivateSessionMessage() = assertPrivateSessionMessage()
+    fun verifyCommonMythsLink() =
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.private_browsing_common_myths)))
 
     fun verifyExistingTopSitesList() = assertExistingTopSitesList()
     fun verifyNotExistingTopSitesList(title: String) = assertNotExistingTopSitesList(title)
@@ -891,16 +899,6 @@ private fun verifySearchEngineIcon(searchEngineName: String) {
         ?: throw AssertionError("No search engine with name $searchEngineName")
     verifySearchEngineIcon(defaultSearchEngine.icon, defaultSearchEngine.name)
 }
-
-private fun assertPrivateSessionMessage() =
-    assertTrue(
-        mDevice.findObject(
-            UiSelector()
-                .textContains(
-                    getStringResource(R.string.private_browsing_common_myths),
-                ),
-        ).waitForExists(waitingTime),
-    )
 
 private fun collectionTitle(title: String, rule: ComposeTestRule) =
     rule.onNode(hasText(title))


### PR DESCRIPTION
Bug 1821266 - Refactor privateModeScreenItemsTest UI test

Summary:
- Removed unnecessary steps to match the manual test we have in TestRail
- Simplified the way we check the Private Browsing home screen elements
- The test successfully ran 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821266