### PR TITLE
Bug 1824928 - Fix and re-enable open links in apps UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -64,6 +64,7 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.helpers.Constants.PackageName.YOUTUBE_APP
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.ext.waitNotNull
@@ -266,17 +267,7 @@ object TestHelper {
         }
     }
 
-    fun assertPlayStoreOpens() {
-        if (isPackageInstalled(Constants.PackageName.GOOGLE_PLAY_SERVICES)) {
-            try {
-                intended(toPackage(Constants.PackageName.GOOGLE_PLAY_SERVICES))
-            } catch (e: AssertionFailedError) {
-                BrowserRobot().verifyRateOnGooglePlayURL()
-            }
-        } else {
-            BrowserRobot().verifyRateOnGooglePlayURL()
-        }
-    }
+    fun assertYoutubeAppOpens() = intended(toPackage(YOUTUBE_APP))
 
     /**
      * Checks whether the latest activity of the application is used for custom tabs or PWAs.

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -10,16 +10,14 @@ import mozilla.components.concept.engine.utils.EngineReleaseChannel
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.Constants.PackageName.YOUTUBE_APP
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper.assertNativeAppOpens
+import org.mozilla.fenix.helpers.TestHelper.assertYoutubeAppOpens
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.runWithCondition
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -117,8 +115,7 @@ class SettingsAdvancedTest {
         }
     }
 
-    // Assumes Play Store is installed and enabled
-    @SmokeTest
+    // Assumes Youtube is installed and enabled
     @Test
     fun neverOpenLinkInAppTest() {
         runWithCondition(
@@ -149,8 +146,7 @@ class SettingsAdvancedTest {
         }
     }
 
-    // Assumes Play Store is installed and enabled
-    @SmokeTest
+    // Assumes Youtube is installed and enabled
     @Test
     fun privateBrowsingNeverOpenLinkInAppTest() {
         runWithCondition(
@@ -184,87 +180,7 @@ class SettingsAdvancedTest {
         }
     }
 
-    // Assumes Play Store is installed and enabled
-    @SmokeTest
-    @Test
-    fun cancelOpeningLinkInAppTest() {
-        runWithCondition(
-            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
-            // Once this feature lands in RC we should remove the wrapper.
-            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
-                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
-        ) {
-            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
-
-            homeScreen {
-            }.openThreeDotMenu {
-            }.openSettings {
-                verifyOpenLinksInAppsButton()
-                verifySettingsOptionSummary("Open links in apps", "Never")
-            }.openOpenLinksInAppsMenu {
-                verifyOpenLinksInAppsView("Never")
-                clickOpenLinkInAppOption("Ask before opening")
-                verifySelectedOpenLinksInAppOption("Ask before opening")
-            }.goBack {
-                verifySettingsOptionSummary("Open links in apps", "Ask before opening")
-            }
-
-            exitMenu()
-
-            navigationToolbar {
-            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-                clickLinkMatchingText("Youtube link")
-                verifyOpenLinkInAnotherAppPrompt()
-                cancelOpenLinkInAnotherApp()
-                waitForPageToLoad()
-                verifyUrl("youtube.com")
-            }
-        }
-    }
-
-    // Assumes Play Store is installed and enabled
-    @SmokeTest
-    @Test
-    fun privateBrowsingCancelOpeningLinkInAppTest() {
-        runWithCondition(
-            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
-            // Once this feature lands in RC we should remove the wrapper.
-            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
-                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
-        ) {
-            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
-
-            homeScreen {
-            }.togglePrivateBrowsingMode()
-
-            homeScreen {
-            }.openThreeDotMenu {
-            }.openSettings {
-                verifyOpenLinksInAppsButton()
-                verifySettingsOptionSummary("Open links in apps", "Never")
-            }.openOpenLinksInAppsMenu {
-                verifyOpenLinksInAppsView("Never")
-                clickOpenLinkInAppOption("Ask before opening")
-                verifySelectedOpenLinksInAppOption("Ask before opening")
-            }.goBack {
-                verifySettingsOptionSummary("Open links in apps", "Ask before opening")
-            }
-
-            exitMenu()
-
-            navigationToolbar {
-            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-                clickLinkMatchingText("Youtube link")
-                verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
-                cancelOpenLinkInAnotherApp()
-                waitForPageToLoad()
-                verifyUrl("youtube.com")
-            }
-        }
-    }
-
-    // Assumes Play Store is installed and enabled
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1824928")
+    // Assumes Youtube is installed and enabled
     @SmokeTest
     @Test
     fun askBeforeOpeningLinkInAppTest() {
@@ -295,15 +211,23 @@ class SettingsAdvancedTest {
             }.enterURLAndEnterToBrowser(defaultWebPage.url) {
                 clickLinkMatchingText("Youtube link")
                 verifyOpenLinkInAnotherAppPrompt()
+                cancelOpenLinkInAnotherApp()
+                waitForPageToLoad()
+                verifyUrl("youtube.com")
+            }
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                verifyOpenLinkInAnotherAppPrompt()
                 confirmOpenLinkInAnotherApp()
                 mDevice.waitForIdle()
-                assertNativeAppOpens(YOUTUBE_APP, defaultWebPage.url.toString())
+                assertYoutubeAppOpens()
             }
         }
     }
 
-    // Assumes Play Store is installed and enabled
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1824928")
+    // Assumes Youtube is installed and enabled
     @SmokeTest
     @Test
     fun privateBrowsingAskBeforeOpeningLinkInAppTest() {
@@ -337,16 +261,23 @@ class SettingsAdvancedTest {
             }.enterURLAndEnterToBrowser(defaultWebPage.url) {
                 clickLinkMatchingText("Youtube link")
                 verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
+                cancelOpenLinkInAnotherApp()
+                waitForPageToLoad()
+                verifyUrl("youtube.com")
+            }
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
                 confirmOpenLinkInAnotherApp()
                 mDevice.waitForIdle()
-                assertNativeAppOpens(YOUTUBE_APP, defaultWebPage.url.toString())
+                assertYoutubeAppOpens()
             }
         }
     }
 
-    // Assumes Play Store is installed and enabled
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1824928")
-    @SmokeTest
+    // Assumes Youtube is installed and enabled
     @Test
     fun alwaysOpenLinkInAppTest() {
         runWithCondition(
@@ -376,14 +307,12 @@ class SettingsAdvancedTest {
             }.enterURLAndEnterToBrowser(defaultWebPage.url) {
                 clickLinkMatchingText("Youtube link")
                 mDevice.waitForIdle()
-                assertNativeAppOpens(YOUTUBE_APP, defaultWebPage.url.toString())
+                assertYoutubeAppOpens()
             }
         }
     }
 
-    // Assumes Play Store is installed and enabled
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1824928")
-    @SmokeTest
+    // Assumes Youtube is installed and enabled
     @Test
     fun privateBrowsingAlwaysOpenLinkInAppTest() {
         runWithCondition(
@@ -416,9 +345,18 @@ class SettingsAdvancedTest {
             }.enterURLAndEnterToBrowser(defaultWebPage.url) {
                 clickLinkMatchingText("Youtube link")
                 verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
+                cancelOpenLinkInAnotherApp()
+                waitForPageToLoad()
+                verifyUrl("youtube.com")
+            }
+
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                clickLinkMatchingText("Youtube link")
+                verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
                 confirmOpenLinkInAnotherApp()
                 mDevice.waitForIdle()
-                assertNativeAppOpens(YOUTUBE_APP, defaultWebPage.url.toString())
+                assertYoutubeAppOpens()
             }
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -17,7 +17,6 @@ import mozilla.components.concept.engine.mediasession.MediaSession
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.IntentReceiverActivity
@@ -25,12 +24,11 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.Constants.PackageName.YOUTUBE_APP
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper.assertNativeAppOpens
+import org.mozilla.fenix.helpers.TestHelper.assertYoutubeAppOpens
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
 import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
@@ -244,7 +242,6 @@ class SmokeTest {
 
     // Device or AVD requires a Google Services Android OS installation with Play Store installed
     // Verifies the Open in app button when an app is installed
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1824928")
     @Test
     fun mainMenuOpenInAppTest() {
         val youtubeURL = "https://m.youtube.com/user/mozilla?cbrd=1"
@@ -254,7 +251,7 @@ class SmokeTest {
             verifyNotificationDotOnMainMenu()
         }.openThreeDotMenu {
         }.clickOpenInApp {
-            assertNativeAppOpens(YOUTUBE_APP, youtubeURL)
+            assertYoutubeAppOpens()
         }
     }
 


### PR DESCRIPTION
Bug 1824928 - Fix and re-enable open links in apps UI tests.

Summary:
- Changed the way we check that the Youtube app is opened
- Had to refactor the UI tests to mach the current manual tests (all sort of changes were made in the meantime)

All tests successfully passed 100x on Firebase. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1824928