### PR TITLE
Bug 1823929 - New ETP UI tests

### DIFF
--- a/fenix/app/src/androidTest/assets/pages/cross-site-cookies.html
+++ b/fenix/app/src/androidTest/assets/pages/cross-site-cookies.html
@@ -1,4 +1,11 @@
 <html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<!-- This asset is using the code behind
+   - https://www.mozilla-anti-tracking.com/test/dfpi/storage_access_api.html
+   - test page.
+   - Source repository: https://github.com/mozilla/anti-tracking-test-pages -->
 <body>
 <h2>Cross-site cookies storage access test</h2>
 <h3>anti-tracker-test.com</h3>

--- a/fenix/app/src/androidTest/assets/pages/trackingPage.html
+++ b/fenix/app/src/androidTest/assets/pages/trackingPage.html
@@ -2,14 +2,16 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<!-- This asset is using the code behind
+   - https://www.mozilla-anti-tracking.com/test/trackingprotection/test_pages/tracking_protection.html
+   - test page.
+   - Source repository: https://github.com/mozilla/anti-tracking-test-pages -->
 <html dir="ltr" xml:lang="en-US" lang="en-US">
   <head>
     <meta charset="utf8">
     <script src="../resources/trackingAPI.js" type="text/javascript"></script>
   </head>
   <body>
-    <iframe src="http://trackertest.org/"></iframe>
-
     <h3>Level 1 (Basic) List</h3>
     <p>social-track-digest256:</p>
     <img
@@ -18,19 +20,19 @@
     <br/>
     <p>ads-track-digest256:</p>
     <img
-            src="https://ads-track-digest256.dummytracker.org/test_not_blocked.png"
+            src="https://ads-track-digest256.dummytracker.org/test_not_blocked.png" alt="ads not blocked"
             onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png';this.alt='ads blocked'">
     <br/>
     <p>analytics-track-digest256:</p>
     <img
-            src="https://analytics-track-digest256.dummytracker.org/test_not_blocked.png"
+            src="https://analytics-track-digest256.dummytracker.org/test_not_blocked.png" alt="analytics not blocked"
             onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png';this.alt='analytics blocked'">
     <br/>
     <p>Fingerprinting:
     <pre id="result">test not run</pre>
     <script src="https://base-fingerprinting-track-digest256.dummytracker.org/tracker.js"
             onerror="this.onerror=null;var result=document.getElementById('result');result.innerHTML='Fingerprinting blocked';"
-            onload="this.onload=null;var result=document.getElementById('result');result.innerHTML='Fingerprinting NOT blocked';"
+            onload="this.onload=null;var result=document.getElementById('result');result.innerHTML='Fingerprinting not blocked';"
     ></script>
     </p>
     <br/>

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/EnhancedTrackingProtectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/EnhancedTrackingProtectionTest.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
+import androidx.test.espresso.Espresso.pressBack
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -13,14 +14,18 @@ import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.HomeActivityTestRule
-import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper.getEnhancedTrackingProtectionAsset
+import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
+import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.TestHelper.restartApp
+import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
+import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.enhancedTrackingProtection
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
-import org.mozilla.fenix.ui.robots.settingsSubMenuEnhancedTrackingProtection
 
 /**
  *  Tests for verifying basic UI functionality of Enhanced Tracking Protection
@@ -32,6 +37,7 @@ import org.mozilla.fenix.ui.robots.settingsSubMenuEnhancedTrackingProtection
  *  - Verifying Enhanced Tracking Protection content sheet
  *  - Verifying Enhanced Tracking Protection content sheet details
  *  - Verifying Enhanced Tracking Protection toggle
+ *  - Verifying Enhanced Tracking Protection options and functionality
  *  - Verifying Enhanced Tracking Protection site exceptions
  */
 
@@ -39,7 +45,7 @@ class EnhancedTrackingProtectionTest {
     private lateinit var mockWebServer: MockWebServer
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule(
+    val activityTestRule = HomeActivityIntentTestRule(
         isJumpBackInCFREnabled = false,
         isTCPCFREnabled = false,
         isWallpaperOnboardingEnabled = false,
@@ -59,7 +65,7 @@ class EnhancedTrackingProtectionTest {
     }
 
     @Test
-    fun testSettingsDefaults() {
+    fun testETPSettingsItemsAndSubMenus() {
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {
@@ -67,17 +73,57 @@ class EnhancedTrackingProtectionTest {
             verifySettingsOptionSummary("Enhanced Tracking Protection", "Standard")
         }.openEnhancedTrackingProtectionSubMenu {
             verifyEnhancedTrackingProtectionHeader()
-            verifyEnhancedTrackingProtectionOptionsEnabled()
+            verifyEnhancedTrackingProtectionHeaderDescription()
+            verifyLearnMoreText()
+            verifyEnhancedTrackingProtectionTextWithSwitchWidget()
             verifyTrackingProtectionSwitchEnabled()
+            verifyEnhancedTrackingProtectionOptionsEnabled()
+            verifyEnhancedTrackingProtectionLevelSelected("Standard (default)", true)
+            verifyStandardOptionDescription()
+            verifyStrictOptionDescription()
+            selectTrackingProtectionOption("Custom")
+            verifyCustomTrackingProtectionSettings()
+            scrollToElementByText("Standard (default)")
+            verifyWhatsBlockedByStandardETPInfo()
+            pressBack()
+            verifyWhatsBlockedByStrictETPInfo()
+            pressBack()
+            verifyWhatsBlockedByCustomETPInfo()
+            pressBack()
         }.openExceptions {
-            verifyDefault()
+            verifyTPExceptionsDefaultView()
+            openExceptionsLearnMoreLink()
+        }
+        browserScreen {
+            verifyUrl("support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-android")
         }
     }
 
-    @SmokeTest
+    @Test
+    fun testETPSettingsSummaryChange() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+            verifyEnhancedTrackingProtectionButton()
+            verifySettingsOptionSummary("Enhanced Tracking Protection", "Standard")
+        }.openEnhancedTrackingProtectionSubMenu {
+            selectTrackingProtectionOption("Strict")
+        }.goBack {
+            verifySettingsOptionSummary("Enhanced Tracking Protection", "Strict")
+        }.openEnhancedTrackingProtectionSubMenu {
+            selectTrackingProtectionOption("Custom")
+        }.goBack {
+            verifySettingsOptionSummary("Enhanced Tracking Protection", "Custom")
+        }.openEnhancedTrackingProtectionSubMenu {
+            switchEnhancedTrackingProtectionToggle()
+        }.goBack {
+            verifySettingsOptionSummary("Enhanced Tracking Protection", "Off")
+        }
+    }
+
     @Test
     fun testETPOffGlobally() {
-        val genericPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val genericPage = getGenericAsset(mockWebServer, 1)
 
         homeScreen {
         }.openThreeDotMenu {
@@ -107,22 +153,98 @@ class EnhancedTrackingProtectionTest {
         }
     }
 
+    // Tests adding ETP exceptions to websites and keeping that preference after restart
+    @SmokeTest
     @Test
-    fun testStrictVisitProtectionSheet() {
-        appContext.settings().setStrictETP()
-        val genericPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        val trackingProtectionTest =
-            TestAssetHelper.getEnhancedTrackingProtectionAsset(mockWebServer)
+    fun testDisableETPExceptionToggle() {
+        val firstPage = getGenericAsset(mockWebServer, 1)
+        val secondPage = "example.com"
 
-        // browsing a generic page to allow GV to load on a fresh run
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(genericPage.url) {
-        }.openTabDrawer {
-            closeTab()
+        }.enterURLAndEnterToBrowser(firstPage.url) {}
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+        }.toggleEnhancedTrackingProtectionFromSheet {
+            verifyEnhancedTrackingProtectionSheetStatus("OFF", false)
+        }.closeEnhancedTrackingProtectionSheet {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(secondPage.toUri()) {
+            verifyPageContent("Example Domain")
         }
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+            verifyEnhancedTrackingProtectionSheetStatus("ON", true)
+        }.toggleEnhancedTrackingProtectionFromSheet {
+            verifyEnhancedTrackingProtectionSheetStatus("OFF", false)
+        }
+        restartApp(activityTestRule)
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+            verifyEnhancedTrackingProtectionSheetStatus("OFF", false)
+        }
+    }
+
+    @Test
+    fun trackingProtectionSwitchEnabledRemovesExceptionTest() {
+        val trackingPage = getEnhancedTrackingProtectionAsset(mockWebServer)
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(trackingProtectionTest.url) {}
+        }.enterURLAndEnterToBrowser(trackingPage.url) {
+            waitForPageToLoad()
+        }
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+        }.toggleEnhancedTrackingProtectionFromSheet {
+            verifyEnhancedTrackingProtectionSheetStatus("OFF", false)
+        }.closeEnhancedTrackingProtectionSheet {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openEnhancedTrackingProtectionSubMenu {
+        }.openExceptions {
+            verifySiteExceptionExists(trackingPage.url.host.toString(), true)
+            exitMenu()
+        }
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+        }.toggleEnhancedTrackingProtectionFromSheet {
+            verifyEnhancedTrackingProtectionSheetStatus("ON", true)
+        }.openProtectionSettings {
+        }.openExceptions {
+            verifySiteExceptionExists(trackingPage.url.host.toString(), false)
+        }
+    }
+
+    // Tests removing TP exceptions individually or all at once
+    @Test
+    fun clearTrackingProtectionExceptionsTest() {
+        val firstPage = getGenericAsset(mockWebServer, 1)
+        val secondPage = "example.com"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstPage.url) {}
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+        }.toggleEnhancedTrackingProtectionFromSheet {
+            verifyEnhancedTrackingProtectionSheetStatus("OFF", false)
+        }.closeEnhancedTrackingProtectionSheet {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(secondPage.toUri()) {
+            verifyPageContent("Example Domain")
+        }
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+        }.toggleEnhancedTrackingProtectionFromSheet {
+            verifyEnhancedTrackingProtectionSheetStatus("OFF", false)
+        }.closeEnhancedTrackingProtectionSheet {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openEnhancedTrackingProtectionSubMenu {
+        }.openExceptions {
+            removeOneSiteException(secondPage)
+        }.disableExceptions {
+            verifyTPExceptionsDefaultView()
+            exitMenu()
+        }
         enhancedTrackingProtection {
         }.openEnhancedTrackingProtectionSheet {
             verifyEnhancedTrackingProtectionSheetStatus("ON", true)
@@ -130,46 +252,41 @@ class EnhancedTrackingProtectionTest {
     }
 
     @Test
-    fun testStrictVisitDisableExceptionToggle() {
-        appContext.settings().setStrictETP()
-        val genericPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        val trackingProtectionTest =
-            TestAssetHelper.getEnhancedTrackingProtectionAsset(mockWebServer)
+    fun testStandardETPVisitSheetDetails() {
+        val genericPage = getGenericAsset(mockWebServer, 1)
+        val trackingProtectionTest = getEnhancedTrackingProtectionAsset(mockWebServer).url
 
         // browsing a generic page to allow GV to load on a fresh run
         navigationToolbar {
         }.enterURLAndEnterToBrowser(genericPage.url) {
-        }.openTabDrawer {
-            closeTab()
+            verifyPageContent(genericPage.content)
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(trackingProtectionTest) {
+            verifyTrackingProtectionWebContent("social not blocked")
+            verifyTrackingProtectionWebContent("ads not blocked")
+            verifyTrackingProtectionWebContent("analytics not blocked")
+            verifyTrackingProtectionWebContent("Fingerprinting blocked")
+            verifyTrackingProtectionWebContent("Cryptomining blocked")
         }
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(trackingProtectionTest.url) {}
         enhancedTrackingProtection {
         }.openEnhancedTrackingProtectionSheet {
             verifyEnhancedTrackingProtectionSheetStatus("ON", true)
-        }.disableEnhancedTrackingProtectionFromSheet {
-            verifyEnhancedTrackingProtectionSheetStatus("OFF", false)
-        }.openProtectionSettings {
-            verifyEnhancedTrackingProtectionHeader()
-            verifyEnhancedTrackingProtectionOptionsEnabled()
-            verifyTrackingProtectionSwitchEnabled()
-        }
-
-        settingsSubMenuEnhancedTrackingProtection {
-        }.openExceptions {
-            verifyListedURL(trackingProtectionTest.url.host.toString())
-        }.disableExceptions {
-            verifyDefault()
-        }
+        }.openDetails {
+            verifyCrossSiteCookiesBlocked(true)
+            navigateBackToDetails()
+            verifyCryptominersBlocked(true)
+            navigateBackToDetails()
+            verifyFingerprintersBlocked(true)
+            navigateBackToDetails()
+            verifyTrackingContentBlocked(false)
+        }.closeEnhancedTrackingProtectionSheet {}
     }
 
     @Test
     fun testStrictVisitSheetDetails() {
         appContext.settings().setStrictETP()
-        val genericPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        val trackingProtectionTest =
-            TestAssetHelper.getEnhancedTrackingProtectionAsset(mockWebServer)
+        val genericPage = getGenericAsset(mockWebServer, 1)
+        val trackingProtectionTest = getEnhancedTrackingProtectionAsset(mockWebServer).url
 
         // browsing a generic page to allow GV to load on a fresh run
         navigationToolbar {
@@ -179,7 +296,7 @@ class EnhancedTrackingProtectionTest {
         }
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(trackingProtectionTest.url) {
+        }.enterURLAndEnterToBrowser(trackingProtectionTest) {
             verifyTrackingProtectionWebContent("social blocked")
             verifyTrackingProtectionWebContent("ads blocked")
             verifyTrackingProtectionWebContent("analytics blocked")
@@ -190,31 +307,31 @@ class EnhancedTrackingProtectionTest {
         }.openEnhancedTrackingProtectionSheet {
             verifyEnhancedTrackingProtectionSheetStatus("ON", true)
         }.openDetails {
-            verifyEnhancedTrackingProtectionDetailsStatus("Blocked")
-            verifyTrackingCookiesBlocked()
-            verifyCryptominersBlocked()
-            verifyFingerprintersBlocked()
-            verifyTrackingContentBlocked()
+            verifySocialMediaTrackersBlocked(true)
+            navigateBackToDetails()
+            verifyCryptominersBlocked(true)
+            navigateBackToDetails()
+            verifyFingerprintersBlocked(true)
+            navigateBackToDetails()
+            verifyTrackingContentBlocked(true)
             viewTrackingContentBlockList()
         }
     }
 
     @SmokeTest
     @Test
-    fun customTrackingProtectionSettingsTest() {
-        val genericWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        val trackingPage = TestAssetHelper.getEnhancedTrackingProtectionAsset(mockWebServer)
+    fun defaultCustomTrackingProtectionSettingsTest() {
+        val genericWebPage = getGenericAsset(mockWebServer, 1)
+        val trackingPage = getEnhancedTrackingProtectionAsset(mockWebServer)
 
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {
         }.openEnhancedTrackingProtectionSubMenu {
-            verifyEnhancedTrackingProtectionOptionsEnabled()
             selectTrackingProtectionOption("Custom")
             verifyCustomTrackingProtectionSettings()
-        }.goBackToHomeScreen {}
-
-        navigationToolbar {
+        }.goBackToHomeScreen {
+        }.openNavigationToolbar {
             // browsing a basic page to allow GV to load on a fresh run
         }.enterURLAndEnterToBrowser(genericWebPage.url) {
         }.openNavigationToolbar {
@@ -229,10 +346,138 @@ class EnhancedTrackingProtectionTest {
         enhancedTrackingProtection {
         }.openEnhancedTrackingProtectionSheet {
         }.openDetails {
-            verifyTrackingCookiesBlocked()
-            verifyCryptominersBlocked()
-            verifyFingerprintersBlocked()
-            verifyTrackingContentBlocked()
+            verifyCrossSiteCookiesBlocked(true)
+            navigateBackToDetails()
+            verifyCryptominersBlocked(true)
+            navigateBackToDetails()
+            verifyFingerprintersBlocked(true)
+            navigateBackToDetails()
+            verifyTrackingContentBlocked(true)
+            viewTrackingContentBlockList()
+        }
+    }
+
+    // Tests the trackers blocked with the following Custom TP set up:
+    // - Cookies set to "All cookies"
+    // - Tracking content option OFF
+    // - Fingerprinters, cryptominers and redirect trackers checked
+    @Test
+    fun customizedTrackingProtectionOptionsTest() {
+        val genericWebPage = getGenericAsset(mockWebServer, 1)
+        val trackingPage = getEnhancedTrackingProtectionAsset(mockWebServer)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openEnhancedTrackingProtectionSubMenu {
+            selectTrackingProtectionOption("Custom")
+            verifyCustomTrackingProtectionSettings()
+            selectTrackingProtectionOption("Isolate cross-site cookies")
+            selectTrackingProtectionOption("All cookies (will cause websites to break)")
+            selectTrackingProtectionOption("Tracking content")
+        }.goBackToHomeScreen {
+            mDevice.waitForIdle()
+        }.openNavigationToolbar {
+            // browsing a basic page to allow GV to load on a fresh run
+        }.enterURLAndEnterToBrowser(genericWebPage.url) {
+            waitForPageToLoad()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(trackingPage.url) {
+            verifyTrackingProtectionWebContent("social not blocked")
+            verifyTrackingProtectionWebContent("ads not blocked")
+            verifyTrackingProtectionWebContent("analytics not blocked")
+        }
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+        }.openDetails {
+            verifyCrossSiteCookiesBlocked(true)
+            navigateBackToDetails()
+            verifyCryptominersBlocked(true)
+            navigateBackToDetails()
+            verifyFingerprintersBlocked(true)
+            navigateBackToDetails()
+            verifyTrackingContentBlocked(false)
+        }
+    }
+
+    @Test
+    fun disableCustomTrackingProtectionOptionsTest() {
+        val genericWebPage = getGenericAsset(mockWebServer, 1)
+        val trackingPage = getEnhancedTrackingProtectionAsset(mockWebServer)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openEnhancedTrackingProtectionSubMenu {
+            selectTrackingProtectionOption("Custom")
+            verifyCustomTrackingProtectionSettings()
+            selectTrackingProtectionOption("Cookies")
+            selectTrackingProtectionOption("Tracking content")
+            selectTrackingProtectionOption("Cryptominers")
+            selectTrackingProtectionOption("Fingerprinters")
+            selectTrackingProtectionOption("Redirect Trackers")
+        }.goBackToHomeScreen {
+            mDevice.waitForIdle()
+        }.openNavigationToolbar {
+            // browsing a basic page to allow GV to load on a fresh run
+        }.enterURLAndEnterToBrowser(genericWebPage.url) {
+            waitForPageToLoad()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(trackingPage.url) {
+            verifyTrackingProtectionWebContent("social not blocked")
+            verifyTrackingProtectionWebContent("ads not blocked")
+            verifyTrackingProtectionWebContent("analytics not blocked")
+            verifyTrackingProtectionWebContent("Fingerprinting not blocked")
+            verifyTrackingProtectionWebContent("Cryptomining not blocked")
+        }
+    }
+
+    @Test
+    fun testTrackingContentBlockedOnlyInPrivateTabs() {
+        val genericWebPage = getGenericAsset(mockWebServer, 1)
+        val trackingPage = getEnhancedTrackingProtectionAsset(mockWebServer)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openEnhancedTrackingProtectionSubMenu {
+            verifyEnhancedTrackingProtectionOptionsEnabled()
+            selectTrackingProtectionOption("Custom")
+            verifyCustomTrackingProtectionSettings()
+            selectTrackingProtectionOption("In all tabs")
+            selectTrackingProtectionOption("Only in Private tabs")
+        }.goBackToHomeScreen {
+        }.openNavigationToolbar {
+            // browsing a basic page to allow GV to load on a fresh run
+        }.enterURLAndEnterToBrowser(genericWebPage.url) {
+            waitForPageToLoad()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(trackingPage.url) {
+            verifyTrackingProtectionWebContent("social not blocked")
+            verifyTrackingProtectionWebContent("ads not blocked")
+            verifyTrackingProtectionWebContent("analytics not blocked")
+            verifyTrackingProtectionWebContent("Fingerprinting blocked")
+            verifyTrackingProtectionWebContent("Cryptomining blocked")
+        }.goToHomescreen {
+        }.togglePrivateBrowsingMode()
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(trackingPage.url) {
+            verifyTrackingProtectionWebContent("social blocked")
+            verifyTrackingProtectionWebContent("ads blocked")
+            verifyTrackingProtectionWebContent("analytics blocked")
+            verifyTrackingProtectionWebContent("Fingerprinting blocked")
+            verifyTrackingProtectionWebContent("Cryptomining blocked")
+        }
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+        }.openDetails {
+            verifyCrossSiteCookiesBlocked(true)
+            navigateBackToDetails()
+            verifyCryptominersBlocked(true)
+            navigateBackToDetails()
+            verifyFingerprintersBlocked(true)
+            navigateBackToDetails()
+            verifyTrackingContentBlocked(true)
             viewTrackingContentBlockList()
         }
     }
@@ -241,12 +486,17 @@ class EnhancedTrackingProtectionTest {
     @Test
     fun blockCookiesStorageAccessTest() {
         // With Standard TrackingProtection settings
-        val page = mockWebServer.url("pages/cross-site-cookies.html").toString().toUri()
+        val genericWebPage = getGenericAsset(mockWebServer, 1)
+        val testPage = mockWebServer.url("pages/cross-site-cookies.html").toString().toUri()
         val originSite = "https://mozilla-mobile.github.io"
         val currentSite = "http://localhost:${mockWebServer.port}"
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(page) {
+        }.enterURLAndEnterToBrowser(genericWebPage.url) {
+            waitForPageToLoad()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage) {
+            waitForPageToLoad()
         }.clickRequestStorageAccessButton {
             verifyCrossOriginCookiesPermissionPrompt(originSite, currentSite)
         }.clickPagePermissionButton(allow = false) {
@@ -258,12 +508,17 @@ class EnhancedTrackingProtectionTest {
     @Test
     fun allowCookiesStorageAccessTest() {
         // With Standard TrackingProtection settings
-        val page = mockWebServer.url("pages/cross-site-cookies.html").toString().toUri()
+        val genericWebPage = getGenericAsset(mockWebServer, 1)
+        val testPage = mockWebServer.url("pages/cross-site-cookies.html").toString().toUri()
         val originSite = "https://mozilla-mobile.github.io"
         val currentSite = "http://localhost:${mockWebServer.port}"
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(page) {
+        }.enterURLAndEnterToBrowser(genericWebPage.url) {
+            waitForPageToLoad()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage) {
+            waitForPageToLoad()
         }.clickRequestStorageAccessButton {
             verifyCrossOriginCookiesPermissionPrompt(originSite, currentSite)
         }.clickPagePermissionButton(allow = true) {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsTest.kt
@@ -67,12 +67,12 @@ class SettingsTest {
             verifySettingsOptionSummary("Enhanced Tracking Protection", "Standard")
         }.openEnhancedTrackingProtectionSubMenu {
             verifyNavigationToolBarHeader()
-            verifyEnhancedTrackingProtectionProtectionSubMenuItems()
+            verifyEnhancedTrackingProtectionOptionsEnabled()
 
             // ENHANCED TRACKING PROTECTION EXCEPTION
         }.openExceptions {
             verifyNavigationToolBarHeader()
-            verifyEnhancedTrackingProtectionProtectionExceptionsSubMenuItems()
+            verifyTPExceptionsDefaultView()
         }.goBack {
         }.goBack {
             // SITE PERMISSIONS

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -1237,6 +1237,7 @@ class BrowserRobot {
         }
 
         fun clickRequestStorageAccessButton(interact: SitePermissionsRobot.() -> Unit): SitePermissionsRobot.Transition {
+            webPageItemContainingText("requestStorageAccess()").waitForExists(waitingTime)
             clickPageObject(webPageItemContainingText("requestStorageAccess()"))
 
             SitePermissionsRobot().interact()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -192,7 +192,6 @@ class SettingsRobot {
 
     fun verifySettingsOptionSummary(setting: String, summary: String) {
         scrollToElementByText(setting)
-
         onView(
             allOf(
                 withText(setting),

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot.kt
@@ -7,6 +7,8 @@ package org.mozilla.fenix.ui.robots
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -14,9 +16,14 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiSelector
 import junit.framework.TestCase.assertTrue
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Matchers.contains
+import org.junit.Assert.assertFalse
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
 
 /**
@@ -26,15 +33,35 @@ class SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot {
 
     fun verifyNavigationToolBarHeader() = assertNavigationToolBarHeader()
 
-    fun verifyDefault() = assertExceptionDefault()
+    fun verifyTPExceptionsDefaultView() {
+        assertTrue(
+            mDevice.findObject(
+                UiSelector().text("Exceptions let you disable tracking protection for selected sites."),
+            ).waitForExists(waitingTime),
+        )
+        learnMoreLink.check(matches(isDisplayed()))
+    }
 
-    fun verifyExceptionLearnMoreText() = assertExceptionLearnMoreText()
+    fun openExceptionsLearnMoreLink() = learnMoreLink.click()
 
-    fun verifyListedURL(url: String) = assertExceptionURL(url)
+    fun removeOneSiteException(siteHost: String) {
+        exceptionsList.waitForExists(waitingTime)
+        removeSiteExceptionButton(siteHost).click()
+    }
 
-    fun verifyEnhancedTrackingProtectionProtectionExceptionsSubMenuItems() {
-        verifyDefault()
-        verifyExceptionLearnMoreText()
+    fun verifySiteExceptionExists(siteUrl: String, shouldExist: Boolean) {
+        exceptionsList.waitForExists(waitingTime)
+        if (shouldExist) {
+            assertTrue(
+                mDevice.findObject(UiSelector().textContains(siteUrl))
+                    .waitForExists(waitingTime),
+            )
+        } else {
+            assertFalse(
+                mDevice.findObject(UiSelector().textContains(siteUrl))
+                    .waitForExists(waitingTime),
+            )
+        }
     }
 
     class Transition {
@@ -46,7 +73,7 @@ class SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot {
         }
 
         fun disableExceptions(interact: SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot.() -> Unit): Transition {
-            disableExceptionsButton().click()
+            disableAllExceptionsButton().click()
 
             SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot().interact()
             return Transition()
@@ -62,26 +89,18 @@ private fun assertNavigationToolBarHeader() {
         .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
 }
 
-private fun assertExceptionDefault() =
-    assertTrue(
-        mDevice.findObject(
-            UiSelector().text("Exceptions let you disable tracking protection for selected sites."),
-        ).waitForExists(waitingTime),
-    )
+private val learnMoreLink = onView(withText("Learn more"))
 
-private fun assertExceptionLearnMoreText() =
-    assertTrue(
-        mDevice.findObject(
-            UiSelector().text("Learn more"),
-        ).waitForExists(waitingTime),
-    )
-
-private fun assertExceptionURL(url: String) =
-    assertTrue(
-        mDevice.findObject(
-            UiSelector().textContains(url.replace("http://", "https://")),
-        ).waitForExists(waitingTime),
-    )
-
-private fun disableExceptionsButton() =
+private fun disableAllExceptionsButton() =
     onView(withId(R.id.removeAllExceptions)).click()
+
+private fun removeSiteExceptionButton(siteHost: String) =
+    onView(
+        allOf(
+            withContentDescription("Delete"),
+            hasSibling(withText(containsString(siteHost))),
+        ),
+    )
+
+private val exceptionsList =
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/exceptions_list"))


### PR DESCRIPTION
Adds some new tests for all ETP options, trackers blocked, adding and removing exceptions.
Also improved the coverage of existing tests.
Worked on improving the stability of tests.
Ran on Firebase multiple times, all green.
Before merging, we should wait for https://github.com/mozilla-mobile/firefox-android/pull/1340 as they might have a conflict.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1823929