### PR TITLE
Bug 1822268 - Part 3: Navigate to juno onboarding

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -267,7 +267,10 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         }
 
         if (settings().shouldShowJunoOnboarding(intent.toSafeIntent().isLauncherIntent)) {
-            navHost.navController.navigate(NavGraphDirections.actionGlobalHomeJunoOnboarding())
+            // Unless activity is recreated due to config change, navigate to onboarding
+            if (savedInstanceState == null) {
+                navHost.navController.navigate(NavGraphDirections.actionGlobalHomeJunoOnboarding())
+            }
         } else {
             // Unless the activity is recreated, navigate to home first (without rendering it)
             // to add it to the back stack.


### PR DESCRIPTION
With this change navigation only happens when the activity is first created. So, on a config change like theme update, when the activity is recreated, the navigation call doesn't happen.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
