### PR TITLE
Use LocalDate in the HistoryItemTimeGroup enum.

### DIFF
--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -201,6 +201,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
+        coreLibraryDesugaringEnabled true
     }
 
     lint {
@@ -478,6 +479,8 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 }
 
 dependencies {
+    coreLibraryDesugaring FenixDependencies.desugar_jdk_libs
+
     jnaForTest FenixDependencies.jna
     testImplementation files(configurations.jnaForTest.copyRecursive().files)
 

--- a/fenix/buildSrc/src/main/java/FenixDependencies.kt
+++ b/fenix/buildSrc/src/main/java/FenixDependencies.kt
@@ -6,6 +6,8 @@
 // FORCE REBUILD 2022-12-11
 
 object FenixVersions {
+    const val desugar = "2.0.2"
+
     const val kotlin = "1.8.10"
     const val coroutines = "1.6.4"
 
@@ -63,6 +65,8 @@ object FenixVersions {
 
 @Suppress("unused")
 object FenixDependencies {
+    const val desugar_jdk_libs = "com.android.tools:desugar_jdk_libs:${FenixVersions.desugar}"
+
     const val tools_androidgradle = "com.android.tools.build:gradle:${FenixVersions.android_gradle_plugin}"
     const val tools_kotlingradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${FenixVersions.kotlin}"
     const val tools_benchmarkgradle = "androidx.benchmark:benchmark-gradle-plugin:${FenixVersions.androidx_benchmark}"


### PR DESCRIPTION
* Enable [core library desugaring](https://developer.android.com/studio/write/java11-default-support-table).
* Switch to `LocalDate` in the `HistoryItemTimeGroup` enum.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
