### PR TITLE
Bug 1822050 - Verify HTTPS only mode and cookie banner reduction summary updates in UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
@@ -5,7 +5,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
-import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.restartApp
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -28,10 +27,13 @@ class CookieBannerReductionTest {
             verifyCookieBannerExists(exists = true)
         }.openThreeDotMenu {
         }.openSettings {
+            verifyCookieBannerReductionSummary("Off")
         }.openCookieBannerReductionSubMenu {
             verifyCookieBannerView(isCookieBannerReductionChecked = false)
             clickCookieBannerReductionToggle()
             verifyCheckedCookieBannerReductionToggle(isCookieBannerReductionChecked = true)
+        }.goBack {
+            verifyCookieBannerReductionSummary("On")
         }
 
         exitMenu()
@@ -40,7 +42,7 @@ class CookieBannerReductionTest {
             verifyCookieBannerExists(exists = false)
         }
 
-        TestHelper.restartApp(activityTestRule)
+        restartApp(activityTestRule)
 
         browserScreen {
             verifyCookieBannerExists(exists = false)
@@ -74,12 +76,17 @@ class CookieBannerReductionTest {
             verifyCookieBannerExists(exists = true)
         }.openThreeDotMenu {
         }.openSettings {
+            verifyCookieBannerReductionSummary("Off")
         }.openCookieBannerReductionSubMenu {
             verifyCookieBannerView(isCookieBannerReductionChecked = false)
             clickCookieBannerReductionToggle()
             verifyCheckedCookieBannerReductionToggle(isCookieBannerReductionChecked = true)
-            exitMenu()
+        }.goBack {
+            verifyCookieBannerReductionSummary("On")
         }
+
+        exitMenu()
+
         browserScreen {
             verifyCookieBannerExists(exists = false)
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHTTPSOnlyModeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHTTPSOnlyModeTest.kt
@@ -68,6 +68,8 @@ class SettingsHTTPSOnlyModeTest {
                 allTabsOptionSelected = true,
                 privateTabsOptionSelected = false,
             )
+        }.goBack {
+            verifyHTTPSOnlyModeSummary("On in all tabs")
             exitMenu()
         }
         navigationToolbar {
@@ -127,6 +129,8 @@ class SettingsHTTPSOnlyModeTest {
                 allTabsOptionSelected = false,
                 privateTabsOptionSelected = true,
             )
+        }.goBack {
+            verifyHTTPSOnlyModeSummary("On in private tabs")
             exitMenu()
         }
         navigationToolbar {
@@ -183,6 +187,8 @@ class SettingsHTTPSOnlyModeTest {
         }.openHttpsOnlyModeMenu {
             clickHttpsOnlyModeSwitch()
             verifyHttpsOnlyModeIsEnabled(false)
+        }.goBack {
+            verifyHTTPSOnlyModeSummary("Off")
             exitMenu()
         }
         navigationToolbar {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsTest.kt
@@ -60,7 +60,7 @@ class SettingsTest {
         }.goBack {
             // HTTPS-Only Mode
             verifyHTTPSOnlyModeButton()
-            verifyHTTPSOnlyModeState("Off")
+            verifyHTTPSOnlyModeSummary("Off")
 
             // ENHANCED TRACKING PROTECTION
             verifyEnhancedTrackingProtectionButton()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -87,7 +87,13 @@ class SettingsRobot {
     fun verifyPrivacyHeading() = assertPrivacyHeading()
 
     fun verifyHTTPSOnlyModeButton() = assertHTTPSOnlyModeButton()
-    fun verifyHTTPSOnlyModeState(state: String) = assertHTTPSOnlyModeState(state)
+    fun verifyHTTPSOnlyModeSummary(HTTPSOnlyModeSummary: String) =
+        onView(
+            allOf(
+                withText(R.string.preferences_https_only_title),
+                hasSibling(withText(HTTPSOnlyModeSummary)),
+            ),
+        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
     fun verifyEnhancedTrackingProtectionButton() = assertEnhancedTrackingProtectionButton()
     fun verifyLoginsAndPasswordsButton() = assertLoginsAndPasswordsButton()
     fun verifyEnhancedTrackingProtectionState(option: String) =
@@ -437,15 +443,6 @@ private fun assertHTTPSOnlyModeButton() {
     scrollToElementByText(getStringResource(R.string.preferences_https_only_title))
     onView(
         withText(R.string.preferences_https_only_title),
-    ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
-private fun assertHTTPSOnlyModeState(state: String) {
-    onView(
-        allOf(
-            withText(R.string.preferences_https_only_title),
-            hasSibling(withText(state)),
-        ),
     ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -94,6 +94,18 @@ class SettingsRobot {
                 hasSibling(withText(HTTPSOnlyModeSummary)),
             ),
         ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+    fun verifyCookieBannerReductionSummary(cookieBannerReductionSummary: String) {
+        scrollToElementByText(getStringResource(R.string.preferences_cookie_banner_reduction))
+
+        onView(
+            allOf(
+                withText(R.string.preferences_cookie_banner_reduction),
+                hasSibling(withText(cookieBannerReductionSummary)),
+            ),
+        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
+
     fun verifyEnhancedTrackingProtectionButton() = assertEnhancedTrackingProtectionButton()
     fun verifyLoginsAndPasswordsButton() = assertLoginsAndPasswordsButton()
     fun verifyEnhancedTrackingProtectionState(option: String) =

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuCookieBannerReductionRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuCookieBannerReductionRobot.kt
@@ -11,7 +11,9 @@ import org.mozilla.fenix.helpers.MatcherHelper.checkedItemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
+import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
+import org.mozilla.fenix.helpers.click
 
 /**
  * Implementation of Robot Pattern for the settings Cookie Banner Reduction sub menu.
@@ -25,7 +27,14 @@ class SettingsSubMenuCookieBannerReductionRobot {
     fun verifyCheckedCookieBannerReductionToggle(isCookieBannerReductionChecked: Boolean) =
         assertCheckedItemWithResIdExists(checkedCookieBannerOptionToggle(isCookieBannerReductionChecked))
 
-    class Transition
+    class Transition {
+        fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            mDevice.pressBack()
+
+            SettingsRobot().interact()
+            return SettingsRobot.Transition()
+        }
+    }
 }
 
 private val cookieBannerOptionTitle =


### PR DESCRIPTION
Bug 1822050 - Verify HTTPS only mode and cookie banner reduction summary updates in UI tests

All 5 affected UI tests successfully passed 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1822050