### PR TITLE
Bug 1822283 - Fix race condition for Ad IDs

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -2988,7 +2988,6 @@ activation:
       This will never be sent in a ping that also contains the client_id.
     send_in_pings:
       - activation
-      - client-deduplication
     bugs:
       - https://bugzilla.mozilla.org/1538011
       - https://bugzilla.mozilla.org/1501822
@@ -9075,6 +9074,23 @@ client_deduplication:
     type: string
     description: |
       A string we use to identify which run of the experiment this is.
+    send_in_pings:
+      - client-deduplication
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1817029
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1813195#c11
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - fbertsch@mozilla.com
+    expires: 122
+  hashed_gaid:
+    type: string
+    lifetime: ping
+    description: |
+      A hashed and salted version of the Google Advertising ID from the device.
     send_in_pings:
       - client-deduplication
     bugs:

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/clientdeduplication/ClientDeduplicationPing.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/clientdeduplication/ClientDeduplicationPing.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.mozilla.fenix.GleanMetrics.Activation
 import org.mozilla.fenix.GleanMetrics.ClientDeduplication
 import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.components.metrics.MetricsUtils.getHashedIdentifier
@@ -29,7 +28,7 @@ class ClientDeduplicationPing(private val context: Context) {
             // Record the metrics.
             if (hashedId != null) {
                 // We have a valid, hashed Google Advertising ID.
-                Activation.identifier.set(hashedId)
+                ClientDeduplication.hashedGaid.set(hashedId)
                 ClientDeduplication.validAdvertisingId.set(true)
             } else {
                 ClientDeduplication.validAdvertisingId.set(false)


### PR DESCRIPTION
There is a race condition when generated hashed Ad IDs because we were using a single metric rather than separate metrics for each.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1822283