### PR TITLE
Bug 1820897 - Disable the private theme from being used in the Composified Tabs Tray

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
@@ -27,7 +27,6 @@ import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.compose.Divider
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.theme.FirefoxTheme
-import org.mozilla.fenix.theme.Theme
 
 /**
  * Top-level UI for displaying the Tabs Tray feature.
@@ -76,16 +75,14 @@ fun TabsTray(
             ) { position ->
                 when (Page.positionToPage(position)) {
                     Page.NormalTabs -> {
-                        FirefoxTheme(theme = Theme.getTheme(allowPrivateTheme = false)) {
-                            if (displayTabsInGrid) {
-                                TabGrid(
-                                    tabs = normalTabs,
-                                )
-                            } else {
-                                TabList(
-                                    tabs = normalTabs,
-                                )
-                            }
+                        if (displayTabsInGrid) {
+                            TabGrid(
+                                tabs = normalTabs,
+                            )
+                        } else {
+                            TabList(
+                                tabs = normalTabs,
+                            )
                         }
                     }
                     Page.PrivateTabs -> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -61,6 +61,7 @@ import org.mozilla.fenix.tabstray.ext.make
 import org.mozilla.fenix.tabstray.ext.showWithTheme
 import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsIntegration
 import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.theme.Theme
 import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.allowUndo
 import kotlin.math.max
@@ -205,7 +206,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
             )
 
             tabsTrayComposeBinding.root.setContent {
-                FirefoxTheme {
+                FirefoxTheme(theme = Theme.getTheme(allowPrivateTheme = false)) {
                     TabsTray(
                         tabsTrayStore = tabsTrayStore,
                         displayTabsInGrid = requireContext().settings().gridTabView,


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1820897