### PR TITLE
Bug 1825071 - Re-evaluate usage of robolectric in Fenix unit tests

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -51,6 +51,7 @@ import mozilla.components.service.glean.net.ConceptFetchHttpUploader
 import mozilla.components.support.base.facts.register
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.base.log.sink.AndroidLogSink
 import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
 import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.components.support.ktx.android.content.runOnlyInMainProcess
@@ -214,7 +215,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         setupCrashReporting()
 
         // We want the log messages of all builds to go to Android logcat
-        Log.addSink(FenixLogSink(logsDebug = Config.channel.isDebug))
+        Log.addSink(FenixLogSink(logsDebug = Config.channel.isDebug, AndroidLogSink()))
     }
 
     @VisibleForTesting

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixLogSink.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixLogSink.kt
@@ -12,10 +12,12 @@ import mozilla.components.support.base.log.sink.LogSink
  * Fenix [LogSink] implementation that writes to Android's log, depending on settings.
  *
  * @param logsDebug If set to false, removes logging of debug logs.
+ * @param androidLogSink an [AndroidLogSink] that writes to Android's log.
  */
-class FenixLogSink(private val logsDebug: Boolean = true) : LogSink {
-
-    private val androidLogSink = AndroidLogSink()
+class FenixLogSink(
+    private val logsDebug: Boolean = true,
+    private val androidLogSink: LogSink,
+) : LogSink {
 
     override fun log(
         priority: Log.Priority,

--- a/fenix/app/src/test/java/org/mozilla/fenix/FenixLogSinkTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/FenixLogSinkTest.kt
@@ -4,78 +4,99 @@
 
 package org.mozilla.fenix
 
-import android.util.Log
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
+import io.mockk.spyk
 import io.mockk.verify
-import org.junit.After
+import mozilla.components.support.base.log.sink.AndroidLogSink
 import org.junit.Before
 import org.junit.Test
 
 class FenixLogSinkTest {
 
+    private lateinit var androidLogSink: AndroidLogSink
+
     @Before
     fun setup() {
-        mockkStatic(Log::class)
-    }
-
-    @After
-    fun teardown() {
-        unmockkStatic(Log::class)
+        androidLogSink = spyk(AndroidLogSink())
     }
 
     @Test
     fun `GIVEN we're in a release build WHEN we log debug statements THEN logs should not be forwarded`() {
-        val logSink = FenixLogSink(false)
+        val logSink = FenixLogSink(false, androidLogSink)
         logSink.log(
             mozilla.components.support.base.log.Log.Priority.DEBUG,
             "test",
             message = "test",
         )
-        verify(exactly = 0) { Log.println(Log.DEBUG, "test", "test") }
+        verify(exactly = 0) { androidLogSink.log(any(), any(), any()) }
     }
 
     @Test
     fun `GIVEN we're in a release build WHEN we log error statements THEN logs should be forwarded`() {
-        val logSink = FenixLogSink(false)
+        val logSink = FenixLogSink(false, androidLogSink)
         logSink.log(
             mozilla.components.support.base.log.Log.Priority.ERROR,
             "test",
             message = "test",
         )
-        verify(exactly = 1) { Log.println(Log.ERROR, "test", "test") }
+
+        verify(exactly = 1) {
+            androidLogSink.log(
+                mozilla.components.support.base.log.Log.Priority.ERROR,
+                "test",
+                message = "test",
+            )
+        }
     }
 
     @Test
     fun `GIVEN we're in a release build WHEN we log warn statements THEN logs should be forwarded`() {
-        val logSink = FenixLogSink(false)
+        val logSink = FenixLogSink(false, androidLogSink)
         logSink.log(
             mozilla.components.support.base.log.Log.Priority.WARN,
             "test",
             message = "test",
         )
-        verify(exactly = 1) { Log.println(Log.WARN, "test", "test") }
+        verify(exactly = 1) {
+            androidLogSink.log(
+                mozilla.components.support.base.log.Log.Priority.WARN,
+                "test",
+                message = "test",
+            )
+        }
     }
 
     @Test
     fun `GIVEN we're in a release build WHEN we log info statements THEN logs should be forwarded`() {
-        val logSink = FenixLogSink(false)
+        val logSink = FenixLogSink(false, androidLogSink)
         logSink.log(
             mozilla.components.support.base.log.Log.Priority.INFO,
             "test",
             message = "test",
         )
-        verify(exactly = 1) { Log.println(Log.INFO, "test", "test") }
+        verify(exactly = 1) {
+            androidLogSink.log(
+                mozilla.components.support.base.log.Log.Priority.INFO,
+                "test",
+                message = "test",
+            )
+        }
     }
 
     @Test
     fun `GIVEN we're in a debug build WHEN we log debug statements THEN logs should be forwarded`() {
-        val logSink = FenixLogSink(true)
+        val logSink = FenixLogSink(true, androidLogSink)
         logSink.log(
             mozilla.components.support.base.log.Log.Priority.DEBUG,
             "test",
             message = "test",
         )
-        verify(exactly = 1) { Log.println(Log.DEBUG, "test", "test") }
+
+        verify(exactly = 1) {
+            androidLogSink.log(
+                mozilla.components.support.base.log.Log.Priority.DEBUG,
+                "test",
+                message = "test",
+            )
+        }
     }
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/HomeActivityTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/HomeActivityTest.kt
@@ -6,12 +6,10 @@ package org.mozilla.fenix
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.utils.toSafeIntent
 import org.junit.Assert.assertEquals
@@ -20,7 +18,6 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.HomeActivity.Companion.PRIVATE_BROWSING_MODE
@@ -34,8 +31,6 @@ import org.mozilla.fenix.utils.Settings
 
 @RunWith(FenixRobolectricTestRunner::class)
 class HomeActivityTest {
-
-    @get:Rule val gleanTestRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
     private lateinit var activity: HomeActivity
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/browser/BaseBrowserFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/browser/BaseBrowserFragmentTest.kt
@@ -21,21 +21,18 @@ import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.session.behavior.EngineViewBrowserToolbarBehavior
-import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.ui.widgets.VerticalSwipeRefreshLayout
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.utils.Settings
 
-@RunWith(FenixRobolectricTestRunner::class)
 class BaseBrowserFragmentTest {
     private lateinit var fragment: TestBaseBrowserFragment
     private lateinit var swipeRefreshLayout: VerticalSwipeRefreshLayout
     private lateinit var engineView: EngineView
     private lateinit var settings: Settings
+    private lateinit var testContext: Context
 
     @Before
     fun setup() {
@@ -43,6 +40,8 @@ class BaseBrowserFragmentTest {
         swipeRefreshLayout = mockk(relaxed = true)
         engineView = mockk(relaxed = true)
         settings = mockk(relaxed = true)
+        testContext = mockk(relaxed = true)
+
         every { testContext.components.settings } returns settings
         every { fragment.isAdded } returns true
         every { fragment.activity } returns mockk()
@@ -145,6 +144,7 @@ class BaseBrowserFragmentTest {
         val download = DownloadState(
             url = "",
             sessionId = "1",
+            destinationDirectory = "/",
         )
 
         val status = DownloadState.Status.values()
@@ -165,6 +165,7 @@ class BaseBrowserFragmentTest {
         val download = DownloadState(
             url = "",
             sessionId = "1",
+            destinationDirectory = "/",
         )
 
         val status = DownloadState.Status.values()
@@ -185,6 +186,7 @@ class BaseBrowserFragmentTest {
         val download = DownloadState(
             url = "",
             sessionId = "2",
+            destinationDirectory = "/",
         )
 
         val status = DownloadState.Status.values()

--- a/fenix/app/src/test/java/org/mozilla/fenix/ext/ImageButtonTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/ext/ImageButtonTest.kt
@@ -6,36 +6,44 @@ package org.mozilla.fenix.ext
 
 import android.view.View
 import android.widget.ImageButton
-import mozilla.components.support.test.robolectric.testContext
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(FenixRobolectricTestRunner::class)
 class ImageButtonTest {
-    private val imageButton = ImageButton(testContext)
+    private val imageButton: ImageButton = mockk()
+
+    @Before
+    fun setup() {
+        every { imageButton.visibility = any() } just Runs
+        every { imageButton.isEnabled = any() } just Runs
+    }
 
     @Test
     fun `Hide and disable`() {
         imageButton.hideAndDisable()
-        assertFalse(imageButton.isEnabled)
-        assertEquals(View.INVISIBLE, imageButton.visibility)
+
+        verify { imageButton.isEnabled = false }
+        verify { imageButton.visibility = View.INVISIBLE }
     }
 
     @Test
     fun `Show and enable`() {
         imageButton.showAndEnable()
-        assertTrue(imageButton.isEnabled)
-        assertEquals(View.VISIBLE, imageButton.visibility)
+
+        verify { imageButton.isEnabled = true }
+        verify { imageButton.visibility = View.VISIBLE }
     }
 
     @Test
     fun `Remove and disable`() {
         imageButton.removeAndDisable()
-        assertFalse(imageButton.isEnabled)
-        assertEquals(View.GONE, imageButton.visibility)
+
+        verify { imageButton.isEnabled = false }
+        verify { imageButton.visibility = View.GONE }
     }
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/ext/TopSiteTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/ext/TopSiteTest.kt
@@ -7,11 +7,8 @@ package org.mozilla.fenix.ext
 import mozilla.components.feature.top.sites.TopSite
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.SupportUtils
 
-@RunWith(FenixRobolectricTestRunner::class)
 class TopSiteTest {
 
     val defaultGoogleTopSite = TopSite.Default(

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/intent/CrashReporterIntentProcessorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/intent/CrashReporterIntentProcessorTest.kt
@@ -16,12 +16,9 @@ import mozilla.components.lib.crash.Crash.NativeCodeCrash
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(FenixRobolectricTestRunner::class)
 class CrashReporterIntentProcessorTest {
     private val appStore: AppStore = mockk(relaxed = true)
     private val navController: NavController = mockk()

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlViewTest.kt
@@ -14,13 +14,10 @@ import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.utils.Settings
 
-@RunWith(FenixRobolectricTestRunner::class)
 class SessionControlViewTest {
 
     @Test

--- a/fenix/app/src/test/java/org/mozilla/fenix/nimbus/NimbusBranchesControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/nimbus/NimbusBranchesControllerTest.kt
@@ -20,17 +20,14 @@ import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mozilla.experiments.nimbus.Branch
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.nimbus.controller.NimbusBranchesController
 import org.mozilla.fenix.utils.Settings
 
-@RunWith(FenixRobolectricTestRunner::class)
 class NimbusBranchesControllerTest {
 
     private val experiments: NimbusApi = mockk(relaxed = true)

--- a/fenix/app/src/test/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsInteractorTest.kt
@@ -8,10 +8,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(FenixRobolectricTestRunner::class)
 class ConnectionDetailsInteractorTest {
 
     private lateinit var controller: ConnectionDetailsController

--- a/fenix/app/src/test/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/DefaultCookieBannerDetailsInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/DefaultCookieBannerDetailsInteractorTest.kt
@@ -8,10 +8,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(FenixRobolectricTestRunner::class)
 class DefaultCookieBannerDetailsInteractorTest {
     private lateinit var controller: CookieBannerDetailsController
     private lateinit var interactor: DefaultCookieBannerDetailsInteractor

--- a/fenix/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelInteractorTest.kt
@@ -14,26 +14,21 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.spyk
 import io.mockk.verify
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.concept.engine.cookiehandling.CookieBannersStorage
 import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.feature.session.TrackingProtectionUseCases
-import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(FenixRobolectricTestRunner::class)
 class TrackingProtectionPanelInteractorTest {
 
     private lateinit var context: Context
@@ -67,7 +62,7 @@ class TrackingProtectionPanelInteractorTest {
         MockKAnnotations.init(this)
         learnMoreClicked = false
 
-        context = spyk(testContext)
+        context = mockk()
         tab = createTab("https://mozilla.org")
         val cookieBannersStorage: CookieBannersStorage = mockk(relaxed = true)
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

















































### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1825071