### PR TITLE
Bug 1821261 – Enables unified search on nightly

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -7,9 +7,9 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
@@ -385,7 +385,7 @@ class SettingsSearchTest {
         }.openThreeDotMenu {
         }.openSettings {
         }.openSearchSubMenu {
-            runWithCondition(!appContext.settings().showUnifiedSearchFeature) {
+            runWithCondition(!FeatureFlags.unifiedSearchFeature) {
                 // If the feature is disabled run old steps.
                 deleteMultipleSearchEngines(
                     "Google",
@@ -405,7 +405,7 @@ class SettingsSearchTest {
                     "eBay",
                 )
             }
-            runWithCondition(appContext.settings().showUnifiedSearchFeature) {
+            runWithCondition(FeatureFlags.unifiedSearchFeature) {
                 // Run steps suitable for the enabled unified search feature.
                 deleteMultipleSearchEngines(
                     "Google",

--- a/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix
 import android.content.Context
 import mozilla.components.support.locale.LocaleManager
 import mozilla.components.support.locale.LocaleManager.getSystemDefault
+import org.mozilla.fenix.nimbus.FxNimbus
 
 /**
  * A single source for setting feature flags that are mostly based on build type.
@@ -50,7 +51,11 @@ object FeatureFlags {
     /**
      * Enables the Unified Search feature.
      */
-    val unifiedSearchFeature = Config.channel.isNightlyOrDebug
+    val unifiedSearchFeature = if (Config.channel.isNightlyOrDebug) {
+        true
+    } else {
+        FxNimbus.features.unifiedSearch.value().enabled
+    }
 
     /**
      * Enables compose on the tabs tray items.

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -576,7 +576,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
      */
     @Suppress("NestedBlockDepth")
     private fun migrateTopicSpecificSearchEngines() {
-        if (settings().showUnifiedSearchFeature) {
+        if (FeatureFlags.unifiedSearchFeature) {
             components.core.store.state.search.selectedOrDefaultSearchEngine.let { currentSearchEngine ->
                 if (currentSearchEngine?.isGeneral == false) {
                     components.core.store.state.search.searchEngines.firstOrNull() { nextSearchEngine ->

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -82,6 +82,7 @@ import mozilla.components.support.locale.LocaleManager
 import org.mozilla.fenix.AppRequestInterceptor
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.search.SearchMigration
@@ -262,7 +263,7 @@ class Core(
         BrowserStore(
             initialState = BrowserState(
                 search = SearchState(
-                    applicationSearchEngines = if (context.settings().showUnifiedSearchFeature) {
+                    applicationSearchEngines = if (FeatureFlags.unifiedSearchFeature) {
                         applicationSearchEngines
                     } else {
                         emptyList()

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -18,6 +18,7 @@ import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.feature.toolbar.ToolbarPresenter
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.view.hideKeyboard
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.ext.components
@@ -41,7 +42,7 @@ abstract class ToolbarIntegration(
         toolbar,
         store,
         sessionId,
-        context.settings().showUnifiedSearchFeature,
+        FeatureFlags.unifiedSearchFeature,
         ToolbarFeature.UrlRenderConfiguration(
             context.components.publicSuffixList,
             ThemeManager.resolveAttribute(R.attr.textPrimary, context),

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -79,6 +79,7 @@ import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import org.mozilla.fenix.Config
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.HomeScreen
 import org.mozilla.fenix.GleanMetrics.PrivateBrowsingShortcutCfr
@@ -350,7 +351,7 @@ class HomeFragment : Fragment() {
             )
         }
 
-        requireContext().settings().showUnifiedSearchFeature.let {
+        FeatureFlags.unifiedSearchFeature.let {
             binding.searchSelectorButton.isVisible = it
             binding.searchEngineIcon.isGone = it
         }
@@ -686,7 +687,7 @@ class HomeFragment : Fragment() {
                         }
                     }
 
-                    if (requireContext().settings().showUnifiedSearchFeature) {
+                    if (FeatureFlags.unifiedSearchFeature) {
                         binding.searchSelectorButton.setIcon(icon, name)
                     } else {
                         binding.searchEngineIcon.setImageDrawable(icon)

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -21,6 +21,7 @@ import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.sync.SyncReason
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
@@ -28,7 +29,6 @@ import org.mozilla.fenix.ext.bookmarkStorage
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.navigateSafe
-import org.mozilla.fenix.utils.Settings
 
 @VisibleForTesting
 internal const val WARN_OPEN_ALL_SIZE = 15
@@ -86,7 +86,6 @@ class DefaultBookmarkController(
     private val deleteBookmarkFolder: (Set<BookmarkNode>) -> Unit,
     private val showTabTray: () -> Unit,
     private val warnLargeOpenAll: (Int, () -> Unit) -> Unit,
-    private val settings: Settings,
 ) : BookmarkController {
 
     private val resources: Resources = activity.resources
@@ -256,7 +255,7 @@ class DefaultBookmarkController(
     }
 
     override fun handleSearch() {
-        val directions = if (settings.showUnifiedSearchFeature) {
+        val directions = if (FeatureFlags.unifiedSearchFeature) {
             BookmarkFragmentDirections.actionGlobalSearchDialog(sessionId = null)
         } else {
             BookmarkFragmentDirections.actionBookmarkFragmentToBookmarkSearchDialogFragment()

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -106,7 +106,6 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
                 deleteBookmarkFolder = ::showRemoveFolderDialog,
                 showTabTray = ::showTabTray,
                 warnLargeOpenAll = ::warnLargeOpenAll,
-                settings = requireComponents.settings,
             ),
         )
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/history/HistoryController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/history/HistoryController.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.state.action.RecentlyClosedAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
@@ -24,7 +25,6 @@ import org.mozilla.fenix.components.history.DefaultPagedHistoryProvider
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.library.history.HistoryFragment.DeleteConfirmationDialogFragment
-import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.GleanMetrics.History as GleanHistory
 
 @Suppress("TooManyFunctions")
@@ -71,7 +71,6 @@ class DefaultHistoryController(
         delete: (Set<History>) -> suspend (context: Context) -> Unit,
     ) -> Unit,
     private val syncHistory: suspend () -> Unit,
-    private val settings: Settings,
 ) : HistoryController {
 
     override fun handleOpen(item: History) {
@@ -117,7 +116,7 @@ class DefaultHistoryController(
     }
 
     override fun handleSearch() {
-        val directions = if (settings.showUnifiedSearchFeature) {
+        val directions = if (FeatureFlags.unifiedSearchFeature) {
             HistoryFragmentDirections.actionGlobalSearchDialog(null)
         } else {
             HistoryFragmentDirections.actionGlobalHistorySearchDialog()

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -111,7 +111,6 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler, 
             deleteSnackbar = ::deleteSnackbar,
             onTimeFrameDeleted = ::onTimeFrameDeleted,
             syncHistory = ::syncHistory,
-            settings = requireContext().components.settings,
         )
         historyInteractor = DefaultHistoryInteractor(
             historyController,

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -19,6 +19,7 @@ import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.ktx.kotlin.isUrl
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.SearchShortcuts
 import org.mozilla.fenix.GleanMetrics.UnifiedSearch
@@ -149,7 +150,7 @@ class SearchDialogController(
         fragmentStore.dispatch(SearchFragmentAction.UpdateQuery(text))
         fragmentStore.dispatch(
             SearchFragmentAction.ShowSearchShortcutEnginePicker(
-                !settings.showUnifiedSearchFeature &&
+                !FeatureFlags.unifiedSearchFeature &&
                     (textMatchesCurrentUrl || textMatchesCurrentSearch || text.isEmpty()) &&
                     settings.shouldShowSearchShortcuts,
             ),
@@ -250,7 +251,7 @@ class SearchDialogController(
             else -> searchEngine.name
         }
 
-        if (settings.showUnifiedSearchFeature) {
+        if (FeatureFlags.unifiedSearchFeature) {
             UnifiedSearch.engineSelected.record(UnifiedSearch.EngineSelectedExtra(engine))
         } else {
             SearchShortcuts.selected.record(SearchShortcuts.SelectedExtra(engine))

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -72,6 +72,7 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.Awesomebar
 import org.mozilla.fenix.GleanMetrics.VoiceSearch
 import org.mozilla.fenix.HomeActivity
@@ -314,7 +315,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val showUnifiedSearchFeature = requireContext().settings().showUnifiedSearchFeature
+        val showUnifiedSearchFeature = FeatureFlags.unifiedSearchFeature
 
         consumeFlow(requireComponents.core.store) { flow ->
             flow.map { state -> state.search }
@@ -946,7 +947,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         areShortcutsAvailable: Boolean,
         showShortcuts: Boolean,
     ) {
-        val showUnifiedSearchFeature = requireContext().settings().showUnifiedSearchFeature
+        val showUnifiedSearchFeature = FeatureFlags.unifiedSearchFeature
 
         view?.apply {
             binding.searchEnginesShortcutButton.isVisible =

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.Components
@@ -167,7 +168,7 @@ fun createInitialSearchFragmentState(
         areShortcutsAvailable = false,
         showSearchShortcutsSetting = settings.shouldShowSearchShortcuts,
         showClipboardSuggestions = settings.shouldShowClipboardSuggestions,
-        showSearchTermHistory = settings.showUnifiedSearchFeature && settings.shouldShowHistorySuggestions,
+        showSearchTermHistory = FeatureFlags.unifiedSearchFeature && settings.shouldShowHistorySuggestions,
         showHistorySuggestionsForCurrentEngine = false,
         showAllHistorySuggestions = settings.shouldShowHistorySuggestions,
         showBookmarksSuggestionsForCurrentEngine = false,
@@ -263,7 +264,7 @@ private fun searchStateReducer(state: SearchFragmentState, action: SearchFragmen
                 showSearchSuggestions = shouldShowSearchSuggestions(action.browsingMode, action.settings),
                 showSearchShortcuts = action.settings.shouldShowSearchShortcuts,
                 showClipboardSuggestions = action.settings.shouldShowClipboardSuggestions,
-                showSearchTermHistory = action.settings.showUnifiedSearchFeature &&
+                showSearchTermHistory = FeatureFlags.unifiedSearchFeature &&
                     action.settings.shouldShowHistorySuggestions,
                 showHistorySuggestionsForCurrentEngine = false, // we'll show all history
                 showAllHistorySuggestions = action.settings.shouldShowHistorySuggestions,
@@ -278,34 +279,34 @@ private fun searchStateReducer(state: SearchFragmentState, action: SearchFragmen
             state.copy(
                 searchEngineSource = SearchEngineSource.Shortcut(action.engine),
                 showSearchSuggestions = shouldShowSearchSuggestions(action.browsingMode, action.settings),
-                showSearchShortcuts = when (action.settings.showUnifiedSearchFeature) {
+                showSearchShortcuts = when (FeatureFlags.unifiedSearchFeature) {
                     true -> false
                     false -> action.settings.shouldShowSearchShortcuts
                 },
                 showClipboardSuggestions = action.settings.shouldShowClipboardSuggestions,
-                showSearchTermHistory = action.settings.showUnifiedSearchFeature &&
+                showSearchTermHistory = FeatureFlags.unifiedSearchFeature &&
                     action.settings.shouldShowHistorySuggestions,
-                showHistorySuggestionsForCurrentEngine = action.settings.showUnifiedSearchFeature &&
+                showHistorySuggestionsForCurrentEngine = FeatureFlags.unifiedSearchFeature &&
                     action.settings.shouldShowHistorySuggestions && !action.engine.isGeneral,
-                showAllHistorySuggestions = when (action.settings.showUnifiedSearchFeature) {
+                showAllHistorySuggestions = when (FeatureFlags.unifiedSearchFeature) {
                     true -> false
                     false -> action.settings.shouldShowHistorySuggestions
                 },
-                showBookmarksSuggestionsForCurrentEngine = action.settings.showUnifiedSearchFeature &&
+                showBookmarksSuggestionsForCurrentEngine = FeatureFlags.unifiedSearchFeature &&
                     action.settings.shouldShowBookmarkSuggestions && !action.engine.isGeneral,
-                showAllBookmarkSuggestions = when (action.settings.showUnifiedSearchFeature) {
+                showAllBookmarkSuggestions = when (FeatureFlags.unifiedSearchFeature) {
                     true -> false
                     false -> action.settings.shouldShowBookmarkSuggestions
                 },
-                showSyncedTabsSuggestionsForCurrentEngine = action.settings.showUnifiedSearchFeature &&
+                showSyncedTabsSuggestionsForCurrentEngine = FeatureFlags.unifiedSearchFeature &&
                     action.settings.shouldShowSyncedTabsSuggestions && !action.engine.isGeneral,
-                showAllSyncedTabsSuggestions = when (action.settings.showUnifiedSearchFeature) {
+                showAllSyncedTabsSuggestions = when (FeatureFlags.unifiedSearchFeature) {
                     true -> false
                     false -> action.settings.shouldShowSyncedTabsSuggestions
                 },
-                showSessionSuggestionsForCurrentEngine = action.settings.showUnifiedSearchFeature &&
+                showSessionSuggestionsForCurrentEngine = FeatureFlags.unifiedSearchFeature &&
                     !action.engine.isGeneral,
-                showAllSessionSuggestions = when (action.settings.showUnifiedSearchFeature) {
+                showAllSessionSuggestions = when (FeatureFlags.unifiedSearchFeature) {
                     true -> false
                     false -> true
                 },

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -31,6 +31,7 @@ import mozilla.components.feature.syncedtabs.DeviceIndicators
 import mozilla.components.feature.syncedtabs.SyncedTabsStorageSuggestionProvider
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.ktx.android.content.getColorFromAttr
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
@@ -316,7 +317,7 @@ class AwesomeBarView(
             providersToAdd.add(getLocalTabsProvider(state.searchEngineSource, true))
         }
 
-        if (!activity.settings().showUnifiedSearchFeature) {
+        if (!FeatureFlags.unifiedSearchFeature) {
             providersToAdd.add(searchEngineSuggestionProvider)
         }
 
@@ -424,7 +425,7 @@ class AwesomeBarView(
                     engine,
                     shortcutSearchUseCase,
                     components.core.client,
-                    limit = if (activity.settings().showUnifiedSearchFeature) {
+                    limit = if (FeatureFlags.unifiedSearchFeature) {
                         METADATA_SHORTCUT_SUGGESTION_LIMIT
                     } else {
                         METADATA_SUGGESTION_LIMIT

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -17,6 +17,7 @@ import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.support.ktx.android.view.hideKeyboard
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.Core
@@ -148,7 +149,7 @@ class ToolbarView(
             interactor.onTextChanged(view.url.toString())
 
             // If search terms are displayed, move the cursor to the end instead of selecting all text.
-            if (settings.showUnifiedSearchFeature && searchState.searchTerms.isNotBlank()) {
+            if (FeatureFlags.unifiedSearchFeature && searchState.searchTerms.isNotBlank()) {
                 view.editMode(cursorPlacement = Toolbar.CursorPlacement.END)
             } else {
                 view.editMode()
@@ -182,7 +183,7 @@ class ToolbarView(
             }
         }
 
-        if (!settings.showUnifiedSearchFeature && searchEngine != null) {
+        if (!FeatureFlags.unifiedSearchFeature && searchEngine != null) {
             val iconSize =
                 context.resources.getDimensionPixelSize(R.dimen.preference_icon_drawable_size)
 
@@ -200,7 +201,7 @@ class ToolbarView(
     }
 
     private fun configureAutocomplete(searchEngineSource: SearchEngineSource) {
-        when (settings.showUnifiedSearchFeature) {
+        when (FeatureFlags.unifiedSearchFeature) {
             true -> configureAutocompleteWithUnifiedSearch(searchEngineSource)
             else -> configureAutocompleteWithoutUnifiedSearch(searchEngineSource)
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -12,7 +12,6 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
@@ -50,12 +49,6 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
         requirePreference<SwitchPreference>(R.string.pref_key_enable_task_continuity).apply {
             isVisible = true
             isChecked = context.settings().enableTaskContinuityEnhancements
-            onPreferenceChangeListener = SharedPreferenceUpdater()
-        }
-
-        requirePreference<SwitchPreference>(R.string.pref_key_show_unified_search).apply {
-            isVisible = FeatureFlags.unifiedSearchFeature
-            isChecked = context.settings().showUnifiedSearchFeature
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
@@ -30,11 +30,11 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.lib.state.ext.flow
 import mozilla.components.support.ktx.android.view.toScope
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.SearchEngineRadioButtonBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.utils.allowUndo
 
 class RadioSearchEngineListPreference @JvmOverloads constructor(
@@ -88,7 +88,7 @@ class RadioSearchEngineListPreference @JvmOverloads constructor(
                 engine = engine,
                 layoutInflater = layoutInflater,
                 res = context.resources,
-                allowDeletion = if (context.settings().showUnifiedSearchFeature) {
+                allowDeletion = if (FeatureFlags.unifiedSearchFeature) {
                     isLastSearchEngineAvailable && !(engine.isGeneral && isLastGeneralOrCustomSearchEngine)
                 } else {
                     isLastSearchEngineAvailable
@@ -113,7 +113,7 @@ class RadioSearchEngineListPreference @JvmOverloads constructor(
 
         val binding = SearchEngineRadioButtonBinding.bind(wrapper)
 
-        if (context.settings().showUnifiedSearchFeature && !engine.isGeneral) {
+        if (FeatureFlags.unifiedSearchFeature && !engine.isGeneral) {
             binding.radioButton.isEnabled = false
             wrapper.isEnabled = false
         } else {
@@ -171,7 +171,7 @@ class RadioSearchEngineListPreference @JvmOverloads constructor(
     ) {
         val selectedOrDefaultSearchEngine = context.components.core.store.state.search.selectedOrDefaultSearchEngine
         if (selectedOrDefaultSearchEngine == engine) {
-            val nextSearchEngine = if (context.settings().showUnifiedSearchFeature) {
+            val nextSearchEngine = if (FeatureFlags.unifiedSearchFeature) {
                 context.components.core.store.state.search.searchEngines.first {
                     it.id != engine.id && (it.isGeneral || it.type == SearchEngine.Type.CUSTOM)
                 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
@@ -12,6 +12,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import mozilla.components.support.ktx.android.view.hideKeyboard
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
@@ -50,7 +51,7 @@ class SearchEngineFragment : PreferenceFragmentCompat() {
         val showSearchShortcuts =
             requirePreference<SwitchPreference>(R.string.pref_key_show_search_engine_shortcuts).apply {
                 isChecked = context.settings().shouldShowSearchShortcuts
-                isVisible = !context.settings().showUnifiedSearchFeature
+                isVisible = !FeatureFlags.unifiedSearchFeature
             }
 
         val showHistorySuggestions =

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1549,15 +1549,6 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
-     * Indicates if the Unified Search feature should be visible.
-     */
-    var showUnifiedSearchFeature by lazyFeatureFlagPreference(
-        key = appContext.getPreferenceKey(R.string.pref_key_show_unified_search),
-        default = { FxNimbus.features.unifiedSearch.value().enabled },
-        featureFlag = FeatureFlags.unifiedSearchFeature,
-    )
-
-    /**
      * Blocklist used to filter items from the home screen that have previously been removed.
      */
     var homescreenBlocklist by stringSetPreference(

--- a/fenix/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarViewTest.kt
@@ -42,7 +42,6 @@ class BrowserToolbarViewTest {
         every { testContext.components.useCases } returns mockk(relaxed = true)
         every { testContext.components.core } returns mockk(relaxed = true)
         every { testContext.components.publicSuffixList } returns PublicSuffixList(testContext)
-        every { testContext.settings().showUnifiedSearchFeature } returns false
 
         toolbarView = BrowserToolbarView(
             context = testContext,

--- a/fenix/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -18,6 +18,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
+import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.spyk
@@ -37,13 +38,13 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.Services
 import org.mozilla.fenix.ext.bookmarkStorage
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.utils.Settings
 
 @Suppress("TooManyFunctions", "LargeClass")
 class BookmarkControllerTest {
@@ -63,7 +64,6 @@ class BookmarkControllerTest {
     private val addNewTabUseCase: TabsUseCases.AddNewTabUseCase = mockk(relaxed = true)
     private val navBackStackEntry: NavBackStackEntry = mockk(relaxed = true)
     private val navDestination: NavDestination = mockk(relaxed = true)
-    private val settings: Settings = mockk(relaxed = true)
 
     private val item =
         BookmarkNode(BookmarkNodeType.ITEM, "456", "123", 0u, "Mozilla", "http://mozilla.org", 0, null)
@@ -122,6 +122,7 @@ class BookmarkControllerTest {
         every { bookmarkStore.dispatch(any()) } returns mockk()
         every { sharedViewModel.selectedFolder = any() } just runs
         every { tabsUseCases.addTab } returns addNewTabUseCase
+        mockkObject(FeatureFlags)
     }
 
     @Test
@@ -243,6 +244,7 @@ class BookmarkControllerTest {
 
     @Test
     fun `WHEN handling search THEN navigate to the search dialog fragment`() {
+        every { FeatureFlags.unifiedSearchFeature } returns false
         createController().handleSearch()
 
         verify {
@@ -544,7 +546,6 @@ class BookmarkControllerTest {
             deleteBookmarkFolder = deleteBookmarkFolder,
             showTabTray = showTabTray,
             warnLargeOpenAll = warnLargeOpenAll,
-            settings = settings,
         )
     }
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -30,7 +30,6 @@ import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.history.DefaultPagedHistoryProvider
 import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
-import org.mozilla.fenix.utils.Settings
 
 @RunWith(FenixRobolectricTestRunner::class)
 class HistoryControllerTest {
@@ -56,7 +55,6 @@ class HistoryControllerTest {
     private val state: HistoryFragmentState = mockk(relaxed = true)
     private val navController: NavController = mockk(relaxed = true)
     private val historyProvider: DefaultPagedHistoryProvider = mockk(relaxed = true)
-    private val settings: Settings = mockk(relaxed = true)
 
     @Before
     fun setUp() {
@@ -269,7 +267,6 @@ class HistoryControllerTest {
             invalidateOptionsMenu,
             { items, _, _ -> deleteHistoryItems.invoke(items) },
             syncHistory,
-            settings,
         )
     }
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -40,6 +40,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.SearchShortcuts
 import org.mozilla.fenix.GleanMetrics.UnifiedSearch
@@ -82,6 +83,7 @@ class SearchDialogControllerTest {
     fun setUp() {
         MockKAnnotations.init(this)
         mockkObject(MetricsUtils)
+        mockkObject(FeatureFlags)
         middleware = CaptureActionsMiddleware()
         browserStore = BrowserStore(
             middleware = listOf(middleware),
@@ -291,6 +293,7 @@ class SearchDialogControllerTest {
     fun `show search shortcuts when setting enabled AND query empty`() {
         val text = ""
         every { settings.shouldShowSearchShortcuts } returns true
+        every { FeatureFlags.unifiedSearchFeature } returns false
 
         createController().handleTextChanged(text)
 
@@ -302,6 +305,7 @@ class SearchDialogControllerTest {
         val text = "mozilla.org"
         every { store.state.url } returns "mozilla.org"
         every { settings.shouldShowSearchShortcuts } returns true
+        every { FeatureFlags.unifiedSearchFeature } returns false
 
         createController().handleTextChanged(text)
 
@@ -312,7 +316,6 @@ class SearchDialogControllerTest {
     fun `GIVEN show search shortcuts setting is enabled AND unified search is enabled WHEN query is empty THEN do not show search shortcuts`() {
         val text = ""
         every { settings.shouldShowSearchShortcuts } returns true
-        every { settings.showUnifiedSearchFeature } returns true
 
         createController().handleTextChanged(text)
 
@@ -324,7 +327,6 @@ class SearchDialogControllerTest {
         val text = "mozilla.org"
         every { store.state.url } returns "mozilla.org"
         every { settings.shouldShowSearchShortcuts } returns true
-        every { settings.showUnifiedSearchFeature } returns true
 
         createController().handleTextChanged(text)
 
@@ -409,6 +411,7 @@ class SearchDialogControllerTest {
         val searchEngine: SearchEngine = mockk(relaxed = true)
         val browsingMode = BrowsingMode.Private
         every { activity.browsingModeManager.mode } returns browsingMode
+        every { FeatureFlags.unifiedSearchFeature } returns false
 
         var focusToolbarInvoked = false
         createController(
@@ -434,7 +437,6 @@ class SearchDialogControllerTest {
         val searchEngine: SearchEngine = mockk(relaxed = true)
         every { searchEngine.type } returns SearchEngine.Type.APPLICATION
         every { searchEngine.id } returns Core.HISTORY_SEARCH_ENGINE_ID
-        every { settings.showUnifiedSearchFeature } returns true
 
         assertNull(UnifiedSearch.engineSelected.testGetValue())
 
@@ -462,7 +464,6 @@ class SearchDialogControllerTest {
         val searchEngine: SearchEngine = mockk(relaxed = true)
         every { searchEngine.type } returns SearchEngine.Type.APPLICATION
         every { searchEngine.id } returns Core.BOOKMARKS_SEARCH_ENGINE_ID
-        every { settings.showUnifiedSearchFeature } returns true
 
         assertNull(UnifiedSearch.engineSelected.testGetValue())
 
@@ -490,7 +491,6 @@ class SearchDialogControllerTest {
         val searchEngine: SearchEngine = mockk(relaxed = true)
         every { searchEngine.type } returns SearchEngine.Type.APPLICATION
         every { searchEngine.id } returns Core.TABS_SEARCH_ENGINE_ID
-        every { settings.showUnifiedSearchFeature } returns true
 
         assertNull(UnifiedSearch.engineSelected.testGetValue())
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
@@ -8,6 +8,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
@@ -27,6 +28,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
@@ -49,6 +51,7 @@ class SearchFragmentStoreTest {
     @Before
     fun setup() {
         MockKAnnotations.init(this)
+        mockkObject(FeatureFlags)
         every { activity.browsingModeManager } returns object : BrowsingModeManager {
             override var mode: BrowsingMode = BrowsingMode.Normal
         }
@@ -60,7 +63,6 @@ class SearchFragmentStoreTest {
         activity.browsingModeManager.mode = BrowsingMode.Normal
         every { components.core.store.state } returns BrowserState()
         every { settings.shouldShowSearchShortcuts } returns true
-        every { settings.showUnifiedSearchFeature } returns true
         every { settings.shouldShowHistorySuggestions } returns true
 
         mockkStatic("org.mozilla.fenix.search.SearchFragmentStoreKt") {
@@ -189,6 +191,7 @@ class SearchFragmentStoreTest {
         every { settings.shouldShowSyncedTabsSuggestions } returns false
         every { settings.shouldShowSearchSuggestions } returns true
         every { settings.shouldShowSearchSuggestionsInPrivate } returns true
+        every { FeatureFlags.unifiedSearchFeature } returns false
 
         mockkStatic("org.mozilla.fenix.search.SearchFragmentStoreKt") {
             store.dispatch(
@@ -222,7 +225,6 @@ class SearchFragmentStoreTest {
         val topicSpecificEngine: SearchEngine = mockk {
             every { isGeneral } returns false
         }
-        every { settings.showUnifiedSearchFeature } returns true
         every { settings.shouldShowSearchShortcuts } returns true
         every { settings.shouldShowClipboardSuggestions } returns true
         every { settings.shouldShowHistorySuggestions } returns true
@@ -285,7 +287,6 @@ class SearchFragmentStoreTest {
         val initialState = emptyDefaultState(showHistorySuggestionsForCurrentEngine = false)
         val store = SearchFragmentStore(initialState)
         every { searchEngine.isGeneral } returns false
-        every { settings.showUnifiedSearchFeature } returns true
         every { settings.shouldShowSearchSuggestions } returns false
         every { settings.shouldShowSearchShortcuts } returns false
         every { settings.shouldShowClipboardSuggestions } returns false
@@ -321,7 +322,7 @@ class SearchFragmentStoreTest {
     fun `GIVEN unified search is disabled WHEN the search engine is updated to a shortcut THEN search suggestions providers are updated`() = runTest {
         val initialState = emptyDefaultState(showHistorySuggestionsForCurrentEngine = false)
         val store = SearchFragmentStore(initialState)
-        every { settings.showUnifiedSearchFeature } returns false
+        every { FeatureFlags.unifiedSearchFeature } returns false
         every { settings.shouldShowSearchShortcuts } returns true
         every { settings.shouldShowClipboardSuggestions } returns false
         every { settings.shouldShowHistorySuggestions } returns true
@@ -359,7 +360,6 @@ class SearchFragmentStoreTest {
             every { name } returns "1"
             every { isGeneral } returns false
         }
-        every { settings.showUnifiedSearchFeature } returns true
 
         every { settings.shouldShowBookmarkSuggestions } returns false
         every { settings.shouldShowSyncedTabsSuggestions } returns false
@@ -409,7 +409,6 @@ class SearchFragmentStoreTest {
             every { id } returns "1"
             every { isGeneral } returns false
         }
-        every { settings.showUnifiedSearchFeature } returns true
 
         every { settings.shouldShowBookmarkSuggestions } returns false
         every { settings.shouldShowSyncedTabsSuggestions } returns true

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/awesomebar/AwesomeBarViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/awesomebar/AwesomeBarViewTest.kt
@@ -33,6 +33,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.Core.Companion
@@ -54,6 +55,7 @@ class AwesomeBarViewTest {
         mockkStatic("org.mozilla.fenix.ext.ContextKt")
         mockkStatic("mozilla.components.support.ktx.android.content.ContextKt")
         mockkObject(AwesomeBarView.Companion)
+        mockkObject(FeatureFlags)
         every { any<Activity>().components.core.engine } returns mockk()
         every { any<Activity>().components.core.icons } returns mockk()
         every { any<Activity>().components.core.store } returns mockk()
@@ -408,9 +410,7 @@ class AwesomeBarViewTest {
 
     @Test
     fun `GIVEN unified search feature is enabled WHEN configuring providers THEN don't add the engine suggestions provider`() {
-        val settings: Settings = mockk(relaxed = true) {
-            every { showUnifiedSearchFeature } returns true
-        }
+        val settings: Settings = mockk(relaxed = true)
         every { activity.settings() } returns settings
         val state = getSearchProviderState(
             searchEngineSource = SearchEngineSource.Default(mockk(relaxed = true)),
@@ -423,10 +423,9 @@ class AwesomeBarViewTest {
 
     @Test
     fun `GIVEN unified search feature is disabled WHEN configuring providers THEN add the engine suggestions provider`() {
-        val settings: Settings = mockk(relaxed = true) {
-            every { showUnifiedSearchFeature } returns false
-        }
+        val settings: Settings = mockk(relaxed = true)
         every { activity.settings() } returns settings
+        every { FeatureFlags.unifiedSearchFeature } returns false
         val state = getSearchProviderState(
             searchEngineSource = SearchEngineSource.Default(mockk(relaxed = true)),
         )
@@ -438,11 +437,10 @@ class AwesomeBarViewTest {
 
     @Test
     fun `GIVEN a search from the default engine with all suggestions asked WHEN configuring providers THEN add them all`() {
-        val settings: Settings = mockk(relaxed = true) {
-            every { showUnifiedSearchFeature } returns false
-        }
+        val settings: Settings = mockk(relaxed = true)
         every { activity.settings() } returns settings
         every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
+        every { FeatureFlags.unifiedSearchFeature } returns false
         val state = getSearchProviderState(
             searchEngineSource = SearchEngineSource.Default(
                 mockk(relaxed = true) {
@@ -476,9 +474,7 @@ class AwesomeBarViewTest {
 
     @Test
     fun `GIVEN a search from the default engine with no suggestions asked WHEN configuring providers THEN don't add any provider`() {
-        val settings: Settings = mockk(relaxed = true) {
-            every { showUnifiedSearchFeature } returns true
-        }
+        val settings: Settings = mockk(relaxed = true)
         every { activity.settings() } returns settings
         every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
         val state = getSearchProviderState(

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
@@ -94,6 +94,7 @@ class ToolbarViewTest {
         context = ContextThemeWrapper(testContext, R.style.NormalTheme)
         every { context.settings() } returns mockk(relaxed = true)
         toolbar = spyk(BrowserToolbar(context))
+        mockkObject(FeatureFlags)
     }
 
     @Test
@@ -139,7 +140,6 @@ class ToolbarViewTest {
 
     @Test
     fun `GIVEN search term is set WHEN switching to edit mode THEN the cursor is set at the end of the search term`() {
-        every { context.settings().showUnifiedSearchFeature } returns true
         every { context.settings().shouldShowHistorySuggestions } returns true
         val view = buildToolbarView(false)
         mockkObject(FeatureFlags)
@@ -153,7 +153,6 @@ class ToolbarViewTest {
 
     @Test
     fun `GIVEN no search term is set WHEN switching to edit mode THEN the cursor is set at the end of the search term`() {
-        every { context.settings().showUnifiedSearchFeature } returns true
         every { context.settings().shouldShowHistorySuggestions } returns true
         val view = buildToolbarView(false)
         mockkObject(FeatureFlags)
@@ -202,6 +201,7 @@ class ToolbarViewTest {
     fun `searchEngine name and icon get set on update`() {
         val editToolbar: EditToolbar = mockk(relaxed = true)
         every { toolbar.edit } returns editToolbar
+        every { FeatureFlags.unifiedSearchFeature } returns false
 
         val toolbarView = buildToolbarView(false)
         toolbarView.update(defaultState)
@@ -404,9 +404,9 @@ class ToolbarViewTest {
             }
 
             val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns false
                 every { shouldShowHistorySuggestions } returns true
             }
+            every { FeatureFlags.unifiedSearchFeature } returns false
             val toolbarView = buildToolbarView(
                 isPrivate = false,
                 settings = settings,
@@ -435,9 +435,9 @@ class ToolbarViewTest {
             }
 
             val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns false
                 every { shouldShowHistorySuggestions } returns false
             }
+            every { FeatureFlags.unifiedSearchFeature } returns false
             val toolbarView = buildToolbarView(
                 isPrivate = false,
                 settings = settings,
@@ -466,9 +466,9 @@ class ToolbarViewTest {
             }
 
             val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns false
                 every { shouldShowHistorySuggestions } returns true
             }
+            every { FeatureFlags.unifiedSearchFeature } returns false
             val toolbarView = buildToolbarView(
                 isPrivate = false,
                 settings = settings,
@@ -528,7 +528,6 @@ class ToolbarViewTest {
             }
 
             val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns true
                 every { shouldShowHistorySuggestions } returns true
             }
             val toolbarView = buildToolbarView(
@@ -558,7 +557,6 @@ class ToolbarViewTest {
                 every { core.domainsAutocompleteProvider } returns domainsProvider
             }
             val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns true
                 every { shouldShowHistorySuggestions } returns false
             }
             val toolbarView = buildToolbarView(
@@ -587,9 +585,7 @@ class ToolbarViewTest {
                 every { core.sessionAutocompleteProvider } returns localSessionProvider
                 every { backgroundServices.syncedTabsAutocompleteProvider } returns syncedSessionsProvider
             }
-            val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns true
-            }
+            val settings: Settings = mockk(relaxed = true)
             val toolbarView = buildToolbarView(
                 isPrivate = false,
                 settings = settings,
@@ -614,9 +610,7 @@ class ToolbarViewTest {
             val components: Components = mockk(relaxed = true) {
                 every { core.bookmarksStorage } returns bookmarksProvider
             }
-            val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns true
-            }
+            val settings: Settings = mockk(relaxed = true)
             val toolbarView = buildToolbarView(
                 isPrivate = false,
                 settings = settings,
@@ -641,9 +635,7 @@ class ToolbarViewTest {
             val components: Components = mockk(relaxed = true) {
                 every { core.historyStorage } returns historyProvider
             }
-            val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns true
-            }
+            val settings: Settings = mockk(relaxed = true)
             val toolbarView = buildToolbarView(
                 isPrivate = false,
                 settings = settings,
@@ -664,9 +656,7 @@ class ToolbarViewTest {
     @Test
     fun `GIVEN a new search state with no engine source selected WHEN updating the toolbar THEN reconfigure autocomplete suggestions`() {
         mockkConstructor(ToolbarAutocompleteFeature::class) {
-            val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns true
-            }
+            val settings: Settings = mockk(relaxed = true)
             val toolbarView = buildToolbarView(
                 false,
                 settings = settings,
@@ -686,9 +676,7 @@ class ToolbarViewTest {
     @Test
     fun `GIVEN a new search state with a shortcut engine source selected WHEN updating the toolbar THEN reconfigure autocomplete suggestions`() {
         mockkConstructor(ToolbarAutocompleteFeature::class) {
-            val settings: Settings = mockk(relaxed = true) {
-                every { showUnifiedSearchFeature } returns true
-            }
+            val settings: Settings = mockk(relaxed = true)
             val toolbarView = buildToolbarView(
                 isPrivate = false,
                 settings = settings,

--- a/fenix/nimbus.fml.yaml
+++ b/fenix/nimbus.fml.yaml
@@ -137,7 +137,10 @@ features:
     defaults:
       - channel: nightly
         value:
-          enabled: false
+          enabled: true
+      - channel: developer
+        value:
+          enabled: true
   
   client-deduplication:
     description: A feature to control the sending of the client-deduplication ping.


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821261