### PR TITLE
Bug 1824341 - Use `browser_specific_settings` instead of `applications` in built-in manifests

### DIFF
--- a/android-components/components/browser/icons/src/main/assets/extensions/browser-icons/manifest.template.json
+++ b/android-components/components/browser/icons/src/main/assets/extensions/browser-icons/manifest.template.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "icons@mozac.org"
     }

--- a/android-components/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.template.json
+++ b/android-components/components/feature/accounts/src/main/assets/extensions/fxawebchannel/manifest.template.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "fxa@mozac.org"
     }

--- a/android-components/components/feature/readerview/src/main/assets/extensions/readerview/manifest.template.json
+++ b/android-components/components/feature/readerview/src/main/assets/extensions/readerview/manifest.template.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "readerview@mozac.org"
     }

--- a/android-components/components/feature/search/src/main/assets/extensions/ads/manifest.template.json
+++ b/android-components/components/feature/search/src/main/assets/extensions/ads/manifest.template.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "ads@mozac.org"
     }

--- a/android-components/components/feature/search/src/main/assets/extensions/search/manifest.template.json
+++ b/android-components/components/feature/search/src/main/assets/extensions/search/manifest.template.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "cookies@mozac.org"
     }

--- a/android-components/components/feature/webcompat-reporter/src/main/assets/extensions/webcompat-reporter/manifest.json
+++ b/android-components/components/feature/webcompat-reporter/src/main/assets/extensions/webcompat-reporter/manifest.json
@@ -5,7 +5,7 @@
   "author": "Thomas Wisniewski <twisniewski@mozilla.com>",
   "version": "2.0.1",
   "homepage_url": "https://github.com/mozilla/webcompat-reporter",
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "webcompat-reporter@mozilla.org"
     }

--- a/android-components/samples/browser/src/main/assets/extensions/borderify/manifest.template.json
+++ b/android-components/samples/browser/src/main/assets/extensions/borderify/manifest.template.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "borderify@mozac.org"
     }

--- a/android-components/samples/browser/src/main/assets/extensions/test/manifest.template.json
+++ b/android-components/samples/browser/src/main/assets/extensions/test/manifest.template.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "testext@mozac.org"
     }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

This change has no impact, visible or not. It does not require a changelog entry.

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

It's not a breaking change.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1824341