### PR TITLE
Bug 1824027 - Revert speculative fix for Onboarding RTL crash

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/UpgradeOnboarding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/UpgradeOnboarding.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.onboarding.view
 
-import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,7 +20,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,9 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.fenix.R
@@ -56,21 +52,6 @@ private enum class UpgradeOnboardingState {
  */
 @Composable
 fun UpgradeOnboarding(
-    isSyncSignIn: Boolean,
-    onDismiss: () -> Unit,
-    onSignInButtonClick: () -> Unit,
-) {
-    CompositionLocalProvider(LocalLayoutDirection provides layoutDirection()) {
-        UpgradeOnboardingContent(
-            isSyncSignIn = isSyncSignIn,
-            onDismiss = onDismiss,
-            onSignInButtonClick = onSignInButtonClick,
-        )
-    }
-}
-
-@Composable
-private fun UpgradeOnboardingContent(
     isSyncSignIn: Boolean,
     onDismiss: () -> Unit,
     onSignInButtonClick: () -> Unit,
@@ -195,16 +176,4 @@ private fun OnboardingPreview() {
             onSignInButtonClick = {},
         )
     }
-}
-
-/**
- * Force Left to Right layout direction when running on Android API level < 23 (Android 5.1).
- * Bug with compose and RTL views causing crash in the Onboarding screen in Android 5.1.
- * Bugzilla link: https://bugzilla.mozilla.org/show_bug.cgi?id=1792796
- */
-@Composable
-private fun layoutDirection() = if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP_MR1) {
-    LocalLayoutDirection.current
-} else {
-    LayoutDirection.Ltr
 }


### PR DESCRIPTION
Removing the speculative fix from the Onboarding.
Forcing LTR on Android 5.1 devices did not lower crash rates and should be removed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1824027