### PR TITLE
Bug 1815620 - Truncate long tab titles before they are composed

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
@@ -42,12 +42,14 @@ import androidx.compose.ui.unit.sp
 import androidx.core.text.BidiFormatter
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
+import mozilla.components.support.ktx.kotlin.MAX_URI_LENGTH
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.Divider
 import org.mozilla.fenix.compose.Favicon
 import org.mozilla.fenix.compose.HorizontalFadingEdgeBox
 import org.mozilla.fenix.compose.ThumbnailCard
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.tabstray.ext.toDisplayTitle
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -135,7 +137,7 @@ fun TabGridItem(
                         isContentRtl = BidiFormatter.getInstance().isRtl(tab.content.title),
                     ) {
                         Text(
-                            text = tab.content.title,
+                            text = tab.toDisplayTitle().take(MAX_URI_LENGTH),
                             fontSize = 14.sp,
                             maxLines = 1,
                             softWrap = false,

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
@@ -28,10 +28,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
+import mozilla.components.support.ktx.kotlin.MAX_URI_LENGTH
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.ThumbnailCard
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.ext.toShortUrl
+import org.mozilla.fenix.tabstray.ext.toDisplayTitle
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -91,7 +93,7 @@ fun TabListItem(
                 .weight(weight = 1f),
         ) {
             Text(
-                text = tab.content.title,
+                text = tab.toDisplayTitle().take(MAX_URI_LENGTH),
                 fontSize = 16.sp,
                 maxLines = 2,
                 color = FirefoxTheme.colors.textPrimary,


### PR DESCRIPTION
This fix is the Compose analog of a patch from a few weeks ago. https://github.com/mozilla-mobile/fenix/pull/28792

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815620