### PR TITLE
Bug 1825453 - Use the same Gradle jvmargs for AC as Fenix

### DIFF
--- a/android-components/gradle.properties
+++ b/android-components/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx7g -Xms2g -XX:MaxMetaspaceSize=6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
 org.gradle.daemon=true
 
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1825453
https://bugzilla.mozilla.org/show_bug.cgi?id=1825453
https://bugzilla.mozilla.org/show_bug.cgi?id=1825453