### PR TITLE
 bug  1815428 - can read text for pbm shortcut in german lang

### DIFF
--- a/fenix/app/src/main/res/layout/pbm_shortcut_popup.xml
+++ b/fenix/app/src/main/res/layout/pbm_shortcut_popup.xml
@@ -42,7 +42,7 @@
             android:id="@+id/cfr_pos_button"
             style="@style/NeutralButton"
             android:layout_width="0dp"
-            android:layout_height="36dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"


### PR DESCRIPTION
Earlier the shortcut button text of pbm in german language was overflowing its boundaries , by this new commit the text fits in the button and users are able to read it without any issue


