### PR TITLE
Bug 1825015 - Remove dreamlte in legacy test configuration

### DIFF
--- a/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -43,9 +43,6 @@ gcloud:
     - model: walleye
       version: 27
       locale: en_US
-    - model: dreamlte
-      version: 28
-      locale: en_US
     - model: HWCOR
       version: 27
       locale: en_US


### PR DESCRIPTION
https://bugzil.la/1825015


https://bugzilla.mozilla.org/show_bug.cgi?id=1825015