### PR TITLE
Bug 1809809 - debounce click events on wallpaper settings

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ext/Modifier.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ext/Modifier.kt
@@ -4,7 +4,14 @@
 
 package org.mozilla.fenix.compose.ext
 
+import android.os.SystemClock
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Color
@@ -49,3 +56,29 @@ fun Modifier.dashedBorder(
         )
     },
 )
+
+/**
+ * Used when clickable needs to be debounced to prevent rapid successive clicks
+ * from calling the onClick function.
+ *
+ * @param debounceInterval The length of time to wait between click events in milliseconds
+ * @param onClick Callback for when item this modifier effects is clicked
+ */
+fun Modifier.debouncedClickable(
+    debounceInterval: Long = 1000L,
+    onClick: () -> Unit,
+) = composed {
+    var lastClickTime: Long by remember { mutableStateOf(0) }
+
+    this.then(
+        Modifier.clickable(
+            onClick = {
+                val currentSystemTime = SystemClock.elapsedRealtime()
+                if (currentSystemTime - lastClickTime > debounceInterval) {
+                    onClick()
+                    lastClickTime = currentSystemTime
+                }
+            },
+        ),
+    )
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -51,6 +50,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.ClickableSubstringLink
+import org.mozilla.fenix.compose.ext.debouncedClickable
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.wallpapers.Wallpaper
 
@@ -300,7 +300,7 @@ private fun WallpaperThumbnailItem(
             .fillMaxWidth()
             .aspectRatio(aspectRatio)
             .then(border)
-            .clickable { onSelect(wallpaper) }
+            .debouncedClickable { onSelect(wallpaper) }
             .then(contentDescriptionModifier),
     ) {
         bitmap?.let {


### PR DESCRIPTION
Added debouncing to the button click event for `WallpaperThumbnailItem` so that a rapid second click doesn't trigger the snackbar again before the new `currentWallpaper` is set from the initial click.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1809809