### PR TITLE
Bug 1823848 - Add binding classes to handle the home search selector toolbar

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/toolbar/SearchSelectorBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/toolbar/SearchSelectorBinding.kt
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.toolbar
+
+import android.content.Context
+import android.graphics.drawable.BitmapDrawable
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.menu.Orientation
+import mozilla.components.lib.state.helpers.AbstractBinding
+import mozilla.components.service.glean.private.NoExtras
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.GleanMetrics.UnifiedSearch
+import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.FragmentHomeBinding
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
+
+/**
+ * A binding that shows the search engine in the search selector button.
+ */
+class SearchSelectorBinding(
+    private val context: Context,
+    private val binding: FragmentHomeBinding,
+    private val searchSelectorMenu: SearchSelectorMenu,
+    browserStore: BrowserStore,
+) : AbstractBinding<BrowserState>(browserStore) {
+
+    override fun start() {
+        super.start()
+
+        context.settings().showUnifiedSearchFeature.let {
+            binding.searchSelectorButton.isVisible = it
+            binding.searchEngineIcon.isGone = it
+        }
+
+        binding.searchSelectorButton.apply {
+            setOnClickListener {
+                val orientation = if (context.settings().shouldUseBottomToolbar) {
+                    Orientation.UP
+                } else {
+                    Orientation.DOWN
+                }
+
+                UnifiedSearch.searchMenuTapped.record(NoExtras())
+
+                searchSelectorMenu.menuController.show(
+                    anchor = it.findViewById(R.id.search_selector),
+                    orientation = orientation,
+                )
+            }
+        }
+    }
+
+    override suspend fun onState(flow: Flow<BrowserState>) {
+        flow.map { state -> state.search.selectedOrDefaultSearchEngine }
+            .ifChanged()
+            .collect { searchEngine ->
+                val name = searchEngine?.name
+                val icon = searchEngine?.let {
+                    val iconSize =
+                        context.resources.getDimensionPixelSize(R.dimen.preference_icon_drawable_size)
+                    BitmapDrawable(context.resources, searchEngine.icon).apply {
+                        setBounds(0, 0, iconSize, iconSize)
+                    }
+                }
+
+                if (context.settings().showUnifiedSearchFeature) {
+                    binding.searchSelectorButton.setIcon(icon, name)
+                } else {
+                    binding.searchEngineIcon.setImageDrawable(icon)
+                }
+            }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/toolbar/SearchSelectorMenuBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/toolbar/SearchSelectorMenuBinding.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.toolbar
+
+import android.content.Context
+import androidx.core.graphics.drawable.toDrawable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.search.SearchEngine
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.searchEngines
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.lib.state.helpers.AbstractBinding
+import mozilla.components.support.ktx.android.content.getColorFromAttr
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.R
+import org.mozilla.fenix.search.toolbar.SearchSelectorInteractor
+import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
+
+/**
+ * A binding that updates the search engine menu items in the search selector menu.
+ */
+class SearchSelectorMenuBinding(
+    private val context: Context,
+    private val interactor: SearchSelectorInteractor,
+    private val searchSelectorMenu: SearchSelectorMenu,
+    browserStore: BrowserStore,
+) : AbstractBinding<BrowserState>(browserStore) {
+
+    override suspend fun onState(flow: Flow<BrowserState>) {
+        flow.map { state -> state.search }
+            .ifChanged()
+            .collect { search ->
+                updateSearchSelectorMenu(search.searchEngines)
+            }
+    }
+
+    private fun updateSearchSelectorMenu(searchEngines: List<SearchEngine>) {
+        val searchEngineList = searchEngines
+            .map {
+                TextMenuCandidate(
+                    text = it.name,
+                    start = DrawableMenuIcon(
+                        drawable = it.icon.toDrawable(context.resources),
+                        tint = if (it.type == SearchEngine.Type.APPLICATION) {
+                            context.getColorFromAttr(R.attr.textPrimary)
+                        } else {
+                            null
+                        },
+                    ),
+                ) {
+                    interactor.onMenuItemTapped(SearchSelectorMenu.Item.SearchEngine(it))
+                }
+            }
+
+        searchSelectorMenu.menuController.submitList(searchSelectorMenu.menuItems(searchEngineList))
+    }
+}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1823848