### PR TITLE
Bug 1821479 - Add support for fullscreen custom tabs

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
@@ -73,12 +73,14 @@ fun createCustomTab(
     private: Boolean = false,
     webAppManifest: WebAppManifest? = null,
     initialLoadFlags: EngineSession.LoadUrlFlags = EngineSession.LoadUrlFlags.none(),
+    fullscreen: Boolean = false,
 ): CustomTabSessionState {
     return CustomTabSessionState(
         id = id,
         source = source,
         content = ContentState(
             url = url,
+            fullScreen = fullscreen,
             title = title,
             private = private,
             webAppManifest = webAppManifest,

--- a/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/CustomTabsUseCases.kt
+++ b/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/CustomTabsUseCases.kt
@@ -38,11 +38,13 @@ class CustomTabsUseCases(
             private: Boolean = false,
             additionalHeaders: Map<String, String>? = null,
             source: SessionState.Source,
+            fullscreen: Boolean = false,
         ): String {
             val loadUrlFlags = EngineSession.LoadUrlFlags.external()
             val tab = createCustomTab(
                 url = url,
                 private = private,
+                fullscreen = fullscreen,
                 source = source,
                 config = customTabConfig,
                 initialLoadFlags = loadUrlFlags,

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -198,7 +198,6 @@ abstract class BaseBrowserFragment :
     private val findInPageIntegration = ViewBoundFeatureWrapper<FindInPageIntegration>()
     private val toolbarIntegration = ViewBoundFeatureWrapper<ToolbarIntegration>()
     private val sitePermissionsFeature = ViewBoundFeatureWrapper<SitePermissionsFeature>()
-    private val fullScreenFeature = ViewBoundFeatureWrapper<FullScreenFeature>()
     private val swipeRefreshFeature = ViewBoundFeatureWrapper<SwipeRefreshFeature>()
     private val webchannelIntegration = ViewBoundFeatureWrapper<FxaWebChannelFeature>()
     private val sitePermissionWifiIntegration =
@@ -212,6 +211,9 @@ abstract class BaseBrowserFragment :
     private val biometricPromptFeature = ViewBoundFeatureWrapper<BiometricPromptFeature>()
     private val crashContentIntegration = ViewBoundFeatureWrapper<CrashContentIntegration>()
     private var pipFeature: PictureInPictureFeature? = null
+
+    @VisibleForTesting
+    internal var fullScreenFeature = ViewBoundFeatureWrapper<FullScreenFeature>()
 
     var customTabSessionId: String? = null
 
@@ -1160,7 +1162,7 @@ abstract class BaseBrowserFragment :
 
         if (browserInitialized) {
             view?.let {
-                fullScreenChanged(false)
+                fullScreenFeature.get()?.exitFullscreenMode()
                 browserToolbarView.expand()
 
                 val toolbarHeight = resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
@@ -1204,7 +1206,7 @@ abstract class BaseBrowserFragment :
             ?.let { session ->
                 // If we didn't enter PiP, exit full screen on stop
                 if (!session.content.pictureInPictureEnabled && fullScreenFeature.onBackPressed()) {
-                    fullScreenChanged(false)
+                    fullScreenFeature.get()?.exitFullscreenMode()
                 }
             }
     }
@@ -1421,7 +1423,7 @@ abstract class BaseBrowserFragment :
     private fun pipModeChanged(session: SessionState) {
         if (!session.content.pictureInPictureEnabled && session.content.fullScreen && isAdded) {
             onBackPressed()
-            fullScreenChanged(false)
+            fullScreenFeature.get()?.exitFullscreenMode()
         }
     }
 
@@ -1486,6 +1488,7 @@ abstract class BaseBrowserFragment :
      * Dereference these views when the fragment view is destroyed to prevent memory leaks
      */
     override fun onDestroyView() {
+        fullScreenChanged(false)
         super.onDestroyView()
 
         // Diagnostic breadcrumb for "Display already aquired" crash:

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -9,11 +9,16 @@ import android.content.Intent
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
+import mozilla.components.browser.state.state.CustomTabConfig
+import mozilla.components.browser.state.state.SessionState
 import mozilla.components.support.ktx.android.content.appVersionName
 import mozilla.components.support.ktx.android.content.getColorFromAttr
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.BuildConfig
+import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.settings.account.AuthIntentReceiverActivity
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
@@ -110,6 +115,26 @@ object SupportUtils {
         .setData(url.toUri())
         .setClassName(context, IntentReceiverActivity::class.java.name)
         .setPackage(context.packageName)
+
+    /**
+     * Opens a custom fullscreen tab.
+     */
+    fun startCustomFullscreenTab(
+        activity: HomeActivity,
+        from: BrowserDirection,
+        url: String,
+        isPrivate: Boolean,
+        config: CustomTabConfig = CustomTabConfig(),
+    ) {
+        val sessionId = activity.components.useCases.customTabsUseCases.add(
+            url,
+            config,
+            fullscreen = true,
+            private = isPrivate,
+            source = SessionState.Source.Internal.CustomTab,
+        )
+        activity.openToBrowser(from, sessionId)
+    }
 
     fun createAuthCustomTabIntent(context: Context, url: String): Intent =
         createCustomTabIntent(context, url).setClassName(context, AuthIntentReceiverActivity::class.java.name)

--- a/fenix/app/src/test/java/org/mozilla/fenix/browser/BrowserFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/browser/BrowserFragmentTest.kt
@@ -27,6 +27,7 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.feature.session.FullScreenFeature
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.After
@@ -148,10 +149,15 @@ class BrowserFragmentTest {
     fun `GIVEN browser UI is initialized WHEN selected tab changes THEN full screen mode is exited`() {
         browserFragment.browserInitialized = true
         browserFragment.observeTabSelection(store)
+        val fullscreenFeature: FullScreenFeature = mockk(relaxed = true)
+        browserFragment.fullScreenFeature = mockk {
+            every { get() } returns fullscreenFeature
+        }
 
         val newSelectedTab = createTab("https://firefox.com")
         addAndSelectTab(newSelectedTab)
-        verify(exactly = 1) { browserFragment.fullScreenChanged(false) }
+
+        verify(exactly = 1) { fullscreenFeature.exitFullscreenMode() }
     }
 
     @Test

--- a/fenix/app/src/test/java/org/mozilla/fenix/settings/SupportUtilsTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/settings/SupportUtilsTest.kt
@@ -9,8 +9,14 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.feature.tabs.CustomTabsUseCases
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.ext.components
 import java.util.Locale
 
 class SupportUtilsTest {
@@ -41,6 +47,27 @@ class SupportUtilsTest {
             "https://support.mozilla.org/de/kb/your-rights",
             SupportUtils.getGenericSumoURLForTopic(SupportUtils.SumoTopic.YOUR_RIGHTS, Locale("de")),
         )
+    }
+
+    @Test
+    fun `WHEN startCustomFullscreenTab is called THEN open a custom fullscreen tab`() {
+        val activity = mockk<HomeActivity>(relaxed = true)
+        val url = "www.mozilla.org"
+        val addUseCase = mockk<CustomTabsUseCases>(relaxed = true)
+        every { activity.components.useCases.customTabsUseCases } returns addUseCase
+
+        SupportUtils.startCustomFullscreenTab(activity, BrowserDirection.FromHome, url, false)
+
+        verify {
+            addUseCase.add(
+                url,
+                any(),
+                fullscreen = true,
+                private = false,
+                source = SessionState.Source.Internal.CustomTab,
+            )
+            activity.openToBrowser(BrowserDirection.FromHome, any())
+        }
     }
 
     @Test


### PR DESCRIPTION
Added support for fullscreen custom tabs.

https://user-images.githubusercontent.com/35462038/226352974-ed1f2042-5eff-4423-b5f3-4de1af3808e1.mp4

https://user-images.githubusercontent.com/35462038/225335562-aa709caf-0e33-43a6-91c0-1fd8e44dc42d.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821479