### PR TITLE
Bug 1820122 - Use b-android-xlarge to speed up external-gradle-dependencies jobs

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -189,6 +189,11 @@ workers:
             implementation: docker-worker
             os: linux
             worker-type: b-linux-large-gcp
+        b-android-xlarge:
+            provisioner: 'mobile-{level}'
+            implementation: docker-worker
+            os: linux
+            worker-type: b-linux-xlarge-gcp
         beetmover:
             provisioner: scriptworker-k8s
             implementation: scriptworker-beetmover

--- a/taskcluster/ci/external-gradle-dependencies/kind.yml
+++ b/taskcluster/ci/external-gradle-dependencies/kind.yml
@@ -49,7 +49,7 @@ task-defaults:
         retry-exit-status:
             - 1     # Test failures (which actually catch any gradle failure)
             - 17    # Download errors
-    worker-type: b-android-large
+    worker-type: b-android-xlarge
 
 tasks:
     lint-components:


### PR DESCRIPTION
Let
https://bugzilla.mozilla.org/show_bug.cgi?id=1820122
https://bugzilla.mozilla.org/show_bug.cgi?id=1820122
https://bugzilla.mozilla.org/show_bug.cgi?id=1820122
https://bugzilla.mozilla.org/show_bug.cgi?id=1820122
https://bugzilla.mozilla.org/show_bug.cgi?id=1820122
https://bugzilla.mozilla.org/show_bug.cgi?id=1820122