### PR TITLE
Bug 1819950 - Ensure a change of orientation on new Androids will dismiss CFRs

### DIFF
--- a/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/helper/DisplayOrientationListener.kt
+++ b/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/helper/DisplayOrientationListener.kt
@@ -7,6 +7,7 @@ package mozilla.components.compose.cfr.helper
 import android.content.Context
 import android.hardware.display.DisplayManager
 import android.hardware.display.DisplayManager.DisplayListener
+import android.os.Build
 import androidx.annotation.VisibleForTesting
 
 /**
@@ -21,13 +22,13 @@ import androidx.annotation.VisibleForTesting
  * No updates will be triggered if the "Auto-rotate" functionality is disabled for the device.
  */
 internal class DisplayOrientationListener(
-    context: Context,
+    private val context: Context,
     val onDisplayRotationChanged: () -> Unit,
 ) : DisplayListener {
     private val displayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
 
     @VisibleForTesting
-    internal var currentOrientation = displayManager.displays[0].rotation
+    internal var currentOrientation = getCurrentOrientation()
 
     /**
      * Start listening for display orientation changes.
@@ -49,11 +50,16 @@ internal class DisplayOrientationListener(
     override fun onDisplayRemoved(displayId: Int) = Unit
 
     override fun onDisplayChanged(displayId: Int) {
-        val display = displayManager.getDisplay(displayId) ?: return // getDisplay may return null
+        val newOrientation = getCurrentOrientation(displayId)
 
-        if (display.rotation != currentOrientation) {
-            currentOrientation = display.rotation
+        if (newOrientation != this.currentOrientation) {
+            this.currentOrientation = newOrientation
             onDisplayRotationChanged()
         }
+    }
+
+    private fun getCurrentOrientation(displayId: Int = 0): Int = when (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        true -> context.resources.configuration.orientation
+        false -> displayManager.getDisplay(displayId)?.rotation ?: currentOrientation
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* * **compose-cfr**
+* 🚒 Bug fixed [bug #1819950](https://bugzilla.mozilla.org/show_bug.cgi?id=1819950). Ensure CFRs are automatically dismissed on screen rotation on all Android versions.
+
 # 112.0.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v111...releases_v112)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/releases_v112/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)


### PR DESCRIPTION
Seems like on Android 33 the current orientation detection calls do not report valid results.
As such on newer Android versions we'll use another way to infer the current rotation based on the configuration read from Resources.

Tested the changes on:
- Samsung J3 with Android api level 22
- Emulator of Android api level 29 
- Emulator of Android api level 30
- Samsung A51 with Android api level 31
- Emulator of Android api level 29 
- Pixel 7 (and a tablet emulator) with Android api level 33

Result on a Pixel 7 with Android 13 on which previously the CFR would not get automatically dismissed:


https://user-images.githubusercontent.com/11428869/225631503-d7e777c4-c7d4-41d7-9083-57d73b458357.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819950