### PR TITLE
Bug 1819727 - Fix imports for FxNimbusMessaging in UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NimbusMessagingHomescreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NimbusMessagingHomescreenTest.kt
@@ -7,6 +7,10 @@ package org.mozilla.fenix.ui
 import android.content.Intent
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import mozilla.components.service.nimbus.messaging.FxNimbusMessaging
+import mozilla.components.service.nimbus.messaging.MessageData
+import mozilla.components.service.nimbus.messaging.Messaging
+import mozilla.components.service.nimbus.messaging.StyleData
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -20,9 +24,6 @@ import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.nimbus.HomeScreenSection
 import org.mozilla.fenix.nimbus.Homescreen
-import org.mozilla.fenix.nimbus.MessageData
-import org.mozilla.fenix.nimbus.Messaging
-import org.mozilla.fenix.nimbus.StyleData
 import org.mozilla.fenix.ui.robots.homeScreen
 
 /**
@@ -55,7 +56,7 @@ class NimbusMessagingHomescreenTest {
     @Before
     fun setUp() {
         // Set up nimbus message
-        FxNimbus.features.messaging.withInitializer {
+        FxNimbusMessaging.features.messaging.withInitializer {
             // FML generated objects.
             Messaging(
                 messages = mapOf(


### PR DESCRIPTION
When #1097 landed, it upstreamed the Nimbus messaging code to components and changed the namespace for those generated classes.

Surprisingly, CI didn't rebase the original patch for bug 1819727 before landing it, leading to the main branch being busted.

This patch fixes that breakage.

cc: @jrbenny35 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1819727