### PR TITLE
Bug 1814995 - Add private tabs to `TabsTray`

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
@@ -44,6 +44,8 @@ fun TabsTray(
         .observeAsComposableState { state -> state.mode }.value ?: TabsTrayState.Mode.Normal
     val normalTabs = tabsTrayStore
         .observeAsComposableState { state -> state.normalTabs }.value ?: emptyList()
+    val privateTabs = tabsTrayStore
+        .observeAsComposableState { state -> state.privateTabs }.value ?: emptyList()
     val pagerState = rememberPagerState(initialPage = 0)
     val scope = rememberCoroutineScope()
     val animateScrollToPage: ((Page) -> Unit) = { page ->
@@ -86,12 +88,15 @@ fun TabsTray(
                         }
                     }
                     Page.PrivateTabs -> {
-                        Text(
-                            text = "Private tabs",
-                            modifier = Modifier.padding(all = 16.dp),
-                            color = FirefoxTheme.colors.textPrimary,
-                            style = FirefoxTheme.typography.body1,
-                        )
+                        if (displayTabsInGrid) {
+                            TabGrid(
+                                tabs = privateTabs,
+                            )
+                        } else {
+                            TabList(
+                                tabs = privateTabs,
+                            )
+                        }
                     }
                     Page.SyncedTabs -> {
                         Text(
@@ -113,6 +118,10 @@ private fun TabsTrayPreview() {
     val store = TabsTrayStore(
         initialState = TabsTrayState(
             normalTabs = generateFakeTabsList(),
+            privateTabs = generateFakeTabsList(
+                tabCount = 7,
+                isPrivate = true,
+            ),
         ),
     )
 
@@ -142,13 +151,13 @@ private fun TabsTrayMultiSelectPreview() {
     }
 }
 
-private fun generateFakeTabsList(tabCount: Int = 10): List<TabSessionState> {
-    val fakeTab = TabSessionState(
-        id = "tabId",
-        content = ContentState(
-            url = "www.mozilla.com",
-        ),
-    )
-
-    return List(tabCount) { fakeTab }
-}
+private fun generateFakeTabsList(tabCount: Int = 10, isPrivate: Boolean = false): List<TabSessionState> =
+    List(tabCount) { index ->
+        TabSessionState(
+            id = "tabId$index-$isPrivate",
+            content = ContentState(
+                url = "www.mozilla.com",
+                private = isPrivate,
+            ),
+        )
+    }


### PR DESCRIPTION



https://user-images.githubusercontent.com/87384386/225459214-e7a61dee-77e5-44ac-8014-72419650ccfd.mov




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1814995