### PR TITLE
Bug 1825576 - Refactor search selector menu handling out of SessionControlController into its own controller

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -110,6 +110,7 @@ import org.mozilla.fenix.onboarding.FenixOnboarding
 import org.mozilla.fenix.onboarding.controller.DefaultOnboardingController
 import org.mozilla.fenix.perf.MarkersFragmentLifecycleCallbacks
 import org.mozilla.fenix.perf.runBlockingIncrement
+import org.mozilla.fenix.search.toolbar.DefaultSearchSelectorController
 import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
 import org.mozilla.fenix.tabstray.TabsTrayAccessPoint
 import org.mozilla.fenix.utils.Settings.Companion.TOP_SITES_PROVIDER_MAX_THRESHOLD
@@ -408,6 +409,10 @@ class HomeFragment : Fragment() {
             onboardingController = DefaultOnboardingController(
                 activity = activity,
                 hideOnboarding = ::hideOnboardingAndOpenSearch,
+            ),
+            searchSelectorController = DefaultSearchSelectorController(
+                activity = activity,
+                navController = findNavController(),
             ),
             toolbarController = DefaultToolbarController(
                 activity = activity,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -39,7 +39,6 @@ import org.mozilla.fenix.GleanMetrics.RecentTabs
 import org.mozilla.fenix.GleanMetrics.TopSites
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.browser.BrowserAnimator
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.AppStore
@@ -53,8 +52,6 @@ import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.messaging.MessageController
 import org.mozilla.fenix.onboarding.WallpaperOnboardingDialogFragment.Companion.THUMBNAILS_SELECTION_COUNT
-import org.mozilla.fenix.search.toolbar.SearchSelectorInteractor
-import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.wallpapers.Wallpaper
@@ -171,11 +168,6 @@ interface SessionControlController {
      * @see [SessionControlInteractor.reportSessionMetrics]
      */
     fun handleReportSessionMetrics(state: AppState)
-
-    /**
-     * @see [SearchSelectorInteractor.onMenuItemTapped]
-     */
-    fun handleMenuItemTapped(item: SearchSelectorMenu.Item)
 }
 
 @Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
@@ -536,27 +528,5 @@ class DefaultSessionControlController(
         }
 
         RecentBookmarks.recentBookmarksCount.set(state.recentBookmarks.size.toLong())
-    }
-
-    override fun handleMenuItemTapped(item: SearchSelectorMenu.Item) {
-        when (item) {
-            SearchSelectorMenu.Item.SearchSettings -> {
-                navController.nav(
-                    R.id.homeFragment,
-                    HomeFragmentDirections.actionGlobalSearchEngineFragment(),
-                )
-            }
-            is SearchSelectorMenu.Item.SearchEngine -> {
-                val directions = HomeFragmentDirections.actionGlobalSearchDialog(
-                    sessionId = null,
-                    searchEngine = item.searchEngine.id,
-                )
-                navController.nav(
-                    R.id.homeFragment,
-                    directions,
-                    BrowserAnimator.getToolbarNavOptions(activity),
-                )
-            }
-        }
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -33,6 +33,7 @@ import org.mozilla.fenix.home.toolbar.ToolbarController
 import org.mozilla.fenix.home.toolbar.ToolbarInteractor
 import org.mozilla.fenix.onboarding.controller.OnboardingController
 import org.mozilla.fenix.onboarding.interactor.OnboardingInteractor
+import org.mozilla.fenix.search.toolbar.SearchSelectorController
 import org.mozilla.fenix.search.toolbar.SearchSelectorInteractor
 import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
 import org.mozilla.fenix.wallpapers.WallpaperState
@@ -226,6 +227,7 @@ class SessionControlInteractor(
     private val pocketStoriesController: PocketStoriesController,
     private val privateBrowsingController: PrivateBrowsingController,
     private val onboardingController: OnboardingController,
+    private val searchSelectorController: SearchSelectorController,
     private val toolbarController: ToolbarController,
 ) : CollectionInteractor,
     OnboardingInteractor,
@@ -438,6 +440,6 @@ class SessionControlInteractor(
     }
 
     override fun onMenuItemTapped(item: SearchSelectorMenu.Item) {
-        controller.handleMenuItemTapped(item)
+        searchSelectorController.handleMenuItemTapped(item)
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorController.kt
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.search.toolbar
+
+import androidx.navigation.NavController
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.BrowserAnimator
+import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.home.HomeFragmentDirections
+
+/**
+ * An interface that handles the view manipulation of the search selector menu.
+ */
+interface SearchSelectorController {
+    /**
+     * @see [SearchSelectorInteractor.onMenuItemTapped]
+     */
+    fun handleMenuItemTapped(item: SearchSelectorMenu.Item)
+}
+
+/**
+ * The default implementation of [SearchSelectorController].
+ */
+class DefaultSearchSelectorController(
+    private val activity: HomeActivity,
+    private val navController: NavController,
+) : SearchSelectorController {
+
+    override fun handleMenuItemTapped(item: SearchSelectorMenu.Item) {
+        when (item) {
+            SearchSelectorMenu.Item.SearchSettings -> {
+                navController.nav(
+                    R.id.homeFragment,
+                    HomeFragmentDirections.actionGlobalSearchEngineFragment(),
+                )
+            }
+
+            is SearchSelectorMenu.Item.SearchEngine -> {
+                val directions = HomeFragmentDirections.actionGlobalSearchDialog(
+                    sessionId = null,
+                    searchEngine = item.searchEngine.id,
+                )
+                navController.nav(
+                    R.id.homeFragment,
+                    directions,
+                    BrowserAnimator.getToolbarNavOptions(activity),
+                )
+            }
+        }
+    }
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.home
 
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
-import androidx.navigation.NavOptions
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -68,7 +67,6 @@ import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
 import org.mozilla.fenix.messaging.MessageController
 import org.mozilla.fenix.onboarding.WallpaperOnboardingDialogFragment.Companion.THUMBNAILS_SELECTION_COUNT
-import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.wallpapers.Wallpaper
@@ -1114,34 +1112,6 @@ class DefaultSessionControlControllerTest {
         }
         verify {
             messageController.onMessageDismissed(message)
-        }
-    }
-
-    @Test
-    fun `WHEN handleMenuItemTapped is called with SearchSettings item THEN navigate to SearchEngineFragment`() {
-        createController().handleMenuItemTapped(SearchSelectorMenu.Item.SearchSettings)
-
-        verify {
-            navController.navigate(
-                match<NavDirections> { it.actionId == R.id.action_global_searchEngineFragment },
-                null,
-            )
-        }
-    }
-
-    @Test
-    fun `WHEN handleMenuItemTapped is called with SearchEngine item THEN navigate to SearchDialogFragment`() {
-        val item = mockk<SearchSelectorMenu.Item.SearchEngine>()
-        every { item.searchEngine.id } returns "DuckDuckGo"
-
-        createController().handleMenuItemTapped(item)
-
-        val expectedDirections = HomeFragmentDirections.actionGlobalSearchDialog(
-            sessionId = null,
-            searchEngine = item.searchEngine.id,
-        )
-        verify {
-            navController.navigate(expectedDirections, any<NavOptions>())
         }
     }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -27,6 +27,7 @@ import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 import org.mozilla.fenix.home.toolbar.ToolbarController
 import org.mozilla.fenix.onboarding.controller.OnboardingController
+import org.mozilla.fenix.search.toolbar.SearchSelectorController
 
 class SessionControlInteractorTest {
 
@@ -37,6 +38,7 @@ class SessionControlInteractorTest {
     private val pocketStoriesController: PocketStoriesController = mockk(relaxed = true)
     private val privateBrowsingController: PrivateBrowsingController = mockk(relaxed = true)
     private val onboardingController: OnboardingController = mockk(relaxed = true)
+    private val searchSelectorController: SearchSelectorController = mockk(relaxed = true)
     private val toolbarController: ToolbarController = mockk(relaxed = true)
 
     // Note: the recent visits tests are handled in [RecentVisitsInteractorTest] and [RecentVisitsControllerTest]
@@ -55,6 +57,7 @@ class SessionControlInteractorTest {
             pocketStoriesController,
             privateBrowsingController,
             onboardingController,
+            searchSelectorController,
             toolbarController,
         )
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractorTest.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 import org.mozilla.fenix.home.toolbar.ToolbarController
 import org.mozilla.fenix.onboarding.controller.OnboardingController
+import org.mozilla.fenix.search.toolbar.SearchSelectorController
 
 class RecentVisitsInteractorTest {
     private val defaultSessionControlController: DefaultSessionControlController =
@@ -34,6 +35,7 @@ class RecentVisitsInteractorTest {
     private val pocketStoriesController: PocketStoriesController = mockk(relaxed = true)
     private val privateBrowsingController: PrivateBrowsingController = mockk(relaxed = true)
     private val onboardingController: OnboardingController = mockk(relaxed = true)
+    private val searchSelectorController: SearchSelectorController = mockk(relaxed = true)
     private val toolbarController: ToolbarController = mockk(relaxed = true)
 
     private lateinit var interactor: SessionControlInteractor
@@ -49,6 +51,7 @@ class RecentVisitsInteractorTest {
             pocketStoriesController,
             privateBrowsingController,
             onboardingController,
+            searchSelectorController,
             toolbarController,
         )
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/DefaultSearchSelectorControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/DefaultSearchSelectorControllerTest.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.search.toolbar
+
+import androidx.navigation.NavController
+import androidx.navigation.NavDirections
+import androidx.navigation.NavOptions
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.home.HomeFragmentDirections
+import org.mozilla.fenix.utils.Settings
+
+class DefaultSearchSelectorControllerTest {
+
+    private val activity: HomeActivity = mockk(relaxed = true)
+    private val navController: NavController = mockk(relaxed = true)
+    private val settings: Settings = mockk(relaxed = true)
+
+    private lateinit var controller: DefaultSearchSelectorController
+
+    @Before
+    fun setup() {
+        controller = DefaultSearchSelectorController(
+            activity = activity,
+            navController = navController,
+        )
+
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.homeFragment
+        }
+        every { activity.components.settings } returns settings
+        every { activity.settings() } returns settings
+    }
+
+    @Test
+    fun `WHEN the search settings menu item is tapped THEN navigate to search engine settings fragment`() {
+        controller.handleMenuItemTapped(SearchSelectorMenu.Item.SearchSettings)
+
+        verify {
+            navController.navigate(
+                match<NavDirections> { it.actionId == R.id.action_global_searchEngineFragment },
+                null,
+            )
+        }
+    }
+
+    @Test
+    fun `WHEN a search engine menu item is tapped THEN open the search dialog with the selected search engine`() {
+        val item = mockk<SearchSelectorMenu.Item.SearchEngine>()
+        every { item.searchEngine.id } returns "DuckDuckGo"
+
+        controller.handleMenuItemTapped(item)
+
+        val expectedDirections = HomeFragmentDirections.actionGlobalSearchDialog(
+            sessionId = null,
+            searchEngine = item.searchEngine.id,
+        )
+        verify {
+            navController.navigate(expectedDirections, any<NavOptions>())
+        }
+    }
+}


### PR DESCRIPTION




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1825576