### PR TITLE
Bug 1824199 - Remove `expanded` parameter from inactive tabs header click interactor/controller function

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -442,7 +442,8 @@ class DefaultTabsTrayController(
         handleTabDeletion(tab.id, TrayPagerAdapter.INACTIVE_TABS_FEATURE_NAME)
     }
 
-    override fun handleInactiveTabsHeaderClicked(expanded: Boolean) {
+    override fun handleInactiveTabsHeaderClicked() {
+        val expanded = !appStore.state.inactiveTabsExpanded
         appStore.dispatch(AppAction.UpdateInactiveExpanded(expanded))
 
         when (expanded) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
@@ -188,8 +188,8 @@ class DefaultTabsTrayInteractor(
     /**
      * See [InactiveTabsInteractor.onInactiveTabsHeaderClicked].
      */
-    override fun onInactiveTabsHeaderClicked(expanded: Boolean) {
-        controller.handleInactiveTabsHeaderClicked(expanded)
+    override fun onInactiveTabsHeaderClicked() {
+        controller.handleInactiveTabsHeaderClicked()
     }
 
     /**

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
@@ -61,7 +61,7 @@ class InactiveTabViewHolder(
                 inactiveTabs = inactiveTabs,
                 expanded = expanded,
                 showAutoCloseDialog = showAutoClosePrompt,
-                onHeaderClick = { interactor.onInactiveTabsHeaderClicked(!expanded) },
+                onHeaderClick = interactor::onInactiveTabsHeaderClicked,
                 onDeleteAllButtonClick = interactor::onDeleteAllInactiveTabsClicked,
                 onAutoCloseDismissClick = {
                     interactor.onAutoCloseDialogCloseButtonClicked()

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsController.kt
@@ -27,10 +27,8 @@ interface InactiveTabsController {
 
     /**
      * Expands or collapses the inactive tabs section.
-     *
-     * @param expanded true when the tap should expand the inactive section.
      */
-    fun handleInactiveTabsHeaderClicked(expanded: Boolean)
+    fun handleInactiveTabsHeaderClicked()
 
     /**
      * Dismisses the inactive tabs auto-close dialog.

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsInteractor.kt
@@ -12,10 +12,8 @@ import mozilla.components.browser.state.state.TabSessionState
 interface InactiveTabsInteractor {
     /**
      * Invoked when the inactive tabs header is clicked.
-     *
-     * @param expanded true when the tap should expand the inactive section.
      */
-    fun onInactiveTabsHeaderClicked(expanded: Boolean)
+    fun onInactiveTabsHeaderClicked()
 
     /**
      * Invoked when an inactive tab is clicked.

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
@@ -687,26 +687,28 @@ class DefaultTabsTrayControllerTest {
         }
     }
 
-    fun `WHEN the inactive tabs section is expanded THEN the expanded telemetry event should be reported`() {
+    fun `GIVEN the inactive tabs section is collapsed WHEN the header is clicked THEN the expanded telemetry event should be reported`() {
         val controller = createController()
+        every { appStore.state.inactiveTabsExpanded } returns false
 
         assertNull(TabsTray.inactiveTabsExpanded.testGetValue())
         assertNull(TabsTray.inactiveTabsCollapsed.testGetValue())
 
-        controller.handleInactiveTabsHeaderClicked(expanded = true)
+        controller.handleInactiveTabsHeaderClicked()
 
         assertNotNull(TabsTray.inactiveTabsExpanded.testGetValue())
         assertNull(TabsTray.inactiveTabsCollapsed.testGetValue())
     }
 
     @Test
-    fun `WHEN the inactive tabs section is collapsed THEN the collapsed telemetry event should be reported`() {
+    fun `GIVEN the inactive tabs inactive tabs section is expanded WHEN the header is clicked THEN the collapsed telemetry event should be reported`() {
         val controller = createController()
+        every { appStore.state.inactiveTabsExpanded } returns true
 
         assertNull(TabsTray.inactiveTabsExpanded.testGetValue())
         assertNull(TabsTray.inactiveTabsCollapsed.testGetValue())
 
-        controller.handleInactiveTabsHeaderClicked(expanded = false)
+        controller.handleInactiveTabsHeaderClicked()
 
         assertNull(TabsTray.inactiveTabsExpanded.testGetValue())
         assertNotNull(TabsTray.inactiveTabsCollapsed.testGetValue())

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayInteractorTest.kt
@@ -60,9 +60,9 @@ class DefaultTabsTrayInteractorTest {
 
     @Test
     fun `WHEN the inactive tabs header is clicked THEN update the expansion state of the inactive tabs card`() {
-        interactor.onInactiveTabsHeaderClicked(true)
+        interactor.onInactiveTabsHeaderClicked()
 
-        verify { controller.handleInactiveTabsHeaderClicked(true) }
+        verify { controller.handleInactiveTabsHeaderClicked() }
     }
 
     @Test


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1824199