### PR TITLE
Update to GeckoView Beta 112.0.20230313153916 on releases_v112

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/Gecko.kt
+++ b/android-components/plugins/dependencies/src/main/java/Gecko.kt
@@ -9,7 +9,7 @@ object Gecko {
     /**
      * GeckoView Version.
      */
-    const val version = "112.0.20230312211644"
+    const val version = "112.0.20230313153916"
 
     /**
      * GeckoView channel


### PR DESCRIPTION
This patch manually updates GV Beta to 112.0.20230313153916.