### PR TITLE
Bug 1812736 - Display snackbar when a new tab is added to a collection

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -49,6 +49,7 @@ import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.searchEngines
 import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
 import mozilla.components.browser.state.store.BrowserStore
@@ -162,6 +163,24 @@ class HomeFragment : Fragment() {
                 binding.sessionControlRecyclerView.adapter?.notifyDataSetChanged()
             }
             showRenamedSnackbar()
+        }
+
+        override fun onTabsAdded(tabCollection: TabCollection, sessions: List<TabSessionState>) {
+            view?.let {
+                val message = if (sessions.size == 1) {
+                    R.string.create_collection_tab_saved
+                } else {
+                    R.string.create_collection_tabs_saved
+                }
+                FenixSnackbar.make(
+                    view = it,
+                    duration = Snackbar.LENGTH_LONG,
+                    isDisplayedWithBrowserToolbar = false,
+                )
+                    .setText(it.context.getString(message))
+                    .setAnchorView(snackbarAnchorView)
+                    .show()
+            }
         }
     }
 


### PR DESCRIPTION
### What
The PR will display a snackbar when a new tab is added to a collection

### Screenshots
| Issue video | Fix Video |
| ----------- | --------- |
| https://www.loom.com/share/2d199e00f9f94c4fb3c7b0e9adafbab3 | https://www.loom.com/share/c4bb32ffac174b8388d739fae0b1f966 |


### Pull Request checklist
 - [X] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1812736