### PR TITLE
Bug 1823707 - Refactor settingsAdvancedItemsTest UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
@@ -27,13 +27,13 @@ class CookieBannerReductionTest {
             verifyCookieBannerExists(exists = true)
         }.openThreeDotMenu {
         }.openSettings {
-            verifyCookieBannerReductionSummary("Off")
+            verifySettingsOptionSummary("Cookie Banner Reduction", "Off")
         }.openCookieBannerReductionSubMenu {
             verifyCookieBannerView(isCookieBannerReductionChecked = false)
             clickCookieBannerReductionToggle()
             verifyCheckedCookieBannerReductionToggle(isCookieBannerReductionChecked = true)
         }.goBack {
-            verifyCookieBannerReductionSummary("On")
+            verifySettingsOptionSummary("Cookie Banner Reduction", "On")
         }
 
         exitMenu()
@@ -76,13 +76,13 @@ class CookieBannerReductionTest {
             verifyCookieBannerExists(exists = true)
         }.openThreeDotMenu {
         }.openSettings {
-            verifyCookieBannerReductionSummary("Off")
+            verifySettingsOptionSummary("Cookie Banner Reduction", "Off")
         }.openCookieBannerReductionSubMenu {
             verifyCookieBannerView(isCookieBannerReductionChecked = false)
             clickCookieBannerReductionToggle()
             verifyCheckedCookieBannerReductionToggle(isCookieBannerReductionChecked = true)
         }.goBack {
-            verifyCookieBannerReductionSummary("On")
+            verifySettingsOptionSummary("Cookie Banner Reduction", "On")
         }
 
         exitMenu()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/EnhancedTrackingProtectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/EnhancedTrackingProtectionTest.kt
@@ -64,7 +64,7 @@ class EnhancedTrackingProtectionTest {
         }.openThreeDotMenu {
         }.openSettings {
             verifyEnhancedTrackingProtectionButton()
-            verifyEnhancedTrackingProtectionState("Standard")
+            verifySettingsOptionSummary("Enhanced Tracking Protection", "Standard")
         }.openEnhancedTrackingProtectionSubMenu {
             verifyEnhancedTrackingProtectionHeader()
             verifyEnhancedTrackingProtectionOptionsEnabled()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -54,18 +54,22 @@ class SettingsAdvancedTest {
 
     // Walks through settings menu and sub-menus to ensure all items are present
     @Test
-    fun settingsAboutItemsTest() {
+    fun settingsAdvancedItemsTest() {
         // ADVANCED
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {
-            // ADVANCED
+            verifySettingsToolbar()
             verifyAdvancedHeading()
             verifyAddons()
             verifyOpenLinksInAppsButton()
-            verifyOpenLinksInAppsState("Never")
-            verifyRemoteDebug()
+            verifySettingsOptionSummary("Open links in apps", "Never")
+            verifyExternalDownloadManagerButton()
+            verifyExternalDownloadManagerToggle(false)
             verifyLeakCanaryButton()
+            verifyLeakCanaryToggle(true)
+            verifyRemoteDebuggingButton()
+            verifyRemoteDebuggingToggle(false)
         }
     }
 
@@ -82,7 +86,7 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
             }
@@ -105,7 +109,7 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
             }
@@ -128,7 +132,7 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
             }
@@ -163,7 +167,7 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
             }
@@ -195,13 +199,13 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
                 clickOpenLinkInAppOption("Ask before opening")
                 verifySelectedOpenLinksInAppOption("Ask before opening")
             }.goBack {
-                verifyOpenLinksInAppsState("Ask before opening")
+                verifySettingsOptionSummary("Open links in apps", "Ask before opening")
             }
 
             exitMenu()
@@ -236,13 +240,13 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
                 clickOpenLinkInAppOption("Ask before opening")
                 verifySelectedOpenLinksInAppOption("Ask before opening")
             }.goBack {
-                verifyOpenLinksInAppsState("Ask before opening")
+                verifySettingsOptionSummary("Open links in apps", "Ask before opening")
             }
 
             exitMenu()
@@ -274,13 +278,13 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
                 clickOpenLinkInAppOption("Ask before opening")
                 verifySelectedOpenLinksInAppOption("Ask before opening")
             }.goBack {
-                verifyOpenLinksInAppsState("Ask before opening")
+                verifySettingsOptionSummary("Open links in apps", "Ask before opening")
             }
 
             exitMenu()
@@ -315,13 +319,13 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
                 clickOpenLinkInAppOption("Ask before opening")
                 verifySelectedOpenLinksInAppOption("Ask before opening")
             }.goBack {
-                verifyOpenLinksInAppsState("Ask before opening")
+                verifySettingsOptionSummary("Open links in apps", "Ask before opening")
             }
 
             exitMenu()
@@ -353,13 +357,13 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
                 clickOpenLinkInAppOption("Always")
                 verifySelectedOpenLinksInAppOption("Always")
             }.goBack {
-                verifyOpenLinksInAppsState("Always")
+                verifySettingsOptionSummary("Open links in apps", "Always")
             }
 
             exitMenu()
@@ -392,13 +396,13 @@ class SettingsAdvancedTest {
             }.openThreeDotMenu {
             }.openSettings {
                 verifyOpenLinksInAppsButton()
-                verifyOpenLinksInAppsState("Never")
+                verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
                 verifyOpenLinksInAppsView("Never")
                 clickOpenLinkInAppOption("Always")
                 verifySelectedOpenLinksInAppOption("Always")
             }.goBack {
-                verifyOpenLinksInAppsState("Always")
+                verifySettingsOptionSummary("Open links in apps", "Always")
             }
 
             exitMenu()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeveloperToolsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeveloperToolsTest.kt
@@ -50,7 +50,7 @@ class SettingsDeveloperToolsTest {
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {
-            verifyRemoteDebug()
+            verifyRemoteDebuggingButton()
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsGeneralTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsGeneralTest.kt
@@ -62,11 +62,11 @@ class SettingsGeneralTest {
             verifySettingsToolbar()
             verifyGeneralHeading()
             verifySearchButton()
-            verifySettingsOptionSummary("Google")
+            verifySettingsOptionSummary("Search", "Google")
             verifyTabsButton()
-            verifySettingsOptionSummary("Close manually")
+            verifySettingsOptionSummary("Tabs", "Close manually")
             verifyHomepageButton()
-            verifySettingsOptionSummary("Open on homepage after four hours")
+            verifySettingsOptionSummary("Homepage", "Open on homepage after four hours")
             verifyCustomizeButton()
             verifyLoginsAndPasswordsButton()
             verifyAutofillButton()
@@ -178,18 +178,18 @@ class SettingsGeneralTest {
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {
-            verifyHomepageButtonSummary("Open on homepage after four hours")
+            verifySettingsOptionSummary("Homepage", "Open on homepage after four hours")
         }.openHomepageSubMenu {
             verifySelectedOpeningScreenOption("Homepage after four hours of inactivity")
             clickOpeningScreenOption("Homepage")
             verifySelectedOpeningScreenOption("Homepage")
         }.goBack {
-            verifyHomepageButtonSummary("Open on homepage")
+            verifySettingsOptionSummary("Homepage", "Open on homepage")
         }.openHomepageSubMenu {
             clickOpeningScreenOption("Last tab")
             verifySelectedOpeningScreenOption("Last tab")
         }.goBack {
-            verifyHomepageButtonSummary("Open on last tab")
+            verifySettingsOptionSummary("Homepage", "Open on last tab")
         }
     }
 
@@ -199,23 +199,23 @@ class SettingsGeneralTest {
         }.openThreeDotMenu {
         }.openSettings {
             verifyTabsButton()
-            verifyTabsButtonSummary("Close manually")
+            verifySettingsOptionSummary("Tabs", "Close manually")
         }.openTabsSubMenu {
             verifySelectedCloseTabsOption("Never")
             clickClosedTabsOption("After one day")
             verifySelectedCloseTabsOption("After one day")
         }.goBack {
-            verifyTabsButtonSummary("Close after one day")
+            verifySettingsOptionSummary("Tabs", "Close after one day")
         }.openTabsSubMenu {
             clickClosedTabsOption("After one week")
             verifySelectedCloseTabsOption("After one week")
         }.goBack {
-            verifyTabsButtonSummary("Close after one week")
+            verifySettingsOptionSummary("Tabs", "Close after one week")
         }.openTabsSubMenu {
             clickClosedTabsOption("After one month")
             verifySelectedCloseTabsOption("After one month")
         }.goBack {
-            verifyTabsButtonSummary("Close after one month")
+            verifySettingsOptionSummary("Tabs", "Close after one month")
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHTTPSOnlyModeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHTTPSOnlyModeTest.kt
@@ -69,7 +69,7 @@ class SettingsHTTPSOnlyModeTest {
                 privateTabsOptionSelected = false,
             )
         }.goBack {
-            verifyHTTPSOnlyModeSummary("On in all tabs")
+            verifySettingsOptionSummary("HTTPS-Only Mode", "On in all tabs")
             exitMenu()
         }
         navigationToolbar {
@@ -130,7 +130,7 @@ class SettingsHTTPSOnlyModeTest {
                 privateTabsOptionSelected = true,
             )
         }.goBack {
-            verifyHTTPSOnlyModeSummary("On in private tabs")
+            verifySettingsOptionSummary("HTTPS-Only Mode", "On in private tabs")
             exitMenu()
         }
         navigationToolbar {
@@ -188,7 +188,7 @@ class SettingsHTTPSOnlyModeTest {
             clickHttpsOnlyModeSwitch()
             verifyHttpsOnlyModeIsEnabled(false)
         }.goBack {
-            verifyHTTPSOnlyModeSummary("Off")
+            verifySettingsOptionSummary("HTTPS-Only Mode", "Off")
             exitMenu()
         }
         navigationToolbar {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsTest.kt
@@ -60,11 +60,11 @@ class SettingsTest {
         }.goBack {
             // HTTPS-Only Mode
             verifyHTTPSOnlyModeButton()
-            verifyHTTPSOnlyModeSummary("Off")
+            verifySettingsOptionSummary("HTTPS-Only Mode", "Off")
 
             // ENHANCED TRACKING PROTECTION
             verifyEnhancedTrackingProtectionButton()
-            verifyEnhancedTrackingProtectionState("Standard")
+            verifySettingsOptionSummary("Enhanced Tracking Protection", "Standard")
         }.openEnhancedTrackingProtectionSubMenu {
             verifyNavigationToolBarHeader()
             verifyEnhancedTrackingProtectionProtectionSubMenuItems()
@@ -128,7 +128,7 @@ class SettingsTest {
         }.goBack {
             // DELETE BROWSING DATA ON QUIT
             verifyDeleteBrowsingDataOnQuitButton()
-            verifyDeleteBrowsingDataOnQuitState("Off")
+            verifySettingsOptionSummary("Delete browsing data on quit", "Off")
         }.openSettingsSubMenuDeleteBrowsingDataOnQuit {
             verifyNavigationToolBarHeader()
             verifyDeleteBrowsingDataOnQuitSubMenuItems()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -26,6 +26,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
+import androidx.test.espresso.matcher.ViewMatchers.withClassName
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -37,6 +38,7 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import junit.framework.AssertionFailedError
 import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.endsWith
 import org.hamcrest.Matchers.allOf
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
@@ -75,11 +77,7 @@ class SettingsRobot {
     fun verifySetAsDefaultBrowserButton() = assertSetAsDefaultBrowserButton()
     fun verifyTabsButton() =
         assertItemContainingTextExists(itemContainingText(getStringResource(R.string.preferences_tabs)))
-    fun verifyTabsButtonSummary(summary: String) =
-        assertItemContainingTextExists(itemContainingText(summary))
     fun verifyHomepageButton() = assertHomepageButton()
-    fun verifyHomepageButtonSummary(summary: String) =
-        assertItemContainingTextExists(itemContainingText(summary))
     fun verifyAutofillButton() = assertAutofillButton()
     fun verifyLanguageButton() = assertLanguageButton()
     fun verifyDefaultBrowserToggle(isEnabled: Boolean) {
@@ -108,39 +106,16 @@ class SettingsRobot {
     fun verifyPrivacyHeading() = assertPrivacyHeading()
 
     fun verifyHTTPSOnlyModeButton() = assertHTTPSOnlyModeButton()
-    fun verifyHTTPSOnlyModeSummary(HTTPSOnlyModeSummary: String) =
-        onView(
-            allOf(
-                withText(R.string.preferences_https_only_title),
-                hasSibling(withText(HTTPSOnlyModeSummary)),
-            ),
-        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    fun verifyCookieBannerReductionSummary(cookieBannerReductionSummary: String) {
-        scrollToElementByText(getStringResource(R.string.preferences_cookie_banner_reduction))
-
-        onView(
-            allOf(
-                withText(R.string.preferences_cookie_banner_reduction),
-                hasSibling(withText(cookieBannerReductionSummary)),
-            ),
-        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-    }
 
     fun verifyEnhancedTrackingProtectionButton() = assertEnhancedTrackingProtectionButton()
     fun verifyLoginsAndPasswordsButton() = assertLoginsAndPasswordsButton()
-    fun verifyEnhancedTrackingProtectionState(option: String) =
-        assertEnhancedTrackingProtectionState(option)
     fun verifyPrivateBrowsingButton() = assertPrivateBrowsingButton()
     fun verifySitePermissionsButton() = assertSitePermissionsButton()
     fun verifyDeleteBrowsingDataButton() = assertDeleteBrowsingDataButton()
     fun verifyDeleteBrowsingDataOnQuitButton() = assertDeleteBrowsingDataOnQuitButton()
-    fun verifyDeleteBrowsingDataOnQuitState(state: String) =
-        assertDeleteBrowsingDataState(state)
     fun verifyNotificationsButton() = assertNotificationsButton()
     fun verifyDataCollectionButton() = assertDataCollectionButton()
     fun verifyOpenLinksInAppsButton() = assertOpenLinksInAppsButton()
-    fun verifyOpenLinksInAppsState(state: String) = assertOpenLinksInAppsSwitchState(state)
     fun verifySettingsView() = assertSettingsView()
     fun verifySettingsToolbar() = assertSettingsToolbar()
 
@@ -148,8 +123,64 @@ class SettingsRobot {
     fun verifyAdvancedHeading() = assertAdvancedHeading()
     fun verifyAddons() = assertAddonsButton()
 
+    fun verifyExternalDownloadManagerButton() =
+        onView(
+            withText(R.string.preferences_external_download_manager),
+        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+    fun verifyExternalDownloadManagerToggle(enabled: Boolean) =
+        onView(withText(R.string.preferences_external_download_manager))
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withClassName(endsWith("Switch")),
+                            if (enabled) {
+                                isChecked()
+                            } else {
+                                isNotChecked()
+                            },
+                        ),
+                    ),
+                ),
+            )
+
+    fun verifyLeakCanaryToggle(enabled: Boolean) =
+        onView(withText(R.string.preference_leakcanary))
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withClassName(endsWith("Switch")),
+                            if (enabled) {
+                                isChecked()
+                            } else {
+                                isNotChecked()
+                            },
+                        ),
+                    ),
+                ),
+            )
+
+    fun verifyRemoteDebuggingToggle(enabled: Boolean) =
+        onView(withText(R.string.preferences_remote_debugging))
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withClassName(endsWith("Switch")),
+                            if (enabled) {
+                                isChecked()
+                            } else {
+                                isNotChecked()
+                            },
+                        ),
+                    ),
+                ),
+            )
+
     // DEVELOPER TOOLS SECTION
-    fun verifyRemoteDebug() = assertRemoteDebug()
+    fun verifyRemoteDebuggingButton() = assertRemoteDebuggingButton()
     fun verifyLeakCanaryButton() = assertLeakCanaryButton()
 
     // ABOUT SECTION
@@ -159,7 +190,16 @@ class SettingsRobot {
     fun verifyAboutFirefoxPreview() = assertTrue(aboutFirefoxHeading().waitForExists(waitingTime))
     fun verifyGooglePlayRedirect() = assertGooglePlayRedirect()
 
-    fun verifySettingsOptionSummary(summary: String) = itemContainingText(summary)
+    fun verifySettingsOptionSummary(setting: String, summary: String) {
+        scrollToElementByText(setting)
+
+        onView(
+            allOf(
+                withText(setting),
+                hasSibling(withText(summary)),
+            ),
+        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
 
     class Transition {
         fun goBack(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
@@ -484,11 +524,6 @@ private fun assertEnhancedTrackingProtectionButton() {
     ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
-private fun assertEnhancedTrackingProtectionState(state: String) {
-    mDevice.wait(Until.findObject(By.text("Enhanced Tracking Protection")), waitingTime)
-    onView(withText(state)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
 private fun assertLoginsAndPasswordsButton() {
     scrollToElementByText("Logins and passwords")
     onView(withText(R.string.preferences_passwords_logins_and_passwords))
@@ -520,15 +555,6 @@ private fun assertDeleteBrowsingDataOnQuitButton() {
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
-private fun assertDeleteBrowsingDataState(state: String) {
-    onView(
-        allOf(
-            withText(R.string.preferences_delete_browsing_data_on_quit),
-            hasSibling(withText(state)),
-        ),
-    ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
 private fun assertNotificationsButton() {
     scrollToElementByText("Notifications")
     onView(withText("Notifications"))
@@ -547,21 +573,6 @@ private fun assertOpenLinksInAppsButton() {
     scrollToElementByText("Open links in apps")
     openLinksInAppsButton()
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
-fun assertOpenLinksInAppsSwitchState(state: String) {
-    onView(
-        allOf(
-            withText(R.string.preferences_open_links_in_apps),
-            hasSibling(withText(state)),
-        ),
-    ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
-// DEVELOPER TOOLS SECTION
-private fun assertDeveloperToolsHeading() {
-    scrollToElementByText("Developer tools")
-    onView(withText("Developer tools"))
 }
 
 // ADVANCED SECTION
@@ -587,7 +598,7 @@ private fun assertAddonsButton() {
         .check(matches(isCompletelyDisplayed()))
 }
 
-private fun assertRemoteDebug() {
+private fun assertRemoteDebuggingButton() {
     scrollToElementByText("Remote debugging via USB")
     onView(withText("Remote debugging via USB"))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))


### PR DESCRIPTION
Bug 1823707 - Refactor settingsAdvancedItemsTest UI tests
`settingsAdvancedItemsTest` successfully passed 100x on Firebase. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1823707