### PR TITLE
Bug 1802010 - After adding a shortcut, show a confirmation message

### DIFF
--- a/focus-android/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/browser/integration/BrowserMenuController.kt
@@ -36,6 +36,7 @@ class BrowserMenuController(
     private val showFindInPageCallback: () -> Unit,
     private val openInCallback: () -> Unit,
     private val openInBrowser: () -> Unit,
+    private val showShortcutAddedSnackBar: () -> Unit,
 ) {
     @VisibleForTesting
     private val currentTab: SessionState?
@@ -72,6 +73,7 @@ class BrowserMenuController(
                         )
                     }
                 }
+                showShortcutAddedSnackBar()
             }
             is ToolbarMenu.Item.RemoveFromShortcuts -> {
                 ioScope.launch {

--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -531,6 +531,7 @@ class BrowserFragment :
             ::showFindInPageBar,
             ::openSelectBrowser,
             ::openInBrowser,
+            ::showShortcutAddedSnackBar,
         )
 
         if (tab.ifCustomTab()?.config == null) {
@@ -562,6 +563,12 @@ class BrowserFragment :
             owner = this,
             view = binding.browserToolbar,
         )
+    }
+
+    private fun showShortcutAddedSnackBar() {
+        FocusSnackbar.make(requireView())
+            .setText(requireContext().getString(R.string.snackbar_added_to_shortcuts))
+            .show()
     }
 
     private fun initialiseNormalBrowserUi() {

--- a/focus-android/app/src/main/res/values/strings.xml
+++ b/focus-android/app/src/main/res/values/strings.xml
@@ -481,6 +481,9 @@
     <!-- Snackbar action to immediately open the successfully downloaded file. -->
     <string name="download_snackbar_open">Open</string>
 
+    <!-- Snackbar that will be displayed after a website has been added to shortcuts. -->
+    <string name="snackbar_added_to_shortcuts">Added to shortcuts!</string>
+
     <string name="error_hostLookup_title">Server not found</string>
 
     <!-- Content description (not visible, for screen readers etc.): This is the description for the close button from the new onboarding flow screen one and two -->

--- a/focus-android/app/src/test/java/org/mozilla/focus/menu/BrowserMenuControllerTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/menu/BrowserMenuControllerTest.kt
@@ -54,6 +54,9 @@ class BrowserMenuControllerTest {
     @Mock
     private lateinit var openInBrowser: () -> Unit
 
+    @Mock
+    private lateinit var showShortcutAddedSnackBar: () -> Unit
+
     @Before
     fun setup() {
         val store = BrowserStore(
@@ -78,6 +81,7 @@ class BrowserMenuControllerTest {
                 showFindInPageCallback,
                 openInCallback,
                 openInBrowser,
+                showShortcutAddedSnackBar,
             ),
         )
 
@@ -147,5 +151,12 @@ class BrowserMenuControllerTest {
         val menuItem = ToolbarMenu.Item.FindInPage
         browserMenuController.handleMenuInteraction(menuItem)
         Mockito.verify(showFindInPageCallback, times(1)).invoke()
+    }
+
+    @Test
+    fun `Given AddToShortCut menu item WHEN  the item is pressed THEN showShortcutAddedSnackBar is called`() {
+        val menuItem = ToolbarMenu.Item.AddToShortcuts
+        browserMenuController.handleMenuInteraction(menuItem)
+        Mockito.verify(showShortcutAddedSnackBar, times(1)).invoke()
     }
 }


### PR DESCRIPTION
### What
Show a snack bar when a website is added to shortcut


### Issue video
[fnx-62-issue.webm](https://user-images.githubusercontent.com/35276272/224277226-f77b37ad-81da-4663-a1d6-26f5f4a86f0c.webm)

### Demo video after fix
[fnx-62-fix.webm](https://user-images.githubusercontent.com/35276272/224272629-29ae582d-9b3e-4cc2-9e0c-5bab7d1f3538.webm)


### Pull Request checklist
 - [x] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [ ] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [ ] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1802010