### PR TITLE
Bug 1815013 - Port over the Tabs Tray FAB 

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFab.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFab.kt
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import mozilla.components.lib.state.ext.observeAsComposableState
+import org.mozilla.fenix.R
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.compose.button.FloatingActionButton
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Floating action button for tabs tray.
+ *
+ * @param tabsTrayStore [TabsTrayStore] used to listen for changes to [TabsTrayState].
+ */
+@Composable
+fun TabsTrayFab(
+    tabsTrayStore: TabsTrayStore,
+) {
+    val currentPage: Page = tabsTrayStore.observeAsComposableState { state ->
+        state.selectedPage
+    }.value ?: Page.NormalTabs
+    val isSyncing: Boolean = tabsTrayStore.observeAsComposableState { state ->
+        state.syncing
+    }.value ?: false
+    val isInNormalMode: Boolean = tabsTrayStore.observeAsComposableState { state ->
+        state.mode == TabsTrayState.Mode.Normal
+    }.value ?: false
+
+    val icon: Painter
+    val contentDescription: String
+    val label: String?
+
+    when (currentPage) {
+        Page.NormalTabs -> {
+            icon = painterResource(id = R.drawable.ic_new)
+            contentDescription = stringResource(id = R.string.add_tab)
+            label = null
+        }
+
+        Page.SyncedTabs -> {
+            icon = painterResource(id = R.drawable.ic_fab_sync)
+            contentDescription = stringResource(id = R.string.tab_drawer_fab_sync)
+            label = if (isSyncing) {
+                stringResource(id = R.string.sync_syncing_in_progress)
+            } else {
+                stringResource(id = R.string.resync_button_content_description)
+            }.uppercase()
+        }
+
+        Page.PrivateTabs -> {
+            icon = painterResource(id = R.drawable.ic_new)
+            contentDescription = stringResource(id = R.string.add_private_tab)
+            label = stringResource(id = R.string.tab_drawer_fab_content).uppercase()
+        }
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        if (isInNormalMode) {
+            FloatingActionButton(
+                icon = icon,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
+                contentDescription = contentDescription,
+                label = label,
+            ) {}
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun TabsTraySyncFabPreview() {
+    val store = TabsTrayStore(
+        initialState = TabsTrayState(
+            selectedPage = Page.SyncedTabs,
+            syncing = true,
+        ),
+    )
+
+    FirefoxTheme {
+        TabsTrayFab(store)
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun TabsTrayPrivateFabPreview() {
+    val store = TabsTrayStore(
+        initialState = TabsTrayState(
+            selectedPage = Page.PrivateTabs,
+        ),
+    )
+    FirefoxTheme {
+        TabsTrayFab(store)
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -40,6 +40,7 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.ComponentTabstray2Binding
 import org.mozilla.fenix.databinding.ComponentTabstray3Binding
+import org.mozilla.fenix.databinding.ComponentTabstray3FabBinding
 import org.mozilla.fenix.databinding.ComponentTabstrayFabBinding
 import org.mozilla.fenix.databinding.FragmentTabTrayDialogBinding
 import org.mozilla.fenix.databinding.TabsTrayTabCounter2Binding
@@ -114,6 +115,10 @@ class TabsTrayFragment : AppCompatDialogFragment() {
     @Suppress("VariableNaming")
     internal var _tabsTrayComposeBinding: ComponentTabstray3Binding? = null
     private val tabsTrayComposeBinding get() = _tabsTrayComposeBinding!!
+
+    @Suppress("VariableNaming")
+    internal var _fabButtonComposeBinding: ComponentTabstray3FabBinding? = null
+    private val fabButtonComposeBinding get() = _fabButtonComposeBinding!!
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -205,6 +210,12 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                 true,
             )
 
+            _fabButtonComposeBinding = ComponentTabstray3FabBinding.inflate(
+                inflater,
+                tabsTrayDialogBinding.root,
+                true,
+            )
+
             tabsTrayComposeBinding.root.setContent {
                 FirefoxTheme(theme = Theme.getTheme(allowPrivateTheme = false)) {
                     TabsTray(
@@ -222,6 +233,12 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                         },
                         onTabLongClick = tabsTrayInteractor::onTabLongClicked,
                     )
+                }
+            }
+
+            fabButtonComposeBinding.root.setContent {
+                FirefoxTheme(theme = Theme.getTheme(allowPrivateTheme = false)) {
+                    TabsTrayFab(tabsTrayStore = tabsTrayStore)
                 }
             }
         } else {

--- a/fenix/app/src/main/res/layout/component_tabstray3_fab.xml
+++ b/fenix/app/src/main/res/layout/component_tabstray3_fab.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.compose.ui.platform.ComposeView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:elevation="99dp" />


### PR DESCRIPTION
Added FAB to composed tabs tray, business logic remains to be added in [1819196](https://bugzilla.mozilla.org/show_bug.cgi?id=1819196).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815013