### PR TITLE
Bug 1821961 -  Improve collapse animation of the tabs tray FAB & scrim

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabSheetBehaviorManager.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabSheetBehaviorManager.kt
@@ -7,14 +7,21 @@ package org.mozilla.fenix.tabstray
 import android.content.res.Configuration
 import android.util.DisplayMetrics
 import android.view.View
+import android.widget.ImageView
 import androidx.annotation.VisibleForTesting
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_DRAGGING
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_SETTLING
+import mozilla.components.support.base.log.Log
 import mozilla.components.support.ktx.android.util.dpToPx
 
-@VisibleForTesting internal const val EXPANDED_OFFSET_IN_LANDSCAPE_DP = 0
 
-@VisibleForTesting internal const val EXPANDED_OFFSET_IN_PORTRAIT_DP = 40
+@VisibleForTesting
+internal const val EXPANDED_OFFSET_IN_LANDSCAPE_DP = 0
+
+@VisibleForTesting
+internal const val EXPANDED_OFFSET_IN_PORTRAIT_DP = 40
 
 /**
  * Helper class for updating how the tray looks and behaves depending on app state / internal tray state.
@@ -33,6 +40,7 @@ internal class TabSheetBehaviorManager(
     private val numberForExpandingTray: Int,
     navigationInteractor: NavigationInteractor,
     private val displayMetrics: DisplayMetrics,
+    tabDrawerHolderBackground: ImageView,
 ) {
     @VisibleForTesting
     internal var currentOrientation = orientation
@@ -40,7 +48,7 @@ internal class TabSheetBehaviorManager(
     init {
         behavior.skipCollapsed = true
         behavior.addBottomSheetCallback(
-            TraySheetBehaviorCallback(behavior, navigationInteractor),
+            TraySheetBehaviorCallback(behavior, navigationInteractor, tabDrawerHolderBackground),
         )
 
         val isInLandscape = isLandscape(orientation)
@@ -87,17 +95,30 @@ internal class TabSheetBehaviorManager(
 internal class TraySheetBehaviorCallback(
     @get:VisibleForTesting internal val behavior: BottomSheetBehavior<out View>,
     @get:VisibleForTesting internal val trayInteractor: NavigationInteractor,
+    @get:VisibleForTesting internal val tabDrawerHolder: ImageView,
 ) : BottomSheetBehavior.BottomSheetCallback() {
 
     override fun onStateChanged(bottomSheet: View, newState: Int) {
         if (newState == STATE_HIDDEN) {
             trayInteractor.onTabTrayDismissed()
+            Log.log(tag = "zzz", message = "STATE_HIDDEN")
         } else if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
+            Log.log(tag = "zzz", message = "STATE_HALF_EXPANDED")
             // We only support expanded and collapsed states.
             // Otherwise the tray may be left in an unusable state. See #14980.
             behavior.state = STATE_HIDDEN
+        } else if (newState == STATE_DRAGGING) {
+            Log.log(tag = "zzz", message = "STATE_DRAGGING")
+        } else if (newState == STATE_SETTLING) {
+            Log.log(tag = "zzz", message = "STATE_SETTLING")
+        } else if (newState == BottomSheetBehavior.STATE_EXPANDED) {
+            Log.log(tag = "zzz", message = "STATE_EXPANDED")
+        } else if (newState == BottomSheetBehavior.STATE_COLLAPSED) {
+            Log.log(tag = "zzz", message = "STATE_COLLAPSED")
         }
     }
 
-    override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
+    override fun onSlide(bottomSheet: View, slideOffset: Float) {
+        tabDrawerHolder.alpha = slideOffset + 1
+    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -253,6 +253,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
         } else {
             tabsTrayBinding.tabWrapper
         }
+
         trayBehaviorManager = TabSheetBehaviorManager(
             behavior = BottomSheetBehavior.from(rootView),
             orientation = resources.configuration.orientation,
@@ -267,6 +268,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
             },
             navigationInteractor = navigationInteractor,
             displayMetrics = requireContext().resources.displayMetrics,
+            tabsTrayDialogBinding.tabDrawerHolderBackground,
         )
 
         if (!requireContext().settings().enableTabsTrayToCompose) {

--- a/fenix/app/src/main/res/layout/fragment_tab_tray_dialog.xml
+++ b/fenix/app/src/main/res/layout/fragment_tab_tray_dialog.xml
@@ -7,4 +7,13 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/tabLayout"
     android:layout_height="match_parent"
-    android:layout_width="match_parent" />
+    android:layout_width="match_parent">
+
+    <ImageView
+        android:id="@+id/tab_drawer_holder_background"
+        android:background="@color/accent_high_contrast_private_theme"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@string/background_image_for_tab_drawer_background" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -840,6 +840,8 @@
     <string name="open_tabs_menu">Open tabs menu</string>
     <!-- Open tabs menu item to save tabs to collection -->
     <string name="tabs_menu_save_to_collection1">Save tabs to collection</string>
+    <!-- Content description (not visible, for screen readers etc.): Open tabs drawer background -->
+    <string name="background_image_for_tab_drawer_background">background image for tab drawer background</string>
     <!-- Text for the menu button to delete a collection -->
     <string name="collection_delete">Delete collection</string>
     <!-- Text for the menu button to rename a collection -->


### PR DESCRIPTION
⚠️ **WIP** 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821961