### PR TITLE
Bug 1821206 - Implement composified tab list click listeners

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTabLayouts.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTabLayouts.kt
@@ -34,10 +34,18 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * Top-level UI for displaying a list of tabs.
  *
  * @param tabs The list of [TabSessionState] to display.
+ * @param onTabClose Invoked when the user clicks to close a tab.
+ * @param onTabMediaClick Invoked when the user interacts with a tab's media controls.
+ * @param onTabClick Invoked when the user clicks on a tab.
+ * @param onTabLongClick Invoked when the user long clicks a tab.
  */
 @Composable
 fun TabList(
     tabs: List<TabSessionState>,
+    onTabClose: (TabSessionState) -> Unit,
+    onTabMediaClick: (TabSessionState) -> Unit,
+    onTabClick: (TabSessionState) -> Unit,
+    onTabLongClick: (TabSessionState) -> Unit,
 ) {
     val tabListBottomPadding = dimensionResource(id = R.dimen.tab_tray_list_bottom_padding)
     val state = rememberLazyListState()
@@ -52,10 +60,10 @@ fun TabList(
         ) { tab ->
             TabListItem(
                 tab = tab,
-                onCloseClick = {},
-                onMediaClick = {},
-                onClick = {},
-                onLongClick = {},
+                onCloseClick = onTabClose,
+                onMediaClick = onTabMediaClick,
+                onClick = onTabClick,
+                onLongClick = onTabLongClick,
             )
         }
 
@@ -69,10 +77,18 @@ fun TabList(
  * Top-level UI for displaying a grid of tabs.
  *
  * @param tabs The list of [TabSessionState] to display.
+ * @param onTabClose Invoked when the user clicks to close a tab.
+ * @param onTabMediaClick Invoked when the user interacts with a tab's media controls.
+ * @param onTabClick Invoked when the user clicks on a tab.
+ * @param onTabLongClick Invoked when the user long clicks a tab.
  */
 @Composable
 fun TabGrid(
     tabs: List<TabSessionState>,
+    onTabClose: (tab: TabSessionState) -> Unit,
+    onTabMediaClick: (tab: TabSessionState) -> Unit,
+    onTabClick: (tab: TabSessionState) -> Unit,
+    onTabLongClick: (tab: TabSessionState) -> Unit,
 ) {
     val tabListBottomPadding = dimensionResource(id = R.dimen.tab_tray_list_bottom_padding)
     val state = rememberLazyGridState()
@@ -88,10 +104,10 @@ fun TabGrid(
         ) { tab ->
             TabGridItem(
                 tab = tab,
-                onCloseClick = {},
-                onMediaClick = {},
-                onClick = {},
-                onLongClick = {},
+                onCloseClick = onTabClose,
+                onMediaClick = onTabMediaClick,
+                onClick = onTabClick,
+                onLongClick = onTabLongClick,
             )
         }
 
@@ -112,6 +128,10 @@ private fun TabListPreview() {
         ) {
             TabList(
                 tabs = generateFakeTabsList(),
+                onTabClose = {},
+                onTabMediaClick = {},
+                onTabClick = {},
+                onTabLongClick = {},
             )
         }
     }
@@ -128,6 +148,10 @@ private fun TabGridPreview() {
         ) {
             TabGrid(
                 tabs = generateFakeTabsList(),
+                onTabClose = {},
+                onTabMediaClick = {},
+                onTabClick = {},
+                onTabLongClick = {},
             )
         }
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
@@ -100,6 +100,7 @@ class TabsTrayFragmentTest {
             every { fragment.context } returns testContext // needed for getString()
             every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } just Runs
             every { fragment.requireView() } returns view
+            every { testContext.settings().enableTabsTrayToCompose } returns false
 
             fragment.showUndoSnackbarForTab(true)
 
@@ -131,6 +132,7 @@ class TabsTrayFragmentTest {
             every { fragment.context } returns testContext // needed for getString()
             every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } just Runs
             every { fragment.requireView() } returns view
+            every { testContext.settings().enableTabsTrayToCompose } returns false
 
             fragment.showUndoSnackbarForTab(true)
 
@@ -163,6 +165,7 @@ class TabsTrayFragmentTest {
             every { fragment.context } returns testContext // needed for getString()
             every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } just Runs
             every { fragment.requireView() } returns view
+            every { testContext.settings().enableTabsTrayToCompose } returns false
 
             fragment.showUndoSnackbarForTab(false)
 
@@ -194,6 +197,7 @@ class TabsTrayFragmentTest {
             every { fragment.context } returns testContext // needed for getString()
             every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } just Runs
             every { fragment.requireView() } returns view
+            every { testContext.settings().enableTabsTrayToCompose } returns false
 
             fragment.showUndoSnackbarForTab(false)
 


### PR DESCRIPTION
The UNDO Snackbar is outside of the scope of this ticket, and will be completed in Bug 1823999.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821206