### PR TITLE
Bug 1794077/1780350/1820404 Persist Readerview position

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -1306,6 +1306,7 @@ class GeckoEngineSession(
     private fun createScrollDelegate() = object : GeckoSession.ScrollDelegate {
         override fun onScrollChanged(session: GeckoSession, scrollX: Int, scrollY: Int) {
             this@GeckoEngineSession.scrollY = scrollY
+            notifyObservers { onScrollChange(scrollX, scrollY) }
         }
     }
 

--- a/android-components/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/BrowserStateReader.kt
+++ b/android-components/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/BrowserStateReader.kt
@@ -180,6 +180,7 @@ private fun JsonReader.tabSession(): RecoverableTab {
 
     var readerStateActive: Boolean? = null
     var readerActiveUrl: String? = null
+    var readerScrollY: Int? = null
 
     var historyMetadataUrl: String? = null
     var historyMetadataSearchTerm: String? = null
@@ -201,6 +202,7 @@ private fun JsonReader.tabSession(): RecoverableTab {
             Keys.SESSION_SEARCH_TERM -> searchTerm = nextStringOrNull() ?: ""
             Keys.SESSION_READER_MODE_KEY -> readerStateActive = nextBooleanOrNull()
             Keys.SESSION_READER_MODE_ACTIVE_URL_KEY -> readerActiveUrl = nextStringOrNull()
+            Keys.SESSION_READER_MODE_SCROLLY_KEY -> readerScrollY = nextIntOrNull()
             Keys.SESSION_HISTORY_METADATA_URL -> historyMetadataUrl = nextStringOrNull()
             Keys.SESSION_HISTORY_METADATA_SEARCH_TERM -> historyMetadataSearchTerm = nextStringOrNull()
             Keys.SESSION_HISTORY_METADATA_REFERRER_URL -> historyMetadataReferrerUrl = nextStringOrNull()
@@ -231,6 +233,7 @@ private fun JsonReader.tabSession(): RecoverableTab {
             readerState = ReaderState(
                 active = readerStateActive ?: false,
                 activeUrl = readerActiveUrl,
+                scrollY = readerScrollY,
             ),
             historyMetadata = if (historyMetadataUrl != null) {
                 HistoryMetadataKey(

--- a/android-components/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/BrowserStateWriter.kt
+++ b/android-components/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/BrowserStateWriter.kt
@@ -112,6 +112,11 @@ private fun JsonWriter.tab(
             value(tab.readerState.activeUrl)
         }
 
+        if (tab.readerState.active && tab.readerState.scrollY != null) {
+            name(Keys.SESSION_READER_MODE_SCROLLY_KEY)
+            value(tab.readerState.scrollY)
+        }
+
         val metadata = tab.historyMetadata
         if (metadata != null) {
             name(Keys.SESSION_HISTORY_METADATA_URL)

--- a/android-components/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/Keys.kt
+++ b/android-components/components/browser/session-storage/src/main/java/mozilla/components/browser/session/storage/serialize/Keys.kt
@@ -20,6 +20,7 @@ internal object Keys {
     const val SESSION_PARENT_UUID_KEY = "parentUuid"
     const val SESSION_READER_MODE_KEY = "readerMode"
     const val SESSION_READER_MODE_ACTIVE_URL_KEY = "readerModeArticleUrl"
+    const val SESSION_READER_MODE_SCROLLY_KEY = "readerModeScrollY"
     const val SESSION_TITLE = "title"
     const val SESSION_SEARCH_TERM = "searchTerm"
     const val SESSION_LAST_ACCESS = "lastAccess"

--- a/android-components/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/serialize/BrowserStateWriterReaderTest.kt
+++ b/android-components/components/browser/session-storage/src/test/java/mozilla/components/browser/session/storage/serialize/BrowserStateWriterReaderTest.kt
@@ -66,6 +66,7 @@ class BrowserStateWriterReaderTest {
         assertEquals(engineState, restoredTab.engineSessionState)
         assertFalse(restoredTab.state.readerState.active)
         assertNull(restoredTab.state.readerState.activeUrl)
+        assertNull(restoredTab.state.readerState.scrollY)
     }
 
     @Test
@@ -77,7 +78,7 @@ class BrowserStateWriterReaderTest {
             url = "https://www.mozilla.org",
             title = "Mozilla",
             contextId = "work",
-            readerState = ReaderState(active = true, activeUrl = "https://www.example.org"),
+            readerState = ReaderState(active = true, activeUrl = "https://www.example.org", scrollY = 1234),
         )
 
         val writer = BrowserStateWriter()
@@ -94,6 +95,7 @@ class BrowserStateWriterReaderTest {
 
         assertTrue(restoredTab.state.readerState.active)
         assertEquals("https://www.example.org", restoredTab.state.readerState.activeUrl)
+        assertEquals(1234, restoredTab.state.readerState.scrollY)
     }
 
     @Test

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -1231,6 +1231,11 @@ sealed class ReaderAction : BrowserAction() {
         ReaderAction()
 
     /**
+     * Updates the [ReaderState.scrollY].
+     */
+    data class UpdateReaderScrollYAction(val tabId: String, val scrollY: Int) : ReaderAction()
+
+    /**
      * Clears the [ReaderState.activeUrl].
      */
     data class ClearReaderActiveUrlAction(val tabId: String) : ReaderAction()

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.state.action.CookieBannerAction
 import mozilla.components.browser.state.action.CrashAction
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.MediaSessionAction
+import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.selector.findTabOrCustomTab
 import mozilla.components.browser.state.state.AppIntentState
@@ -44,6 +45,11 @@ internal class EngineObserver(
     private val tabId: String,
     private val store: Store<BrowserState, BrowserAction>,
 ) : EngineSession.Observer {
+
+    override fun onScrollChange(scrollX: Int, scrollY: Int) {
+        store.dispatch(ReaderAction.UpdateReaderScrollYAction(tabId, scrollY))
+    }
+
     override fun onNavigateBack() {
         store.dispatch(ContentAction.UpdateSearchTermsAction(tabId, ""))
     }

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/ReaderStateReducer.kt
@@ -37,6 +37,13 @@ internal object ReaderStateReducer {
         is ReaderAction.ClearReaderActiveUrlAction -> state.copyWithReaderState(action.tabId) {
             it.copy(activeUrl = null)
         }
+        is ReaderAction.UpdateReaderScrollYAction -> state.copyWithReaderState(action.tabId) {
+            if (it.active) {
+                it.copy(scrollY = action.scrollY)
+            } else {
+                it
+            }
+        }
     }
 }
 

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/ReaderState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/ReaderState.kt
@@ -16,6 +16,8 @@ package mozilla.components.browser.state.state
  * content script is required.
  * @property baseUrl the base URL of the reader view extension page.
  * @property activeUrl the URL of the page currently displayed in reader view.
+ * @property scrollY the vertical scroll position of the page currently
+ * displayed in reader view.
  */
 data class ReaderState(
     val readerable: Boolean = false,

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/ReaderState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/ReaderState.kt
@@ -24,4 +24,5 @@ data class ReaderState(
     val connectRequired: Boolean = false,
     val baseUrl: String? = null,
     val activeUrl: String? = null,
+    val scrollY: Int? = null,
 )

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/ReaderActionTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/ReaderActionTest.kt
@@ -116,6 +116,31 @@ class ReaderActionTest {
     }
 
     @Test
+    fun `UpdateReaderScrollYAction - Updates scrollY of ReaderState when active`() {
+        assertFalse(readerState().active)
+
+        store.dispatch(ReaderAction.UpdateReaderActiveAction(tabId = tab.id, active = true))
+            .joinBlocking()
+
+        assertTrue(readerState().active)
+
+        store.dispatch(ReaderAction.UpdateReaderScrollYAction(tabId = tab.id, scrollY = 1234))
+            .joinBlocking()
+
+        assertEquals(1234, readerState().scrollY)
+    }
+
+    @Test
+    fun `UpdateReaderScrollYAction - Does not update scrollY of ReaderState when not active`() {
+        assertFalse(readerState().active)
+
+        store.dispatch(ReaderAction.UpdateReaderScrollYAction(tabId = tab.id, scrollY = 1234))
+            .joinBlocking()
+
+        assertNull(readerState().scrollY)
+    }
+
+    @Test
     fun `ClearReaderActiveUrlAction - Clears active url of ReaderState`() {
         assertNull(readerState().activeUrl)
 

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CookieBannerAction
 import mozilla.components.browser.state.action.CrashAction
+import mozilla.components.browser.state.action.ReaderAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.action.TrackingProtectionAction
 import mozilla.components.browser.state.selector.findTab
@@ -1546,6 +1547,21 @@ class EngineObserverTest {
                     HistoryItem("Mozilla", "http://mozilla.org"),
                 ),
                 currentIndex = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `onScrollChange dispatches UpdateReaderScrollYAction`() {
+        val store: BrowserStore = mock()
+        whenever(store.state).thenReturn(mock())
+        val observer = EngineObserver("tab-id", store)
+
+        observer.onScrollChange(4321, 1234)
+        verify(store).dispatch(
+            ReaderAction.UpdateReaderScrollYAction(
+                "tab-id",
+                1234,
             ),
         )
     }

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -33,6 +33,14 @@ abstract class EngineSession(
      * Interface to be implemented by classes that want to observe this engine session.
      */
     interface Observer {
+        /**
+         * Event to indicate the scroll position of the content has changed.
+         *
+         * @param scrollX The new horizontal scroll position in pixels.
+         * @param scrollY The new vertical scroll position in pixels.
+         */
+        fun onScrollChange(scrollX: Int, scrollY: Int) = Unit
+
         fun onLocationChange(url: String) = Unit
         fun onTitleChange(title: String) = Unit
 

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -46,6 +46,8 @@ class EngineSessionTest {
         val mediaSessionElementMetadata: MediaSession.ElementMetadata = mock()
         val tracker = Tracker("tracker")
 
+        session.notifyInternalObservers { onScrollChange(1234, 4321) }
+        session.notifyInternalObservers { onScrollChange(2345, 5432) }
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
         session.notifyInternalObservers { onProgress(25) }
@@ -81,6 +83,8 @@ class EngineSessionTest {
 
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onLocationChange("https://www.firefox.com")
+        verify(observer).onScrollChange(1234, 4321)
+        verify(observer).onScrollChange(2345, 5432)
         verify(observer).onProgress(25)
         verify(observer).onProgress(100)
         verify(observer).onLoadingStateChange(true)
@@ -127,6 +131,7 @@ class EngineSessionTest {
 
         session.register(observer)
 
+        session.notifyInternalObservers { onScrollChange(1234, 4321) }
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onProgress(25) }
         session.notifyInternalObservers { onLoadingStateChange(true) }
@@ -155,6 +160,7 @@ class EngineSessionTest {
         val mediaSessionPositionState: MediaSession.PositionState = mock()
         val mediaSessionElementMetadata: MediaSession.ElementMetadata = mock()
 
+        session.notifyInternalObservers { onScrollChange(2345, 5432) }
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
         session.notifyInternalObservers { onProgress(100) }
         session.notifyInternalObservers { onLoadingStateChange(false) }
@@ -184,6 +190,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onLaunchIntentRequest("https://www.firefox.com", null) }
         session.notifyInternalObservers { onShowDynamicToolbar() }
 
+        verify(observer).onScrollChange(1234, 4321)
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
         verify(observer).onLoadingStateChange(true)
@@ -204,6 +211,7 @@ class EngineSessionTest {
         verify(observer).onLoadRequest("https://www.mozilla.org", true, true)
         verify(observer).onLaunchIntentRequest("https://www.mozilla.org", null)
         verify(observer).onShowDynamicToolbar()
+        verify(observer, never()).onScrollChange(2345, 5432)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -248,6 +256,7 @@ class EngineSessionTest {
         session.register(observer)
         session.register(otherObserver)
 
+        session.notifyInternalObservers { onScrollChange(1234, 4321) }
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onProgress(25) }
         session.notifyInternalObservers { onLoadingStateChange(true) }
@@ -274,6 +283,7 @@ class EngineSessionTest {
         val mediaSessionPositionState: MediaSession.PositionState = mock()
         val mediaSessionElementMetadata: MediaSession.ElementMetadata = mock()
 
+        session.notifyInternalObservers { onScrollChange(2345, 5432) }
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
         session.notifyInternalObservers { onProgress(100) }
         session.notifyInternalObservers { onLoadingStateChange(false) }
@@ -300,6 +310,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onMediaFullscreenChanged(true, mediaSessionElementMetadata) }
         session.notifyInternalObservers { onShowDynamicToolbar() }
 
+        verify(observer).onScrollChange(1234, 4321)
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
         verify(observer).onLoadingStateChange(true)
@@ -317,6 +328,7 @@ class EngineSessionTest {
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
         verify(observer).onWindowRequest(windowRequest)
         verify(observer).onShowDynamicToolbar()
+        verify(observer, never()).onScrollChange(2345, 5432)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -341,6 +353,7 @@ class EngineSessionTest {
         verify(observer, never()).onMediaPositionStateChanged(mediaSessionPositionState)
         verify(observer, never()).onMediaMuteChanged(true)
         verify(observer, never()).onMediaFullscreenChanged(true, mediaSessionElementMetadata)
+        verify(otherObserver, never()).onScrollChange(2345, 5432)
         verify(otherObserver, never()).onLocationChange("https://www.firefox.com")
         verify(otherObserver, never()).onProgress(100)
         verify(otherObserver, never()).onLoadingStateChange(false)
@@ -380,6 +393,7 @@ class EngineSessionTest {
 
         session.register(observer)
 
+        session.notifyInternalObservers { onScrollChange(1234, 4321) }
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onProgress(25) }
         session.notifyInternalObservers { onLoadingStateChange(true) }
@@ -406,6 +420,7 @@ class EngineSessionTest {
         val mediaSessionPositionState: MediaSession.PositionState = mock()
         val mediaSessionElementMetadata: MediaSession.ElementMetadata = mock()
 
+        session.notifyInternalObservers { onScrollChange(2345, 5432) }
         session.notifyInternalObservers { onLocationChange("https://www.firefox.com") }
         session.notifyInternalObservers { onProgress(100) }
         session.notifyInternalObservers { onLoadingStateChange(false) }
@@ -432,6 +447,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onMediaFullscreenChanged(true, mediaSessionElementMetadata) }
         session.notifyInternalObservers { onShowDynamicToolbar() }
 
+        verify(observer).onScrollChange(1234, 4321)
         verify(observer).onLocationChange("https://www.mozilla.org")
         verify(observer).onProgress(25)
         verify(observer).onLoadingStateChange(true)
@@ -449,6 +465,7 @@ class EngineSessionTest {
         verify(observer).onCancelContentPermissionRequest(permissionRequest)
         verify(observer).onWindowRequest(windowRequest)
         verify(observer).onShowDynamicToolbar()
+        verify(observer, never()).onScrollChange(2345, 5432)
         verify(observer, never()).onLocationChange("https://www.firefox.com")
         verify(observer, never()).onProgress(100)
         verify(observer, never()).onLoadingStateChange(false)
@@ -491,6 +508,7 @@ class EngineSessionTest {
         val mediaSessionElementMetadata: MediaSession.ElementMetadata = mock()
         session.register(observer)
 
+        otherSession.notifyInternalObservers { onScrollChange(1234, 4321) }
         otherSession.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         otherSession.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         otherSession.notifyInternalObservers { onProgress(25) }
@@ -517,6 +535,7 @@ class EngineSessionTest {
         otherSession.notifyInternalObservers { onMediaMuteChanged(true) }
         otherSession.notifyInternalObservers { onMediaFullscreenChanged(true, mediaSessionElementMetadata) }
         otherSession.notifyInternalObservers { onShowDynamicToolbar() }
+        verify(observer, never()).onScrollChange(1234, 4321)
         verify(observer, never()).onLocationChange("https://www.mozilla.org")
         verify(observer, never()).onProgress(25)
         verify(observer, never()).onLoadingStateChange(true)
@@ -543,6 +562,7 @@ class EngineSessionTest {
         verify(observer, never()).onMediaFullscreenChanged(true, mediaSessionElementMetadata)
         verify(observer, never()).onShowDynamicToolbar()
 
+        session.notifyInternalObservers { onScrollChange(1234, 4321) }
         session.notifyInternalObservers { onLocationChange("https://www.mozilla.org") }
         session.notifyInternalObservers { onProgress(25) }
         session.notifyInternalObservers { onLoadingStateChange(true) }
@@ -568,6 +588,7 @@ class EngineSessionTest {
         session.notifyInternalObservers { onMediaMuteChanged(true) }
         session.notifyInternalObservers { onMediaFullscreenChanged(true, mediaSessionElementMetadata) }
         session.notifyInternalObservers { onShowDynamicToolbar() }
+        verify(observer, times(1)).onScrollChange(1234, 4321)
         verify(observer, times(1)).onLocationChange("https://www.mozilla.org")
         verify(observer, times(1)).onProgress(25)
         verify(observer, times(1)).onLoadingStateChange(true)
@@ -804,6 +825,7 @@ class EngineSessionTest {
         val defaultObserver = object : EngineSession.Observer {}
 
         defaultObserver.onTitleChange("")
+        defaultObserver.onScrollChange(0, 0)
         defaultObserver.onLocationChange("")
         defaultObserver.onPreviewImageChange("")
         defaultObserver.onLongPress(HitResult.UNKNOWN(""))
@@ -905,6 +927,7 @@ class EngineSessionTest {
         val windowRequest = mock(WindowRequest::class.java)
         val tracker: Tracker = mock()
 
+        observer.onScrollChange(1234, 4321)
         observer.onLocationChange("https://www.mozilla.org")
         observer.onLocationChange("https://www.firefox.com")
         observer.onProgress(25)

--- a/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
+++ b/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview.js
@@ -56,6 +56,9 @@ class ReaderView {
     this.setFontSize(options.fontSize);
     this.setFontType(options.fontType);
     this.setColorScheme(options.colorScheme);
+    if (options.scrollY) {
+      window.scrollTo({top: options.scrollY, left: 0, behavior: "instant"});
+    }
   }
 
   /**

--- a/android-components/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/android-components/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -264,7 +264,7 @@ class ReaderViewFeature(
                 val baseUrl = message.getString(BASE_URL_RESPONSE_MESSAGE_KEY)
                 store.dispatch(ReaderAction.UpdateReaderBaseUrlAction(sessionId, baseUrl))
 
-                port.postMessage(createShowReaderMessage(config.get()))
+                port.postMessage(createShowReaderMessage(config.get(), store.state.selectedTab?.readerState?.scrollY))
 
                 val activeUrl = message.getString(ACTIVE_URL_RESPONSE_MESSAGE_KEY)
                 store.dispatch(ReaderAction.UpdateReaderActiveUrlAction(sessionId, activeUrl))
@@ -301,6 +301,7 @@ class ReaderViewFeature(
         internal const val ACTION_VALUE_SHOW_FONT_SIZE = "fontSize"
         internal const val ACTION_VALUE_SHOW_FONT_TYPE = "fontType"
         internal const val ACTION_VALUE_SHOW_COLOR_SCHEME = "colorScheme"
+        internal const val ACTION_VALUE_SCROLLY = "scrollY"
         internal const val READERABLE_RESPONSE_MESSAGE_KEY = "readerable"
         internal const val BASE_URL_RESPONSE_MESSAGE_KEY = "baseUrl"
         internal const val ACTIVE_URL_RESPONSE_MESSAGE_KEY = "activeUrl"
@@ -316,7 +317,7 @@ class ReaderViewFeature(
             return JSONObject().put(ACTION_MESSAGE_KEY, ACTION_CHECK_READER_STATE)
         }
 
-        internal fun createShowReaderMessage(config: ReaderViewConfig?): JSONObject {
+        internal fun createShowReaderMessage(config: ReaderViewConfig?, scrollY: Int? = null): JSONObject {
             if (config == null) {
                 logger.warn("No config provided. Falling back to default values.")
             }
@@ -328,7 +329,9 @@ class ReaderViewFeature(
                 .put(ACTION_VALUE_SHOW_FONT_SIZE, fontSize)
                 .put(ACTION_VALUE_SHOW_FONT_TYPE, fontType.value.lowercase(Locale.ROOT))
                 .put(ACTION_VALUE_SHOW_COLOR_SCHEME, colorScheme.name.lowercase(Locale.ROOT))
-
+            if (scrollY != null) {
+                configJson.put(ACTION_VALUE_SCROLLY, scrollY)
+            }
             return JSONObject()
                 .put(ACTION_MESSAGE_KEY, ACTION_SHOW)
                 .put(ACTION_VALUE, configJson)

--- a/android-components/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/android-components/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -275,6 +275,16 @@ class ReaderViewFeatureTest {
             ReaderViewFeature.ColorScheme.LIGHT.name.lowercase(Locale.ROOT),
             config[ReaderViewFeature.ACTION_VALUE_SHOW_COLOR_SCHEME],
         )
+        assertFalse(config.has(ReaderViewFeature.ACTION_VALUE_SCROLLY))
+    }
+
+    @Test
+    fun `pass scrollY for showing reader view`() {
+        val message = ReaderViewFeature.createShowReaderMessage(null, 1234)
+        assertEquals(ReaderViewFeature.ACTION_SHOW, message[ReaderViewFeature.ACTION_MESSAGE_KEY])
+        val config = message[ReaderViewFeature.ACTION_VALUE] as JSONObject?
+        assertNotNull(config)
+        assertEquals(1234, config!![ReaderViewFeature.ACTION_VALUE_SCROLLY])
     }
 
     @Test


### PR DESCRIPTION
1.  Keep Readerview's position between active and inactive
2.  Persiste Readerview's position between restart fenix

Note:  Value of position (scrollY) is accurate, however after fenix restart , the Readerview may not remain in same place ( a bit above). This may be caused by re-generating DOM. There's no such problem when toggling between active and inactive.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
4. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
5. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
6. Click on `View task in Taskcluster` in the new `DETAILS` section.
7. The APK links should be on the right side of the screen, named for each CPU architecture.














### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1820404