### PR TITLE
Bug 1819153 - Adjust startup task to resolve NoSuchMethodError on Firebase Test Lab

### DIFF
--- a/taskcluster/ci/startup-test/kind.yml
+++ b/taskcluster/ci/startup-test/kind.yml
@@ -35,7 +35,7 @@ task-defaults:
               json: true
     run-on-tasks-for: []
     attributes:
-        build-type: nightly
+        build-type: nightly-firebase
         shipping-product: fenix
         # cannot safely run this in Firebase
         # turning off til we can safely run test in taskcluster


### PR DESCRIPTION
Bug 1819153 is still problematic on Firebase Test Lab.

`build-type: nightly` -> `build-type: nightly-firebase` let's try this
https://bugzilla.mozilla.org/show_bug.cgi?id=1819153
https://bugzilla.mozilla.org/show_bug.cgi?id=1819153