### PR TITLE
Bug 1827686 - Add telemetry for user updating Default Search Engine

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -568,6 +568,26 @@ events:
     metadata:
       tags:
         - Performance
+  default_engine_selected:
+    type: event
+    description: |
+      A user selected a new default search engine to use
+    extra_keys:
+      engine:
+        type: string
+        description: |
+          The name of the default search engine the user selected as a string.
+          Custom search engine user created will have the name `Custom`.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1827686
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/1674
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 127
+    metadata:
+      tags:
+        - Search
 
 onboarding:
   syn_cfr_shown:

--- a/fenix/app/src/main/java/org/mozilla/fenix/ext/SearchEngine.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ext/SearchEngine.kt
@@ -5,6 +5,9 @@
 package org.mozilla.fenix.ext
 
 import mozilla.components.browser.state.search.SearchEngine
+import org.mozilla.fenix.components.Core.Companion.BOOKMARKS_SEARCH_ENGINE_ID
+import org.mozilla.fenix.components.Core.Companion.HISTORY_SEARCH_ENGINE_ID
+import org.mozilla.fenix.components.Core.Companion.TABS_SEARCH_ENGINE_ID
 
 // List of well known search domains, taken from
 // https://searchfox.org/mozilla-central/source/toolkit/components/search/SearchService.jsm#2405
@@ -31,3 +34,19 @@ fun SearchEngine.isCustomEngine(): Boolean =
  */
 fun SearchEngine.isKnownSearchDomain(): Boolean =
     this.resultUrls[0].findAnyOf(wellKnownSearchDomains, 0, true) != null
+
+/**
+ * Return safe search engine name for telemetry purposes.
+ */
+fun SearchEngine.telemetryName(): String =
+    when (type) {
+        SearchEngine.Type.CUSTOM -> "custom"
+        SearchEngine.Type.APPLICATION ->
+            when (id) {
+                HISTORY_SEARCH_ENGINE_ID -> "history"
+                BOOKMARKS_SEARCH_ENGINE_ID -> "bookmarks"
+                TABS_SEARCH_ENGINE_ID -> "tabs"
+                else -> "application"
+            }
+        else -> name
+    }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -25,13 +25,11 @@ import org.mozilla.fenix.GleanMetrics.UnifiedSearch
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Core
-import org.mozilla.fenix.components.Core.Companion.BOOKMARKS_SEARCH_ENGINE_ID
-import org.mozilla.fenix.components.Core.Companion.HISTORY_SEARCH_ENGINE_ID
-import org.mozilla.fenix.components.Core.Companion.TABS_SEARCH_ENGINE_ID
 import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.crashes.CrashListActivity
 import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.telemetryName
 import org.mozilla.fenix.search.toolbar.SearchSelectorInteractor
 import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
 import org.mozilla.fenix.settings.SupportUtils
@@ -238,22 +236,10 @@ class SearchDialogController(
             }
         }
 
-        val engine = when (searchEngine.type) {
-            SearchEngine.Type.CUSTOM -> "custom"
-            SearchEngine.Type.APPLICATION ->
-                when (searchEngine.id) {
-                    HISTORY_SEARCH_ENGINE_ID -> "history"
-                    BOOKMARKS_SEARCH_ENGINE_ID -> "bookmarks"
-                    TABS_SEARCH_ENGINE_ID -> "tabs"
-                    else -> "application"
-                }
-            else -> searchEngine.name
-        }
-
         if (settings.showUnifiedSearchFeature) {
-            UnifiedSearch.engineSelected.record(UnifiedSearch.EngineSelectedExtra(engine))
+            UnifiedSearch.engineSelected.record(UnifiedSearch.EngineSelectedExtra(searchEngine.telemetryName()))
         } else {
-            SearchShortcuts.selected.record(SearchShortcuts.SelectedExtra(engine))
+            SearchShortcuts.selected.record(SearchShortcuts.SelectedExtra(searchEngine.telemetryName()))
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
@@ -30,11 +30,13 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.lib.state.ext.flow
 import mozilla.components.support.ktx.android.view.toScope
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.SearchEngineRadioButtonBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.telemetryName
 import org.mozilla.fenix.utils.allowUndo
 
 class RadioSearchEngineListPreference @JvmOverloads constructor(
@@ -156,6 +158,8 @@ class RadioSearchEngineListPreference @JvmOverloads constructor(
         )
 
         context.components.useCases.searchUseCases.selectSearchEngine(engine)
+
+        Events.defaultEngineSelected.record(Events.DefaultEngineSelectedExtra(engine.telemetryName()))
     }
 
     private fun editCustomSearchEngine(view: View, engine: SearchEngine) {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1827686