### PR TITLE
Bug 1816059 - Show the notification for entering fullscreen as a Toast

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -17,6 +17,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityManager
+import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.CallSuper
 import androidx.annotation.VisibleForTesting
@@ -1442,12 +1443,8 @@ abstract class BaseBrowserFragment :
         if (inFullScreen) {
             // Close find in page bar if opened
             findInPageIntegration.onBackPressed()
-            FenixSnackbar.make(
-                view = binding.dynamicSnackbarContainer,
-                duration = Snackbar.LENGTH_SHORT,
-                isDisplayedWithBrowserToolbar = false,
-            )
-                .setText(getString(R.string.full_screen_notification))
+            Toast
+                .makeText(requireContext(), R.string.full_screen_notification, Toast.LENGTH_SHORT)
                 .show()
             activity?.enterToImmersiveMode()
             (view as? SwipeGestureLayout)?.isSwipeEnabled = false

--- a/focus-android/app/src/main/java/org/mozilla/focus/browser/integration/FullScreenIntegration.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/browser/integration/FullScreenIntegration.kt
@@ -7,9 +7,9 @@ package org.mozilla.focus.browser.integration
 import android.app.Activity
 import android.os.Build
 import android.view.View
+import android.widget.Toast
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.isVisible
-import com.google.android.material.snackbar.Snackbar
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.EngineView
@@ -24,7 +24,6 @@ import org.mozilla.focus.ext.disableDynamicBehavior
 import org.mozilla.focus.ext.enableDynamicBehavior
 import org.mozilla.focus.ext.hide
 import org.mozilla.focus.ext.showAsFixed
-import org.mozilla.focus.utils.FocusSnackbarDelegate
 import org.mozilla.focus.utils.Settings
 
 class FullScreenIntegration(
@@ -60,11 +59,9 @@ class FullScreenIntegration(
             enterBrowserFullscreen()
             statusBar.isVisible = false
 
-            FocusSnackbarDelegate(toolbarView).show(
-                toolbarView,
-                R.string.full_screen_notification,
-                Snackbar.LENGTH_SHORT,
-            )
+            Toast
+                .makeText(activity, R.string.full_screen_notification, Toast.LENGTH_SHORT)
+                .show()
 
             switchToImmersiveMode()
         } else {


### PR DESCRIPTION

| Result on Fenix | Result on Focus |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/11428869/225364322-5c853785-17cc-45c7-b4a8-6ff78a055653.mp4" /> | <video src="https://user-images.githubusercontent.com/11428869/225364404-f46652cf-89eb-4184-be68-360e7cfad6e1.mp4" /> |





### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816059