### PR TITLE
Bug 1825028 - Delay init of MozillaOnline build until privacy notice is accepted

### DIFF
--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -31,6 +31,11 @@ android {
         testBuildType project.property("testBuildType")
     }
 
+    // This allows overriding the target activity for MozillaOnline builds, which happens
+    // as part of the defaultConfig below, and applies to all other configurations (Nightly,
+    // Beta, and Release.)
+    def targetActivity = "HomeActivity"
+
     defaultConfig {
         applicationId "org.mozilla"
         minSdkVersion Config.minSdkVersion
@@ -64,16 +69,18 @@ android {
         buildConfigField "String", "AMO_SERVER_URL", "\"https://services.addons.mozilla.org\""
         def deepLinkSchemeValue = "fenix-dev"
         buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
-        manifestPlaceholders = [
-                "deepLinkScheme": deepLinkSchemeValue
-        ]
 
         // Build flag for "Mozilla Online" variants. See `Config.isMozillaOnline`.
         if (project.hasProperty("mozillaOnline") || gradle.hasProperty("localProperties.mozillaOnline")) {
             buildConfigField "boolean", "MOZILLA_ONLINE", "true"
+            targetActivity = "MozillaOnlineHomeActivity"
         } else {
             buildConfigField "boolean", "MOZILLA_ONLINE", "false"
         }
+        manifestPlaceholders = [
+                "targetActivity": targetActivity,
+                "deepLinkScheme": deepLinkSchemeValue
+        ]
     }
 
     def releaseTemplate = {
@@ -110,7 +117,10 @@ android {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
             def deepLinkSchemeValue = "fenix-nightly"
             buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
-            manifestPlaceholders = ["deepLinkScheme": deepLinkSchemeValue]
+            manifestPlaceholders = [
+                    "deepLinkScheme": deepLinkSchemeValue,
+                    "targetActivity": targetActivity
+            ]
         }
         beta releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
@@ -126,7 +136,8 @@ android {
                     //  - https://issuetracker.google.com/issues/36924841
                     //  - https://issuetracker.google.com/issues/36905922
                     "sharedUserId": "org.mozilla.firefox.sharedID",
-                    "deepLinkScheme": deepLinkSchemeValue
+                    "deepLinkScheme": deepLinkSchemeValue,
+                    "targetActivity": targetActivity
             ]
         }
         release releaseTemplate >> {
@@ -143,7 +154,8 @@ android {
                     //  - https://issuetracker.google.com/issues/36924841
                     //  - https://issuetracker.google.com/issues/36905922
                     "sharedUserId": "org.mozilla.firefox.sharedID",
-                    "deepLinkScheme": deepLinkSchemeValue
+                    "deepLinkScheme": deepLinkSchemeValue,
+                    "targetActivity": targetActivity,
             ]
         }
         benchmark releaseTemplate >> {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
@@ -33,7 +33,7 @@ import org.mozilla.fenix.helpers.HomeActivityTestRule
  *
  * Say no to main thread IO! 🙅
  */
-private const val EXPECTED_SUPPRESSION_COUNT = 18
+private const val EXPECTED_SUPPRESSION_COUNT = 17
 
 /**
  * The number of times we call the `runBlocking` coroutine method on the main thread during this

--- a/fenix/app/src/main/AndroidManifest.xml
+++ b/fenix/app/src/main/AndroidManifest.xml
@@ -62,7 +62,7 @@
         <activity-alias
             android:name="${applicationId}.App"
             android:exported="true"
-            android:targetActivity=".HomeActivity">
+            android:targetActivity=".${targetActivity}">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -143,6 +143,9 @@
                     android:host="urls_history"/>
             </intent-filter>
         </activity>
+
+        <activity android:name=".MozillaOnlineHomeActivity"
+                android:exported="false"/>
 
         <activity android:name=".home.mozonline.PrivacyContentDisplayActivity"
                 android:exported="false"/>

--- a/fenix/app/src/main/java/org/mozilla/fenix/MozillaOnlineHomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/MozillaOnlineHomeActivity.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import org.mozilla.fenix.home.mozonline.showPrivacyPopWindow
+
+/**
+ * This activity is specific to the Mozilla Online build and used to display
+ * a privacy notice on first run. Once the privacy notice is accepted, and for
+ * all subsequent launches, it will simply launch the Fenix [HomeActivity].
+ */
+open class MozillaOnlineHomeActivity : AppCompatActivity() {
+
+    final override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if ((this.application as FenixApplication).shouldShowPrivacyNotice()) {
+            showPrivacyPopWindow(this.applicationContext, this)
+        } else {
+            startActivity(Intent(this, HomeActivity::class.java))
+            finish()
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -62,7 +62,6 @@ import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
-import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.HomeScreen
 import org.mozilla.fenix.GleanMetrics.PrivateBrowsingShortcutCfr
 import org.mozilla.fenix.HomeActivity
@@ -87,7 +86,6 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.gleanplumb.DefaultMessageController
 import org.mozilla.fenix.gleanplumb.MessagingFeature
 import org.mozilla.fenix.gleanplumb.NimbusMessagingController
-import org.mozilla.fenix.home.mozonline.showPrivacyPopWindow
 import org.mozilla.fenix.home.pocket.DefaultPocketStoriesController
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmarksFeature
@@ -217,13 +215,6 @@ class HomeFragment : Fragment() {
         super.onCreate(savedInstanceState)
 
         bundleArgs = args.toBundle()
-
-        if (!onboarding.userHasBeenOnboarded() &&
-            requireContext().settings().shouldShowPrivacyPopWindow &&
-            Config.channel.isMozillaOnline
-        ) {
-            showPrivacyPopWindow(requireContext(), requireActivity())
-        }
 
         // DO NOT MOVE ANYTHING BELOW THIS addMarker CALL!
         requireComponents.core.engine.profiler?.addMarker(

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentDisplayActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentDisplayActivity.kt
@@ -5,29 +5,20 @@
 package org.mozilla.fenix.home.mozonline
 
 import android.app.Activity
-import android.content.Context
 import android.os.Bundle
-import android.util.AttributeSet
 import android.view.View
+import android.webkit.WebView
 import android.widget.ImageButton
 import mozilla.components.concept.engine.EngineSession
-import mozilla.components.concept.engine.EngineView
-import mozilla.components.feature.contextmenu.DefaultSelectionActionDelegate
-import mozilla.components.feature.search.BrowserStoreSearchAdapter
-import mozilla.components.support.ktx.android.content.call
-import mozilla.components.support.ktx.android.content.email
-import mozilla.components.support.ktx.android.content.share
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.components
 
 /**
  * A special activity for displaying the detail content about privacy hyperlinked in alert dialog.
  */
 
 class PrivacyContentDisplayActivity : Activity(), EngineSession.Observer {
-    private lateinit var engineView: EngineView
+    private lateinit var webView: WebView
     private lateinit var closeButton: ImageButton
-    private lateinit var engineSession: EngineSession
     private var url: String? = ""
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -37,48 +28,20 @@ class PrivacyContentDisplayActivity : Activity(), EngineSession.Observer {
             url = addr.getString("url")
         }
 
-        engineView = findViewById<View>(R.id.privacyContentEngineView) as EngineView
+        webView = findViewById<View>(R.id.privacyContentEngineView) as WebView
+        webView.settings.javaScriptEnabled = true
         closeButton = findViewById<View>(R.id.privacyContentCloseButton) as ImageButton
-        engineSession = components.core.engine.createSession()
-    }
-
-    override fun onCreateView(
-        parent: View?,
-        name: String,
-        context: Context,
-        attrs: AttributeSet,
-    ): View? = when (name) {
-        EngineView::class.java.name -> components.core.engine.createView(context, attrs).apply {
-            selectionActionDelegate = DefaultSelectionActionDelegate(
-                BrowserStoreSearchAdapter(
-                    components.core.store,
-                ),
-                resources = context.resources,
-                shareTextClicked = { share(it) },
-                emailTextClicked = { email(it) },
-                callTextClicked = { call(it) },
-            )
-        }.asView()
-        else -> super.onCreateView(parent, name, context, attrs)
     }
 
     override fun onStart() {
         super.onStart()
-        engineSession.register(this)
-        engineSession.let { engineSession ->
-            engineView.render(engineSession)
-            url?.let { engineSession.loadUrl(it) }
+
+        url?.let {
+            webView.loadUrl(it)
         }
-        closeButton.setOnClickListener { finish() }
-    }
 
-    override fun onStop() {
-        super.onStop()
-        engineSession.unregister(this)
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        engineSession.close()
+        closeButton.setOnClickListener {
+            finish()
+        }
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentDisplayHelper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentDisplayHelper.kt
@@ -6,13 +6,16 @@ package org.mozilla.fenix.home.mozonline
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.MetricServiceType
+import org.mozilla.fenix.ext.application
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import kotlin.system.exitProcess
@@ -57,6 +60,10 @@ fun showPrivacyPopWindow(context: Context, activity: Activity) {
             context.settings().shouldShowPrivacyPopWindow = false
             context.settings().isMarketingTelemetryEnabled = true
             context.components.analytics.metrics.start(MetricServiceType.Marketing)
+            // Now that the privacy notice is accepted, application initialization can continue.
+            context.application.initialize()
+            activity.startActivity(Intent(activity, HomeActivity::class.java))
+            activity.finish()
         }
         .setNeutralButton(
             context.getString(R.string.privacy_notice_neutral_button_2),

--- a/fenix/app/src/main/java/org/mozilla/fenix/perf/StrictModeManager.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/perf/StrictModeManager.kt
@@ -33,7 +33,7 @@ private val mainLooper = Looper.getMainLooper()
  * Manages strict mode settings for the application.
  */
 open class StrictModeManager(
-    config: Config,
+    private val config: Config,
 
     // Ideally, we'd pass in a more specific value but there is a circular dependency: StrictMode
     // is passed into Core but we'd need to pass in Core here. Instead, we take components and later
@@ -112,6 +112,14 @@ open class StrictModeManager(
      */
     open fun <R> resetAfter(policy: StrictMode.ThreadPolicy, functionBlock: () -> R): R {
         fun instrumentedFunctionBlock(): R {
+            // For Mozilla Online builds, we decided not to add a profile marker because we need to
+            // prevent early initialization of the engine. These markers also have no distinct
+            // meaning to the Mozilla Online build variant.
+            // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1825028
+            if (config.channel.isMozillaOnline) {
+                return functionBlock()
+            }
+
             val startProfilerTime = components.core.engine.profiler?.getProfilerTime()
 
             val returnValue = functionBlock()

--- a/fenix/app/src/main/res/layout/activity_privacy_content_display.xml
+++ b/fenix/app/src/main/res/layout/activity_privacy_content_display.xml
@@ -35,7 +35,7 @@
 
 
     </LinearLayout>
-    <mozilla.components.concept.engine.EngineView
+    <WebView
             tools:ignore="Instantiatable"
             android:id="@+id/privacyContentEngineView"
             android:layout_width="match_parent"


### PR DESCRIPTION
See ticket for motivation.

We're essentially introducing a new activity for the `MozillaOnline` build so we can show our privacy notice prompt before initializing `FenixApplication` and `HomeActivity`, which in turn would otherwise initialize all our submodules e.g., Nimbus, Glean, Gecko. This change prevents unnecessary initialization.

Verify before landing:
- [x] MozillaOnline build uses new `MozillaOnlineHome` activity, all other builds do NOT.
- [x] Only MozillaOnline build shows privacy notice.
- [x] App initialization starts and completes only after user taps on "Agree and Continue", subsequent launches should not show the prompt. 
- [x] If the user taps on "Disagree and exit", Fenix exits and subsequent launches will continue to display the prompt.
- [x] No sub modules are initialized when notice is shown.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1825028