### PR TITLE
Bug 1825279 - Remove dreamlte device in legacy test configuration

### DIFF
--- a/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -43,9 +43,6 @@ gcloud:
     - model: walleye
       version: 27
       locale: en_US
-    - model: dreamlte
-      version: 28
-      locale: en_US
     - model: HWCOR
       version: 27
       locale: en_US


### PR DESCRIPTION
Device seems to still (Apr. 4) be hitting frequent inconclusive result (infrastructure error) on Firebase Test Lab on recent commits on `firefox-android` likely due to another Play Services update on the device. I'll reach out to Firebase Test Lab Community Slack again.
https://bugzilla.mozilla.org/show_bug.cgi?id=1825279