### PR TITLE
Bug 1814032 - Retry attempts for address autofill in UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -539,8 +539,23 @@ class BrowserRobot {
     }
 
     fun clickSelectAddressButton() {
-        selectAddressButton.waitForExists(waitingTime)
-        selectAddressButton.clickAndWaitForNewWindow(waitingTime)
+        for (i in 1..RETRY_COUNT) {
+            try {
+                assertTrue(selectAddressButton.waitForExists(waitingTime))
+                selectAddressButton.clickAndWaitForNewWindow(waitingTime)
+
+                break
+            } catch (e: AssertionError) {
+                // Retrying, in case we hit https://bugzilla.mozilla.org/show_bug.cgi?id=1816869
+                // This should be removed when the bug is fixed.
+                if (i == RETRY_COUNT) {
+                    throw e
+                } else {
+                    clickPageObject(webPageItemWithResourceId("city"))
+                    clickPageObject(webPageItemWithResourceId("country"))
+                }
+            }
+        }
     }
 
     fun verifySelectAddressButtonExists(exists: Boolean) = assertItemWithResIdExists(selectAddressButton, exists = exists)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
@@ -407,11 +407,22 @@ class SettingsSubMenuAutofillRobot {
 
 private val autofillToolbarTitle = itemContainingText(getStringResource(R.string.preferences_autofill))
 private val addressesSectionTitle = itemContainingText(getStringResource(R.string.preferences_addresses))
-private val manageAddressesToolbarTitle = itemContainingText(getStringResource(R.string.addresses_manage_addresses))
+private val manageAddressesToolbarTitle =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/navigationToolbar")
+            .childSelector(UiSelector().text(getStringResource(R.string.addresses_manage_addresses))),
+    )
+
 private val saveAndAutofillAddressesOption = itemContainingText(getStringResource(R.string.preferences_addresses_save_and_autofill_addresses))
 private val saveAndAutofillAddressesSummary = itemContainingText(getStringResource(R.string.preferences_addresses_save_and_autofill_addresses_summary))
 private val addAddressButton = itemContainingText(getStringResource(R.string.preferences_addresses_add_address))
-private val manageAddressesButton = itemContainingText(getStringResource(R.string.preferences_addresses_manage_addresses))
+private val manageAddressesButton =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("android:id/title")
+            .text(getStringResource(R.string.preferences_addresses_manage_addresses)),
+    )
 private val addAddressToolbarTitle = itemContainingText(getStringResource(R.string.addresses_add_address))
 private val editAddressToolbarTitle = itemContainingText(getStringResource(R.string.addresses_edit_address))
 private val toolbarCheckmarkButton = itemWithResId("$packageName:id/save_address_button")


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1814032