### PR TITLE
Bug 1814138 - Fix nimbus branch item check mark visibility

### DIFF
--- a/android-components/components/service/nimbus/src/main/res/layout/mozac_service_nimbus_branch_item.xml
+++ b/android-components/components/service/nimbus/src/main/res/layout/mozac_service_nimbus_branch_item.xml
@@ -16,6 +16,7 @@
         android:layout_marginStart="16dp"
         android:importantForAccessibility="no"
         android:visibility="visible"
+        app:tint="?android:attr/textColorPrimary"
         app:srcCompat="@drawable/mozac_ic_check"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
### Screenshot
<img width="296" alt="nimbus branch-check mark fix" src="https://user-images.githubusercontent.com/38040960/230329703-3c05917a-b02c-45d3-8081-8e141c7e25da.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1814138