### PR TITLE
Bug 1823085 - NoSuchElementException fix

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
@@ -171,16 +171,30 @@ class RadioSearchEngineListPreference @JvmOverloads constructor(
     ) {
         val selectedOrDefaultSearchEngine = context.components.core.store.state.search.selectedOrDefaultSearchEngine
         if (selectedOrDefaultSearchEngine == engine) {
-            val nextSearchEngine = if (context.settings().showUnifiedSearchFeature) {
-                context.components.core.store.state.search.searchEngines.first {
-                    it.id != engine.id && (it.isGeneral || it.type == SearchEngine.Type.CUSTOM)
+            val nextSearchEngine = try {
+                if (context.settings().showUnifiedSearchFeature) {
+                    context.components.core.store.state.search.searchEngines.first {
+                        it.id != engine.id && (it.isGeneral || it.type == SearchEngine.Type.CUSTOM)
+                    }
+                } else {
+                    context.components.core.store.state.search.searchEngines.first {
+                        it.id != engine.id
+                    }
                 }
-            } else {
-                context.components.core.store.state.search.searchEngines.first {
-                    it.id != engine.id
+            } catch (ex: NoSuchElementException) {
+                try {
+                    context.components.core.store.state.search.searchEngines.first {
+                        it.id != engine.id
+                    }
+                } catch (ex: NoSuchElementException) {
+                    null
                 }
             }
-            context.components.useCases.searchUseCases.selectSearchEngine(nextSearchEngine)
+            nextSearchEngine?.let {
+                context.components.useCases.searchUseCases.selectSearchEngine(
+                    nextSearchEngine,
+                )
+            }
         }
         context.components.useCases.searchUseCases.removeSearchEngine(engine)
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
@@ -171,25 +171,20 @@ class RadioSearchEngineListPreference @JvmOverloads constructor(
     ) {
         val selectedOrDefaultSearchEngine = context.components.core.store.state.search.selectedOrDefaultSearchEngine
         if (selectedOrDefaultSearchEngine == engine) {
-            val nextSearchEngine = try {
+            val nextSearchEngine =
                 if (context.settings().showUnifiedSearchFeature) {
-                    context.components.core.store.state.search.searchEngines.first {
+                    context.components.core.store.state.search.searchEngines.firstOrNull {
                         it.id != engine.id && (it.isGeneral || it.type == SearchEngine.Type.CUSTOM)
                     }
+                        ?: context.components.core.store.state.search.searchEngines.firstOrNull {
+                            it.id != engine.id
+                        }
                 } else {
-                    context.components.core.store.state.search.searchEngines.first {
+                    context.components.core.store.state.search.searchEngines.firstOrNull {
                         it.id != engine.id
                     }
                 }
-            } catch (ex: NoSuchElementException) {
-                try {
-                    context.components.core.store.state.search.searchEngines.first {
-                        it.id != engine.id
-                    }
-                } catch (ex: NoSuchElementException) {
-                    null
-                }
-            }
+
             nextSearchEngine?.let {
                 context.components.useCases.searchUseCases.selectSearchEngine(
                     nextSearchEngine,


### PR DESCRIPTION
The search engines list does not contain any element matching the predicate

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.
















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1823085