### PR TITLE
Bug 1803130 - Remove leftover .git-blame-ignore-revs file

### DIFF
--- a/fenix/.git-blame-ignore-revs
+++ b/fenix/.git-blame-ignore-revs
@@ -1,5 +1,0 @@
-# .git-blame-ignore-revs
-# For #27667 - Remove import-ordering from the list of disabled ktlint rules (#27680)
-9654b4dfb122b54b04369fe80a2f9c95811478e8
-# For #26844: Fix ktlint issues and remove them from baseline. (#26901)
-ffcef5ff2e3f78b6972dd16551f3f653b7035ccc


### PR DESCRIPTION
This file is a leftover post migration. https://github.com/mozilla-mobile/firefox-android/blob/2d0ce92593ecb04e24397c3947d1c8862c76041f/.git-blame-ignore-revs was already updated and contain the up-to-date hashes.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1803130