### PR TITLE
Bug 1828437 - Disable sponsored shortcut UI tests for investigation

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SponsoredShortcutsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SponsoredShortcutsTest.kt
@@ -68,6 +68,7 @@ class SponsoredShortcutsTest {
         }
     }
 
+    @Ignore("Failing: https://bugzilla.mozilla.org/show_bug.cgi?id=1828437")
     @Test
     fun openSponsoredShortcutTest() {
         homeScreen {
@@ -77,6 +78,7 @@ class SponsoredShortcutsTest {
         }
     }
 
+    @Ignore("Failing: https://bugzilla.mozilla.org/show_bug.cgi?id=1828437")
     @Test
     fun openSponsoredShortcutInPrivateBrowsingTest() {
         homeScreen {
@@ -109,6 +111,7 @@ class SponsoredShortcutsTest {
         }
     }
 
+    @Ignore("Failing: https://bugzilla.mozilla.org/show_bug.cgi?id=1828437")
     @Test
     fun verifySponsoredShortcutsDetailsTest() {
         homeScreen {
@@ -141,6 +144,7 @@ class SponsoredShortcutsTest {
     }
 
     // 1 sponsored shortcut should be displayed if there are 7 pinned top sites
+    @Ignore("Failing: https://bugzilla.mozilla.org/show_bug.cgi?id=1828437")
     @Test
     fun verifySponsoredShortcutsListWithSevenPinnedSitesTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -191,6 +195,7 @@ class SponsoredShortcutsTest {
     }
 
     // No sponsored shortcuts should be displayed if there are 8 pinned top sites
+    @Ignore("Failing: https://bugzilla.mozilla.org/show_bug.cgi?id=1828437")
     @Test
     fun verifySponsoredShortcutsListWithEightPinnedSitesTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)


### PR DESCRIPTION
With https://github.com/mozilla-mobile/firefox-android/commit/e035d09af2d0ae0bd7ed7e3864e2d4c3a9058c1f

The following are failing:

* openSponsoredShortcutTest
* verifySponsoredShortcutsDetailsTest
* verifySponsoredShortcutsListWithEightPinnedSitesTest
* verifySponsoredShortcutsListWithSevenPinnedSitesTest

[matrix-3jvfi7xtfjm3z](https://console.firebase.google.com/u/0/project/moz-fenix/testlab/histories/bh.66b7091e15d53d45/matrices/6966304169613699889/details?stepId=bs.4a76a28aa6cb9e76&testCaseId=2)

https://bugzilla.mozilla.org/show_bug.cgi?id=1828437
https://bugzilla.mozilla.org/show_bug.cgi?id=1828437
https://bugzilla.mozilla.org/show_bug.cgi?id=1828437
https://bugzilla.mozilla.org/show_bug.cgi?id=1828437