### PR TITLE
Bug 1821718 - Add feature and nimbus flag for juno onboarding

### DIFF
--- a/fenix/app/.experimenter.yaml
+++ b/fenix/app/.experimenter.yaml
@@ -31,6 +31,14 @@ homescreen:
     sections-enabled:
       type: json
       description: "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default."
+juno-onboarding:
+  description: A feature that shows juno onboarding flow.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "if true, juno onboarding is shown to the user."
 messaging:
   description: "Configuration for the messaging system.\n\nIn practice this is a set of growable lookup tables for the\nmessage controller to piece together.\n"
   hasExposure: true

--- a/fenix/app/nimbus.fml.yaml
+++ b/fenix/app/nimbus.fml.yaml
@@ -186,6 +186,14 @@ features:
         type: Boolean
         default: true
 
+  juno-onboarding:
+    description: A feature that shows juno onboarding flow.
+    variables:
+      enabled:
+        description: if true, juno onboarding is shown to the user.
+        type: Boolean
+        default: false
+
   onboarding:
     description: "A feature that configures the new user onboarding page.
     Note that onboarding is a **first run** feature, and should only be modified by first run experiments."

--- a/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -71,4 +71,9 @@ object FeatureFlags {
      * Enables the notification pre permission prompt.
      */
     const val notificationPrePermissionPromptEnabled = true
+
+    /**
+     * Enables the redesigned onboarding.
+     */
+    const val junoOnboardingEnabled = false
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1590,6 +1590,23 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
+     * Indicates if juno onboarding feature is enabled.
+     */
+    var junoOnboardingEnabled by lazyFeatureFlagPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_juno_onboarding_enabled),
+        default = { FxNimbus.features.junoOnboarding.value().enabled },
+        featureFlag = FeatureFlags.junoOnboardingEnabled,
+    )
+
+    /**
+     * Indicates if the juno onboarding has been shown to the user.
+     */
+    var isJunoOnboardingShown by booleanPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_is_juno_onboarding_shown),
+        default = false,
+    )
+
+    /**
      * Get the current mode for how https-only is enabled.
      */
     fun getHttpsOnlyMode(): HttpsOnlyMode {

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -342,4 +342,8 @@
     <!-- Notification Pre Permission Prompt -->
     <string name="pref_key_notification_pre_permission_prompt_enabled">pref_key_notification_pre_permission_prompt_enabled</string>
     <string name="pref_key_is_notification_pre_permission_prompt_shown">pref_key_is_notification_pre_permission_prompt_shown</string>
+
+    <!-- Juno Onboarding -->
+    <string name="pref_key_juno_onboarding_enabled">pref_key_juno_onboarding_enabled</string>
+    <string name="pref_key_is_juno_onboarding_shown">pref_key_is_juno_onboarding_shown</string>
 </resources>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821718