### PR TITLE
Bug 1823987 - onScroll NPE fix

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/SimpleOnGestureListenerCompat.java
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/SimpleOnGestureListenerCompat.java
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.browser;
+
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Defines a class extending {@link android.view.GestureDetector.SimpleOnGestureListener} that allows nullable MotionEvents parameters
+ */
+public class SimpleOnGestureListenerCompat extends GestureDetector.SimpleOnGestureListener {
+    @Override
+    public boolean onSingleTapUp(@Nullable MotionEvent e) {
+        return false;
+    }
+
+    @Override
+    public void onLongPress(@Nullable MotionEvent e) {
+    }
+
+    @Override
+    public boolean onScroll(@Nullable MotionEvent e1, @Nullable MotionEvent e2,
+                            float distanceX, float distanceY) {
+        return false;
+    }
+
+    @Override
+    public boolean onFling(@Nullable MotionEvent e1, @Nullable MotionEvent e2, float velocityX,
+                           float velocityY) {
+        return false;
+    }
+
+    @Override
+    public void onShowPress(@Nullable MotionEvent e) {
+    }
+
+    @Override
+    public boolean onDown(@Nullable MotionEvent e) {
+        return false;
+    }
+
+    @Override
+    public boolean onDoubleTap(@Nullable MotionEvent e) {
+        return false;
+    }
+
+    @Override
+    public boolean onDoubleTapEvent(@Nullable MotionEvent e) {
+        return false;
+    }
+
+    @Override
+    public boolean onSingleTapConfirmed(@Nullable MotionEvent e) {
+        return false;
+    }
+
+    @Override
+    public boolean onContextClick(@Nullable MotionEvent e) {
+        return false;
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/SwipeGestureLayout.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/SwipeGestureLayout.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.browser
 import android.content.Context
 import android.graphics.PointF
 import android.util.AttributeSet
-import android.view.GestureDetector
 import android.view.MotionEvent
 import android.widget.FrameLayout
 import androidx.core.view.GestureDetectorCompat
@@ -61,19 +60,19 @@ class SwipeGestureLayout @JvmOverloads constructor(
      */
     var isSwipeEnabled = true
 
-    private val gestureListener = object : GestureDetector.SimpleOnGestureListener() {
-        override fun onDown(e: MotionEvent): Boolean {
+    private val gestureListener = object : SimpleOnGestureListenerCompat() {
+        override fun onDown(e: MotionEvent?): Boolean {
             return true
         }
 
         override fun onScroll(
-            e1: MotionEvent,
-            e2: MotionEvent,
+            e1: MotionEvent?,
+            e2: MotionEvent?,
             distanceX: Float,
             distanceY: Float,
         ): Boolean {
-            val start = e1.let { event -> PointF(event.rawX, event.rawY) }
-            val next = e2.let { event -> PointF(event.rawX, event.rawY) }
+            val start = e1?.let { event -> PointF(event.rawX, event.rawY) } ?: return false
+            val next = e2?.let { event -> PointF(event.rawX, event.rawY) } ?: return false
 
             if (activeListener == null && !handledInitialScroll) {
                 activeListener = listeners.firstOrNull { listener ->
@@ -86,8 +85,8 @@ class SwipeGestureLayout @JvmOverloads constructor(
         }
 
         override fun onFling(
-            e1: MotionEvent,
-            e2: MotionEvent,
+            e1: MotionEvent?,
+            e2: MotionEvent?,
             velocityX: Float,
             velocityY: Float,
         ): Boolean {


### PR DESCRIPTION
The current solution represents a workaround for trying to fix the crash generated by onScroll gesture when receiving a null event. It can be a temporary solution, as there are many Google IssueTracker issues open at this moment regarding this problem.

The issue appeared after we adapted our app to Android 13 (API level 33) where all the methods of the SimpleOnGestureListener do not accept nullable event parameters as they did before.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1823987