### PR TITLE
Bug 1825649 - Introduce shared-settings.gradle to allow reusing build logic.

### DIFF
--- a/android-components/build.gradle
+++ b/android-components/build.gradle
@@ -138,23 +138,6 @@ subprojects {
         apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
     }
 
-    // Define a reusable task for updating the version in manifest.json for modules that package
-    // a web extension. We automate this to make sure we never forget to update the version, either
-    // in local development or for releases. In both cases, we want to make sure the latest version
-    // of all extensions (including their latest changes) are installed on first start-up.
-    ext.updateExtensionVersion = { task, extDir ->
-        configure(task) {
-            from extDir
-            include 'manifest.template.json'
-            rename { 'manifest.json' }
-            into extDir
-
-            def values = ['version': rootProject.ext.config.componentsVersion.split("a|b")[0] + "." + new Date().format('MMddHHmmss')]
-            inputs.properties(values)
-            expand(values)
-        }
-    }
-
     afterEvaluate {
         if (it.hasProperty('android')) {
             jacoco {

--- a/android-components/settings.gradle
+++ b/android-components/settings.gradle
@@ -2,33 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import org.yaml.snakeyaml.Yaml
-
 pluginManagement {
     includeBuild("plugins/dependencies")
     includeBuild("plugins/publicsuffixlist")
 }
 
-buildscript {
-    repositories {
-        if (hasProperty("centralRepo")) {
-            maven {
-                name "MavenCentral"
-                url property("centralRepo")
-            }
-        } else {
-            mavenCentral()
-        }
-    }
-
-    dependencies {
-        classpath 'org.yaml:snakeyaml:1.33'
-    }
-}
-
 plugins {
     id 'mozac.DependenciesPlugin'
 }
+
+apply from: file('../shared-settings.gradle')
 
 buildCache {
     local {
@@ -37,58 +20,7 @@ buildCache {
     }
 }
 
-// Synchronized library configuration for all modules
-// This "componentsVersion" number is defined in "version.txt" and should follow
-// semantic versioning (MAJOR.MINOR.PATCH). See https://semver.org/
-class Config {
-
-    public final String componentsVersion
-    public final String componentsGroupId
-    public final Integer compileSdkVersion
-    public final Integer minSdkVersion
-    public final Integer targetSdkVersion
-
-    Config(
-        String componentsVersion,
-        String componentsGroupId,
-        Integer compileSdkVersion,
-        Integer minSdkVersion,
-        Integer targetSdkVersion
-    ) {
-        this.componentsVersion = componentsVersion
-        this.componentsGroupId = componentsGroupId
-        this.compileSdkVersion = compileSdkVersion
-        this.minSdkVersion = minSdkVersion
-        this.targetSdkVersion = targetSdkVersion
-    }
-}
-
-def setupProject(name, path, description) {
-    settings.include(":$name")
-
-    project(":$name").projectDir = new File(rootDir, path)
-
-    // project(...) gives us a skeleton project that we can't set ext.* on
-    gradle.beforeProject { project ->
-        // However, the "afterProject" listener iterates over every project and gives us the actual project
-        // So, once we filter for the project we care about, we can set whatever we want
-        if (project.name == name) {
-            project.ext.description = description
-        }
-    }
-}
-
-def yaml = new Yaml()
-def buildconfig = yaml.load(new File(rootDir, '.buildconfig.yml').newInputStream())
-def componentsVersion = new File(rootDir, '../version.txt').text.stripTrailing()
-buildconfig.projects.each { project ->
-    setupProject(project.key, project.value.path, project.value.description)
-}
-
 gradle.projectsLoaded { ->
-    def configData = yaml.load(new File(rootDir, '.config.yml').newInputStream())
-    String version = componentsVersion
-
     if (gradle.rootProject.hasProperty("nightlyVersion")) {
         version = gradle.rootProject.nightlyVersion
     } else if (gradle.rootProject.hasProperty("local")) {
@@ -97,17 +29,6 @@ gradle.projectsLoaded { ->
     } else if (gradle.hasProperty("localProperties.branchBuild.android-components.version")) {
         version = gradle.getProperty("localProperties.branchBuild.android-components.version")
     }
-    // Wait until root project is "loaded" before we set "config"
-    // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
-    // gradle files. This means that they can just access "config.<value>", and it'll function properly
-    gradle.rootProject.ext.config = new Config(
-        version,
-        configData.componentsGroupId,
-        configData.compileSdkVersion,
-        configData.minSdkVersion,
-        configData.targetSdkVersion
-    )
-    gradle.rootProject.ext.buildConfig = buildconfig
 }
 
 def runCmd(cmd, workingDir, successMessage) {

--- a/fenix/build.gradle
+++ b/fenix/build.gradle
@@ -143,25 +143,6 @@ allprojects {
     }
 }
 
-subprojects {
-    // Define a reusable task for updating the version in manifest.json for modules that package
-    // a web extension. We automate this to make sure we never forget to update the version, either
-    // in local development or for releases. In both cases, we want to make sure the latest version
-    // of all extensions (including their latest changes) are installed on first start-up.
-    ext.updateExtensionVersion = { task, extDir ->
-        configure(task) {
-            from extDir
-            include 'manifest.template.json'
-            rename { 'manifest.json' }
-            into extDir
-
-            def values = ['version': rootProject.ext.config.componentsVersion.split("a|b")[0] + "." + new Date().format('MMddHHmmss')]
-            inputs.properties(values)
-            expand(values)
-        }
-    }
-}
-
 tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/fenix/settings.gradle
+++ b/fenix/settings.gradle
@@ -2,99 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import org.yaml.snakeyaml.Yaml
-
 pluginManagement {
     includeBuild("../android-components/plugins/publicsuffixlist")
     includeBuild("../android-components/plugins/dependencies")
-}
-
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'org.yaml:snakeyaml:1.33'
-    }
 }
 
 plugins {
     id 'mozac.DependenciesPlugin'
 }
 
+apply from: file('../shared-settings.gradle')
+
 include ':app'
 include ':mozilla-detekt-rules'
 include ':mozilla-lint-rules'
 include ':benchmark'
 
-// Synchronized library configuration for all modules
-// This "componentsVersion" number is defined in "version.txt" and should follow
-// semantic versioning (MAJOR.MINOR.PATCH). See https://semver.org/
-class Config {
-
-    public final String componentsVersion
-    public final String componentsGroupId
-    public final Integer compileSdkVersion
-    public final Integer minSdkVersion
-    public final Integer targetSdkVersion
-
-    Config(
-            String componentsVersion,
-            String componentsGroupId,
-            Integer compileSdkVersion,
-            Integer minSdkVersion,
-            Integer targetSdkVersion
-    ) {
-        this.componentsVersion = componentsVersion
-        this.componentsGroupId = componentsGroupId
-        this.compileSdkVersion = compileSdkVersion
-        this.minSdkVersion = minSdkVersion
-        this.targetSdkVersion = targetSdkVersion
-    }
-}
-
-def setupProject(name, path, description) {
-    settings.include(":$name")
-
-    project(":$name").projectDir = new File(rootDir, "../android-components/${path}")
-
-    // project(...) gives us a skeleton project that we can't set ext.* on
-    gradle.beforeProject { project ->
-        // However, the "afterProject" listener iterates over every project and gives us the actual project
-        // So, once we filter for the project we care about, we can set whatever we want
-        if (project.name == name) {
-            project.ext.description = description
-        }
-    }
-}
-
-def yaml = new Yaml()
-def buildconfig = yaml.load(new File(rootDir, '../android-components/.buildconfig.yml').newInputStream())
-
-buildconfig.projects.each { project ->
-    if (!project.key.startsWith("samples")) {
-        setupProject(project.key, project.value.path, project.value.description)
-    }
-}
-
 gradle.projectsLoaded { ->
-    def componentsVersion = new File(rootDir, '../version.txt').text.stripTrailing()
-    def configData = yaml.load(new File(rootDir, '../android-components/.config.yml').newInputStream())
-
-    // Wait until root project is "loaded" before we set "config"
-    // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
-    // gradle files. This means that they can just access "config.<value>", and it'll function properly
-    gradle.rootProject.ext.config = new Config(
-            componentsVersion,
-            configData.componentsGroupId,
-            configData.compileSdkVersion,
-            configData.minSdkVersion,
-            configData.targetSdkVersion
-    )
-    gradle.rootProject.ext.buildConfig = buildconfig
-
     // Disables A-C tests and lint when building Fenix.
     gradle.allprojects { project ->
         if (project.projectDir.absolutePath.contains("/android-components/")) {

--- a/focus-android/build.gradle
+++ b/focus-android/build.gradle
@@ -58,25 +58,6 @@ allprojects {
     }
 }
 
-subprojects {
-    // Define a reusable task for updating the version in manifest.json for modules that package
-    // a web extension. We automate this to make sure we never forget to update the version, either
-    // in local development or for releases. In both cases, we want to make sure the latest version
-    // of all extensions (including their latest changes) are installed on first start-up.
-    ext.updateExtensionVersion = { task, extDir ->
-        configure(task) {
-            from extDir
-            include 'manifest.template.json'
-            rename { 'manifest.json' }
-            into extDir
-
-            def values = ['version': rootProject.ext.config.componentsVersion.split("a|b")[0] + "." + new Date().format('MMddHHmmss')]
-            inputs.properties(values)
-            expand(values)
-        }
-    }
-}
-
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/focus-android/settings.gradle
+++ b/focus-android/settings.gradle
@@ -2,96 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import org.yaml.snakeyaml.Yaml
-
 pluginManagement {
     includeBuild("../android-components/plugins/publicsuffixlist")
     includeBuild("../android-components/plugins/dependencies")
-}
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'org.yaml:snakeyaml:1.33'
-    }
 }
 
 plugins {
     id 'mozac.DependenciesPlugin'
 }
 
+apply from: file('../shared-settings.gradle')
+
 include ':app'
 include ':service-telemetry'
 
-// Synchronized library configuration for all modules
-// This "componentsVersion" number is defined in "version.txt" and should follow
-// semantic versioning (MAJOR.MINOR.PATCH). See https://semver.org/
-class Config {
-
-    public final String componentsVersion
-    public final String componentsGroupId
-    public final Integer compileSdkVersion
-    public final Integer minSdkVersion
-    public final Integer targetSdkVersion
-
-    Config(
-            String componentsVersion,
-            String componentsGroupId,
-            Integer compileSdkVersion,
-            Integer minSdkVersion,
-            Integer targetSdkVersion
-    ) {
-        this.componentsVersion = componentsVersion
-        this.componentsGroupId = componentsGroupId
-        this.compileSdkVersion = compileSdkVersion
-        this.minSdkVersion = minSdkVersion
-        this.targetSdkVersion = targetSdkVersion
-    }
-}
-
-def setupProject(name, path, description) {
-    settings.include(":$name")
-
-    project(":$name").projectDir = new File(rootDir, "../android-components/${path}")
-
-    // project(...) gives us a skeleton project that we can't set ext.* on
-    gradle.beforeProject { project ->
-        // However, the "afterProject" listener iterates over every project and gives us the actual project
-        // So, once we filter for the project we care about, we can set whatever we want
-        if (project.name == name) {
-            project.ext.description = description
-        }
-    }
-}
-
-def yaml = new Yaml()
-def buildconfig = yaml.load(new File(rootDir, '../android-components/.buildconfig.yml').newInputStream())
-
-buildconfig.projects.each { project ->
-    if (!project.key.startsWith("samples")) {
-        setupProject(project.key, project.value.path, project.value.description)
-    }
-}
-
 gradle.projectsLoaded { ->
-    def componentsVersion = new File(rootDir, '../version.txt').text.stripTrailing()
-    def configData = yaml.load(new File(rootDir, '../android-components/.config.yml').newInputStream())
-
-    // Wait until root project is "loaded" before we set "config"
-    // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
-    // gradle files. This means that they can just access "config.<value>", and it'll function properly
-    gradle.rootProject.ext.config = new Config(
-            componentsVersion,
-            configData.componentsGroupId,
-            configData.compileSdkVersion,
-            configData.minSdkVersion,
-            configData.targetSdkVersion
-    )
-    gradle.rootProject.ext.buildConfig = buildconfig
-
     // Disables A-C tests and lint when building Focus.
     gradle.allprojects { project ->
         if (project.projectDir.absolutePath.contains("/android-components/")) {

--- a/shared-settings.gradle
+++ b/shared-settings.gradle
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import org.yaml.snakeyaml.Yaml
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'org.yaml:snakeyaml:1.33'
+    }
+}
+
+// Synchronized library configuration for all modules
+// This "componentsVersion" number is defined in "version.txt" and should follow
+// semantic versioning (MAJOR.MINOR.PATCH). See https://semver.org/
+class Config {
+
+    public final String componentsVersion
+    public final String componentsGroupId
+    public final Integer compileSdkVersion
+    public final Integer minSdkVersion
+    public final Integer targetSdkVersion
+
+    Config(
+            String componentsVersion,
+            String componentsGroupId,
+            Integer compileSdkVersion,
+            Integer minSdkVersion,
+            Integer targetSdkVersion
+    ) {
+        this.componentsVersion = componentsVersion
+        this.componentsGroupId = componentsGroupId
+        this.compileSdkVersion = compileSdkVersion
+        this.minSdkVersion = minSdkVersion
+        this.targetSdkVersion = targetSdkVersion
+    }
+}
+
+def setupProject(name, path, description) {
+    settings.include(":$name")
+
+    project(":$name").projectDir = new File(rootDir, "../android-components/${path}")
+
+    // project(...) gives us a skeleton project that we can't set ext.* on
+    gradle.beforeProject { project ->
+        // However, the "afterProject" listener iterates over every project and gives us the actual project
+        // So, once we filter for the project we care about, we can set whatever we want
+        if (project.name == name) {
+            project.ext.description = description
+        }
+    }
+}
+
+def yaml = new Yaml()
+def buildconfig = yaml.load(new File(rootDir, '../android-components/.buildconfig.yml').newInputStream())
+
+buildconfig.projects.each { project ->
+    // If we're building A-C, set up all projects, otherwise exclude samples e.g., if we're building Fenix or Focus.
+    // The samples are not relevant for the Fenix and Focus builds.
+    if (rootDir.toString().contains("android-components") || !project.key.startsWith("samples")) {
+        setupProject(project.key, project.value.path, project.value.description)
+    }
+}
+
+gradle.projectsLoaded { ->
+    def componentsVersion = new File(rootDir, '../version.txt').text.stripTrailing()
+    def configData = yaml.load(new File(rootDir, '../android-components/.config.yml').newInputStream())
+
+    // Wait until root project is "loaded" before we set "config"
+    // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
+    // gradle files. This means that they can just access "config.<value>", and it'll function properly
+    gradle.rootProject.ext.config = new Config(
+            componentsVersion,
+            configData.componentsGroupId,
+            configData.compileSdkVersion,
+            configData.minSdkVersion,
+            configData.targetSdkVersion
+    )
+
+    gradle.rootProject.ext.buildConfig = buildconfig
+    
+    // Define a reusable task for updating the version in manifest.json for modules that package
+    // a web extension. We automate this to make sure we never forget to update the version, either
+    // in local development or for releases. In both cases, we want to make sure the latest version
+    // of all extensions (including their latest changes) are installed on first start-up.
+    gradle.rootProject.allprojects {
+        ext.updateExtensionVersion = { task, extDir ->
+            configure(task) {
+                from extDir
+                include 'manifest.template.json'
+                rename { 'manifest.json' }
+                into extDir
+
+                def values = ['version': rootProject.ext.config.componentsVersion.split("a|b")[0] + "." + new Date().format('MMddHHmmss')]
+                inputs.properties(values)
+                expand(values)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows code re-use in our Gradle files, which currently have quite a bit of code duplication. For now, I just unified our settings.gradle files, but as a next step we can define shared functions in this new `shared-setting.gradle` e.g., for the `getManifestVersionString` function introduced in https://github.com/mozilla-mobile/firefox-android/pull/1429/.














### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1825649