### PR TITLE
Bug 1823868 - Fix cookie banner details layout.

### DIFF
--- a/focus-android/app/src/main/res/layout/cookie_banner_reducer_details.xml
+++ b/focus-android/app/src/main/res/layout/cookie_banner_reducer_details.xml
@@ -66,22 +66,24 @@
         android:layout_marginTop="16dp"
         android:text="@string/cookie_banner_exception_panel_site_is_not_supported_cancel_button"
         android:textAllCaps="true"
-        android:visibility="gone"
         android:gravity="center"
+        android:visibility="gone"
+        android:layout_marginEnd="16dp"
         android:background="@android:color/transparent"
         android:textSize="14sp"
         android:textColor="@color/cookie_banner_details_panel_report_a_site_text_color"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/details_back"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/details" />
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/request_support"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:visibility="gone"
         android:minHeight="48dp"
+        android:visibility="gone"
         android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
         android:text="@string/cookie_banner_exception_panel_site_is_not_supported_request_support_button"
         android:textAllCaps="true"
         android:gravity="center"
@@ -90,5 +92,6 @@
         android:textColor="@color/cookie_banner_details_panel_report_a_site_text_color"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/cancel_button"
-        app:layout_constraintTop_toBottomOf="@id/details" />
+        app:layout_constraintTop_toBottomOf="@id/details"
+        app:layout_constraintLeft_toLeftOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
"Request support" button should be displayed fully.

<img src="https://user-images.githubusercontent.com/8118371/227949034-50b9d61d-16ae-455a-bc13-9544bf2a9f1d.jpg" width="300" height="600" /> 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
