### PR TITLE
Bug 1819123 - Re-evaluate usage of robolectric in Focus unit tests

### DIFF
--- a/focus-android/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteCustomDomainsPreference.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteCustomDomainsPreference.kt
@@ -16,5 +16,8 @@ class AutocompleteCustomDomainsPreference(
     context: Context,
     attrs: AttributeSet?,
 ) : LearnMoreSwitchPreference(context, attrs) {
-    override fun getLearnMoreUrl() = SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.AUTOCOMPLETE)
+    override fun getLearnMoreUrl() = SupportUtils.getSumoURLForTopic(
+        SupportUtils.getAppVersion(context),
+        SupportUtils.SumoTopic.AUTOCOMPLETE,
+    )
 }

--- a/focus-android/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteDefaultDomainsPreference.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/autocomplete/AutocompleteDefaultDomainsPreference.kt
@@ -16,5 +16,8 @@ class AutocompleteDefaultDomainsPreference(
     context: Context,
     attrs: AttributeSet?,
 ) : LearnMoreSwitchPreference(context, attrs) {
-    override fun getLearnMoreUrl() = SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.AUTOCOMPLETE)
+    override fun getLearnMoreUrl() = SupportUtils.getSumoURLForTopic(
+        SupportUtils.getAppVersion(context),
+        SupportUtils.SumoTopic.AUTOCOMPLETE,
+    )
 }

--- a/focus-android/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragment.kt
@@ -47,6 +47,8 @@ class BiometricAuthenticationFragment : Fragment(), AuthenticationDelegate {
                     BiometricPromptContent(biometricErrorText) {
                         showBiometricPrompt(
                             biometricPromptAuth.get(),
+                            getString(R.string.biometric_prompt_title),
+                            getString(R.string.biometric_prompt_subtitle),
                         )
                     }
                 }
@@ -72,13 +74,15 @@ class BiometricAuthenticationFragment : Fragment(), AuthenticationDelegate {
     }
 
     @VisibleForTesting
-    internal fun showBiometricPrompt(biometricPromptAuth: BiometricPromptAuth?) {
+    internal fun showBiometricPrompt(
+        biometricPromptAuth: BiometricPromptAuth?,
+        title: String,
+        subtitle: String,
+    ) {
         if (context?.canUseBiometricFeature() == true) {
             biometricPromptAuth?.requestAuthentication(
-                title = getString(R.string.biometric_prompt_title),
-                subtitle = getString(
-                    R.string.biometric_prompt_subtitle,
-                ),
+                title = title,
+                subtitle = subtitle,
             )
         }
     }

--- a/focus-android/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
@@ -57,8 +57,6 @@ class BrowserMenuController(
             )
             is ToolbarMenu.Item.Reload, ToolbarMenu.CustomTabItem.Reload -> {
                 sessionUseCases.reload(currentTabId)
-
-                TelemetryWrapper.menuReloadEvent()
             }
             is ToolbarMenu.Item.Stop, ToolbarMenu.CustomTabItem.Stop -> sessionUseCases.stopLoading(
                 currentTabId,
@@ -95,7 +93,8 @@ class BrowserMenuController(
     }
 
     @Suppress("LongMethod")
-    private fun recordBrowserMenuTelemetry(item: ToolbarMenu.Item) {
+    @VisibleForTesting
+    internal fun recordBrowserMenuTelemetry(item: ToolbarMenu.Item) {
         when (item) {
             is ToolbarMenu.Item.Back -> BrowserMenu.navigationToolbarAction.record(
                 BrowserMenu.NavigationToolbarActionExtra("back"),
@@ -103,9 +102,13 @@ class BrowserMenuController(
             is ToolbarMenu.Item.Forward -> BrowserMenu.navigationToolbarAction.record(
                 BrowserMenu.NavigationToolbarActionExtra("forward"),
             )
-            is ToolbarMenu.Item.Reload -> BrowserMenu.navigationToolbarAction.record(
-                BrowserMenu.NavigationToolbarActionExtra("reload"),
-            )
+            is ToolbarMenu.Item.Reload -> {
+                BrowserMenu.navigationToolbarAction.record(
+                    BrowserMenu.NavigationToolbarActionExtra("reload"),
+                )
+
+                TelemetryWrapper.menuReloadEvent()
+            }
             is ToolbarMenu.Item.Stop -> BrowserMenu.navigationToolbarAction.record(
                 BrowserMenu.NavigationToolbarActionExtra("stop"),
             )
@@ -155,9 +158,13 @@ class BrowserMenuController(
                 CustomTabsToolbar.NavigationToolbarActionExtra("stop"),
             )
 
-            ToolbarMenu.CustomTabItem.Reload -> CustomTabsToolbar.navigationToolbarAction.record(
-                CustomTabsToolbar.NavigationToolbarActionExtra("reload"),
-            )
+            ToolbarMenu.CustomTabItem.Reload -> {
+                CustomTabsToolbar.navigationToolbarAction.record(
+                    CustomTabsToolbar.NavigationToolbarActionExtra("reload"),
+                )
+
+                TelemetryWrapper.menuReloadEvent()
+            }
 
             ToolbarMenu.CustomTabItem.AddToHomeScreen -> CustomTabsToolbar.browserMenuAction.record(
                 CustomTabsToolbar.BrowserMenuActionExtra("add_to_home_screen"),

--- a/focus-android/app/src/main/java/org/mozilla/focus/cookiebanner/CookieBannerRejectAllPreference.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/cookiebanner/CookieBannerRejectAllPreference.kt
@@ -12,6 +12,9 @@ class CookieBannerRejectAllPreference(context: Context, attrs: AttributeSet?) :
     LearnMoreSwitchPreference(context, attrs) {
 
     override fun getLearnMoreUrl(): String {
-        return SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.COOKIE_BANNER)
+        return SupportUtils.getSumoURLForTopic(
+            SupportUtils.getAppVersion(context),
+            SupportUtils.SumoTopic.COOKIE_BANNER,
+        )
     }
 }

--- a/focus-android/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsPreference.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsPreference.kt
@@ -18,7 +18,10 @@ class SearchSuggestionsPreference(
     attrs: AttributeSet?,
 ) : LearnMoreSwitchPreference(context, attrs) {
     override fun getLearnMoreUrl(): String =
-        SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.SEARCH_SUGGESTIONS)
+        SupportUtils.getSumoURLForTopic(
+            SupportUtils.getAppVersion(context),
+            SupportUtils.SumoTopic.SEARCH_SUGGESTIONS,
+        )
 
     override fun getDescription(): String =
         context.getString(

--- a/focus-android/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/settings/ManualAddSearchEngineSettingsFragment.kt
@@ -78,7 +78,7 @@ class ManualAddSearchEngineSettingsFragment : BaseSettingsFragment() {
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
         val openLearnMore = {
             val learnMoreUrl = SupportUtils.getSumoURLForTopic(
-                requireContext(),
+                SupportUtils.getAppVersion(requireContext()),
                 SupportUtils.SumoTopic.ADD_SEARCH_ENGINE,
             )
             SupportUtils.openUrlInCustomTab(requireActivity(), learnMoreUrl)

--- a/focus-android/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/settings/SettingsFragment.kt
@@ -78,7 +78,7 @@ class SettingsFragment : BaseSettingsFragment() {
             SupportUtils.SumoTopic.WHATS_NEW_FOCUS
         }
 
-        val url = SupportUtils.getSumoURLForTopic(context, sumoTopic)
+        val url = SupportUtils.getSumoURLForTopic(SupportUtils.getAppVersion(context), sumoTopic)
         requireComponents.tabsUseCases.addTab(
             url,
             source = SessionState.Source.Internal.Menu,

--- a/focus-android/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
@@ -63,9 +63,11 @@ object SupportUtils {
         return "https://support.mozilla.org/$langTag/kb/$escapedTopic"
     }
 
-    fun getSumoURLForTopic(context: Context, topic: SumoTopic): String {
+    /**
+     * Returns the SUMO URL for a specific topic
+     */
+    fun getSumoURLForTopic(appVersion: String, topic: SumoTopic): String {
         val escapedTopic = getEncodedTopicUTF8(topic.topicStr)
-        val appVersion = getAppVersion(context)
         val osTarget = "Android"
         val langTag = Locales.getLanguageTag(Locale.getDefault())
         return "https://support.mozilla.org/1/mobile/$appVersion/$osTarget/$langTag/$escapedTopic"
@@ -85,7 +87,10 @@ object SupportUtils {
         }
     }
 
-    private fun getAppVersion(context: Context): String {
+    /**
+     * Returns the version name of this package.
+     */
+    fun getAppVersion(context: Context): String {
         try {
             return context.packageManager.getPackageInfoCompat(context.packageName, 0).versionName
         } catch (e: PackageManager.NameNotFoundException) {
@@ -122,7 +127,7 @@ object SupportUtils {
         val openCustomTabActivityIntent =
             Intent(activity, CustomTabActivity::class.java).apply {
                 action = Intent.ACTION_VIEW
-                data = getSumoURLForTopic(activity, SumoTopic.ADD_SEARCH_ENGINE).toUri()
+                data = getSumoURLForTopic(getAppVersion(activity), SumoTopic.ADD_SEARCH_ENGINE).toUri()
                 putExtra(CustomTabActivity.CUSTOM_TAB_ID, tabId)
             }
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/widget/TelemetrySwitchPreference.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/widget/TelemetrySwitchPreference.kt
@@ -47,6 +47,9 @@ internal class TelemetrySwitchPreference(context: Context, attrs: AttributeSet?)
     }
 
     override fun getLearnMoreUrl(): String {
-        return SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.USAGE_DATA)
+        return SupportUtils.getSumoURLForTopic(
+            SupportUtils.getAppVersion(context),
+            SupportUtils.SumoTopic.USAGE_DATA,
+        )
     }
 }

--- a/focus-android/app/src/test/java/org/mozilla/focus/TestFocusApplication.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/TestFocusApplication.kt
@@ -34,6 +34,15 @@ class TestFocusApplication : FocusApplication() {
     override fun initializeNimbus() = Unit
 }
 
+/**
+ * Empty [FocusApplication] override for unit tests.
+ */
+class EmptyFocusApplication : FocusApplication() {
+    override fun onCreate() {
+        //
+    }
+}
+
 // Borrowed this from AC unit tests. This is something we should consider moving to support-test, so
 // that everyone who needs an Engine in unit tests can use it. It also allows us to enhance this mock
 // and maybe do some actual things that help in tests. :)

--- a/focus-android/app/src/test/java/org/mozilla/focus/animation/TransitionDrawableGroupTest.java
+++ b/focus-android/app/src/test/java/org/mozilla/focus/animation/TransitionDrawableGroupTest.java
@@ -7,13 +7,10 @@ package org.mozilla.focus.animation;
 import android.graphics.drawable.TransitionDrawable;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-@RunWith(RobolectricTestRunner.class)
 public class TransitionDrawableGroupTest {
     @Test
     public void testStartIsCalledOnAllItems() {

--- a/focus-android/app/src/test/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragmentTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragmentTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.focus.biometrics
 
+import android.content.Context
 import android.os.Build
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
@@ -11,28 +12,23 @@ import androidx.fragment.app.FragmentTransaction
 import mozilla.components.lib.auth.AuthenticationDelegate
 import mozilla.components.lib.auth.BiometricPromptAuth
 import mozilla.components.support.test.mock
-import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.mozilla.focus.R
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
-@RunWith(RobolectricTestRunner::class)
 class BiometricAuthenticationFragmentTest {
     private lateinit var biometricPromptAuth: BiometricPromptAuth
     private lateinit var fragment: BiometricAuthenticationFragment
     private val activity: FragmentActivity = mock()
+    private val testContext: Context = mock()
+
     private val fragmentManger: FragmentManager = mock()
     private val fragmentTransaction: FragmentTransaction = mock()
-    private lateinit var titleBiometric: String
-    private lateinit var subTitleBiometric: String
 
     @Before
     fun setup() {
@@ -55,17 +51,14 @@ class BiometricAuthenticationFragmentTest {
                 },
             ),
         )
-
-        titleBiometric = testContext.getString(R.string.biometric_prompt_title)
-        subTitleBiometric = testContext.getString(R.string.biometric_prompt_subtitle)
     }
 
     @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
     @Test
     fun `GIVEN biometric authentication fragment WHEN show biometric prompt is called and can use feature returns false THEN request authentication is not called`() {
-        fragment.showBiometricPrompt(biometricPromptAuth)
+        fragment.showBiometricPrompt(biometricPromptAuth, "title", "subtitle")
 
-        verify(biometricPromptAuth, never()).requestAuthentication(titleBiometric, subTitleBiometric)
+        verify(biometricPromptAuth, never()).requestAuthentication("title", "subtitle")
     }
 
     @Test

--- a/focus-android/app/src/test/java/org/mozilla/focus/cfr/CfrMiddlewareTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/cfr/CfrMiddlewareTest.kt
@@ -21,13 +21,16 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations
+import org.mozilla.focus.TestFocusApplication
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.nimbus.FocusNimbus
 import org.mozilla.focus.nimbus.Onboarding
 import org.mozilla.focus.state.AppStore
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(application = TestFocusApplication::class)
 class CfrMiddlewareTest {
     private lateinit var onboardingExperiment: Onboarding
     private val browserStore: BrowserStore = testContext.components.store

--- a/focus-android/app/src/test/java/org/mozilla/focus/contextmenu/ContextMenuCandidatesTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/contextmenu/ContextMenuCandidatesTest.kt
@@ -4,15 +4,21 @@
 
 package org.mozilla.focus.contextmenu
 
+import android.content.Context
 import mozilla.components.support.test.mock
-import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.mockito.ArgumentMatchers.anyInt
 
-@RunWith(RobolectricTestRunner::class)
 class ContextMenuCandidatesTest {
+    private val testContext: Context = mock()
+
+    @Before
+    fun setUp() {
+        whenever(testContext.getString(anyInt())).thenReturn("dummy label")
+    }
 
     @Test
     fun `WHEN the tab is a custom tab THEN the proper context candidates are created `() {

--- a/focus-android/app/src/test/java/org/mozilla/focus/locale/LocalesTest.java
+++ b/focus-android/app/src/test/java/org/mozilla/focus/locale/LocalesTest.java
@@ -6,14 +6,11 @@
 package org.mozilla.focus.locale;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
 public class LocalesTest {
     @Test
     public void testLanguage() {

--- a/focus-android/app/src/test/java/org/mozilla/focus/menu/BrowserMenuControllerTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/menu/BrowserMenuControllerTest.kt
@@ -9,19 +9,19 @@ import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.top.sites.TopSitesUseCases
+import mozilla.components.support.test.any
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.MockitoAnnotations
 import org.mockito.Spy
 import org.mozilla.focus.browser.integration.BrowserMenuController
 import org.mozilla.focus.state.AppStore
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class BrowserMenuControllerTest {
     private lateinit var browserMenuController: BrowserMenuController
 
@@ -65,19 +65,23 @@ class BrowserMenuControllerTest {
         sessionUseCases = SessionUseCases(store)
         MockitoAnnotations.openMocks(this)
 
-        browserMenuController = BrowserMenuController(
-            sessionUseCases,
-            appStore,
-            store,
-            topSitesUseCases,
-            currentTabId,
-            shareCallback,
-            requestDesktopCallback,
-            addToHomeScreenCallback,
-            showFindInPageCallback,
-            openInCallback,
-            openInBrowser,
+        browserMenuController = spy(
+            BrowserMenuController(
+                sessionUseCases,
+                appStore,
+                store,
+                topSitesUseCases,
+                currentTabId,
+                shareCallback,
+                requestDesktopCallback,
+                addToHomeScreenCallback,
+                showFindInPageCallback,
+                openInCallback,
+                openInBrowser,
+            ),
         )
+
+        doNothing().`when`(browserMenuController).recordBrowserMenuTelemetry(any())
     }
 
     @Test

--- a/focus-android/app/src/test/java/org/mozilla/focus/searchwidget/ExternalIntentNavigationTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/searchwidget/ExternalIntentNavigationTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.runner.RunWith
 import org.mozilla.focus.GleanMetrics.SearchWidget
+import org.mozilla.focus.TestFocusApplication
 import org.mozilla.focus.activity.IntentReceiverActivity
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.settings
@@ -38,6 +39,7 @@ import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
 
 @RunWith(RobolectricTestRunner::class)
+@Config(application = TestFocusApplication::class)
 internal class ExternalIntentNavigationTest {
     @get:Rule
     val gleanTestRule = GleanTestRule(testContext)

--- a/focus-android/app/src/test/java/org/mozilla/focus/sitepermissions/SitePermissionOptionsStoreTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/sitepermissions/SitePermissionOptionsStoreTest.kt
@@ -5,15 +5,12 @@ package org.mozilla.focus.sitepermissions
 
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.mock
-import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.verify
-import org.mozilla.focus.R
 import org.mozilla.focus.settings.permissions.AutoplayOption
 import org.mozilla.focus.settings.permissions.SitePermissionOption
 import org.mozilla.focus.settings.permissions.permissionoptions.SitePermission
@@ -22,9 +19,7 @@ import org.mozilla.focus.settings.permissions.permissionoptions.SitePermissionOp
 import org.mozilla.focus.settings.permissions.permissionoptions.SitePermissionOptionsScreenStore
 import org.mozilla.focus.settings.permissions.permissionoptions.SitePermissionOptionsStorage
 import org.mozilla.focus.settings.permissions.permissionoptions.SitePermissionOptionsStorageMiddleware
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class SitePermissionOptionsStoreTest {
     private lateinit var sitePermissionOptionsStorageMiddleware: SitePermissionOptionsStorageMiddleware
     private lateinit var store: SitePermissionOptionsScreenStore
@@ -38,7 +33,7 @@ class SitePermissionOptionsStoreTest {
 
         doReturn(listOf(SitePermissionOption.AskToAllow(), SitePermissionOption.Blocked())).`when`(storage).getSitePermissionOptions(SitePermission.CAMERA)
         doReturn(SitePermissionOption.AskToAllow()).`when`(storage).permissionSelectedOption(SitePermission.CAMERA)
-        doReturn(testContext.getString(R.string.preference_phone_feature_camera)).`when`(storage).getSitePermissionLabel(SitePermission.CAMERA)
+        doReturn("Camera").`when`(storage).getSitePermissionLabel(SitePermission.CAMERA)
         doReturn(false).`when`(storage).isAndroidPermissionGranted(SitePermission.CAMERA)
 
         store = SitePermissionOptionsScreenStore(sitePermissionState, listOf(sitePermissionOptionsStorageMiddleware))
@@ -65,6 +60,7 @@ class SitePermissionOptionsStoreTest {
 
     @Test
     fun `GIVEN site permission screen store WHEN update site permission options is dispatched THEN site permission options screen state is updated`() {
+        val sitePermissionLabel = "Autoplay"
         store.dispatch(
             SitePermissionOptionsScreenAction.UpdateSitePermissionOptions(
                 listOf(
@@ -73,7 +69,7 @@ class SitePermissionOptionsStoreTest {
                     AutoplayOption.BlockAudioVideo(),
                 ),
                 AutoplayOption.AllowAudioVideo(),
-                testContext.getString(R.string.preference_autoplay),
+                sitePermissionLabel,
                 true,
             ),
         ).joinBlocking()
@@ -88,6 +84,6 @@ class SitePermissionOptionsStoreTest {
             ),
             store.state.sitePermissionOptionList,
         )
-        assertEquals(testContext.getString(R.string.preference_autoplay), store.state.sitePermissionLabel)
+        assertEquals(sitePermissionLabel, store.state.sitePermissionLabel)
     }
 }

--- a/focus-android/app/src/test/java/org/mozilla/focus/telemetry/HistogramTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/telemetry/HistogramTest.kt
@@ -7,10 +7,7 @@ package org.mozilla.focus.telemetry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class HistogramTest {
 
     @Test

--- a/focus-android/app/src/test/java/org/mozilla/focus/telemetry/ProfilerMarkerFactProcessorTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/telemetry/ProfilerMarkerFactProcessorTest.kt
@@ -14,15 +14,12 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class ProfilerMarkerFactProcessorTest {
 
     private val profiler: Profiler = mock(Profiler::class.java)

--- a/focus-android/app/src/test/java/org/mozilla/focus/topsites/DefaultTopSitesStorageTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/topsites/DefaultTopSitesStorageTest.kt
@@ -14,12 +14,9 @@ import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
-import org.robolectric.RobolectricTestRunner
 
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
 class DefaultTopSitesStorageTest {
 
     private val pinnedSitesStorage: PinnedSiteStorage = mock()

--- a/focus-android/app/src/test/java/org/mozilla/focus/utils/IntentUtilsTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/utils/IntentUtilsTest.kt
@@ -7,22 +7,32 @@ import android.app.PendingIntent
 import android.os.Build
 import org.junit.Assert
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
 
-@RunWith(RobolectricTestRunner::class)
 class IntentUtilsTest {
 
     @Test
-    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP_MR1])
     fun `given a build version lower than 23, when defaultIntentPendingFlags is called, then flag 0 should be returned`() {
+        setFinalStaticValue(Build.VERSION::class.java.getField("SDK_INT"), 22)
+
         Assert.assertEquals(0, IntentUtils.defaultIntentPendingFlags)
     }
 
     @Test
-    @Config(sdk = [Build.VERSION_CODES.M])
     fun `given a build version bigger than 22, when defaultIntentPendingFlags is called, then flag FLAG_IMMUTABLE should be returned`() {
+        setFinalStaticValue(Build.VERSION::class.java.getField("SDK_INT"), 23)
         Assert.assertEquals(PendingIntent.FLAG_IMMUTABLE, IntentUtils.defaultIntentPendingFlags)
+    }
+
+    @Throws(Exception::class)
+    fun setFinalStaticValue(field: Field, newValue: Any) {
+        field.isAccessible = true
+
+        val modifiersField = Field::class.java.getDeclaredField("modifiers")
+        modifiersField.isAccessible = true
+        modifiersField.setInt(field, field.modifiers and Modifier.FINAL.inv())
+
+        field.set(null, newValue)
     }
 }

--- a/focus-android/app/src/test/java/org/mozilla/focus/utils/SupportUtilsTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/utils/SupportUtilsTest.kt
@@ -1,15 +1,9 @@
 package org.mozilla.focus.utils
 
-import android.app.Application
-import androidx.test.core.app.ApplicationProvider
-import mozilla.components.support.utils.ext.getPackageInfoCompat
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import java.util.Locale
 
-@RunWith(RobolectricTestRunner::class)
 class SupportUtilsTest {
 
     @Test
@@ -26,8 +20,7 @@ class SupportUtilsTest {
     @Test
     @Throws(Exception::class)
     fun getSumoURLForTopic() {
-        val context = ApplicationProvider.getApplicationContext() as Application
-        val versionName = context.packageManager.getPackageInfoCompat(context.packageName, 0).versionName
+        val versionName = "testVersion"
 
         val testTopic = SupportUtils.SumoTopic.TRACKERS
         val testTopicStr = testTopic.topicStr
@@ -35,13 +28,13 @@ class SupportUtilsTest {
         Locale.setDefault(Locale.GERMANY)
         assertEquals(
             "https://support.mozilla.org/1/mobile/$versionName/Android/de-DE/$testTopicStr",
-            SupportUtils.getSumoURLForTopic(ApplicationProvider.getApplicationContext(), testTopic),
+            SupportUtils.getSumoURLForTopic(versionName, testTopic),
         )
 
         Locale.setDefault(Locale.CANADA_FRENCH)
         assertEquals(
             "https://support.mozilla.org/1/mobile/$versionName/Android/fr-CA/$testTopicStr",
-            SupportUtils.getSumoURLForTopic(ApplicationProvider.getApplicationContext(), testTopic),
+            SupportUtils.getSumoURLForTopic(versionName, testTopic),
         )
     }
 

--- a/focus-android/app/src/test/java/org/mozilla/focus/whatsnew/WhatsNewVersionTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/whatsnew/WhatsNewVersionTest.kt
@@ -7,10 +7,7 @@ package org.mozilla.focus.whatsnew
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class WhatsNewVersionTest {
     @Test
     fun testMajorVersionNumber() {

--- a/focus-android/app/src/test/resources/robolectric.properties
+++ b/focus-android/app/src/test/resources/robolectric.properties
@@ -1,3 +1,3 @@
 # Needed until Robolectric supports SDK 29+
 sdk=28
-application=org.mozilla.focus.TestFocusApplication
+application=org.mozilla.focus.EmptyFocusApplication

--- a/focus-android/quality/detekt-baseline.xml
+++ b/focus-android/quality/detekt-baseline.xml
@@ -428,7 +428,6 @@
     <ID>UndocumentedPublicFunction:StudiesViewModel.kt$StudiesViewModel$fun setStudiesState(state: Boolean)</ID>
     <ID>UndocumentedPublicFunction:SupportUtils.kt$SupportUtils$// For some reason this URL has a different format than the other SUMO URLs fun getSafeBrowsingURL(): String</ID>
     <ID>UndocumentedPublicFunction:SupportUtils.kt$SupportUtils$fun getGenericSumoURLForTopic(topic: SumoTopic): String</ID>
-    <ID>UndocumentedPublicFunction:SupportUtils.kt$SupportUtils$fun getSumoURLForTopic(context: Context, topic: SumoTopic): String</ID>
     <ID>UndocumentedPublicFunction:SupportUtils.kt$SupportUtils$fun openDefaultBrowserSumoPage(context: Context)</ID>
     <ID>UndocumentedPublicFunction:SupportUtils.kt$SupportUtils$fun openUrlInCustomTab(activity: FragmentActivity, destinationUrl: String)</ID>
     <ID>UndocumentedPublicFunction:TabViewHolder.kt$TabViewHolder$fun bind( tab: TabSessionState, isCurrentSession: Boolean, selectSession: (TabSessionState) -&gt; Unit, closeSession: (TabSessionState) -&gt; Unit, )</ID>


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.
































### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819123