### PR TITLE
Bug 1822634 - Refactor tab counter code from HomeFragment into TabCounterView

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -188,7 +188,9 @@ class HomeFragment : Fragment() {
         get() = _sessionControlInteractor!!
 
     private var sessionControlView: SessionControlView? = null
+    private var tabCounterView: TabCounterView? = null
     private var appBarLayout: AppBarLayout? = null
+
     private lateinit var currentMode: CurrentMode
 
     private var lastAppliedWallpaperName: String = Wallpaper.defaultName
@@ -580,7 +582,7 @@ class HomeFragment : Fragment() {
             hideOnboardingIfNeeded = ::hideOnboardingIfNeeded,
         ).build()
 
-        TabCounterView(
+        tabCounterView = TabCounterView(
             context = requireContext(),
             browsingModeManager = browsingModeManager,
             navController = findNavController(),
@@ -611,7 +613,8 @@ class HomeFragment : Fragment() {
         }
 
         consumeFrom(requireComponents.core.store) {
-            updateTabCounter(it)
+            tabCounterView?.update(it)
+            showCollectionsPlaceholder(it)
         }
 
         homeViewModel.sessionToDelete?.also {
@@ -624,7 +627,7 @@ class HomeFragment : Fragment() {
 
         homeViewModel.sessionToDelete = null
 
-        updateTabCounter(requireComponents.core.store.state)
+        tabCounterView?.update(requireComponents.core.store.state)
 
         if (bundleArgs.getBoolean(FOCUS_ON_ADDRESS_BAR)) {
             navigateToSearch()
@@ -789,8 +792,10 @@ class HomeFragment : Fragment() {
 
         _sessionControlInteractor = null
         sessionControlView = null
+        tabCounterView = null
         appBarLayout = null
         _binding = null
+
         bundleArgs.clear()
         lastAppliedWallpaperName = Wallpaper.defaultName
     }
@@ -1020,16 +1025,13 @@ class HomeFragment : Fragment() {
         )
     }
 
-    // TODO use [FenixTabCounterToolbarButton] instead of [TabCounter]:
-    // https://github.com/mozilla-mobile/fenix/issues/16792
-    private fun updateTabCounter(browserState: BrowserState) {
+    private fun showCollectionsPlaceholder(browserState: BrowserState) {
         val tabCount = if (browsingModeManager.mode.isPrivate) {
             browserState.privateTabs.size
         } else {
             browserState.normalTabs.size
         }
 
-        binding.tabButton.setCountWithAnimation(tabCount)
         // The add_tabs_to_collections_button is added at runtime. We need to search for it in the same way.
         sessionControlView?.view?.findViewById<MaterialButton>(R.id.add_tabs_to_collections_button)
             ?.isVisible = tabCount > 0

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/TabCounterView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/TabCounterView.kt
@@ -7,6 +7,9 @@ package org.mozilla.fenix.home
 import android.content.Context
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
+import mozilla.components.browser.state.selector.normalTabs
+import mozilla.components.browser.state.selector.privateTabs
+import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.ui.tabcounter.TabCounter
 import mozilla.components.ui.tabcounter.TabCounterMenu
 import mozilla.telemetry.glean.private.NoExtras
@@ -63,6 +66,22 @@ class TabCounterView(
                 HomeFragmentDirections.actionGlobalTabsTrayFragment(),
             )
         }
+    }
+
+    /**
+     * Updates the tab counter count based on the current browser state.
+     *
+     * @param browserState [BrowserState] used to get the current tab count for the current
+     * browsing mode.
+     */
+    fun update(browserState: BrowserState) {
+        val tabCount = if (browsingModeManager.mode.isPrivate) {
+            browserState.privateTabs.size
+        } else {
+            browserState.normalTabs.size
+        }
+
+        tabCounter.setCountWithAnimation(tabCount)
     }
 
     /**


### PR DESCRIPTION




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1822634