### PR TITLE
Bug 1823987 - NullPointerException possible fix

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1464,7 +1464,7 @@ abstract class BaseBrowserFragment :
                 .makeText(requireContext(), R.string.full_screen_notification, Toast.LENGTH_SHORT)
                 .show()
             activity?.enterToImmersiveMode()
-            (view as? SwipeGestureLayout)?.isSwipeEnabled = false
+            requireContext().settings().isSwipeEnabled = false
             browserToolbarView.collapse()
             browserToolbarView.view.isVisible = false
             val browserEngine = binding.swipeRefresh.layoutParams as CoordinatorLayout.LayoutParams
@@ -1479,7 +1479,7 @@ abstract class BaseBrowserFragment :
             MediaState.fullscreen.record(NoExtras())
         } else {
             activity?.exitImmersiveMode()
-            (view as? SwipeGestureLayout)?.isSwipeEnabled = true
+            requireContext().settings().isSwipeEnabled = true
             (activity as? HomeActivity)?.let { activity ->
                 activity.themeManager.applyStatusBarTheme(activity)
             }

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/SwipeGestureLayout.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/SwipeGestureLayout.kt
@@ -11,6 +11,7 @@ import android.view.GestureDetector
 import android.view.MotionEvent
 import android.widget.FrameLayout
 import androidx.core.view.GestureDetectorCompat
+import org.mozilla.fenix.ext.settings
 
 /**
  * Interface that allows intercepting and handling swipe gestures received in a [SwipeGestureLayout].
@@ -55,11 +56,6 @@ class SwipeGestureLayout @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,
 ) : FrameLayout(context, attrs, defStyleAttr) {
-
-    /**
-     * Controls whether the swiping functionality is active or not.
-     */
-    var isSwipeEnabled = true
 
     private val gestureListener = object : GestureDetector.SimpleOnGestureListener() {
         override fun onDown(e: MotionEvent): Boolean {
@@ -112,7 +108,7 @@ class SwipeGestureLayout @JvmOverloads constructor(
     }
 
     override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
-        if (!isSwipeEnabled) {
+        if (!context.settings().isSwipeEnabled) {
             return false
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1688,4 +1688,12 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         key = appContext.getPreferenceKey(R.string.pref_key_enable_tabs_tray_to_compose),
         default = FeatureFlags.composeTabsTray,
     )
+
+    /**
+     * Indicates if swipe is enabled
+     */
+    var isSwipeEnabled by booleanPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_is_swipe_enabled),
+        default = true,
+    )
 }

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -71,6 +71,7 @@
     <string name="pref_key_is_first_run" translatable="false">pref_key_is_first_run</string>
     <string name="pref_key_nimbus_last_fetch" translatable="false">pref_key_nimbus_last_fetch</string>
     <string name="pref_key_home_blocklist">pref_key_home_blocklist</string>
+    <string name="pref_key_is_swipe_enabled" translatable="false">pref_key_is_swipe_enabled</string>
 
     <!-- Data Choices -->
     <string name="pref_key_telemetry" translatable="false">pref_key_telemetry</string>


### PR DESCRIPTION
The bug couldn't be reproduced.

As it looks to be a regression in Fenix 109, where a boolean indicating if swipe is enabled/disabled was introduced in the  SwipeGestureLayout and then, used in the BaseBrowserFragment by casting the view before setting its value - the proposed solution is to define this boolean outside the layout class, as a preference, in order to avoid the cast when changing its value.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1823987