### PR TITLE
Bug 1821986 - new opening screen option summary updates UI smoke test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -166,7 +166,7 @@ class HomeScreenTest {
         }.openThreeDotMenu {
         }.openCustomizeHome {
             clickPocketButton()
-        }.goBack {
+        }.goBackToHomeScreen {
             verifyThoughtProvokingStories(false)
             verifyStoriesByTopic(false)
         }
@@ -257,12 +257,12 @@ class HomeScreenTest {
             clickRecentBookmarksButton()
             clickRecentSearchesButton()
             clickPocketButton()
-        }.goBack {
+        }.goBackToHomeScreen {
             verifyCustomizeHomepageButton(false)
         }.openThreeDotMenu {
         }.openCustomizeHome {
             clickJumpBackInButton()
-        }.goBack {
+        }.goBackToHomeScreen {
             verifyCustomizeHomepageButton(true)
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsGeneralTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsGeneralTest.kt
@@ -168,6 +168,27 @@ class SettingsGeneralTest {
         }
     }
 
+    @SmokeTest
+    @Test
+    fun verifyHomepageOptionSummaryUpdatesTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+            verifyHomepageButtonSummary("Open on homepage after four hours")
+        }.openHomepageSubMenu {
+            verifySelectedOpeningScreenOption("Homepage after four hours of inactivity")
+            clickOpeningScreenOption("Homepage")
+            verifySelectedOpeningScreenOption("Homepage")
+        }.goBack {
+            verifyHomepageButtonSummary("Open on homepage")
+        }.openHomepageSubMenu {
+            clickOpeningScreenOption("Last tab")
+            verifySelectedOpeningScreenOption("Last tab")
+        }.goBack {
+            verifyHomepageButtonSummary("Open on last tab")
+        }
+    }
+
     @Test
     fun verifyTabsOptionSummaryUpdatesTest() {
         homeScreen {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
@@ -75,7 +75,7 @@ class SettingsHomepageTest {
         }.openThreeDotMenu {
         }.openCustomizeHome {
             clickShortcutsButton()
-        }.goBack {
+        }.goBackToHomeScreen {
             defaultTopSites.forEach { item ->
                 verifyNotExistingTopSitesList(item)
             }
@@ -96,7 +96,7 @@ class SettingsHomepageTest {
         }.openThreeDotMenu {
         }.openCustomizeHome {
             clickRecentlyVisited()
-        }.goBack {
+        }.goBackToHomeScreen {
             verifyRecentlyVisitedSectionIsNotDisplayed()
         }
     }
@@ -116,7 +116,7 @@ class SettingsHomepageTest {
         }.openThreeDotMenu {
         }.openCustomizeHome {
             clickPocketButton()
-        }.goBack {
+        }.goBackToHomeScreen {
             verifyPocketSectionIsNotDisplayed()
         }
     }
@@ -133,7 +133,7 @@ class SettingsHomepageTest {
         }.openThreeDotMenu {
         }.openCustomizeHome {
             clickJumpBackInButton()
-        }.goBack {
+        }.goBackToHomeScreen {
             verifyJumpBackInSectionIsNotDisplayed()
         }
     }
@@ -152,7 +152,7 @@ class SettingsHomepageTest {
         }.openThreeDotMenu {
         }.openCustomizeHome {
             clickRecentBookmarksButton()
-        }.goBack {
+        }.goBackToHomeScreen {
             verifyRecentBookmarksSectionIsNotDisplayed()
         }
     }
@@ -167,7 +167,7 @@ class SettingsHomepageTest {
         }.openThreeDotMenu {
         }.openSettings {
         }.openHomepageSubMenu {
-            clickStartOnHomepageButton()
+            clickOpeningScreenOption("Homepage")
         }
 
         restartApp(activityIntentTestRule)
@@ -187,7 +187,7 @@ class SettingsHomepageTest {
         }.goToHomescreen {
         }.openThreeDotMenu {
         }.openCustomizeHome {
-            clickStartOnLastTabButton()
+            clickOpeningScreenOption("Last tab")
         }
 
         restartApp(activityIntentTestRule)
@@ -205,8 +205,8 @@ class SettingsHomepageTest {
         }.openThreeDotMenu {
         }.openSettings {
         }.openHomepageSubMenu {
-            clickStartOnHomepageButton()
-        }.goBack {}
+            clickOpeningScreenOption("Homepage")
+        }.goBackToHomeScreen {}
 
         with(activityIntentTestRule) {
             finishActivity()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SponsoredShortcutsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SponsoredShortcutsTest.kt
@@ -63,7 +63,7 @@ class SponsoredShortcutsTest {
             verifySponsoredShortcutsCheckBox(true)
             clickSponsoredShortcuts()
             verifySponsoredShortcutsCheckBox(false)
-        }.goBack {
+        }.goBackToHomeScreen {
             verifyNotExistingSponsoredTopSitesList()
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -82,7 +82,7 @@ class ThreeDotMenuMainTest {
         }.openThreeDotMenu {
         }.openCustomizeHome {
             verifyHomePageView()
-        }.goBack {
+        }.goBackToHomeScreen {
         }.openThreeDotMenu {
         }.openSettings {
             verifySettingsView()
@@ -133,7 +133,7 @@ class ThreeDotMenuMainTest {
         }.openThreeDotMenu {
         }.openCustomizeHome {
             verifyHomePageView()
-        }.goBack {
+        }.goBackToHomeScreen {
         }.openThreeDotMenu {
         }.openSettings {
             verifySettingsView()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -75,6 +75,8 @@ class SettingsRobot {
     fun verifyTabsButtonSummary(summary: String) =
         assertItemContainingTextExists(itemContainingText(summary))
     fun verifyHomepageButton() = assertHomepageButton()
+    fun verifyHomepageButtonSummary(summary: String) =
+        assertItemContainingTextExists(itemContainingText(summary))
     fun verifyAutofillButton() = assertAutofillButton()
     fun verifyLanguageButton() = assertLanguageButton()
     fun verifyDefaultBrowserIsDisabled() = assertDefaultBrowserIsDisabled()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -26,6 +26,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.isChecked
 
 /**
  * Implementation of Robot Pattern for the settings Homepage sub menu.
@@ -61,6 +62,14 @@ class SettingsSubMenuHomepageRobot {
         assertHomepageAfterFourHoursButton()
     }
 
+    fun verifySelectedOpeningScreenOption(openingScreenOption: String) =
+        onView(
+            allOf(
+                withId(R.id.radio_button),
+                hasSibling(withText(openingScreenOption)),
+            ),
+        ).check(matches(isChecked(true)))
+
     fun clickShortcutsButton() = shortcutsButton().click()
 
     fun clickSponsoredShortcuts() = sponsoredShortcutsButton().click()
@@ -75,9 +84,13 @@ class SettingsSubMenuHomepageRobot {
 
     fun clickPocketButton() = pocketButton().click()
 
-    fun clickStartOnHomepageButton() = homepageButton().click()
-
-    fun clickStartOnLastTabButton() = lastTabButton().click()
+    fun clickOpeningScreenOption(openingScreenOption: String) {
+        when (openingScreenOption) {
+            "Homepage" -> homepageButton().click()
+            "Last tab" -> lastTabButton().click()
+            "Homepage after four hours of inactivity" -> homepageAfterFourHoursButton().click()
+        }
+    }
 
     fun openWallpapersMenu() = wallpapersMenuButton.click()
 
@@ -96,11 +109,18 @@ class SettingsSubMenuHomepageRobot {
 
     class Transition {
 
-        fun goBack(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
+        fun goBackToHomeScreen(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
             goBackButton().click()
 
             HomeScreenRobot().interact()
             return HomeScreenRobot.Transition()
+        }
+
+        fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            goBackButton().click()
+
+            SettingsRobot().interact()
+            return SettingsRobot.Transition()
         }
 
         fun clickSnackBarViewButton(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {


### PR DESCRIPTION
Bug 1821986 - new opening screen option summary updates UI smoke test

`verifyHomepageOptionSummaryUpdatesTest` ✅ successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821986