### PR TITLE
Bug 1812730 - Prevent collections with empty name from being created

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
@@ -65,8 +65,8 @@ class CollectionCreationView(
             COLLECTION_NAME_MAX_LENGTH,
         )
         binding.nameCollectionEdittext.setOnEditorActionListener { view, actionId, _ ->
-            val text = view.text.toString()
-            if (actionId == EditorInfo.IME_ACTION_DONE && text.isNotBlank()) {
+            val text = view.text.toString().trim()
+            if (actionId == EditorInfo.IME_ACTION_DONE && text.isNotEmpty()) {
                 when (step) {
                     SaveCollectionStep.NameCollection ->
                         interactor.onNewCollectionNameSaved(selectedTabs.toList(), text)
@@ -76,7 +76,7 @@ class CollectionCreationView(
                     }
                 }
             }
-            false
+            actionId == EditorInfo.IME_ACTION_DONE && text.isEmpty()
         }
 
         binding.tabList.run {

--- a/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionsDialog.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionsDialog.kt
@@ -5,9 +5,12 @@
 package org.mozilla.fenix.collections
 
 import android.content.Context
+import android.content.DialogInterface
 import android.view.LayoutInflater
+import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
+import androidx.core.widget.doOnTextChanged
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.MainScope
@@ -109,13 +112,13 @@ internal fun CollectionsDialog.showAddNewDialog(
         ),
     )
 
-    AlertDialog.Builder(context)
+    val dialog = AlertDialog.Builder(context)
         .setTitle(R.string.tab_tray_add_new_collection)
         .setView(layout).setPositiveButton(R.string.create_collection_positive) { dialog, _ ->
 
             MainScope().launch {
                 val id = storage.createCollection(
-                    collectionNameEditText.text.toString(),
+                    collectionNameEditText.text.toString().trim(),
                     sessionList,
                 )
                 onPositiveButtonClick.invoke(id, true)
@@ -128,8 +131,18 @@ internal fun CollectionsDialog.showAddNewDialog(
             dialog.cancel()
         }
         .create().withCenterAlignedButtons()
-        .show()
+
+    collectionNameEditText.doOnTextChanged { text, _, _, _ ->
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).isClickable = text.toString().isNotBlank()
+    }
+
+    dialog.show()
 
     collectionNameEditText.setSelection(0, collectionNameEditText.text.length)
     collectionNameEditText.showKeyboard()
+
+    collectionNameEditText.setOnEditorActionListener { _, actionId, _ ->
+        val text = collectionNameEditText.text.toString()
+        actionId == EditorInfo.IME_ACTION_DONE && text.isBlank()
+    }
 }


### PR DESCRIPTION
### What
The PR will disable the dialog `OK` button and keyboard `DONE` button if the collection name is `blank`

### Steps to test
### Method 1

1. Open a tab with a web page open
2. Click on `three dot menu`
3. Select `Save to collection`
4. Delete the default name
5. Try saving by clicking on the keyboard `Done` button
6. Repeat steps `1 - 3`  
7. Enter a name with spaces at the beginning and end 

### Method 2
1. Make sure you have more than 1 tab open with a web page open
2. Click on the tab tray
3. Click on `three dot menu`
4. Click on `Select tabs`
5. Select one or more tabs
6. Click on `Collection button`
7. Click on ~Add new collection`
8. Delete the name and try saving or
9. Append and prepend spaces on the name 

### Screenshots
| Issue video | Fix Video |
| ----------- | --------- |
| https://www.loom.com/share/6880e832f260420ab3a26a5a88045420 | https://www.loom.com/share/5155001bee58479c91856252c611affe|


### Pull Request checklist
 - [X] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1812730