### PR TITLE
Bug 1821464 Add UI test to NotificationWorker

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NimbusMessagingNotificationTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NimbusMessagingNotificationTest.kt
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
+
+import android.content.Context
+import android.os.Build
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import androidx.test.rule.GrantPermissionRule.grant
+import androidx.test.uiautomator.UiDevice
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.experiments.nimbus.HardcodedNimbusFeatures
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.TestHelper
+import org.mozilla.fenix.nimbus.FxNimbus
+import org.mozilla.fenix.ui.robots.notificationShade
+
+/**
+ * A UI test for testing the notification surface for Nimbus Messaging.
+ */
+class NimbusMessagingNotificationTest {
+    private lateinit var mDevice: UiDevice
+
+    private lateinit var context: Context
+    private lateinit var hardcodedNimbus: HardcodedNimbusFeatures
+
+    @get:Rule
+    val activityTestRule =
+        HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
+
+    @get:Rule
+    val grantPermissionRule: GrantPermissionRule =
+        if (Build.VERSION.SDK_INT >= 33) {
+            grant("android.permission.POST_NOTIFICATIONS")
+        } else {
+            grant()
+        }
+
+    @Before
+    fun setUp() {
+        context = TestHelper.appContext
+        mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    }
+
+    @Test
+    fun testShowingNotificationMessage() {
+        hardcodedNimbus = HardcodedNimbusFeatures(
+            context,
+            "messaging" to JSONObject(
+                """
+                {
+                  "message-under-experiment": "test-default-browser-notification",
+                  "messages": {
+                    "test-default-browser-notification": {
+                      "title": "preferences_set_as_default_browser",
+                      "text": "default_browser_experiment_card_text",
+                      "surface": "notification",
+                      "style": "NOTIFICATION",
+                      "action": "MAKE_DEFAULT_BROWSER",
+                      "trigger": [
+                        "ALWAYS"
+                      ]
+                    }
+                  }
+                }
+                """.trimIndent(),
+            ),
+        )
+        // The scheduling of the Messaging Notification Worker happens in the HomeActivity
+        // onResume().
+        // We need to have connected FxNimbus to hardcodedNimbus by the time it is scheduled, so
+        // we finishActivity, connect, _then_ re-launch the activity so that the worker has
+        // hardcodedNimbus by the time its re-scheduled.
+        // Because the scheduling happens for a second time, the work request needs to replace the
+        // existing one.
+        activityTestRule.finishActivity()
+        hardcodedNimbus.connectWith(FxNimbus)
+        activityTestRule.launchActivity(null)
+
+        mDevice.openNotification()
+        notificationShade {
+            val data =
+                FxNimbus.features.messaging.value().messages["test-default-browser-notification"]
+            verifySystemNotificationExists(data!!.title!!)
+            verifySystemNotificationExists(data.text)
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/gleanplumb/MessageNotificationWorker.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/gleanplumb/MessageNotificationWorker.kt
@@ -147,7 +147,8 @@ class MessageNotificationWorker(
          * Initialize the [Worker] to begin polling Nimbus.
          */
         fun setMessageNotificationWorker(context: Context) {
-            val featureConfig = FxNimbus.features.messaging.value()
+            val messaging = FxNimbus.features.messaging
+            val featureConfig = messaging.value()
             val notificationConfig = featureConfig.notificationConfig
             val pollingInterval = notificationConfig.refreshInterval.toLong()
 
@@ -159,8 +160,13 @@ class MessageNotificationWorker(
             val instanceWorkManager = WorkManager.getInstance(context)
             instanceWorkManager.enqueueUniquePeriodicWork(
                 MESSAGE_WORK_NAME,
-                // We want to keep any existing scheduled work.
-                ExistingPeriodicWorkPolicy.KEEP,
+                // We want to keep any existing scheduled work, unless
+                // when we're under test.
+                if (messaging.isUnderTest()) {
+                    ExistingPeriodicWorkPolicy.REPLACE
+                } else {
+                    ExistingPeriodicWorkPolicy.KEEP
+                },
                 messageWorkRequest,
             )
         }


### PR DESCRIPTION
Fixes [EXP-3184](https://mozilla-hub.atlassian.net/browse/EXP-3184).
Fixes [Bug 1821464](https://bugzilla.mozilla.org/show_bug.cgi?id=1821464).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821464