### PR TITLE
Bug 1828201 - Disable cookie banner reduction UI tests for investigation

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
@@ -2,6 +2,7 @@ package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
 import org.junit.Rule
+import org.junit.Ignore
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -15,6 +16,7 @@ class CookieBannerReductionTest {
     @get:Rule
     val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
 
+    @Ignore("Failing: Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1815426")
     @SmokeTest
     @Test
     fun verifyCookieBannerReductionTest() {
@@ -62,6 +64,7 @@ class CookieBannerReductionTest {
         }
     }
 
+    @Ignore("Failing: Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1814030")
     @SmokeTest
     @Test
     fun verifyCookieBannerReductionInPrivateBrowsingTest() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1828201

```Kotlin
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists(MatcherHelper.kt:51)
	at org.mozilla.fenix.ui.robots.BrowserRobot.verifyCookieBannerExists(BrowserRobot.kt:1019)
	at org.mozilla.fenix.ui.CookieBannerReductionTest$verifyCookieBannerReductionInPrivateBrowsingTest$3.invoke(CookieBannerReductionTest.kt:76)
	at org.mozilla.fenix.ui.CookieBannerReductionTest$verifyCookieBannerReductionInPrivateBrowsingTest$3.invoke(CookieBannerReductionTest.kt:74)
	at org.mozilla.fenix.ui.robots.NavigationToolbarRobot$Transition.enterURLAndEnterToBrowser(NavigationToolbarRobot.kt:140)
	at org.mozilla.fenix.ui.CookieBannerReductionTest.verifyCookieBannerReductionInPrivateBrowsingTest(CookieBannerReductionTest.kt:74) 
```

It's possible that the source used is not showing a cookie banner anymore, or possibly regressed with GeckoView Nightly [Update GeckoView (Nightly) to 114.0.20230413152644.](https://github.com/mozilla-mobile/firefox-android/commit/10dbca6e937aaa448bc8b57cf0a0fe34cafd5a66) - if the former, can we use a mock source? 
https://bugzilla.mozilla.org/show_bug.cgi?id=128201
https://bugzilla.mozilla.org/show_bug.cgi?id=128201