### PR TITLE
Bug 1825549 Disallow messages with blank text fields

### DIFF
--- a/android-components/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorage.kt
+++ b/android-components/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorage.kt
@@ -54,20 +54,27 @@ class NimbusMessagingStorage(
     /**
      * Returns the [Message] for the given [key] or returns null if none found.
      */
+    suspend fun getMessage(key: String): Message? =
+        createMessage(messagingFeature.value(), key)
+
     @Suppress("ReturnCount")
-    suspend fun getMessage(key: String): Message? {
-        val featureValue = messagingFeature.value()
-        val value = featureValue.messages[key] ?: return null
-        val trigger = sanitizeTriggers(key, value.trigger, featureValue.triggers) ?: return null
-        val action = sanitizeAction(key, value.action, featureValue.actions, value.isControl) ?: return null
+    private suspend fun createMessage(featureValue: Messaging, key: String): Message? {
+        val message = featureValue.messages[key] ?: return null
+        if (message.text.isBlank()) {
+            reportMalformedMessage(key)
+            return null
+        }
+
+        val trigger = sanitizeTriggers(key, message.trigger, featureValue.triggers) ?: return null
+        val action = sanitizeAction(key, message.action, featureValue.actions, message.isControl) ?: return null
         val defaultStyle = StyleData()
         val storageMetadata = metadataStorage.getMetadata()
 
         return Message(
             id = key,
-            data = value,
+            data = message,
             action = action,
-            style = featureValue.styles[value.style] ?: defaultStyle,
+            style = featureValue.styles[message.style] ?: defaultStyle,
             metadata = storageMetadata[key] ?: addMetadata(key),
             triggers = trigger,
         )
@@ -79,27 +86,10 @@ class NimbusMessagingStorage(
      */
     suspend fun getMessages(): List<Message> {
         val featureValue = messagingFeature.value()
-        val nimbusTriggers = featureValue.triggers
-        val nimbusStyles = featureValue.styles
-        val nimbusActions = featureValue.actions
-
         val nimbusMessages = featureValue.messages
-        val defaultStyle = StyleData()
-        val storageMetadata = metadataStorage.getMetadata()
-
-        return nimbusMessages
-            .mapNotNull { (key, value) ->
-                val action = sanitizeAction(key, value.action, nimbusActions, value.isControl)
-                    ?: return@mapNotNull null
-                Message(
-                    id = key,
-                    data = value,
-                    action = action,
-                    style = nimbusStyles[value.style] ?: defaultStyle,
-                    metadata = storageMetadata[key] ?: addMetadata(key),
-                    triggers = sanitizeTriggers(key, value.trigger, nimbusTriggers)
-                        ?: return@mapNotNull null,
-                )
+        return nimbusMessages.keys
+            .mapNotNull { key ->
+                createMessage(featureValue, key)
             }.filter {
                 !it.isExpired &&
                     !it.metadata.dismissed &&


### PR DESCRIPTION
Fixes [Bug 1825549](https://bugzilla.mozilla.org/show_bug.cgi?id=1825549).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1825549