### PR TITLE
Bug 1814994 - Create Tabs Tray list and grid layouts

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -208,6 +208,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                 FirefoxTheme {
                     TabsTray(
                         tabsTrayStore = tabsTrayStore,
+                        displayTabsInGrid = requireContext().settings().gridTabView,
                     )
                 }
             }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTabLayouts.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTabLayouts.kt
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
+import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.TabSessionState
+import org.mozilla.fenix.R
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.compose.tabstray.TabGridItem
+import org.mozilla.fenix.compose.tabstray.TabListItem
+import org.mozilla.fenix.tabstray.ext.MIN_COLUMN_WIDTH_DP
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Top-level UI for displaying a list of tabs.
+ *
+ * @param tabs The list of [TabSessionState] to display.
+ */
+@Composable
+fun TabList(
+    tabs: List<TabSessionState>,
+) {
+    val tabListBottomPadding = dimensionResource(id = R.dimen.tab_tray_list_bottom_padding)
+    val state = rememberLazyListState()
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        state = state,
+    ) {
+        items(
+            items = tabs,
+            key = { tab -> tab.id },
+        ) { tab ->
+            TabListItem(
+                tab = tab,
+                onCloseClick = {},
+                onMediaClick = {},
+                onClick = {},
+                onLongClick = {},
+            )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(tabListBottomPadding))
+        }
+    }
+}
+
+/**
+ * Top-level UI for displaying a grid of tabs.
+ *
+ * @param tabs The list of [TabSessionState] to display.
+ */
+@Composable
+fun TabGrid(
+    tabs: List<TabSessionState>,
+) {
+    val tabListBottomPadding = dimensionResource(id = R.dimen.tab_tray_list_bottom_padding)
+    val state = rememberLazyGridState()
+
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = MIN_COLUMN_WIDTH_DP.dp),
+        modifier = Modifier.fillMaxSize(),
+        state = state,
+    ) {
+        items(
+            items = tabs,
+            key = { tab -> tab.id },
+        ) { tab ->
+            TabGridItem(
+                tab = tab,
+                onCloseClick = {},
+                onMediaClick = {},
+                onClick = {},
+                onLongClick = {},
+            )
+        }
+
+        item(span = { GridItemSpan(maxLineSpan) }) {
+            Spacer(modifier = Modifier.height(tabListBottomPadding))
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun TabListPreview() {
+    FirefoxTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(FirefoxTheme.colors.layer1),
+        ) {
+            TabList(
+                tabs = generateFakeTabsList(),
+            )
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun TabGridPreview() {
+    FirefoxTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(FirefoxTheme.colors.layer1),
+        ) {
+            TabGrid(
+                tabs = generateFakeTabsList(),
+            )
+        }
+    }
+}
+
+private fun generateFakeTabsList(tabCount: Int = 10): List<TabSessionState> {
+    val fakeTab = TabSessionState(
+        id = "tabId",
+        content = ContentState(
+            url = "www.mozilla.com",
+        ),
+    )
+
+    return List(tabCount) { fakeTab }
+}


### PR DESCRIPTION
Note: the disabling of the Private theme will be examined at-large in [Bug 1820897](https://bugzilla.mozilla.org/show_bug.cgi?id=1820897)https://bugzilla.mozilla.org/show_bug.cgi?id=1820897 


https://user-images.githubusercontent.com/87384386/224806154-a60466ef-54f1-4b47-b6fc-b5fb4bf38b63.mov



### Pull Request checklist

<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1814994