### PR TITLE
Bug 1822375 - Remove unneeded and now incorrect AndroidComponents.kt

### DIFF
--- a/fenix/buildSrc/src/main/java/AndroidComponents.kt
+++ b/fenix/buildSrc/src/main/java/AndroidComponents.kt
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-object AndroidComponents {
-    const val VERSION = "111.0.20230213143237"
-}


### PR DESCRIPTION
AndroidComponents.kt in Fenix is no longer used in the Monorepo and contains an outdated version. Let's remove it.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1822375