### PR TITLE
Bug 1807592 -  Made parent container to be clickable

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoView.kt
@@ -57,7 +57,7 @@ class WebsiteInfoView(
 
     @VisibleForTesting
     internal fun bindConnectionDetailsListener() {
-        binding.securityInfo.setOnClickListener {
+        binding.securityInfoContainer.setOnClickListener {
             interactor.onConnectionDetailsClicked()
         }
     }

--- a/fenix/app/src/main/res/layout/quicksettings_website_info.xml
+++ b/fenix/app/src/main/res/layout/quicksettings_website_info.xml
@@ -42,6 +42,7 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/securityInfoContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="@dimen/tracking_protection_item_height"


### PR DESCRIPTION
### What
Connection is secure" option isn't selected along with the icon

### Screenshots
### Issue video

https://user-images.githubusercontent.com/39338964/226320395-f7f84866-81d6-4aee-921b-3e996d46786e.mp4

### Demo video after fix

https://user-images.githubusercontent.com/39338964/226320299-2f75c7e4-3f7a-4fc4-baec-24f5e9ada239.mp4


### Pull Request checklist
 - [x] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.

### GitHub Automation
Used by GitHub Actions.