### PR TITLE
Bug 1820130 - Remove unused accompanist insets dependency

### DIFF
--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -491,7 +491,6 @@ dependencies {
     implementation FenixDependencies.androidx_constraintlayout
     implementation FenixDependencies.androidx_coordinatorlayout
     implementation FenixDependencies.google_accompanist_drawablepainter
-    implementation FenixDependencies.google_accompanist_insets
     implementation FenixDependencies.google_accompanist_pager
 
     implementation FenixDependencies.sentry

--- a/fenix/buildSrc/src/main/java/FenixDependencies.kt
+++ b/fenix/buildSrc/src/main/java/FenixDependencies.kt
@@ -42,7 +42,6 @@ object FenixVersions {
     const val androidx_datastore = "1.0.0"
     const val google_material = "1.2.1"
     const val accompanist_drawablepainter = "0.23.1"
-    const val accompanist_insets = "0.23.1"
     const val accompanist_pager = "0.28.0"
 
     const val adjust = "4.33.0"
@@ -112,8 +111,6 @@ object FenixDependencies {
     const val google_material = "com.google.android.material:material:${FenixVersions.google_material}"
     const val google_accompanist_drawablepainter =
         "com.google.accompanist:accompanist-drawablepainter:${FenixVersions.accompanist_drawablepainter}"
-    const val google_accompanist_insets =
-        "com.google.accompanist:accompanist-insets:${FenixVersions.accompanist_drawablepainter}"
     const val google_accompanist_pager =
         "com.google.accompanist:accompanist-pager:${FenixVersions.accompanist_pager}"
 


### PR DESCRIPTION
Was probably mistakenly added back in a different rebased PR. Removing for good.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1820130