### PR TITLE
Bug 1802627 - Microphone icon is incorrectly placed on the 2x1 size widget

### DIFF
--- a/android-components/components/feature/search/src/main/res/layout/mozac_search_widget_small.xml
+++ b/android-components/components/feature/search/src/main/res/layout/mozac_search_widget_small.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="50dp"
-    android:background="@drawable/mozac_rounded_search_widget_background"
-    android:orientation="horizontal">
+    android:background="@drawable/mozac_rounded_search_widget_background" >
 
     <ImageView
         android:id="@+id/mozac_button_search_widget_new_tab_icon"
+        android:layout_alignParentStart="true"
         android:layout_width="50dp"
         android:layout_height="50dp"
         android:contentDescription="@string/search_widget_content_description"
@@ -16,6 +16,7 @@
 
     <ImageView
         android:id="@+id/mozac_button_search_widget_voice"
+        android:layout_alignParentEnd="true"
         android:layout_width="50dp"
         android:layout_height="50dp"
         android:contentDescription="@string/search_widget_voice"
@@ -23,4 +24,4 @@
         android:background="@android:color/transparent"
         android:scaleType="centerInside" />
 
-</LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
This PR fixes issue where microphone icon is not placed correctly in 2x1 widget for Firefox Focus app.
> Bugzilla issue [#1802627](https://bugzilla.mozilla.org/show_bug.cgi?id=1802627))
> GitHub issue [#7547](https://github.com/mozilla-mobile/focus-android/issues/7547) 

<img src="https://user-images.githubusercontent.com/13991373/223923320-954b7f62-f169-4623-ad1c-95dd0f800001.png" width="250"/>


**Reproduction step**

https://user-images.githubusercontent.com/13991373/223920673-b6a6d18d-f5d1-4d72-b7c8-1210c7cd471a.mov 

<br> **Fix Description**

Changed parent container to `RelativeLayout` to distribute two child views in start & end of the parent container.
> No additional tests added

- Screenshot
![fix-screenshot](https://user-images.githubusercontent.com/13991373/223920862-43782ce4-d8d3-4e04-b7c5-86c6cc418555.png)

- Recording

https://user-images.githubusercontent.com/13991373/223920980-d14e3f1a-cf63-4436-a5e4-d7f13ede9a70.mov



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Milestone**: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- **Breaking Changes**: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1802627