### PR TITLE
Bug 1819153 - Add nightly-firebase build type in nightly tasks + cleanup

### DIFF
--- a/taskcluster/android_taskgraph/target_tasks.py
+++ b/taskcluster/android_taskgraph/target_tasks.py
@@ -30,7 +30,7 @@ def index_exists(index_path, reason=""):
 def target_tasks_nightly(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
         build_type = task.attributes.get("build-type", "")
-        return build_type in ("nightly", "focus-nightly", "fenix-nightly")
+        return build_type in ("nightly", "focus-nightly", "fenix-nightly", "fenix-nightly-firebase", "focus-nightly-firebase")
 
     index_path = (
         f"{graph_config['trust-domain']}.v2.{parameters['project']}.branch."

--- a/taskcluster/ci/startup-test/kind.yml
+++ b/taskcluster/ci/startup-test/kind.yml
@@ -35,7 +35,7 @@ task-defaults:
               json: true
     run-on-tasks-for: []
     attributes:
-        build-type: nightly-firebase
+        build-type: fenix-nightly-firebase
         shipping-product: fenix
         # cannot safely run this in Firebase
         # turning off til we can safely run test in taskcluster

--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -103,6 +103,7 @@ tasks:
             shipping-product: focus
         description: 'Focus UI tests with firebase'
         run-on-tasks-for: [github-pull-request, github-push]
+        run-on-git-branches: ["^((?!releases[_/]).+)$"]
         run:
             secrets:
                 - name: project/mobile/firefox-android/focus-android/firebase
@@ -128,7 +129,7 @@ tasks:
                 GOOGLE_PROJECT: 'moz-focus-android'
     focus-arm-nightly:
         attributes:
-            build-type: nightly-firebase
+            build-type: focus-nightly-firebase
             shipping-product: focus
         description: 'UI tests on Nightly with firebase'
         run-on-tasks-for: [github-push]
@@ -157,11 +158,11 @@ tasks:
                 GOOGLE_PROJECT: 'moz-focus-android'
     focus-arm-beta:
         attributes:
-            build-type: nightly-firebase
+            build-type: focus-beta-firebase
             shipping-product: focus
         description: 'UI tests on Beta with firebase'
         run-on-tasks-for: [github-push]
-        run-on-git-branches: [main, releases_v]
+        run-on-git-branches: [releases_v]
         dependencies:
             signed-apk-debug-apk: signing-apk-focus-beta-firebase
             signed-apk-android-test: signing-apk-focus-android-test-beta
@@ -242,11 +243,11 @@ tasks:
                 GOOGLE_PROJECT: moz-fenix
     fenix-arm-beta:
         attributes:
-            build-type: beta-firebase
+            build-type: fenix-beta-firebase
             shipping-product: fenix
         description: Test Fenix
         run-on-tasks-for: [github-push]
-        run-on-git-branches: ["^releases[/_].+$"]
+        run-on-git-branches: [releases_v]
         dependencies:
             signed-apk-debug-apk: signing-apk-fenix-beta-firebase
             signed-apk-android-test: signing-apk-fenix-android-test-beta
@@ -270,10 +271,11 @@ tasks:
                 GOOGLE_PROJECT: moz-fenix
     fenix-arm-nightly:
         attributes:
-            build-type: nightly-firebase
+            build-type: fenix-nightly-firebase
             shipping-product: fenix
         description: Test Fenix
         run-on-tasks-for: [github-push]
+        run-on-git-branches: [main]
         dependencies:
             signed-apk-debug-apk: signing-apk-fenix-nightly-firebase
             signed-apk-android-test: signing-apk-fenix-android-test-nightly


### PR DESCRIPTION
Hopefully the last fix needed for https://bugzil.la/1819153.

Can confirm `startup-test-nightly-arm` is scheduled with the additional build-type (testing as part of `main-repo-cron-nightly.yml` using newer parameters offered by @jcristau [1]

`% taskgraph target-graph -p taskcluster/test/params/main-repo-cron-nightly.yml` 

[1] https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/Twes5msbQ3-AnHAaElEX4Q/runs/0/artifacts/public/parameters.yml
https://bugzilla.mozilla.org/show_bug.cgi?id=1819153

Previous change in https://github.com/mozilla-mobile/firefox-android/commit/4893d00c4adb2b725c8e71f4f1ef09b06deadbe4 where the `build-type` was adjusted to a build with no optimizations suitable for Firebase Test Lab

https://bugzilla.mozilla.org/show_bug.cgi?id=1819153
https://bugzilla.mozilla.org/show_bug.cgi?id=1819153
https://bugzilla.mozilla.org/show_bug.cgi?id=1819153