### PR TITLE
Bug 1826933 - Avoid memory leaks in NotificationsDelegate

### DIFF
--- a/android-components/components/support/base/src/main/java/mozilla/components/support/base/android/NotificationsDelegate.kt
+++ b/android-components/components/support/base/src/main/java/mozilla/components/support/base/android/NotificationsDelegate.kt
@@ -15,6 +15,8 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.Lifecycle
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
 
 typealias OnPermissionGranted = () -> Unit
 typealias OnPermissionRejected = () -> Unit
@@ -36,8 +38,9 @@ class NotificationsDelegate(
 ) {
     private var onPermissionGranted: OnPermissionGranted = { }
     private var onPermissionRejected: OnPermissionRejected = { }
-    private val notificationPermissionHandler: MutableMap<AppCompatActivity, ActivityResultLauncher<String>> =
-        mutableMapOf()
+    private val notificationPermissionHandler:
+        WeakHashMap<AppCompatActivity, WeakReference<ActivityResultLauncher<String>>> =
+        WeakHashMap()
 
     /**
      * Provides the context for a permission request.
@@ -53,7 +56,7 @@ class NotificationsDelegate(
                 }
             }
 
-        notificationPermissionHandler[activity] = activityResultLauncher
+        notificationPermissionHandler[activity] = WeakReference(activityResultLauncher)
     }
 
     /**
@@ -151,7 +154,7 @@ class NotificationsDelegate(
         } else {
             notificationPermissionHandler.entries.firstOrNull {
                 it.key.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
-            }?.value?.launch(POST_NOTIFICATIONS)
+            }?.value?.get()?.launch(POST_NOTIFICATIONS)
         }
     }
 

--- a/android-components/components/support/base/src/main/java/mozilla/components/support/base/android/NotificationsDelegate.kt
+++ b/android-components/components/support/base/src/main/java/mozilla/components/support/base/android/NotificationsDelegate.kt
@@ -12,6 +12,7 @@ import android.os.RemoteException
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.Lifecycle
@@ -38,9 +39,10 @@ class NotificationsDelegate(
 ) {
     private var onPermissionGranted: OnPermissionGranted = { }
     private var onPermissionRejected: OnPermissionRejected = { }
-    private val notificationPermissionHandler:
-        WeakHashMap<AppCompatActivity, WeakReference<ActivityResultLauncher<String>>> =
-        WeakHashMap()
+
+    @VisibleForTesting
+    internal val notificationPermissionHandler:
+        WeakHashMap<AppCompatActivity, WeakReference<ActivityResultLauncher<String>>> = WeakHashMap()
 
     /**
      * Provides the context for a permission request.

--- a/android-components/components/support/base/src/test/java/mozilla/components/support/base/android/NotificationsDelegateTest.kt
+++ b/android-components/components/support/base/src/test/java/mozilla/components/support/base/android/NotificationsDelegateTest.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.support.base.android
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.NotificationManagerCompat
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NotificationsDelegateTest {
+
+    @Test
+    fun `given 2 bound activities, when one of them is unbound, its reference is removed from the notificationPermissionHandler`() {
+        val activity = AppCompatActivity()
+        val activity2 = AppCompatActivity()
+
+        val notificationManagerCompat: NotificationManagerCompat = mock()
+
+        val notificationsDelegate = NotificationsDelegate(notificationManagerCompat)
+
+        notificationsDelegate.bindToActivity(activity)
+        notificationsDelegate.bindToActivity(activity2)
+
+        notificationsDelegate.unBindActivity(activity)
+
+        assertEquals(1, notificationsDelegate.notificationPermissionHandler.size)
+        assertEquals(activity2, notificationsDelegate.notificationPermissionHandler.keys.first())
+    }
+
+    @Test
+    fun `given 2 bound activities, when one of them is garbage collected, its reference is removed from the notificationPermissionHandler`() {
+        var activity: AppCompatActivity? = AppCompatActivity()
+        val activity2 = AppCompatActivity()
+
+        val notificationManagerCompat: NotificationManagerCompat = mock()
+
+        val notificationsDelegate = NotificationsDelegate(notificationManagerCompat)
+
+        notificationsDelegate.bindToActivity(activity!!)
+        notificationsDelegate.bindToActivity(activity2)
+
+        activity = null
+
+        System.gc()
+
+        Thread.sleep(10)
+
+        @Suppress("KotlinConstantConditions")
+        assertNull(activity)
+        assertEquals(1, notificationsDelegate.notificationPermissionHandler.size)
+        assertEquals(activity2, notificationsDelegate.notificationPermissionHandler.keys.first())
+    }
+}


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1826933