### PR TITLE
Bug 1813193 - Increased the `X` close button from the tabs tray opened tab

### DIFF
--- a/fenix/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/fenix/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -15,7 +15,7 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tab_tray_grid_item"
     android:layout_width="match_parent"
-    android:layout_height="202dp"
+    android:layout_height="wrap_content"
     android:clipChildren="false"
     android:clipToPadding="false"
     android:padding="8dp">
@@ -55,7 +55,8 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
                 android:layout_alignParentTop="true"
                 android:ellipsize="none"
                 android:fadingEdgeLength="25dp"
-                android:minHeight="30dp"
+                android:minHeight="48dp"
+                android:gravity="start|center"
                 android:paddingHorizontal="7dp"
                 android:paddingVertical="5dp"
                 android:requiresFadingEdge="horizontal"
@@ -70,8 +71,8 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
 
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/mozac_browser_tabstray_close"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
                 android:contentDescription="@string/close_tab"
                 app:layout_constraintBottom_toTopOf="@+id/horizonatal_divider"


### PR DESCRIPTION
### What
Consider increasing the X close button from the tabs tray opened tab

### Screenshots
### Issue video
https://www.loom.com/share/7496805aecc746c3ac0408b3cc19933d

### Demo video after fix
https://www.loom.com/share/208a6e3093284ece9a24e368acf4549e

### Pull Request checklist
 - [ ] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.


---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1813193