### PR TITLE
Bug 1822267 - Improve coverage for "Edit bookmarks" related UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -43,7 +43,7 @@ class BookmarksTest {
     private val bookmarksFolderName = "New Folder"
     private val testBookmark = object {
         var title: String = "Bookmark title"
-        var url: String = "https://www.test.com"
+        var url: String = "https://www.example.com"
     }
 
     @get:Rule
@@ -171,28 +171,53 @@ class BookmarksTest {
 
     @SmokeTest
     @Test
+    fun cancelEditBookmarkTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.openThreeDotMenu {
+        }.bookmarkPage {
+            clickSnackbarButton("EDIT")
+        }
+        bookmarksMenu {
+            verifyEditBookmarksView()
+            changeBookmarkTitle(testBookmark.title)
+            changeBookmarkUrl(testBookmark.url)
+        }.closeEditBookmarkSection {
+        }
+        browserScreen {
+        }.openThreeDotMenu {
+        }.openBookmarks {
+            verifyBookmarkTitle(defaultWebPage.title)
+            verifyBookmarkedURL(defaultWebPage.url.toString())
+        }
+    }
+
+    @SmokeTest
+    @Test
     fun editBookmarkTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
+        }.editBookmarkPage {
+            verifyEditBookmarksView()
+            changeBookmarkTitle(testBookmark.title)
+            changeBookmarkUrl(testBookmark.url)
+            saveEditBookmark()
+        }
+        browserScreen {
+        }.openThreeDotMenu {
         }.openBookmarks {
             registerAndCleanupIdlingResources(
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
             ) {}
-        }.openThreeDotMenu(defaultWebPage.url) {
-        }.clickEdit {
-            verifyEditBookmarksView()
-            verifyBookmarkNameEditBox()
-            verifyBookmarkURLEditBox()
-            verifyParentFolderSelector()
-            changeBookmarkTitle(testBookmark.title)
-            changeBookmarkUrl(testBookmark.url)
-            saveEditBookmark()
             verifyBookmarkTitle(testBookmark.title)
             verifyBookmarkedURL(testBookmark.url)
-            verifyKeyboardHidden()
+        }.openBookmarkWithTitle(testBookmark.title) {
+            verifyUrl("example.com")
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -75,7 +75,7 @@ class ContextMenusTest {
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInNewTab()
             verifySnackBarText("New tab opened")
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             verifyUrl(genericURL.url.toString())
         }.openTabDrawer {
             verifyNormalModeSelected()
@@ -99,7 +99,7 @@ class ContextMenusTest {
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInPrivateTab()
             verifySnackBarText("New private tab opened")
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             verifyUrl(genericURL.url.toString())
         }.openTabDrawer {
             verifyPrivateModeSelected()
@@ -179,7 +179,7 @@ class ContextMenusTest {
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextOpenImageNewTab()
             verifySnackBarText("New tab opened")
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             verifyUrl(imageResource.url.toString())
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -181,12 +181,12 @@ class SearchTest {
         }.submitQuery(queryString) {
             longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
             pressBack()
             longClickLink("Link 2")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
         }.openTabDrawer {
         }.openTabsListThreeDotMenu {
@@ -219,22 +219,22 @@ class SearchTest {
         }.submitQuery(queryString) {
             longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
             pressBack()
             longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
             pressBack()
             longClickLink("Link 2")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
             pressBack()
             longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
         }.openTabDrawer {
         }.openTabsListThreeDotMenu {
@@ -339,12 +339,12 @@ class SearchTest {
         }.submitQuery(queryString) {
             longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
             mDevice.pressBack()
             longClickLink("Link 2")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
         }.openTabDrawer {
         }.openTabsListThreeDotMenu {
@@ -386,12 +386,12 @@ class SearchTest {
         }.submitQuery(queryString) {
             longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
             mDevice.pressBack()
             longClickLink("Link 2")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
         }.openTabDrawer {
         }.openTabsListThreeDotMenu {
@@ -434,12 +434,12 @@ class SearchTest {
         }.submitQuery(queryString) {
             longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
             mDevice.pressBack()
             longClickLink("Link 2")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
         }.openTabDrawer {
         }.openTabsListThreeDotMenu {
@@ -487,12 +487,12 @@ class SearchTest {
         }.submitQuery(queryString) {
             longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
             mDevice.pressBack()
             longClickLink("Link 2")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
             waitForPageToLoad()
         }.openTabDrawer {
         }.openTabsListThreeDotMenu {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -161,7 +161,7 @@ class ThreeDotMenuMainTest {
         }.enterURLAndEnterToBrowser(webPage.url) {
             longClickLink("Link 2")
             clickContextOpenLinkInNewTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
         }.openThreeDotMenu {
             verifyDesktopSiteModeEnabled(false)
         }
@@ -191,7 +191,7 @@ class ThreeDotMenuMainTest {
         }.enterURLAndEnterToBrowser(webPage.url) {
             longClickLink("Link 2")
             clickContextOpenLinkInPrivateTab()
-            snackBarButtonClick()
+            clickSnackbarButton("SWITCH")
         }.openThreeDotMenu {
             verifyDesktopSiteModeEnabled(false)
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -32,8 +32,17 @@ import org.hamcrest.Matchers.containsString
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
@@ -90,13 +99,17 @@ class BookmarksRobot {
 
     fun verifyCopySnackBarText() = assertSnackBarText("URL copied")
 
-    fun verifyEditBookmarksView() = assertEditBookmarksView()
-
-    fun verifyBookmarkNameEditBox() = assertBookmarkNameEditBox()
-
-    fun verifyBookmarkURLEditBox() = assertBookmarkURLEditBox()
-
-    fun verifyParentFolderSelector() = assertBookmarkFolderSelector()
+    fun verifyEditBookmarksView() {
+        assertItemWithDescriptionExists(itemWithDescription("Navigate up"))
+        assertItemContainingTextExists(itemWithText(getStringResource(R.string.edit_bookmark_fragment_title)))
+        assertItemWithResIdExists(
+            itemWithResId("$packageName:id/delete_bookmark_button"),
+            itemWithResId("$packageName:id/save_bookmark_button"),
+            itemWithResId("$packageName:id/bookmarkNameEdit"),
+            itemWithResId("$packageName:id/bookmarkUrlEdit"),
+            itemWithResId("$packageName:id/bookmarkParentFolderSelector"),
+        )
+    }
 
     fun verifyKeyboardHidden() = assertKeyboardVisibility(isExpectedToBeVisible = false)
 
@@ -265,6 +278,24 @@ class BookmarksRobot {
             HomeScreenRobot().interact()
             return HomeScreenRobot.Transition()
         }
+
+        fun closeEditBookmarkSection(interact: BookmarksRobot.() -> Unit): BookmarksRobot.Transition {
+            goBackButton().click()
+
+            BookmarksRobot().interact()
+            return BookmarksRobot.Transition()
+        }
+
+        fun openBookmarkWithTitle(bookmarkTitle: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            itemWithResIdAndText("$packageName:id/title", bookmarkTitle)
+                .also {
+                    it.waitForExists(waitingTime)
+                    it.clickAndWaitForNewWindow(waitingTimeShort)
+                }
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
     }
 }
 
@@ -394,21 +425,6 @@ private fun assertUndoDeleteSnackBarButton() =
 
 private fun assertSnackBarText(text: String) =
     snackBarText().check(matches(withText(containsString(text))))
-
-private fun assertEditBookmarksView() = onView(withText("Edit bookmark"))
-    .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-
-private fun assertBookmarkNameEditBox() =
-    onView(withId(R.id.bookmarkNameEdit))
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-
-private fun assertBookmarkFolderSelector() =
-    onView(withId(R.id.bookmarkParentFolderSelector))
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-
-private fun assertBookmarkURLEditBox() =
-    onView(withId(R.id.bookmarkUrlEdit))
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertKeyboardVisibility(isExpectedToBeVisible: Boolean) =
     assertEquals(

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -395,15 +395,12 @@ class BrowserRobot {
         searchText.click()
     }
 
-    fun snackBarButtonClick() {
-        val switchButton =
-            mDevice.findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/snackbar_btn"),
-            )
-        switchButton.waitForExists(waitingTime)
-        switchButton.clickAndWaitForNewWindow(waitingTime)
-    }
+    fun clickSnackbarButton(expectedText: String) =
+        itemWithResIdAndText("$packageName:id/snackbar_btn", expectedText)
+            .also {
+                it.waitForExists(waitingTime)
+                it.click()
+            }
 
     fun clickSubmitLoginButton() = clickPageObject(webPageItemWithResourceId("submit"))
 


### PR DESCRIPTION
Bug 1822267 - Improve coverage for "Edit bookmarks" related UI tests.

Summary:
- Updated `editBookmarkTest` based on the toDoAutomation note from TestRail
- Created a new UI test cancelEditBookmarkTest based on the toDoAutomation note from TestRail
- Other refactoring work

Both bookmark editing UI tests successfully passed 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1822267