### PR TITLE
Bug 1824869 - Add PrivateBrowsing[Interactor|Controller] for handling private browsing mode

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -90,6 +90,7 @@ import org.mozilla.fenix.gleanplumb.NimbusMessagingController
 import org.mozilla.fenix.home.mozonline.showPrivacyPopWindow
 import org.mozilla.fenix.home.pocket.DefaultPocketStoriesController
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
+import org.mozilla.fenix.home.privatebrowsing.controller.DefaultPrivateBrowsingController
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmarksFeature
 import org.mozilla.fenix.home.recentbookmarks.controller.DefaultRecentBookmarksController
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabFeature
@@ -407,6 +408,11 @@ class HomeFragment : Fragment() {
             pocketStoriesController = DefaultPocketStoriesController(
                 homeActivity = activity,
                 appStore = components.appStore,
+            ),
+            privateBrowsingController = DefaultPrivateBrowsingController(
+                activity = activity,
+                appStore = components.appStore,
+                navController = findNavController(),
             ),
             onboardingController = DefaultOnboardingController(
                 activity = activity,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/privatebrowsing/controller/PrivateBrowsingController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/privatebrowsing/controller/PrivateBrowsingController.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.privatebrowsing.controller
+
+import androidx.navigation.NavController
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.BrowserFragmentDirections
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.home.Mode
+import org.mozilla.fenix.home.privatebrowsing.interactor.PrivateBrowsingInteractor
+import org.mozilla.fenix.settings.SupportUtils
+
+/**
+ * An interface that handles the view manipulation of the private browsing mode.
+ */
+interface PrivateBrowsingController {
+    /**
+     * @see [PrivateBrowsingInteractor.onLearnMoreClicked]
+     */
+    fun handleLearnMoreClicked()
+
+    /**
+     * @see [PrivateBrowsingInteractor.onPrivateModeButtonClicked]
+     */
+    fun handlePrivateModeButtonClicked(newMode: BrowsingMode, userHasBeenOnboarded: Boolean)
+}
+
+/**
+ * The default implementation of [PrivateBrowsingController].
+ */
+class DefaultPrivateBrowsingController(
+    private val activity: HomeActivity,
+    private val appStore: AppStore,
+    private val navController: NavController,
+) : PrivateBrowsingController {
+
+    override fun handleLearnMoreClicked() {
+        activity.openToBrowserAndLoad(
+            searchTermOrURL = SupportUtils.getGenericSumoURLForTopic(SupportUtils.SumoTopic.PRIVATE_BROWSING_MYTHS),
+            newTab = true,
+            from = BrowserDirection.FromHome,
+        )
+    }
+
+    override fun handlePrivateModeButtonClicked(
+        newMode: BrowsingMode,
+        userHasBeenOnboarded: Boolean,
+    ) {
+        if (newMode == BrowsingMode.Private) {
+            activity.settings().incrementNumTimesPrivateModeOpened()
+        }
+
+        if (userHasBeenOnboarded) {
+            appStore.dispatch(
+                AppAction.ModeChange(Mode.fromBrowsingMode(newMode)),
+            )
+
+            if (navController.currentDestination?.id == R.id.searchDialogFragment) {
+                navController.navigate(
+                    BrowserFragmentDirections.actionGlobalSearchDialog(
+                        sessionId = null,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/privatebrowsing/interactor/PrivateBrowsingInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/privatebrowsing/interactor/PrivateBrowsingInteractor.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.privatebrowsing.interactor
+
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+
+/**
+ * Interface for private browsing mode related actions.
+ */
+interface PrivateBrowsingInteractor {
+    /**
+     * Shows the Private Browsing Learn More page in a new tab. Called when a user clicks on the
+     * "Common myths about private browsing" link in private mode.
+     */
+    fun onLearnMoreClicked()
+
+    /**
+     * Called when a user clicks on the Private Mode button on the homescreen.
+     */
+    fun onPrivateModeButtonClicked(newMode: BrowsingMode, userHasBeenOnboarded: Boolean)
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -39,7 +39,6 @@ import org.mozilla.fenix.GleanMetrics.TopSites
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserAnimator
-import org.mozilla.fenix.browser.BrowserFragmentDirections
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.AppStore
@@ -49,17 +48,14 @@ import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.gleanplumb.MessageController
 import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.home.HomeFragmentDirections
-import org.mozilla.fenix.home.Mode
 import org.mozilla.fenix.onboarding.WallpaperOnboardingDialogFragment.Companion.THUMBNAILS_SELECTION_COUNT
 import org.mozilla.fenix.search.toolbar.SearchSelectorInteractor
 import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
 import org.mozilla.fenix.settings.SupportUtils
-import org.mozilla.fenix.settings.SupportUtils.SumoTopic.PRIVATE_BROWSING_MYTHS
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.wallpapers.Wallpaper
 import org.mozilla.fenix.wallpapers.WallpaperState
@@ -105,11 +101,6 @@ interface SessionControlController {
      * @see [TopSiteInteractor.onOpenInPrivateTabClicked]
      */
     fun handleOpenInPrivateTabClicked(topSite: TopSite)
-
-    /**
-     * @see [TabSessionInteractor.onPrivateBrowsingLearnMoreClicked]
-     */
-    fun handlePrivateBrowsingLearnMoreClicked()
 
     /**
      * @see [TopSiteInteractor.onRenameTopSiteClicked]
@@ -165,11 +156,6 @@ interface SessionControlController {
      * @see [MessageCardInteractor.onMessageClosedClicked]
      */
     fun handleMessageClosed(message: Message)
-
-    /**
-     * @see [TabSessionInteractor.onPrivateModeButtonClicked]
-     */
-    fun handlePrivateModeButtonClicked(newMode: BrowsingMode, userHasBeenOnboarded: Boolean)
 
     /**
      * @see [CustomizeHomeIteractor.openCustomizeHomePage]
@@ -299,14 +285,6 @@ class DefaultSessionControlController(
                 from = BrowserDirection.FromHome,
             )
         }
-    }
-
-    override fun handlePrivateBrowsingLearnMoreClicked() {
-        activity.openToBrowserAndLoad(
-            searchTermOrURL = SupportUtils.getGenericSumoURLForTopic(PRIVATE_BROWSING_MYTHS),
-            newTab = true,
-            from = BrowserDirection.FromHome,
-        )
     }
 
     @SuppressLint("InflateParams")
@@ -548,29 +526,6 @@ class DefaultSessionControlController(
 
     override fun handleMessageClosed(message: Message) {
         messageController.onMessageDismissed(message)
-    }
-
-    override fun handlePrivateModeButtonClicked(
-        newMode: BrowsingMode,
-        userHasBeenOnboarded: Boolean,
-    ) {
-        if (newMode == BrowsingMode.Private) {
-            activity.settings().incrementNumTimesPrivateModeOpened()
-        }
-
-        if (userHasBeenOnboarded) {
-            appStore.dispatch(
-                AppAction.ModeChange(Mode.fromBrowsingMode(newMode)),
-            )
-
-            if (navController.currentDestination?.id == R.id.searchDialogFragment) {
-                navController.navigate(
-                    BrowserFragmentDirections.actionGlobalSearchDialog(
-                        sessionId = null,
-                    ),
-                )
-            }
-        }
     }
 
     override fun handleReportSessionMetrics(state: AppState) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -14,6 +14,8 @@ import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.PocketStoriesController
 import org.mozilla.fenix.home.pocket.PocketStoriesInteractor
+import org.mozilla.fenix.home.privatebrowsing.controller.PrivateBrowsingController
+import org.mozilla.fenix.home.privatebrowsing.interactor.PrivateBrowsingInteractor
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
 import org.mozilla.fenix.home.recentbookmarks.controller.RecentBookmarksController
 import org.mozilla.fenix.home.recentbookmarks.interactor.RecentBookmarksInteractor
@@ -39,17 +41,6 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  * Interface for tab related actions in the [SessionControlInteractor].
  */
 interface TabSessionInteractor {
-    /**
-     * Shows the Private Browsing Learn More page in a new tab. Called when a user clicks on the
-     * "Common myths about private browsing" link in private mode.
-     */
-    fun onPrivateBrowsingLearnMoreClicked()
-
-    /**
-     * Called when a user clicks on the Private Mode button on the homescreen.
-     */
-    fun onPrivateModeButtonClicked(newMode: BrowsingMode, userHasBeenOnboarded: Boolean)
-
     /**
      * Called when there is an update to the session state and updated metrics need to be reported
      *
@@ -233,6 +224,7 @@ class SessionControlInteractor(
     private val recentBookmarksController: RecentBookmarksController,
     private val recentVisitsController: RecentVisitsController,
     private val pocketStoriesController: PocketStoriesController,
+    private val privateBrowsingController: PrivateBrowsingController,
     private val onboardingController: OnboardingController,
     private val toolbarController: ToolbarController,
 ) : CollectionInteractor,
@@ -247,6 +239,7 @@ class SessionControlInteractor(
     RecentVisitsInteractor,
     CustomizeHomeIteractor,
     PocketStoriesInteractor,
+    PrivateBrowsingInteractor,
     SearchSelectorInteractor,
     WallpaperInteractor {
 
@@ -322,12 +315,12 @@ class SessionControlInteractor(
         controller.handleCreateCollection()
     }
 
-    override fun onPrivateBrowsingLearnMoreClicked() {
-        controller.handlePrivateBrowsingLearnMoreClicked()
+    override fun onLearnMoreClicked() {
+        privateBrowsingController.handleLearnMoreClicked()
     }
 
     override fun onPrivateModeButtonClicked(newMode: BrowsingMode, userHasBeenOnboarded: Boolean) {
-        controller.handlePrivateModeButtonClicked(newMode, userHasBeenOnboarded)
+        privateBrowsingController.handlePrivateModeButtonClicked(newMode, userHasBeenOnboarded)
     }
 
     override fun onPasteAndGo(clipboardText: String) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolder.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.LifecycleOwner
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.ComposeViewHolder
-import org.mozilla.fenix.home.sessioncontrol.TabSessionInteractor
+import org.mozilla.fenix.home.privatebrowsing.interactor.PrivateBrowsingInteractor
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -35,12 +35,12 @@ import org.mozilla.fenix.theme.FirefoxTheme
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param viewLifecycleOwner [LifecycleOwner] life cycle owner for the view.
- * @param interactor [TabSessionInteractor] which will have delegated to all user interactions.
+ * @param interactor [PrivateBrowsingInteractor] which will have delegated to all user interactions.
  */
 class PrivateBrowsingDescriptionViewHolder(
     composeView: ComposeView,
     viewLifecycleOwner: LifecycleOwner,
-    val interactor: TabSessionInteractor,
+    val interactor: PrivateBrowsingInteractor,
 ) : ComposeViewHolder(composeView, viewLifecycleOwner) {
 
     init {
@@ -52,7 +52,7 @@ class PrivateBrowsingDescriptionViewHolder(
     @Composable
     override fun Content() {
         PrivateBrowsingDescription(
-            onLearnMoreClick = interactor::onPrivateBrowsingLearnMoreClicked,
+            onLearnMoreClick = interactor::onLearnMoreClicked,
         )
     }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -16,6 +16,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.PocketStoriesController
+import org.mozilla.fenix.home.privatebrowsing.controller.PrivateBrowsingController
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
 import org.mozilla.fenix.home.recentbookmarks.controller.RecentBookmarksController
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
@@ -34,6 +35,7 @@ class SessionControlInteractorTest {
     private val recentSyncedTabController: RecentSyncedTabController = mockk(relaxed = true)
     private val recentBookmarksController: RecentBookmarksController = mockk(relaxed = true)
     private val pocketStoriesController: PocketStoriesController = mockk(relaxed = true)
+    private val privateBrowsingController: PrivateBrowsingController = mockk(relaxed = true)
     private val onboardingController: OnboardingController = mockk(relaxed = true)
     private val toolbarController: ToolbarController = mockk(relaxed = true)
 
@@ -51,6 +53,7 @@ class SessionControlInteractorTest {
             recentBookmarksController,
             recentVisitsController,
             pocketStoriesController,
+            privateBrowsingController,
             onboardingController,
             toolbarController,
         )
@@ -101,8 +104,8 @@ class SessionControlInteractorTest {
 
     @Test
     fun onPrivateBrowsingLearnMoreClicked() {
-        interactor.onPrivateBrowsingLearnMoreClicked()
-        verify { controller.handlePrivateBrowsingLearnMoreClicked() }
+        interactor.onLearnMoreClicked()
+        verify { privateBrowsingController.handleLearnMoreClicked() }
     }
 
     @Test
@@ -215,7 +218,7 @@ class SessionControlInteractorTest {
         val hasBeenOnboarded = true
 
         interactor.onPrivateModeButtonClicked(newMode, hasBeenOnboarded)
-        verify { controller.handlePrivateModeButtonClicked(newMode, hasBeenOnboarded) }
+        verify { privateBrowsingController.handlePrivateModeButtonClicked(newMode, hasBeenOnboarded) }
     }
 
     @Test

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/privatebrowsing/DefaultPrivateBrowsingControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/privatebrowsing/DefaultPrivateBrowsingControllerTest.kt
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.privatebrowsing
+
+import androidx.navigation.NavController
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.ext.joinBlocking
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.BrowserFragmentDirections
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.appstate.AppState
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.home.Mode
+import org.mozilla.fenix.home.privatebrowsing.controller.DefaultPrivateBrowsingController
+import org.mozilla.fenix.settings.SupportUtils
+import org.mozilla.fenix.utils.Settings
+
+class DefaultPrivateBrowsingControllerTest {
+
+    private val activity: HomeActivity = mockk(relaxed = true)
+    private val appStore: AppStore = mockk(relaxed = true)
+    private val navController: NavController = mockk(relaxed = true)
+    private val settings: Settings = mockk(relaxed = true)
+
+    private lateinit var store: BrowserStore
+    private lateinit var controller: DefaultPrivateBrowsingController
+
+    @Before
+    fun setup() {
+        store = BrowserStore()
+        controller = DefaultPrivateBrowsingController(
+            activity = activity,
+            appStore = appStore,
+            navController = navController,
+        )
+
+        every { appStore.state } returns AppState()
+
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.homeFragment
+        }
+        every { activity.components.settings } returns settings
+        every { activity.settings() } returns settings
+    }
+
+    @Test
+    fun `WHEN private browsing learn more link is clicked THEN open support page in browser`() {
+        controller.handleLearnMoreClicked()
+
+        verify {
+            activity.openToBrowserAndLoad(
+                searchTermOrURL = SupportUtils.getGenericSumoURLForTopic
+                    (SupportUtils.SumoTopic.PRIVATE_BROWSING_MYTHS),
+                newTab = true,
+                from = BrowserDirection.FromHome,
+            )
+        }
+    }
+
+    @Test
+    fun `WHEN private mode button is selected from home THEN handle mode change`() {
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.homeFragment
+        }
+
+        every { settings.incrementNumTimesPrivateModeOpened() } just Runs
+
+        val newMode = BrowsingMode.Private
+        val hasBeenOnboarded = true
+
+        controller.handlePrivateModeButtonClicked(newMode, hasBeenOnboarded)
+
+        verify {
+            settings.incrementNumTimesPrivateModeOpened()
+            AppAction.ModeChange(Mode.fromBrowsingMode(newMode))
+        }
+    }
+
+    @Test
+    fun `WHEN private mode is selected on home from behind search THEN handle mode change`() {
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.searchDialogFragment
+        }
+
+        every { settings.incrementNumTimesPrivateModeOpened() } just Runs
+
+        val url = "https://mozilla.org"
+        val tab = createTab(
+            id = "otherTab",
+            url = url,
+            private = false,
+            engineSession = mockk(relaxed = true),
+        )
+        store.dispatch(TabListAction.AddTabAction(tab, select = true)).joinBlocking()
+
+        val newMode = BrowsingMode.Private
+        val hasBeenOnboarded = true
+
+        controller.handlePrivateModeButtonClicked(newMode, hasBeenOnboarded)
+
+        verify {
+            settings.incrementNumTimesPrivateModeOpened()
+            AppAction.ModeChange(Mode.fromBrowsingMode(newMode))
+            navController.navigate(
+                BrowserFragmentDirections.actionGlobalSearchDialog(
+                    sessionId = null,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `WHEN private mode is deselected on home from behind search THEN handle mode change`() {
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.searchDialogFragment
+        }
+
+        val url = "https://mozilla.org"
+        val tab = createTab(
+            id = "otherTab",
+            url = url,
+            private = true,
+            engineSession = mockk(relaxed = true),
+        )
+        store.dispatch(TabListAction.AddTabAction(tab, select = true)).joinBlocking()
+
+        val newMode = BrowsingMode.Normal
+        val hasBeenOnboarded = true
+
+        controller.handlePrivateModeButtonClicked(newMode, hasBeenOnboarded)
+
+        verify(exactly = 0) {
+            settings.incrementNumTimesPrivateModeOpened()
+        }
+        verify {
+            appStore.dispatch(
+                AppAction.ModeChange(Mode.fromBrowsingMode(newMode)),
+            )
+            navController.navigate(
+                BrowserFragmentDirections.actionGlobalSearchDialog(
+                    sessionId = null,
+                ),
+            )
+        }
+    }
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractorTest.kt
@@ -12,6 +12,7 @@ import mozilla.components.concept.storage.HistoryMetadataKey
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.home.pocket.PocketStoriesController
+import org.mozilla.fenix.home.privatebrowsing.controller.PrivateBrowsingController
 import org.mozilla.fenix.home.recentbookmarks.controller.RecentBookmarksController
 import org.mozilla.fenix.home.recentsyncedtabs.controller.RecentSyncedTabController
 import org.mozilla.fenix.home.recenttabs.controller.RecentTabController
@@ -29,8 +30,9 @@ class RecentVisitsInteractorTest {
     private val recentTabController: RecentTabController = mockk(relaxed = true)
     private val recentSyncedTabController: RecentSyncedTabController = mockk(relaxed = true)
     private val recentBookmarksController: RecentBookmarksController = mockk(relaxed = true)
-    private val pocketStoriesController: PocketStoriesController = mockk(relaxed = true)
     private val recentVisitsController: RecentVisitsController = mockk(relaxed = true)
+    private val pocketStoriesController: PocketStoriesController = mockk(relaxed = true)
+    private val privateBrowsingController: PrivateBrowsingController = mockk(relaxed = true)
     private val onboardingController: OnboardingController = mockk(relaxed = true)
     private val toolbarController: ToolbarController = mockk(relaxed = true)
 
@@ -45,6 +47,7 @@ class RecentVisitsInteractorTest {
             recentBookmarksController,
             recentVisitsController,
             pocketStoriesController,
+            privateBrowsingController,
             onboardingController,
             toolbarController,
         )


### PR DESCRIPTION



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1824869