### PR TITLE
 Bug 1823430 - Refactor home menu button dismissal into HomeMenuView

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -40,7 +40,6 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import mozilla.components.browser.menu.view.MenuButton
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.selector.privateTabs
@@ -193,6 +192,9 @@ class HomeFragment : Fragment() {
     private var toolbarView: ToolbarView? = null
     private var appBarLayout: AppBarLayout? = null
 
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal var homeMenuView: HomeMenuView? = null
+
     private lateinit var currentMode: CurrentMode
 
     private var lastAppliedWallpaperName: String = Wallpaper.defaultName
@@ -205,9 +207,6 @@ class HomeFragment : Fragment() {
     private val historyMetadataFeature = ViewBoundFeatureWrapper<RecentVisitsFeature>()
     private val searchSelectorBinding = ViewBoundFeatureWrapper<SearchSelectorBinding>()
     private val searchSelectorMenuBinding = ViewBoundFeatureWrapper<SearchSelectorMenuBinding>()
-
-    @VisibleForTesting
-    internal var getMenuButton: () -> MenuButton? = { binding.menuButton }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // DO NOT ADD ANYTHING ABOVE THIS getProfilerTime CALL!
@@ -450,7 +449,7 @@ class HomeFragment : Fragment() {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
 
-        getMenuButton()?.dismissMenu()
+        homeMenuView?.dismissMenu()
 
         val currentWallpaperName = requireContext().settings().currentWallpaperName
         applyWallpaper(wallpaperName = currentWallpaperName, orientationChange = true)
@@ -530,7 +529,7 @@ class HomeFragment : Fragment() {
         observeSearchEngineNameChanges()
         observeWallpaperUpdates()
 
-        HomeMenuView(
+        homeMenuView = HomeMenuView(
             view = view,
             context = view.context,
             lifecycleOwner = viewLifecycleOwner,
@@ -538,7 +537,7 @@ class HomeFragment : Fragment() {
             navController = findNavController(),
             menuButton = WeakReference(binding.menuButton),
             hideOnboardingIfNeeded = ::hideOnboardingIfNeeded,
-        ).build()
+        ).also { it.build() }
 
         tabCounterView = TabCounterView(
             context = requireContext(),
@@ -703,6 +702,7 @@ class HomeFragment : Fragment() {
         super.onDestroyView()
 
         _sessionControlInteractor = null
+        homeMenuView = null
         sessionControlView = null
         tabCounterView = null
         toolbarView = null

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
@@ -75,6 +75,13 @@ class HomeMenuView(
     }
 
     /**
+     * Dismisses the menu.
+     */
+    fun dismissMenu() {
+        menuButton.get()?.dismissMenu()
+    }
+
+    /**
      * Callback invoked when a menu item is tapped on.
      */
     @Suppress("LongMethod", "ComplexMethod")

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/HomeFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/HomeFragmentTest.kt
@@ -10,7 +10,6 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
-import mozilla.components.browser.menu.view.MenuButton
 import mozilla.components.browser.state.state.SearchState
 import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
 import mozilla.components.feature.top.sites.TopSite
@@ -97,12 +96,13 @@ class HomeFragmentTest {
     }
 
     @Test
-    fun `WHEN configuration changed menu is dismissed`() {
-        val menuButton: MenuButton = mockk(relaxed = true)
-        homeFragment.getMenuButton = { menuButton }
+    fun `WHEN configuration changed THEN menu is dismissed`() {
+        val homeMenuView: HomeMenuView = mockk(relaxed = true)
+        homeFragment.homeMenuView = homeMenuView
+
         homeFragment.onConfigurationChanged(mockk(relaxed = true))
 
-        verify(exactly = 1) { menuButton.dismissMenu() }
+        verify(exactly = 1) { homeMenuView.dismissMenu() }
     }
 
     fun `GIVEN the user is in normal mode WHEN checking if should enable wallpaper THEN return true`() {

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/HomeMenuViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/HomeMenuViewTest.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.menu.view.MenuButton
@@ -46,7 +47,7 @@ class HomeMenuViewTest {
     private lateinit var lifecycleOwner: LifecycleOwner
     private lateinit var homeActivity: HomeActivity
     private lateinit var navController: NavController
-    private lateinit var menuButton: WeakReference<MenuButton>
+    private lateinit var menuButton: MenuButton
     private lateinit var homeMenuView: HomeMenuView
 
     @Before
@@ -54,8 +55,9 @@ class HomeMenuViewTest {
         view = mockk(relaxed = true)
         lifecycleOwner = mockk(relaxed = true)
         homeActivity = mockk(relaxed = true)
-        menuButton = mockk(relaxed = true)
         navController = mockk(relaxed = true)
+
+        menuButton = spyk(MenuButton(testContext))
 
         homeMenuView = HomeMenuView(
             view = view,
@@ -63,9 +65,18 @@ class HomeMenuViewTest {
             lifecycleOwner = lifecycleOwner,
             homeActivity = homeActivity,
             navController = navController,
-            menuButton = menuButton,
+            menuButton = WeakReference(menuButton),
             hideOnboardingIfNeeded = {},
         )
+    }
+
+    @Test
+    fun `WHEN dismiss menu is called THEN the menu is dismissed`() {
+        homeMenuView.dismissMenu()
+
+        verify {
+            menuButton.dismissMenu()
+        }
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1823430