### PR TITLE
Bug 1815015 - Set the engine session for background tabs inactive

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -172,10 +172,16 @@ class GeckoEngine(
     /**
      * See [Engine.createSession].
      */
-    override fun createSession(private: Boolean, contextId: String?): EngineSession {
+    override fun createSession(private: Boolean, contextId: String?, isBackground: Boolean): EngineSession {
         ThreadUtils.assertOnUiThread()
         val speculativeSession = speculativeConnectionFactory.get(private, contextId)
-        return speculativeSession ?: GeckoEngineSession(runtime, private, defaultSettings, contextId)
+        return speculativeSession ?: GeckoEngineSession(
+            runtime,
+            private,
+            defaultSettings,
+            contextId,
+            isBackground = isBackground,
+        )
     }
 
     /**

--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -90,6 +90,7 @@ class GeckoEngineSession(
     },
     private val context: CoroutineContext = Dispatchers.IO,
     openGeckoSession: Boolean = true,
+    isBackground: Boolean = false,
 ) : CoroutineScope, EngineSession() {
 
     // This logger is temporary and parsed by FNPRMS for performance measurements. It can be
@@ -138,7 +139,7 @@ class GeckoEngineSession(
         get() = context + job
 
     init {
-        createGeckoSession(shouldOpen = openGeckoSession)
+        createGeckoSession(shouldOpen = openGeckoSession, isBackground = isBackground)
     }
 
     /**
@@ -1269,7 +1270,7 @@ class GeckoEngineSession(
         }
     }
 
-    private fun createGeckoSession(shouldOpen: Boolean = true) {
+    private fun createGeckoSession(shouldOpen: Boolean = true, isBackground: Boolean = false) {
         this.geckoSession = geckoSessionProvider()
 
         defaultSettings?.trackingProtectionPolicy?.let { updateTrackingProtection(it) }
@@ -1298,6 +1299,7 @@ class GeckoEngineSession(
         geckoSession.historyDelegate = createHistoryDelegate()
         geckoSession.mediaSessionDelegate = GeckoMediaSessionDelegate(this)
         geckoSession.scrollDelegate = createScrollDelegate()
+        geckoSession.setActive(!isBackground)
     }
 
     companion object {

--- a/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
+++ b/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngine.kt
@@ -44,7 +44,7 @@ class SystemEngine(
     /**
      * Creates a new WebView-based EngineSession implementation.
      */
-    override fun createSession(private: Boolean, contextId: String?): EngineSession {
+    override fun createSession(private: Boolean, contextId: String?, isBackground: Boolean): EngineSession {
         if (private) {
             // TODO Implement private browsing: https://github.com/mozilla-mobile/android-components/issues/649
             throw UnsupportedOperationException("Private browsing is not supported in ${this::class.java.simpleName}")

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -964,6 +964,7 @@ sealed class EngineAction : BrowserAction() {
         override val tabId: String,
         val skipLoading: Boolean = false,
         val followupAction: BrowserAction? = null,
+        val isBackground: Boolean = false,
     ) : EngineAction(), ActionWithTab
 
     /**
@@ -974,6 +975,7 @@ sealed class EngineAction : BrowserAction() {
         val url: String,
         val flags: EngineSession.LoadUrlFlags = EngineSession.LoadUrlFlags.none(),
         val additionalHeaders: Map<String, String>? = null,
+        val loadInBackground: Boolean = false,
     ) : EngineAction(), ActionWithTab
 
     /**

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddleware.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddleware.kt
@@ -68,6 +68,7 @@ internal class CreateEngineSessionMiddleware(
                 logger,
                 store,
                 action.tabId,
+                action.isBackground,
             )
 
             action.followupAction?.let {
@@ -84,6 +85,7 @@ private fun getOrCreateEngineSession(
     logger: Logger,
     store: Store<BrowserState, BrowserAction>,
     tabId: String,
+    isBackground: Boolean,
 ): EngineSession? {
     val tab = store.state.findTabOrCustomTab(tabId)
     if (tab == null) {
@@ -101,7 +103,7 @@ private fun getOrCreateEngineSession(
         return it
     }
 
-    return createEngineSession(engine, logger, store, tab)
+    return createEngineSession(engine, logger, store, tab, isBackground)
 }
 
 @MainThread
@@ -110,8 +112,9 @@ private fun createEngineSession(
     logger: Logger,
     store: Store<BrowserState, BrowserAction>,
     tab: SessionState,
+    isBackground: Boolean,
 ): EngineSession {
-    val engineSession = engine.createSession(tab.content.private, tab.contextId)
+    val engineSession = engine.createSession(tab.content.private, tab.contextId, isBackground)
     logger.debug("Created engine session for tab ${tab.id}")
 
     val engineSessionState = tab.engineState.engineSessionState

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddleware.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddleware.kt
@@ -60,7 +60,7 @@ internal class EngineDelegateMiddleware(
             // session is already pointing to. Creating an EngineSession will do exactly
             // that in the linking step. So let's do that. Otherwise we would load the URL
             // twice.
-            store.dispatch(EngineAction.CreateEngineSessionAction(action.tabId))
+            store.dispatch(EngineAction.CreateEngineSessionAction(action.tabId, isBackground = action.loadInBackground))
             return@launch
         }
 

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddlewareTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddlewareTest.kt
@@ -43,7 +43,7 @@ class CreateEngineSessionMiddlewareTest {
     fun `creates engine session if needed`() = runTestOnMain {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
-        whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
+        whenever(engine.createSession(anyBoolean(), any(), anyBoolean())).thenReturn(engineSession)
 
         val middleware = CreateEngineSessionMiddleware(engine, scope)
         val tab = createTab("https://www.mozilla.org", id = "1")
@@ -70,7 +70,7 @@ class CreateEngineSessionMiddlewareTest {
     fun `restores engine session state if available`() = runTestOnMain {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
-        whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
+        whenever(engine.createSession(anyBoolean(), any(), anyBoolean())).thenReturn(engineSession)
         val engineSessionState: EngineSessionState = mock()
 
         val middleware = CreateEngineSessionMiddleware(engine, scope)
@@ -93,7 +93,7 @@ class CreateEngineSessionMiddlewareTest {
     @Test
     fun `creates no engine session if tab does not exist`() = runTestOnMain {
         val engine: Engine = mock()
-        `when`(engine.createSession(anyBoolean(), anyString())).thenReturn(mock())
+        `when`(engine.createSession(anyBoolean(), anyString(), anyBoolean())).thenReturn(mock())
 
         val middleware = CreateEngineSessionMiddleware(engine, scope)
         val store = BrowserStore(
@@ -105,14 +105,14 @@ class CreateEngineSessionMiddlewareTest {
         store.waitUntilIdle()
         dispatcher.scheduler.advanceUntilIdle()
 
-        verify(engine, never()).createSession(anyBoolean(), any())
+        verify(engine, never()).createSession(anyBoolean(), any(), anyBoolean())
         Unit
     }
 
     @Test
     fun `creates no engine session if session does not exist`() = runTestOnMain {
         val engine: Engine = mock()
-        `when`(engine.createSession(anyBoolean(), anyString())).thenReturn(mock())
+        `when`(engine.createSession(anyBoolean(), anyString(), anyBoolean())).thenReturn(mock())
 
         val middleware = CreateEngineSessionMiddleware(engine, scope)
         val tab = createTab("https://www.mozilla.org", id = "1")
@@ -129,7 +129,7 @@ class CreateEngineSessionMiddlewareTest {
         store.waitUntilIdle()
         dispatcher.scheduler.advanceUntilIdle()
 
-        verify(engine, never()).createSession(anyBoolean(), any())
+        verify(engine, never()).createSession(anyBoolean(), any(), anyBoolean())
         Unit
     }
 
@@ -137,7 +137,7 @@ class CreateEngineSessionMiddlewareTest {
     fun `dispatches follow-up action after engine session is created`() = runTestOnMain {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
-        whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
+        whenever(engine.createSession(anyBoolean(), any(), anyBoolean())).thenReturn(engineSession)
 
         val middleware = CreateEngineSessionMiddleware(engine, scope)
         val tab = createTab("https://www.mozilla.org", id = "1")
@@ -162,7 +162,7 @@ class CreateEngineSessionMiddlewareTest {
     fun `dispatches follow-up action once engine session is created by pending action`() = runTestOnMain {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
-        whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
+        whenever(engine.createSession(anyBoolean(), any(), anyBoolean())).thenReturn(engineSession)
 
         val middleware = CreateEngineSessionMiddleware(engine, scope)
         val tab = createTab("https://www.mozilla.org", id = "1")
@@ -190,7 +190,7 @@ class CreateEngineSessionMiddlewareTest {
     fun `creating engine session for custom tab`() {
         val engine: Engine = mock()
         val engineSession: EngineSession = mock()
-        whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
+        whenever(engine.createSession(anyBoolean(), any(), anyBoolean())).thenReturn(engineSession)
 
         val middleware = CreateEngineSessionMiddleware(engine, scope)
         val customTab = createCustomTab("https://www.mozilla.org", id = "1")

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddlewareTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddlewareTest.kt
@@ -158,7 +158,11 @@ class EngineDelegateMiddlewareTest {
         dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
-        verify(engine, never()).createSession(ArgumentMatchers.anyBoolean(), ArgumentMatchers.anyString())
+        verify(engine, never()).createSession(
+            ArgumentMatchers.anyBoolean(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyBoolean(),
+        )
         verify(engineSession, times(1)).loadUrl("https://www.firefox.com")
         assertEquals(engineSession, store.state.tabs[0].engineState.engineSession)
     }
@@ -192,7 +196,11 @@ class EngineDelegateMiddlewareTest {
         dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
-        verify(engine, never()).createSession(ArgumentMatchers.anyBoolean(), ArgumentMatchers.anyString())
+        verify(engine, never()).createSession(
+            ArgumentMatchers.anyBoolean(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyBoolean(),
+        )
         verify(engineSession, times(1)).loadUrl("https://www.firefox.com")
         assertEquals(engineSession, store.state.tabs[0].engineState.engineSession)
     }
@@ -209,7 +217,11 @@ class EngineDelegateMiddlewareTest {
             ),
             initialState = BrowserState(
                 tabs = listOf(
-                    createTab("https://www.mozilla.org", id = "test-tab", contextId = "test-container").copy(
+                    createTab(
+                        "https://www.mozilla.org",
+                        id = "test-tab",
+                        contextId = "test-container",
+                    ).copy(
                         engineState = EngineState(engineSession),
                     ),
                 ),
@@ -226,7 +238,11 @@ class EngineDelegateMiddlewareTest {
         dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
-        verify(engine, never()).createSession(ArgumentMatchers.anyBoolean(), ArgumentMatchers.anyString())
+        verify(engine, never()).createSession(
+            ArgumentMatchers.anyBoolean(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyBoolean(),
+        )
         verify(engineSession, times(1)).loadUrl("https://www.firefox.com")
         assertEquals(engineSession, store.state.tabs[0].engineState.engineSession)
     }
@@ -408,7 +424,11 @@ class EngineDelegateMiddlewareTest {
         dispatcher.scheduler.advanceUntilIdle()
         store.waitUntilIdle()
 
-        verify(engine, never()).createSession(ArgumentMatchers.anyBoolean(), ArgumentMatchers.anyString())
+        verify(engine, never()).createSession(
+            ArgumentMatchers.anyBoolean(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyBoolean(),
+        )
         assertNull(store.state.tabs[0].engineState.engineSession)
     }
 

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -110,11 +110,12 @@ interface Engine : WebExtensionRuntime, DataCleanable {
      *
      * @param private whether or not this session should use private mode.
      * @param contextId the session context ID for this session.
+     * @param isBackground whether or not this session is created in the background
      *
      * @return the newly created [EngineSession].
      */
     @MainThread
-    fun createSession(private: Boolean = false, contextId: String? = null): EngineSession
+    fun createSession(private: Boolean = false, contextId: String? = null, isBackground: Boolean = false): EngineSession
 
     /**
      * Create a new [EngineSessionState] instance from the serialized JSON representation.

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -205,6 +205,8 @@ abstract class Settings {
      * Setting the HTTPS-Only mode for upgrading connections to HTTPS.
      */
     open var httpsOnlyMode: Engine.HttpsOnlyMode by UnsupportedSetting()
+
+    open var isBackground: Boolean by UnsupportedSetting()
 }
 
 /**
@@ -247,6 +249,7 @@ data class DefaultSettings(
     override var cookieBannerHandlingModePrivateBrowsing: CookieBannerHandlingMode =
         CookieBannerHandlingMode.DISABLED,
     override var cookieBannerHandlingDetectOnlyMode: Boolean = false,
+    override var isBackground: Boolean = false,
 ) : Settings()
 
 class UnsupportedSetting<T> {

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineTest.kt
@@ -28,7 +28,7 @@ class EngineTest {
             throw NotImplementedError("Not needed for test")
         }
 
-        override fun createSession(private: Boolean, contextId: String?): EngineSession {
+        override fun createSession(private: Boolean, contextId: String?, isBackground: Boolean): EngineSession {
             throw NotImplementedError("Not needed for test")
         }
 

--- a/android-components/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
+++ b/android-components/components/feature/intent/src/test/java/mozilla/components/feature/intent/processing/TabIntentProcessorTest.kt
@@ -73,7 +73,7 @@ class TabIntentProcessorTest {
 
         engine = mock()
         engineSession = mock()
-        doReturn(engineSession).`when`(engine).createSession(anyBoolean(), anyString())
+        doReturn(engineSession).`when`(engine).createSession(anyBoolean(), anyString(), anyBoolean())
 
         middleware = CaptureActionsMiddleware()
 

--- a/android-components/components/feature/tab-collections/src/test/java/mozilla/components/feature/tab/collections/ext/TabsUseCasesKtTest.kt
+++ b/android-components/components/feature/tab-collections/src/test/java/mozilla/components/feature/tab/collections/ext/TabsUseCasesKtTest.kt
@@ -47,7 +47,7 @@ class TabsUseCasesKtTest {
         filesDir = mock()
         whenever(filesDir.path).thenReturn("/test")
 
-        whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
+        whenever(engine.createSession(anyBoolean(), any(), anyBoolean())).thenReturn(engineSession)
         store = BrowserStore(
             middleware = EngineMiddleware.create(
                 engine = engine,

--- a/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
+++ b/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/TabsUseCases.kt
@@ -189,6 +189,7 @@ class TabsUseCases(
                         tab.id,
                         url,
                         flags,
+                        loadInBackground = !selectTab,
                     ),
                 )
             }

--- a/android-components/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/CustomTabsUseCasesTest.kt
+++ b/android-components/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/CustomTabsUseCasesTest.kt
@@ -38,7 +38,7 @@ class CustomTabsUseCasesTest {
         engineSession = mock()
         engine = mock()
 
-        whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
+        whenever(engine.createSession(anyBoolean(), any(), anyBoolean())).thenReturn(engineSession)
         store = BrowserStore(
             middleware = EngineMiddleware.create(
                 engine = engine,

--- a/android-components/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/android-components/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -63,7 +63,7 @@ class TabsUseCasesTest {
         engineSession = mock()
         engine = mock()
 
-        whenever(engine.createSession(anyBoolean(), any())).thenReturn(engineSession)
+        whenever(engine.createSession(anyBoolean(), any(), anyBoolean())).thenReturn(engineSession)
         store = BrowserStore(
             middleware = EngineMiddleware.create(
                 engine = engine,

--- a/android-components/components/support/test-fakes/src/main/java/mozilla/components/support/test/fakes/engine/FakeEngine.kt
+++ b/android-components/components/support/test-fakes/src/main/java/mozilla/components/support/test/fakes/engine/FakeEngine.kt
@@ -34,7 +34,7 @@ class FakeEngine(
     override fun createView(context: Context, attrs: AttributeSet?): EngineView =
         FakeEngineView(context)
 
-    override fun createSession(private: Boolean, contextId: String?): EngineSession =
+    override fun createSession(private: Boolean, contextId: String?, isBackground: Boolean): EngineSession =
         throw UnsupportedOperationException()
 
     override fun createSessionState(json: JSONObject) = FakeEngineSessionState(json.getString("engine"))

--- a/focus-android/app/src/test/java/org/mozilla/focus/TestFocusApplication.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/TestFocusApplication.kt
@@ -53,7 +53,7 @@ class FakeEngine : Engine {
     override fun createView(context: Context, attrs: AttributeSet?): EngineView =
         throw UnsupportedOperationException()
 
-    override fun createSession(private: Boolean, contextId: String?): EngineSession =
+    override fun createSession(private: Boolean, contextId: String?, isBackground: Boolean): EngineSession =
         throw UnsupportedOperationException()
 
     override fun createSessionState(json: JSONObject) = FakeEngineSessionState()


### PR DESCRIPTION
When a tab is created in the background via "Open Link in New Tab", its engine session should be inactive.

Note: This is a draft, no unit tests are written at the moment. This api change is the last-resort in case the problem is not fixable in the GeckoView APIs internally. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815015