### PR TITLE
Bug 1822606 - Refactor HomeFragment.navigateToSearch() to the ToolbarController

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -79,14 +79,12 @@ import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import org.mozilla.fenix.Config
-import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.HomeScreen
 import org.mozilla.fenix.GleanMetrics.PrivateBrowsingShortcutCfr
 import org.mozilla.fenix.GleanMetrics.UnifiedSearch
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.addons.showSnackBar
-import org.mozilla.fenix.browser.BrowserAnimator.Companion.getToolbarNavOptions
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.PrivateShortcutCreateManager
@@ -590,7 +588,7 @@ class HomeFragment : Fragment() {
         binding.toolbar.compoundDrawablePadding =
             view.resources.getDimensionPixelSize(R.dimen.search_bar_search_engine_icon_padding)
         binding.toolbarWrapper.setOnClickListener {
-            navigateToSearch()
+            sessionControlInteractor.onNavigateSearch()
         }
 
         binding.toolbarWrapper.setOnLongClickListener {
@@ -627,7 +625,7 @@ class HomeFragment : Fragment() {
         updateTabCounter(requireComponents.core.store.state)
 
         if (bundleArgs.getBoolean(FOCUS_ON_ADDRESS_BAR)) {
-            navigateToSearch()
+            sessionControlInteractor.onNavigateSearch()
         } else if (bundleArgs.getBoolean(SCROLL_TO_COLLECTION)) {
             MainScope().launch {
                 delay(ANIM_SCROLL_DELAY)
@@ -971,19 +969,7 @@ class HomeFragment : Fragment() {
     private fun hideOnboardingAndOpenSearch() {
         hideOnboardingIfNeeded()
         appBarLayout?.setExpanded(true, true)
-        navigateToSearch()
-    }
-
-    @VisibleForTesting
-    internal fun navigateToSearch() {
-        val directions =
-            HomeFragmentDirections.actionGlobalSearchDialog(
-                sessionId = null,
-            )
-
-        nav(R.id.homeFragment, directions, getToolbarNavOptions(requireContext()))
-
-        Events.searchBarTapped.record(Events.SearchBarTappedExtra("HOME"))
+        sessionControlInteractor.onNavigateSearch()
     }
 
     private fun subscribeToTabCollections(): Observer<List<TabCollection>> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -169,6 +169,11 @@ interface SessionControlController {
     fun handlePaste(clipboardText: String)
 
     /**
+     * @see [ToolbarInteractor.onNavigateSearch]
+     */
+    fun handleNavigateSearch()
+
+    /**
      * @see [CollectionInteractor.onAddTabsToCollectionTapped]
      */
     fun handleCreateCollection()
@@ -607,6 +612,21 @@ class DefaultSessionControlController(
             pastedText = clipboardText,
         )
         navController.nav(R.id.homeFragment, directions)
+    }
+
+    override fun handleNavigateSearch() {
+        val directions =
+            HomeFragmentDirections.actionGlobalSearchDialog(
+                sessionId = null,
+            )
+
+        navController.nav(
+            R.id.homeFragment,
+            directions,
+            BrowserAnimator.getToolbarNavOptions(activity),
+        )
+
+        Events.searchBarTapped.record(Events.SearchBarTappedExtra("HOME"))
     }
 
     override fun handleMessageClicked(message: Message) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -146,6 +146,11 @@ interface ToolbarInteractor {
      * Navigates to search with clipboard text.
      */
     fun onPaste(clipboardText: String)
+
+    /**
+     * Navigates to the search dialog.
+     */
+    fun onNavigateSearch()
 }
 
 interface CustomizeHomeIteractor {
@@ -343,6 +348,10 @@ class SessionControlInteractor(
 
     override fun onPaste(clipboardText: String) {
         controller.handlePaste(clipboardText)
+    }
+
+    override fun onNavigateSearch() {
+        controller.handleNavigateSearch()
     }
 
     override fun onRemoveCollectionsPlaceholder() {

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -1047,6 +1047,25 @@ class DefaultSessionControlControllerTest {
     }
 
     @Test
+    fun handleNavigateSearch() {
+        assertNull(Events.searchBarTapped.testGetValue())
+
+        createController().handleNavigateSearch()
+
+        assertNotNull(Events.searchBarTapped.testGetValue())
+        val recordedEvents = Events.searchBarTapped.testGetValue()!!
+        assertEquals(1, recordedEvents.size)
+        assertEquals("HOME", recordedEvents.single().extra?.getValue("source"))
+
+        verify {
+            navController.navigate(
+                match<NavDirections> { it.actionId == R.id.action_global_search_dialog },
+                any<NavOptions>(),
+            )
+        }
+    }
+
+    @Test
     fun handleRemoveCollectionsPlaceholder() {
         createController().handleRemoveCollectionsPlaceholder()
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -138,6 +138,12 @@ class SessionControlInteractorTest {
     }
 
     @Test
+    fun onNavigateSearch() {
+        interactor.onNavigateSearch()
+        verify { controller.handleNavigateSearch() }
+    }
+
+    @Test
     fun onRemoveCollectionsPlaceholder() {
         interactor.onRemoveCollectionsPlaceholder()
         verify { controller.handleRemoveCollectionsPlaceholder() }


### PR DESCRIPTION




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1822606