### PR TITLE
Bug 1827381 - Remove running condition for UI tests related to the PDF reader feature

### DIFF
--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/DownloadFileTest.kt
@@ -4,7 +4,6 @@
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
-import mozilla.components.concept.engine.utils.EngineReleaseChannel
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -14,7 +13,6 @@ import org.junit.runner.RunWith
 import org.mozilla.focus.activity.robots.downloadRobot
 import org.mozilla.focus.activity.robots.notificationTray
 import org.mozilla.focus.activity.robots.searchScreen
-import org.mozilla.focus.ext.components
 import org.mozilla.focus.helpers.DeleteFilesHelper.deleteFileUsingDisplayName
 import org.mozilla.focus.helpers.FeatureSettingsHelper
 import org.mozilla.focus.helpers.MainActivityIntentsTestRule
@@ -26,7 +24,6 @@ import org.mozilla.focus.helpers.TestHelper.assertNativeAppOpens
 import org.mozilla.focus.helpers.TestHelper.getTargetContext
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.permAllowBtn
-import org.mozilla.focus.helpers.TestHelper.runWithCondition
 import org.mozilla.focus.helpers.TestHelper.verifyDownloadedFileOnStorage
 import org.mozilla.focus.helpers.TestHelper.verifySnackBarText
 import org.mozilla.focus.helpers.TestHelper.waitingTime
@@ -147,19 +144,12 @@ class DownloadFileTest {
         downloadFileName = "washington.pdf"
         val pdfFileURL = "https://storage.googleapis.com/mobile_test_assets/public/washington.pdf"
         val pdfFileContent = "Washington Crossing the Delaware"
-
-        runWithCondition(
-            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly.
-            // Once this feature lands in Beta/RC we should remove the wrapper.
-            mActivityTestRule.activity.components.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY,
-        ) {
-            searchScreen {
-            }.loadPage(downloadTestPage) {
-                progressBar.waitUntilGone(waitingTime)
-                clickLinkMatchingText(downloadFileName)
-                verifyPageURL(pdfFileURL)
-                verifyPageContent(pdfFileContent)
-            }
+        searchScreen {
+        }.loadPage(downloadTestPage) {
+            progressBar.waitUntilGone(waitingTime)
+            clickLinkMatchingText(downloadFileName)
+            verifyPageURL(pdfFileURL)
+            verifyPageContent(pdfFileContent)
         }
     }
 


### PR DESCRIPTION
Remove running condition for UI tests related to the "PDF reader" feature as It's now available on all current releases.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1827381