### PR TITLE
Bug 1823903 - Fix flaky ContileTopSitesProviderTest test

### DIFF
--- a/android-components/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesProviderTest.kt
+++ b/android-components/components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesProviderTest.kt
@@ -116,7 +116,7 @@ class ContileTopSitesProviderTest {
         runTest {
             val client = prepareClient()
             val provider = spy(ContileTopSitesProvider(testContext, client))
-            val file = mock<File>() {
+            val file = mock<File> {
                 whenever(exists()).thenReturn(true)
                 whenever(lastModified()).thenReturn(Date().time)
             }
@@ -132,7 +132,7 @@ class ContileTopSitesProviderTest {
             assertFalse(provider.isCacheExpired(shouldUseServerMaxAge = true))
 
             provider.cacheState = provider.cacheState.invalidate()
-            whenever(file.lastModified()).thenReturn(Date().time - 300000)
+            whenever(file.lastModified()).thenReturn(Date().time - 500000)
             whenever(provider.getBaseCacheFile()).thenReturn(file)
 
             assertTrue(provider.isCacheExpired(shouldUseServerMaxAge = true))


### PR DESCRIPTION
Fixed flaky `GIVEN a set of top sites is cached WHEN checking the server specified cache max age THEN max age is calculated correctly` unit test.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
