### PR TITLE
Bug 1821973 - New tabs option summary updates UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
@@ -22,6 +22,9 @@ object MatcherHelper {
     fun itemContainingText(itemText: String) =
         mDevice.findObject(UiSelector().textContains(itemText))
 
+    fun itemWithText(itemText: String) =
+        mDevice.findObject(UiSelector().text(itemText))
+
     fun itemWithDescription(description: String) =
         mDevice.findObject(UiSelector().descriptionContains(description))
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsGeneralTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsGeneralTest.kt
@@ -34,7 +34,7 @@ import java.util.Locale
  *  Tests for verifying the General section of the Settings menu
  *
  */
-class SettingsBasicsTest {
+class SettingsGeneralTest {
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
     private lateinit var mockWebServer: MockWebServer
 
@@ -165,6 +165,32 @@ class SettingsBasicsTest {
                 verifyLanguageHeaderIsTranslated(FRENCH_LANGUAGE_HEADER)
                 verifySelectedLanguage(FRENCH_SYSTEM_LOCALE_OPTION)
             }
+        }
+    }
+
+    @Test
+    fun verifyTabsOptionSummaryUpdatesTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+            verifyTabsButton()
+            verifyTabsButtonSummary("Close manually")
+        }.openTabsSubMenu {
+            verifySelectedCloseTabsOption("Never")
+            clickClosedTabsOption("After one day")
+            verifySelectedCloseTabsOption("After one day")
+        }.goBack {
+            verifyTabsButtonSummary("Close after one day")
+        }.openTabsSubMenu {
+            clickClosedTabsOption("After one week")
+            verifySelectedCloseTabsOption("After one week")
+        }.goBack {
+            verifyTabsButtonSummary("Close after one week")
+        }.openTabsSubMenu {
+            clickClosedTabsOption("After one month")
+            verifySelectedCloseTabsOption("After one month")
+        }.goBack {
+            verifyTabsButtonSummary("Close after one month")
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -41,8 +41,11 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.LISTS_MAXSWIPES
 import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_PLAY_SERVICES
 import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.isPackageInstalled
@@ -67,7 +70,10 @@ class SettingsRobot {
     fun verifyThemeSelected() = assertThemeSelected()
     fun verifyAccessibilityButton() = assertAccessibilityButton()
     fun verifySetAsDefaultBrowserButton() = assertSetAsDefaultBrowserButton()
-    fun verifyTabsButton() = assertTabsButton()
+    fun verifyTabsButton() =
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.preferences_tabs)))
+    fun verifyTabsButtonSummary(summary: String) =
+        assertItemContainingTextExists(itemContainingText(summary))
     fun verifyHomepageButton() = assertHomepageButton()
     fun verifyAutofillButton() = assertAutofillButton()
     fun verifyLanguageButton() = assertLanguageButton()
@@ -152,8 +158,11 @@ class SettingsRobot {
         }
 
         fun openTabsSubMenu(interact: SettingsSubMenuTabsRobot.() -> Unit): SettingsSubMenuTabsRobot.Transition {
-            fun tabsButton() = onView(withText("Tabs"))
-            tabsButton().click()
+            itemWithText(getStringResource(R.string.preferences_tabs))
+                .also {
+                    it.waitForExists(waitingTime)
+                    it.clickAndWaitForNewWindow(waitingTimeShort)
+                }
 
             SettingsSubMenuTabsRobot().interact()
             return SettingsSubMenuTabsRobot.Transition()
@@ -413,12 +422,6 @@ private fun toggleDefaultBrowserSwitch() {
 
 private fun assertAndroidDefaultAppsMenuAppears() {
     intended(IntentMatchers.hasAction(DEFAULT_APPS_SETTINGS_ACTION))
-}
-
-private fun assertTabsButton() {
-    mDevice.wait(Until.findObject(By.text("Tabs")), waitingTime)
-    onView(withText(R.string.preferences_tabs))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
 // PRIVACY SECTION

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuTabsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuTabsRobot.kt
@@ -11,11 +11,15 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.allOf
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.isChecked
 
 /**
  * Implementation of Robot Pattern for the settings Tabs sub menu.
@@ -27,6 +31,23 @@ class SettingsSubMenuTabsRobot {
     fun verifyCloseTabsOptions() = assertCloseTabsOptions()
 
     fun verifyMoveOldTabsToInactiveOptions() = assertMoveOldTabsToInactiveOptions()
+
+    fun verifySelectedCloseTabsOption(closedTabsOption: String) =
+        onView(
+            allOf(
+                withId(R.id.radio_button),
+                hasSibling(withText(closedTabsOption)),
+            ),
+        ).check(matches(isChecked(true)))
+
+    fun clickClosedTabsOption(closedTabsOption: String) {
+        when (closedTabsOption) {
+            "Never" -> neverOption().click()
+            "After one day" -> afterOneDayOption().click()
+            "After one week" -> afterOneWeekOption().click()
+            "After one month" -> afterOneMonthOption().click()
+        }
+    }
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
@@ -51,13 +72,13 @@ private fun assertTabViewOptions() {
 private fun assertCloseTabsOptions() {
     closeTabsHeading()
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    neverToggle()
+    neverOption()
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    afterOneDayToggle()
+    afterOneDayOption()
         .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    afterOneWeekToggle()
+    afterOneWeekOption()
         .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    afterOneMonthToggle()
+    afterOneMonthOption()
         .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }
 
@@ -78,13 +99,13 @@ private fun closeTabsHeading() = onView(withText("Close tabs"))
 
 private fun manuallyToggle() = onView(withText("Manually"))
 
-private fun neverToggle() = onView(withText("Never"))
+private fun neverOption() = onView(withText("Never"))
 
-private fun afterOneDayToggle() = onView(withText("After one day"))
+private fun afterOneDayOption() = onView(withText("After one day"))
 
-private fun afterOneWeekToggle() = onView(withText("After one week"))
+private fun afterOneWeekOption() = onView(withText("After one week"))
 
-private fun afterOneMonthToggle() = onView(withText("After one month"))
+private fun afterOneMonthOption() = onView(withText("After one month"))
 
 private fun moveOldTabsToInactiveHeading() = onView(withText("Move old tabs to inactive"))
 


### PR DESCRIPTION
Bug 1821973 - New tabs option summary updates UI tests

Summary:

- Renamed SettingsBasicTest to SettingsGeneralTest class
- Created a new UI test `verifyTabsOptionSummaryUpdatesTest` ✅ successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821973