### PR TITLE
Bug 1807350 - Generate baseline profiles for nightly

### DIFF
--- a/fenix/.buildconfig.yml
+++ b/fenix/.buildconfig.yml
@@ -137,13 +137,13 @@ variants:
   name: fenixBeta
 - apks:
   - abi: arm64-v8a
-    fileName: app-fenix-arm64-v8a-benchmark-unsigned.apk
+    fileName: app-fenix-arm64-v8a-benchmark.apk
   - abi: armeabi-v7a
-    fileName: app-fenix-armeabi-v7a-benchmark-unsigned.apk
+    fileName: app-fenix-armeabi-v7a-benchmark.apk
   - abi: x86
-    fileName: app-fenix-x86-benchmark-unsigned.apk
+    fileName: app-fenix-x86-benchmark.apk
   - abi: x86_64
-    fileName: app-fenix-x86_64-benchmark-unsigned.apk
+    fileName: app-fenix-x86_64-benchmark.apk
   build_type: benchmark
   name: fenixBenchmark
 - apks:

--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -160,6 +160,7 @@ android {
         benchmark releaseTemplate >> {
             initWith buildTypes.nightly
             applicationIdSuffix ".fenix"
+            signingConfig signingConfigs.debug
             debuggable false
         }
     }
@@ -208,7 +209,11 @@ android {
 
             reset()
 
-            include "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
+            if (project.hasProperty("baselineProfileGeneration")) {
+                include "x86_64"
+            } else {
+                include "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
+            }
         }
     }
 

--- a/fenix/benchmark/build.gradle
+++ b/fenix/benchmark/build.gradle
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id 'com.android.test'
     id 'org.jetbrains.kotlin.android'
@@ -39,6 +41,18 @@ android {
 
     targetProjectPath = ":app"
     experimentalProperties["android.experimental.self-instrumenting"] = true
+
+    testOptions {
+        managedDevices {
+            devices {
+                pixel3Api31(ManagedVirtualDevice) {
+                    device = "Pixel 3"
+                    apiLevel = 31
+                    systemImageSource = "aosp"
+                }
+            }
+        }
+    }
 }
 
 /**

--- a/fenix/benchmark/src/main/java/org/mozilla/fenix/benchmark/baselineprofile/StartupOnlyBaselineProfileGenerator.kt
+++ b/fenix/benchmark/src/main/java/org/mozilla/fenix/benchmark/baselineprofile/StartupOnlyBaselineProfileGenerator.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.benchmark.baselineprofile
+
+import androidx.benchmark.macro.ExperimentalBaselineProfilesApi
+import androidx.benchmark.macro.junit4.BaselineProfileRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.benchmark.utils.TARGET_PACKAGE
+
+@OptIn(ExperimentalBaselineProfilesApi::class)
+@RunWith(AndroidJUnit4::class)
+class StartupOnlyBaselineProfileGenerator {
+
+    @get:Rule
+    val rule = BaselineProfileRule()
+
+    @Test
+    fun generateBaselineProfile() {
+        rule.collectBaselineProfile(
+            packageName = TARGET_PACKAGE,
+        ) {
+            startActivityAndWait()
+        }
+    }
+}

--- a/fenix/build.gradle
+++ b/fenix/build.gradle
@@ -2,6 +2,11 @@
 
 import org.mozilla.fenix.gradle.tasks.GithubDetailsTask
 
+import java.nio.file.CopyOption
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
 buildscript {
     // This logic is duplicated in the allprojects block: I don't know how to fix that.
     repositories {
@@ -264,4 +269,76 @@ tasks.register("githubLintDetektDetails", GithubDetailsTask) {
 
 tasks.register("githubLintAndroidDetails", GithubDetailsTask) {
     text = "### [Android Lint Results Fenix]({reportsUrl}/lint-results-debug.html)"
+}
+
+// Task to copy generated baseline profile to the app module
+// to be used in the nightly release pipeline only.
+tasks.register("copyBaselineProfile", DefaultTask) {
+    doLast {
+        File profileFile = fileTree('benchmark/build/outputs') {
+            include '**/*baseline-prof.txt'
+        }.getSingleFile()
+        def destinationPath = Paths.get("app", "src", "main", "baseline-prof.txt")
+        Files.copy(profileFile.toPath(), destinationPath, StandardCopyOption.REPLACE_EXISTING)
+    }
+}
+
+def gmd = "dev31_default_x86_64_Pixel_3"
+def emulator = "pixel5_api31"
+def system_image = "system-images';'android-31';'google_apis';'x86_64"
+
+// Task to generate baseline profile for fenix on the defined gradle managed device.
+tasks.register('generateBaselineProfileAlt', DefaultTask) {
+    doLast {
+        exec {
+            commandLine 'sh', '-c', "./gradlew :benchmark:pixel3Api31BenchmarkAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect -P android.testInstrumentationRunnerArguments.class=org.mozilla.fenix.benchmark.baselineprofile.StartupOnlyBaselineProfileGenerator -P baselineProfileGeneration"
+        }
+    }
+}
+
+// Task to generate baseline profile for fenix on the defined gradle managed device.
+tasks.register('generateBaselineProfile', DefaultTask) {
+    doLast {
+        def sdkRoot = System.getenv('ANDROID_SDK_ROOT')
+        exec {
+            commandLine 'sh', '-c', """
+                ${sdkRoot}/emulator/emulator -avd ${emulator} -no-accel -no-snapstorage -no-snapshot -no-window -no-audio & 
+                (adb wait-for-device && ./gradlew :benchmark:connectedBenchmarkAndroidTest -P android.testInstrumentationRunnerArguments.class=org.mozilla.fenix.benchmark.baselineprofile.StartupOnlyBaselineProfileGenerator -P baselineProfileGeneration && adb emu kill)
+            """
+        }
+    }
+}
+
+// Task to setup the emulator
+tasks.register("setupEmulator", DefaultTask) {
+    doLast {
+        def sdkRoot = System.getenv('ANDROID_SDK_ROOT')
+        exec {
+            commandLine 'sh', '-c', """
+                $sdkRoot/cmdline-tools/latest/bin/sdkmanager --install ${system_image} &&
+                $sdkRoot/cmdline-tools/latest/bin/sdkmanager "platforms;android-31" "platform-tools" &&
+                $sdkRoot/cmdline-tools/latest/bin/avdmanager create avd --force --name ${emulator} --package ${system_image} --device "pixel_5" -c 2000M
+            """
+        }
+    }
+}
+
+// Task to setup the gradle managed device and copy the emulator to the parent directory so
+// it can be ran using command line emulator tool.
+tasks.register("setupGradleManagedDevice", DefaultTask) {
+    doLast {
+        def home = System.getProperty('user.home')
+        def sourceDirectory = "${home}/.android/avd/gradle-managed"
+        def targetDirectory = "${home}/.android/avd"
+        def iniFilePath = "${targetDirectory}/${gmd}.ini"
+
+        exec {
+            commandLine 'sh', '-c', """
+                ./gradlew :benchmark:pixel3Api31Setup &&
+                cp -R ${sourceDirectory}/${gmd}.avd ${targetDirectory} &&
+                cp ${sourceDirectory}/${gmd}.ini ${targetDirectory} &&
+                sed -i '' "s|/gradle-managed||g" ${iniFilePath}
+            """
+        }
+    }
 }

--- a/taskcluster/ci/build-apk/kind.yml
+++ b/taskcluster/ci/build-apk/kind.yml
@@ -13,6 +13,7 @@ transforms:
 kind-dependencies:
     - toolchain
     - external-gradle-dependencies
+    - generate-baseline-profiles
 
 task-defaults:
     apk-artifact-template:
@@ -197,6 +198,7 @@ tasks:
             shipping-product: fenix
         dependencies:
             external-gradle-dependencies: external-gradle-dependencies-fenix
+            generate-baseline-profiles: generate-baseline-profiles-fenix
         run-on-tasks-for: []
         include-shippable-secrets: true
         include-nightly-version: true

--- a/taskcluster/ci/generate-baseline-profiles/kind.yml
+++ b/taskcluster/ci/generate-baseline-profiles/kind.yml
@@ -1,0 +1,54 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - android_taskgraph.transforms.gradle_optimization:transforms
+    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - toolchain
+    - external-gradle-dependencies
+
+task-defaults:
+    attributes:
+        retrigger: true
+    fetches:
+        toolchain:
+            - android-sdk-linux
+        external-gradle-dependencies:
+            - external-gradle-dependencies.tar.xz
+    optimization:
+        skip-unless-changed: [] # Paths are dynamically added by transforms
+    run-on-tasks-for: []
+    run:
+        using: gradlew
+        use-caches: false
+    treeherder:
+        kind: test
+        tier: 1
+    worker-type: b-android-large
+    worker:
+        docker-image: {in-tree: base}
+        max-run-time: 7200
+
+tasks:
+    fenix:
+        description: 'Generate baseline profile for fenix.'
+        dependencies:
+            external-gradle-dependencies: external-gradle-dependencies-fenix
+        attributes:
+            build-type: nightly
+            shipping-product: fenix
+        run:
+            pre-gradlew:
+                - ["cd", "fenix"]
+                - ['java', '-version']
+            gradlew: ['setupEmulator', 'generateBaselineProfile', 'copyBaselineProfile']
+        run-on-tasks-for: []
+        treeherder:
+            symbol: fenix-baseline-profile
+            platform: fenix-android-all/opt


### PR DESCRIPTION
### How
– Create `StartupOnlyBaselineProfileGenerator` that generates baseline profile for the path of app startup.
– Define gradle managed virtual device in `benchmark/build.gradle`
– Generate baseline profiles by running `generateBaselineProfile` which execute the following gradle task with params.
```
 ./gradlew :benchmark:pixel3Api31BenchmarkAndroidTest -P android.testInstrumentationRunnerArguments.class=org.mozilla.fenix.benchmark.baselineprofile.StartupOnlyBaselineProfileGenerator -P baselineProfileGeneration
 ````
Note: when the flag `baselineProfileGeneration` is used, only `arm64-v8a` abi is created as that's what the gradle managed virtual device needs. Baseline profiles are generated for Kotlin/Java code, so any abi can be picked based on the device available.
– Add Copy gradle task `copyBaselineProfile` to copy generated baseline profiles to `app/src/main`. 
– Run these two gradle tasks in the fenix-nightly pipeline, before the build step as the apk needs to be build with the generated `baseline-prof.txt`.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





























### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807350