### PR TITLE
Bug 1824648 - Upstream CFRPopup null window fix to A-C

### DIFF
--- a/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/CFRPopup.kt
+++ b/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/CFRPopup.kt
@@ -81,6 +81,19 @@ class CFRPopup(
      */
     fun show() {
         anchor.post {
+            // When we're in this Runnable, the 'show' method might have been called right before
+            // the activity is no longer attached to the WindowManager. When we get to calling
+            // the CFRPopupFullscreenLayout#show method below, we are now trying to attach the View
+            // with the WindowManager that has an unusable Activity.
+            //
+            // To protect against this, within this same Runnable, we check if the anchor view is
+            // safe to use before continuing.
+            //
+            // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1799996
+            if (anchor.context == null || !anchor.isAttachedToWindow) {
+                return@post
+            }
+
             CFRPopupFullscreenLayout(anchor, properties, onDismiss, text, action).apply {
                 this.show()
                 popup = WeakReference(this)


### PR DESCRIPTION
Upstreamed speculative fix to A-C `CFRPopup`. For more context, see [1799996](https://bugzilla.mozilla.org/show_bug.cgi?id=1799996).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1824648