### PR TITLE
Bug 1822611 - New open links in apps related UI smoke tests

### DIFF
--- a/fenix/app/src/androidTest/assets/pages/externalLinks.html
+++ b/fenix/app/src/androidTest/assets/pages/externalLinks.html
@@ -19,4 +19,8 @@
     <a href="tel://1234567890">Telephone link</a>
 </section>
 
+<section>
+    <a href="https://m.youtube.com/user/mozilla?cbrd=1">Youtube link</a>
+</section>
+
 </html>

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -79,7 +79,7 @@ class PwaTest {
             clickAddAutomaticallyButton()
         }.openHomeScreenShortcut(shortcutTitle) {
             clickLinkMatchingText("Telephone link")
-            clickOpenInAppPromptButton()
+            confirmOpenLinkInAnotherApp()
             assertNativeAppOpens(PHONE_APP, phoneLink)
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -6,17 +6,21 @@ package org.mozilla.fenix.ui
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import mozilla.components.concept.engine.utils.EngineReleaseChannel
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.Constants.PackageName.YOUTUBE_APP
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper
-import org.mozilla.fenix.ui.robots.clickAlwaysButton
+import org.mozilla.fenix.helpers.TestHelper.assertNativeAppOpens
+import org.mozilla.fenix.helpers.TestHelper.exitMenu
+import org.mozilla.fenix.helpers.TestHelper.runWithCondition
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -32,10 +36,7 @@ class SettingsAdvancedTest {
     private lateinit var mockWebServer: MockWebServer
 
     @get:Rule
-    val activityIntentTestRule = HomeActivityIntentTestRule(
-        isPocketEnabled = false,
-        isTCPCFREnabled = false,
-    )
+    val activityIntentTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
 
     @Before
     fun setUp() {
@@ -68,28 +69,348 @@ class SettingsAdvancedTest {
         }
     }
 
+    @SmokeTest
+    @Test
+    fun verifyOpenLinkInAppViewTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+            }
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun verifyOpenLinkInAppViewInPrivateBrowsingTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            homeScreen {
+            }.togglePrivateBrowsingMode()
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+            }
+        }
+    }
+
     // Assumes Play Store is installed and enabled
     @SmokeTest
     @Test
-    fun openLinkInAppTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 3)
+    fun neverOpenLinkInAppTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
 
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openSettings {
-            verifyOpenLinksInAppsButton()
-            verifyOpenLinksInAppsState("Never")
-        }.openOpenLinksInAppsMenu {
-            clickAlwaysButton()
-        }.goBack {
-        }.goBack {}
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+            }
 
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            mDevice.waitForIdle()
-            clickLinkMatchingText("Mozilla Playstore link")
-            mDevice.waitForIdle()
-            TestHelper.assertPlayStoreOpens()
+            exitMenu()
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                waitForPageToLoad()
+                verifyUrl("youtube.com")
+            }
+        }
+    }
+
+    // Assumes Play Store is installed and enabled
+    @SmokeTest
+    @Test
+    fun privateBrowsingNeverOpenLinkInAppTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
+
+            homeScreen {
+            }.togglePrivateBrowsingMode()
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+            }
+
+            exitMenu()
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                waitForPageToLoad()
+                verifyUrl("youtube.com")
+            }
+        }
+    }
+
+    // Assumes Play Store is installed and enabled
+    @SmokeTest
+    @Test
+    fun cancelOpeningLinkInAppTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+                clickOpenLinkInAppOption("Ask before opening")
+                verifySelectedOpenLinksInAppOption("Ask before opening")
+            }.goBack {
+                verifyOpenLinksInAppsState("Ask before opening")
+            }
+
+            exitMenu()
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                verifyOpenLinkInAnotherAppPrompt()
+                cancelOpenLinkInAnotherApp()
+                waitForPageToLoad()
+                verifyUrl("youtube.com")
+            }
+        }
+    }
+
+    // Assumes Play Store is installed and enabled
+    @SmokeTest
+    @Test
+    fun privateBrowsingCancelOpeningLinkInAppTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
+
+            homeScreen {
+            }.togglePrivateBrowsingMode()
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+                clickOpenLinkInAppOption("Ask before opening")
+                verifySelectedOpenLinksInAppOption("Ask before opening")
+            }.goBack {
+                verifyOpenLinksInAppsState("Ask before opening")
+            }
+
+            exitMenu()
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
+                cancelOpenLinkInAnotherApp()
+                waitForPageToLoad()
+                verifyUrl("youtube.com")
+            }
+        }
+    }
+
+    // Assumes Play Store is installed and enabled
+    @SmokeTest
+    @Test
+    fun askBeforeOpeningLinkInAppTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+                clickOpenLinkInAppOption("Ask before opening")
+                verifySelectedOpenLinksInAppOption("Ask before opening")
+            }.goBack {
+                verifyOpenLinksInAppsState("Ask before opening")
+            }
+
+            exitMenu()
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                verifyOpenLinkInAnotherAppPrompt()
+                confirmOpenLinkInAnotherApp()
+                mDevice.waitForIdle()
+                assertNativeAppOpens(YOUTUBE_APP, defaultWebPage.url.toString())
+            }
+        }
+    }
+
+    // Assumes Play Store is installed and enabled
+    @SmokeTest
+    @Test
+    fun privateBrowsingAskBeforeOpeningLinkInAppTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
+
+            homeScreen {
+            }.togglePrivateBrowsingMode()
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+                clickOpenLinkInAppOption("Ask before opening")
+                verifySelectedOpenLinksInAppOption("Ask before opening")
+            }.goBack {
+                verifyOpenLinksInAppsState("Ask before opening")
+            }
+
+            exitMenu()
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
+                confirmOpenLinkInAnotherApp()
+                mDevice.waitForIdle()
+                assertNativeAppOpens(YOUTUBE_APP, defaultWebPage.url.toString())
+            }
+        }
+    }
+
+    // Assumes Play Store is installed and enabled
+    @SmokeTest
+    @Test
+    fun alwaysOpenLinkInAppTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+                clickOpenLinkInAppOption("Always")
+                verifySelectedOpenLinksInAppOption("Always")
+            }.goBack {
+                verifyOpenLinksInAppsState("Always")
+            }
+
+            exitMenu()
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                mDevice.waitForIdle()
+                assertNativeAppOpens(YOUTUBE_APP, defaultWebPage.url.toString())
+            }
+        }
+    }
+
+    // Assumes Play Store is installed and enabled
+    @SmokeTest
+    @Test
+    fun privateBrowsingAlwaysOpenLinkInAppTest() {
+        runWithCondition(
+            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
+            // Once this feature lands in RC we should remove the wrapper.
+            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
+                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
+        ) {
+            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
+
+            homeScreen {
+            }.togglePrivateBrowsingMode()
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+                verifyOpenLinksInAppsButton()
+                verifyOpenLinksInAppsState("Never")
+            }.openOpenLinksInAppsMenu {
+                verifyOpenLinksInAppsView("Never")
+                clickOpenLinkInAppOption("Always")
+                verifySelectedOpenLinksInAppOption("Always")
+            }.goBack {
+                verifyOpenLinksInAppsState("Always")
+            }
+
+            exitMenu()
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
+                confirmOpenLinkInAnotherApp()
+                mDevice.waitForIdle()
+                assertNativeAppOpens(YOUTUBE_APP, defaultWebPage.url.toString())
+            }
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/WebControlsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/WebControlsTest.kt
@@ -170,7 +170,7 @@ class WebControlsTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(externalLinksPage.url) {
             clickLinkMatchingText("Email link")
-            clickOpenInAppPromptButton()
+            confirmOpenLinkInAnotherApp()
             assertNativeAppOpens(Constants.PackageName.GMAIL_APP, emailLink)
         }
     }
@@ -182,7 +182,7 @@ class WebControlsTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(externalLinksPage.url) {
             clickLinkMatchingText("Telephone link")
-            clickOpenInAppPromptButton()
+            confirmOpenLinkInAnotherApp()
             assertNativeAppOpens(Constants.PackageName.PHONE_APP, phoneLink)
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -45,8 +45,10 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.MatcherHelper
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
@@ -1013,8 +1015,35 @@ class BrowserRobot {
             it.click()
         }
 
-    fun clickOpenInAppPromptButton() =
+    fun verifyOpenLinkInAnotherAppPrompt() {
+        assertItemWithResIdExists(itemWithResId("$packageName:id/parentPanel"))
+        assertItemContainingTextExists(
+            itemContainingText(
+                getStringResource(R.string.mozac_feature_applinks_normal_confirm_dialog_title),
+            ),
+            itemContainingText(
+                getStringResource(R.string.mozac_feature_applinks_normal_confirm_dialog_message),
+            ),
+        )
+    }
+
+    fun verifyPrivateBrowsingOpenLinkInAnotherAppPrompt(url: String) =
+        assertItemContainingTextExists(
+            itemContainingText(
+                getStringResource(R.string.mozac_feature_applinks_confirm_dialog_title),
+            ),
+            itemContainingText(url),
+        )
+
+    fun confirmOpenLinkInAnotherApp() =
         itemWithResIdAndText("android:id/button1", "OPEN")
+            .also {
+                it.waitForExists(waitingTime)
+                it.click()
+            }
+
+    fun cancelOpenLinkInAnotherApp() =
+        itemWithResIdAndText("android:id/button2", "CANCEL")
             .also {
                 it.waitForExists(waitingTime)
                 it.click()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuOpenLinksInAppsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuOpenLinksInAppsRobot.kt
@@ -5,32 +5,67 @@
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.allOf
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.isChecked
 
 /**
  * Implementation of Robot Pattern for the Open Links In Apps sub menu.
  */
 class SettingsSubMenuOpenLinksInAppsRobot {
 
+    fun verifyOpenLinksInAppsView(selectedOpenLinkInAppsOption: String) {
+        assertItemWithDescriptionExists(goBackButton)
+        assertItemContainingTextExists(
+            itemContainingText(getStringResource(R.string.preferences_open_links_in_apps)),
+            itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_always)),
+            itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_ask)),
+            itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_never)),
+        )
+        verifySelectedOpenLinksInAppOption(selectedOpenLinkInAppsOption)
+    }
+
+    fun verifySelectedOpenLinksInAppOption(openLinkInAppsOption: String) =
+        onView(
+            allOf(
+                withId(R.id.radio_button),
+                hasSibling(withText(openLinkInAppsOption)),
+            ),
+        ).check(matches(isChecked(true)))
+
+    fun clickOpenLinkInAppOption(openLinkInAppsOption: String) {
+        when (openLinkInAppsOption) {
+            "Always" -> alwaysOption.click()
+            "Ask before opening" -> askBeforeOpeningOption.click()
+            "Never" -> neverOption.click()
+        }
+    }
+
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
             mDevice.waitForIdle()
-            goBackButton().perform(ViewActions.click())
+            goBackButton.click()
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()
         }
     }
 }
-
-fun clickAlwaysButton() = alwaysRadioButton().click()
-
-private fun alwaysRadioButton() = onView(withText("Always"))
-
-private fun goBackButton() =
-    onView(allOf(ViewMatchers.withContentDescription("Navigate up")))
+private val goBackButton = itemWithDescription("Navigate up")
+private val alwaysOption =
+    itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_always))
+private val askBeforeOpeningOption =
+    itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_ask))
+private val neverOption =
+    itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_never))


### PR DESCRIPTION
Bug 1822611 - New open links in apps related UI smoke tests

Summary:
- Refactored existing UI smoke test to match the new functionality
- Created new UI smoke tests based on TestRail toDoAutomation notes
- Added running conditions (the upgraded feature is not available yet on the RC, 111 branch)
- Added a Youtube link to the `externalLinks.html` asset because it didn't work properly with the Playstore link from `generic3.html`

✅ All 10 UI tests successfully passed 100x on Firebase. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1822611