### PR TITLE
Bug 1824136 - New tests coverage for site permissions settings

### DIFF
--- a/fenix/app/src/androidTest/assets/pages/mutedVideoPage.html
+++ b/fenix/app/src/androidTest/assets/pages/mutedVideoPage.html
@@ -4,10 +4,10 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html>
 <head>
-    <title>Video_Test_Page</title>
+    <title>Muted_Video_Test_Page</title>
 </head>
 <body>
-<p id="testContent">Page content: video player</p>
+<p id="testContent">Page content: muted video player</p>
 <div class="playbackState">
     <p>Media file not playing</p>
 </div>
@@ -16,33 +16,33 @@
     <button onclick="pause()">Pause</button>
     <button onclick="fullscreen()">Full Screen</button>
     <br><br>
-    <video id="video" width="420" autoplay controls loop>
+    <video id="mutedVideo" width="420" autoplay muted controls loop>
         <source src="../resources/clip.mp4" type="video/mp4">
         Your browser does not support HTML video.
     </video>
 </div>
 
 <script>
-    const video = document.getElementById("video");
+    const mutedVideo = document.getElementById("mutedVideo");
 
     function play() {
-        video.play();
+        mutedVideo.play();
     }
 
     function pause() {
-        video.pause();
+        mutedVideo.pause();
     }
 
     function fullscreen() {
-        video.requestFullscreen();
+        mutedVideo.requestFullscreen();
     }
 
-    video.addEventListener('playing', (event) => {
-        document.querySelector('.playbackState').innerHTML="Media file is playing";
+    mutedVideo.addEventListener('playing', (event) => {
+     document.querySelector('.playbackState').innerHTML="Media file is playing";
     });
 
-    video.addEventListener('pause', (event) => {
-         document.querySelector('.playbackState').innerHTML="Media file is paused";
+    mutedVideo.addEventListener('pause', (event) => {
+        document.querySelector('.playbackState').innerHTML="Media file is paused";
     });
 </script>
 </body>

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestAssetHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestAssetHelper.kt
@@ -127,6 +127,14 @@ object TestAssetHelper {
         return TestAsset(url, content, title)
     }
 
+    fun getMutedVideoPageAsset(server: MockWebServer): TestAsset {
+        val url = server.url("pages/mutedVideoPage.html").toString().toUri()!!
+        val title = "Muted_Video_Test_Page"
+        val content = "Page content: muted video player"
+
+        return TestAsset(url, content, title)
+    }
+
     fun getStorageTestAsset(server: MockWebServer, pageAsset: String): TestAsset {
         val url = server.url("pages/$pageAsset").toString().toUri()!!
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -65,7 +65,6 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.Constants.PackageName.YOUTUBE_APP
-import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.ext.waitNotNull
@@ -339,25 +338,20 @@ object TestHelper {
         }
     }
 
-    fun grantPermission() {
+    // Method used to press allow on the different system permission dialogs
+    fun grantSystemPermission() {
         if (Build.VERSION.SDK_INT >= 23) {
-            when (Build.VERSION.SDK_INT) {
-                Build.VERSION_CODES.R ->
-                    itemWithResIdAndText(
-                        "com.android.permissioncontroller:id/permission_allow_foreground_only_button",
-                        "While using the app",
-                    ).also {
-                        it.waitForExists(waitingTime)
-                        it.click()
-                    }
-                else ->
-                    itemWithResIdAndText(
-                        "com.android.packageinstaller:id/permission_allow_button",
-                        "ALLOW",
-                    ).also {
-                        it.waitForExists(waitingTime)
-                        it.click()
-                    }
+            if (mDevice.findObject(UiSelector().textContains("While using the app")).waitForExists(
+                    waitingTimeShort,
+                )
+            ) {
+                mDevice.findObject(UiSelector().textContains("While using the app")).click()
+            } else {
+                mDevice.findObject(
+                    UiSelector()
+                        .textContains("Allow")
+                        .className("android.widget.Button"),
+                ).click()
             }
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -30,7 +30,7 @@ import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.assertNativeAppOpens
 import org.mozilla.fenix.helpers.TestHelper.denyPermission
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
-import org.mozilla.fenix.helpers.TestHelper.grantPermission
+import org.mozilla.fenix.helpers.TestHelper.grantSystemPermission
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.setCustomSearchEngine
@@ -117,7 +117,7 @@ class SearchTest {
         homeScreen {
         }.openSearch {
             clickScanButton()
-            grantPermission()
+            grantSystemPermission()
             verifyScannerOpen()
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -144,15 +144,4 @@ class SettingsPrivacyTest {
             verifySitePermissionOption("Exceptions")
         }
     }
-
-    @Test
-    fun notificationPermissionsItemsTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openSettingsSubMenuSitePermissions {
-        }.openNotification {
-            verifyNotificationSubMenuItems()
-        }
-    }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSitePermissionsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSitePermissionsTest.kt
@@ -1,15 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
+import androidx.core.net.toUri
+import androidx.test.espresso.Espresso.pressBack
 import androidx.test.filters.SdkSuppress
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.mediasession.MediaSession
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
+import org.mozilla.fenix.helpers.TestAssetHelper.getMutedVideoPageAsset
+import org.mozilla.fenix.helpers.TestAssetHelper.getVideoPageAsset
+import org.mozilla.fenix.helpers.TestHelper.exitMenu
+import org.mozilla.fenix.helpers.TestHelper.grantSystemPermission
+import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.navigationToolbar
 
+/**
+ *  Tests for verifying
+ *  - site permissions settings sub-menu
+ *  - the settings effects on the app behavior
+ *
+ */
 class SettingsSitePermissionsTest {
+    /* Test page created and handled by the Mozilla mobile test-eng team */
+    private val permissionsTestPage = "https://mozilla-mobile.github.io/testapp/v2.0/permissions"
+    private val permissionsTestPageHost = "https://mozilla-mobile.github.io"
+    private val testPageSubstring = "https://mozilla-mobile.github.io:443"
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var browserStore: BrowserStore
+
     @get:Rule
-    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
+    val activityTestRule = HomeActivityTestRule(
+        isJumpBackInCFREnabled = false,
+        isPWAsPromptEnabled = false,
+        isTCPCFREnabled = false,
+        isDeleteSitePermissionsEnabled = true,
+    )
+
+    @Before
+    fun setUp() {
+        // Initializing this as part of class construction, below the rule would throw a NPE
+        // So we are initializing this here instead of in all tests.
+        browserStore = activityTestRule.activity.components.core.store
+
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
 
     // Verifies that you can go to System settings and change app's permissions from inside the app
     @SmokeTest
@@ -21,13 +77,13 @@ class SettingsSitePermissionsTest {
         }.openSettings {
         }.openSettingsSubMenuSitePermissions {
         }.openCamera {
-            verifyBlockedByAndroid()
+            verifyBlockedByAndroidSection()
         }.goBack {
         }.openLocation {
-            verifyBlockedByAndroid()
+            verifyBlockedByAndroidSection()
         }.goBack {
         }.openMicrophone {
-            verifyBlockedByAndroid()
+            verifyBlockedByAndroidSection()
             clickGoToSettingsButton()
             openAppSystemPermissionsSettings()
             switchAppPermissionSystemSetting("Camera", "Allow")
@@ -47,6 +103,425 @@ class SettingsSitePermissionsTest {
         }.goBack {
         }.openCamera {
             verifyUnblockedByAndroid()
+        }
+    }
+
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1827599")
+    @SmokeTest
+    @Test
+    fun verifyAutoplayBlockAudioOnlySettingTest() {
+        val genericPage = getGenericAsset(mockWebServer, 1)
+        val videoTestPage = getVideoPageAsset(mockWebServer)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuSitePermissions {
+        }.openAutoPlay {
+            verifySitePermissionsAutoPlaySubMenuItems()
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericPage.url) {
+            verifyPageContent(genericPage.content)
+        }.openTabDrawer {
+            closeTab()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(videoTestPage.url) {
+            try {
+                verifyPageContent(videoTestPage.content)
+                clickMediaPlayerPlayButton()
+                assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
+            } catch (e: java.lang.AssertionError) {
+                navigationToolbar {
+                }.openThreeDotMenu {
+                }.refreshPage {
+                    verifyPageContent(videoTestPage.content)
+                    clickMediaPlayerPlayButton()
+                    assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
+                }
+            }
+        }
+    }
+
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1827599")
+    @SmokeTest
+    @Test
+    fun verifyAutoplayBlockAudioOnlySettingOnMutedVideoTest() {
+        val genericPage = getGenericAsset(mockWebServer, 1)
+        val mutedVideoTestPage = getMutedVideoPageAsset(mockWebServer)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericPage.url) {
+            verifyPageContent(genericPage.content)
+        }.openTabDrawer {
+            closeTab()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(mutedVideoTestPage.url) {
+            try {
+                verifyPageContent("Media file is playing")
+            } catch (e: java.lang.AssertionError) {
+                navigationToolbar {
+                }.openThreeDotMenu {
+                }.refreshPage {
+                    verifyPageContent("Media file is playing")
+                }
+            }
+        }
+    }
+
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1827599")
+    @Test
+    fun verifyAutoplayAllowAudioVideoSettingTest() {
+        val genericPage = getGenericAsset(mockWebServer, 1)
+        val videoTestPage = getVideoPageAsset(mockWebServer)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuSitePermissions {
+        }.openAutoPlay {
+            selectAutoplayOption("Allow audio and video")
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericPage.url) {
+            verifyPageContent(genericPage.content)
+        }.openTabDrawer {
+            closeTab()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(videoTestPage.url) {
+            try {
+                verifyPageContent(videoTestPage.content)
+                assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
+            } catch (e: java.lang.AssertionError) {
+                navigationToolbar {
+                }.openThreeDotMenu {
+                }.refreshPage {
+                    verifyPageContent(videoTestPage.content)
+                    assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
+                }
+            }
+        }
+    }
+
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1827599")
+    @Test
+    fun verifyAutoplayAllowAudioVideoSettingOnMutedVideoTest() {
+        val mutedVideoTestPage = getMutedVideoPageAsset(mockWebServer)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuSitePermissions {
+        }.openAutoPlay {
+            selectAutoplayOption("Allow audio and video")
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(mutedVideoTestPage.url) {
+            try {
+                verifyPageContent("Media file is playing")
+            } catch (e: java.lang.AssertionError) {
+                navigationToolbar {
+                }.openThreeDotMenu {
+                }.refreshPage {
+                    verifyPageContent("Media file is playing")
+                }
+            }
+        }
+    }
+
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1827599")
+    @Test
+    fun verifyAutoplayBlockAudioAndVideoSettingTest() {
+        val videoTestPage = getVideoPageAsset(mockWebServer)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuSitePermissions {
+        }.openAutoPlay {
+            selectAutoplayOption("Block audio and video")
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(videoTestPage.url) {
+            try {
+                verifyPageContent(videoTestPage.content)
+                clickMediaPlayerPlayButton()
+                assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
+            } catch (e: java.lang.AssertionError) {
+                navigationToolbar {
+                }.openThreeDotMenu {
+                }.refreshPage {
+                    verifyPageContent(videoTestPage.content)
+                    clickMediaPlayerPlayButton()
+                    assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
+                }
+            }
+        }
+    }
+
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1827599")
+    @Test
+    fun verifyAutoplayBlockAudioAndVideoSettingOnMutedVideoTest() {
+        val mutedVideoTestPage = getMutedVideoPageAsset(mockWebServer)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuSitePermissions {
+        }.openAutoPlay {
+            selectAutoplayOption("Block audio and video")
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(mutedVideoTestPage.url) {
+            verifyPageContent("Media file not playing")
+            clickMediaPlayerPlayButton()
+            try {
+                verifyPageContent("Media file is playing")
+            } catch (e: java.lang.AssertionError) {
+                navigationToolbar {
+                }.openThreeDotMenu {
+                }.refreshPage {
+                    clickMediaPlayerPlayButton()
+                    verifyPageContent("Media file is playing")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun verifyCameraPermissionSettingsTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
+        }.clickStartCameraButton {
+            grantSystemPermission()
+            verifyCameraPermissionPrompt(testPageSubstring)
+            pressBack()
+        }
+        browserScreen {
+            navigationToolbar {
+            }.openThreeDotMenu {
+            }.openSettings {
+            }.openSettingsSubMenuSitePermissions {
+            }.openCamera {
+                verifySitePermissionsCommonSubMenuItems()
+                selectPermissionSettingOption("Blocked")
+                exitMenu()
+            }
+        }.clickStartCameraButton {}
+        browserScreen {
+            verifyPageContent("Camera not allowed")
+        }
+    }
+
+    @Test
+    fun verifyMicrophonePermissionSettingsTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
+        }.clickStartMicrophoneButton {
+            grantSystemPermission()
+            verifyMicrophonePermissionPrompt(testPageSubstring)
+            pressBack()
+        }
+        browserScreen {
+            navigationToolbar {
+            }.openThreeDotMenu {
+            }.openSettings {
+            }.openSettingsSubMenuSitePermissions {
+            }.openMicrophone {
+                verifySitePermissionsCommonSubMenuItems()
+                selectPermissionSettingOption("Blocked")
+                exitMenu()
+            }
+        }.clickStartMicrophoneButton {}
+        browserScreen {
+            verifyPageContent("Microphone not allowed")
+        }
+    }
+
+    @Test
+    fun verifyLocationPermissionSettingsTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
+        }.clickGetLocationButton {
+            verifyLocationPermissionPrompt(testPageSubstring)
+            pressBack()
+        }
+        browserScreen {
+            navigationToolbar {
+            }.openThreeDotMenu {
+            }.openSettings {
+            }.openSettingsSubMenuSitePermissions {
+            }.openLocation {
+                verifySitePermissionsCommonSubMenuItems()
+                selectPermissionSettingOption("Blocked")
+                exitMenu()
+            }
+        }.clickGetLocationButton {}
+        browserScreen {
+            verifyPageContent("User denied geolocation prompt")
+        }
+    }
+
+    @Test
+    fun verifyNotificationsPermissionSettingsTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
+        }.clickOpenNotificationButton {
+            verifyNotificationsPermissionPrompt(testPageSubstring)
+            pressBack()
+        }
+        browserScreen {
+            navigationToolbar {
+            }.openThreeDotMenu {
+            }.openSettings {
+            }.openSettingsSubMenuSitePermissions {
+            }.openNotification {
+                verifyNotificationSubMenuItems()
+                selectPermissionSettingOption("Blocked")
+                exitMenu()
+            }
+        }.clickOpenNotificationButton {}
+        browserScreen {
+            verifyPageContent("Notifications not allowed")
+        }
+    }
+
+    @Test
+    fun verifyPersistentStoragePermissionSettingsTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
+        }.clickRequestPersistentStorageAccessButton {
+            verifyPersistentStoragePermissionPrompt(testPageSubstring)
+            pressBack()
+        }
+        browserScreen {
+            navigationToolbar {
+            }.openThreeDotMenu {
+            }.openSettings {
+            }.openSettingsSubMenuSitePermissions {
+            }.openPersistentStorage {
+                verifySitePermissionsPersistentStorageSubMenuItems()
+                selectPermissionSettingOption("Blocked")
+                exitMenu()
+            }
+        }.clickRequestPersistentStorageAccessButton {}
+        browserScreen {
+            verifyPageContent("Persistent storage permission denied")
+        }
+    }
+
+    @Test
+    fun verifyDRMControlledContentPermissionSettingsTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
+        }.clickRequestDRMControlledContentAccessButton {
+            verifyDRMContentPermissionPrompt(testPageSubstring)
+            pressBack()
+            browserScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+            }.openSettingsSubMenuSitePermissions {
+            }.openDRMControlledContent {
+                verifyDRMControlledContentSubMenuItems()
+                selectDRMControlledContentPermissionSettingOption("Blocked")
+                exitMenu()
+            }
+            browserScreen {
+            }.clickRequestDRMControlledContentAccessButton {}
+            browserScreen {
+                verifyPageContent("DRM-controlled content not allowed")
+            }.openThreeDotMenu {
+            }.openSettings {
+            }.openSettingsSubMenuSitePermissions {
+            }.openDRMControlledContent {
+                selectDRMControlledContentPermissionSettingOption("Allowed")
+                exitMenu()
+            }
+            browserScreen {
+            }.openThreeDotMenu {
+            }.refreshPage {
+            }.clickRequestDRMControlledContentAccessButton {}
+            browserScreen {
+                verifyPageContent("DRM-controlled content allowed")
+            }
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun clearAllSitePermissionsExceptionsTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
+        }.clickOpenNotificationButton {
+            verifyNotificationsPermissionPrompt(testPageSubstring)
+        }.clickPagePermissionButton(true) {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuSitePermissions {
+        }.openExceptions {
+            verifyExceptionCreated(permissionsTestPageHost, true)
+            clickClearPermissionsOnAllSites()
+            verifyClearPermissionsDialog()
+            clickCancel()
+            clickClearPermissionsOnAllSites()
+            clickOK()
+            verifyExceptionsEmptyList()
+        }
+    }
+
+    @Test
+    fun clearOneSiteAllPermissionsExceptionsTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
+        }.clickOpenNotificationButton {
+            verifyNotificationsPermissionPrompt(testPageSubstring)
+        }.clickPagePermissionButton(true) {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuSitePermissions {
+        }.openExceptions {
+            verifyExceptionCreated(permissionsTestPageHost, true)
+            openSiteExceptionsDetails(permissionsTestPageHost)
+            clickClearPermissionsForOneSite()
+            verifyClearPermissionsForOneSiteDialog()
+            clickCancel()
+            clickClearPermissionsForOneSite()
+            clickOK()
+            verifyExceptionsEmptyList()
+        }
+    }
+
+    @Test
+    fun clearOneSiteOnePermissionExceptionTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
+        }.clickOpenNotificationButton {
+            verifyNotificationsPermissionPrompt(testPageSubstring)
+        }.clickPagePermissionButton(true) {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuSitePermissions {
+        }.openExceptions {
+            verifyExceptionCreated(permissionsTestPageHost, true)
+            openSiteExceptionsDetails(permissionsTestPageHost)
+            verifyPermissionSettingSummary("Notification", "Allowed")
+            openChangePermissionSettingsMenu("Notification")
+            clickClearOnePermissionForOneSite()
+            verifyResetPermissionDefaultForThisSiteDialog()
+            clickOK()
+            pressBack()
+            verifyPermissionSettingSummary("Notification", "Ask to allow")
+            pressBack()
+            // This should be changed to false, when https://bugzilla.mozilla.org/show_bug.cgi?id=1826297 is fixed
+            verifyExceptionCreated(permissionsTestPageHost, true)
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
@@ -6,6 +6,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -134,6 +135,7 @@ class TextSelectionTest {
         }
     }
 
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1828663")
     @SmokeTest
     @Test
     fun selectAllAndCopyPDFTextTest() {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -1262,8 +1262,28 @@ class BrowserRobot {
         }
 
         fun clickRequestStorageAccessButton(interact: SitePermissionsRobot.() -> Unit): SitePermissionsRobot.Transition {
+            // Clicks the "request storage access" button from the "cross-site-cookies.html" local asset
             webPageItemContainingText("requestStorageAccess()").waitForExists(waitingTime)
             clickPageObject(webPageItemContainingText("requestStorageAccess()"))
+
+            SitePermissionsRobot().interact()
+            return SitePermissionsRobot.Transition()
+        }
+
+        fun clickRequestPersistentStorageAccessButton(interact: SitePermissionsRobot.() -> Unit): SitePermissionsRobot.Transition {
+            // Clicks the "Persistent storage" button from "https://mozilla-mobile.github.io/testapp/permissions"
+            webPageItemWithResourceId("persistentStorageButton").waitForExists(waitingTime)
+            clickPageObject(webPageItemWithResourceId("persistentStorageButton"))
+
+            SitePermissionsRobot().interact()
+            return SitePermissionsRobot.Transition()
+        }
+
+        fun clickRequestDRMControlledContentAccessButton(interact: SitePermissionsRobot.() -> Unit): SitePermissionsRobot.Transition {
+            // Clicks the "DRM-controlled content" button from "https://mozilla-mobile.github.io/testapp/permissions"
+
+            webPageItemWithResourceId("drmPermissionButton").waitForExists(waitingTime)
+            clickPageObject(webPageItemWithResourceId("drmPermissionButton"))
 
             SitePermissionsRobot().interact()
             return SitePermissionsRobot.Transition()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsCommonRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsCommonRobot.kt
@@ -29,6 +29,7 @@ import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.assertIsChecked
 import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.isChecked
 
 /**
  * Implementation of Robot Pattern for the settings Site Permissions sub menu.
@@ -77,6 +78,9 @@ class SettingsSubMenuSitePermissionsCommonRobot {
     fun verifySitePermissionsCommonSubMenuItems() {
         verifyAskToAllowButton()
         verifyBlockedButton()
+    }
+
+    fun verifyBlockedByAndroidSection() {
         verifyBlockedByAndroid()
         verifyToAllowIt()
         verifyGotoAndroidSettings()
@@ -86,13 +90,19 @@ class SettingsSubMenuSitePermissionsCommonRobot {
 
     fun verifyNotificationSubMenuItems() {
         verifyNotificationToolbar()
-        verifyAskToAllowButton()
-        verifyBlockedButton()
+        verifySitePermissionsCommonSubMenuItems()
     }
 
     fun verifySitePermissionsPersistentStorageSubMenuItems() {
         verifyAskToAllowButton()
         verifyBlockedButton()
+    }
+
+    fun verifyDRMControlledContentSubMenuItems() {
+        verifyAskToAllowButton()
+        verifyBlockedButton()
+        // Third option is "Allowed"
+        thirdRadioButton.check(matches(withText("Allowed")))
     }
 
     fun clickGoToSettingsButton() {
@@ -154,6 +164,30 @@ class SettingsSubMenuSitePermissionsCommonRobot {
         assertItemWithDescriptionExists(itemWithDescription(getStringResource(R.string.action_bar_up_description)))
     }
 
+    fun selectAutoplayOption(text: String) {
+        when (text) {
+            "Allow audio and video" -> askToAllowRadioButton.click()
+            "Block audio and video on cellular data only" -> blockRadioButton.click()
+            "Block audio only" -> thirdRadioButton.click()
+            "Block audio and video" -> fourthRadioButton.click()
+        }
+    }
+
+    fun selectPermissionSettingOption(text: String) {
+        when (text) {
+            "Ask to allow" -> askToAllowRadioButton.click()
+            "Blocked" -> blockRadioButton.click()
+        }
+    }
+
+    fun selectDRMControlledContentPermissionSettingOption(text: String) {
+        when (text) {
+            "Ask to allow" -> askToAllowRadioButton.click()
+            "Blocked" -> blockRadioButton.click()
+            "Allowed" -> thirdRadioButton.click()
+        }
+    }
+
     class Transition {
         fun goBack(interact: SettingsSubMenuSitePermissionsRobot.() -> Unit): SettingsSubMenuSitePermissionsRobot.Transition {
             goBackButton().click()
@@ -164,33 +198,44 @@ class SettingsSubMenuSitePermissionsCommonRobot {
     }
 }
 
+// common Blocked radio button for all settings
+private val blockRadioButton = onView(withId(R.id.block_radio))
+
+// common Ask to Allow radio button for all settings
+private val askToAllowRadioButton = onView(withId(R.id.ask_to_allow_radio))
+
+// common extra 3rd radio button for all settings
+private val thirdRadioButton = onView(withId(R.id.third_radio))
+
+// common extra 4th radio button for all settings
+private val fourthRadioButton = onView(withId(R.id.fourth_radio))
+
 private fun assertNavigationToolBarHeader(header: String) = onView(allOf(withContentDescription(header)))
 
 private fun assertBlockAudioAndVideoOnMobileDataOnlyAudioAndVideoWillPlayOnWiFi() =
-    onView(withId(R.id.block_radio))
-        .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
+    blockRadioButton.check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
 
-private fun assertBlockAudioOnly() = onView(withId(R.id.third_radio))
-    .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
+private fun assertBlockAudioOnly() =
+    thirdRadioButton.check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
 
 private fun assertVideoAndAudioBlockedRecommended() = onView(withId(R.id.fourth_radio))
     .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
 
 private fun assertCheckAutoPayRadioButtonDefault() {
     // Allow audio and video
-    onView(withId(R.id.block_radio))
+    askToAllowRadioButton
         .assertIsChecked(isChecked = false)
 
     // Block audio and video on cellular data only
-    onView(withId(R.id.block_radio))
+    blockRadioButton
         .assertIsChecked(isChecked = false)
 
-    // Block audio only
-    onView(withId(R.id.third_radio))
+    // Block audio only (default)
+    thirdRadioButton
         .assertIsChecked(isChecked = true)
 
     // Block audio and video
-    onView(withId(R.id.fourth_radio))
+    fourthRadioButton
         .assertIsChecked(isChecked = false)
 }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsExceptionsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsExceptionsRobot.kt
@@ -6,26 +6,107 @@ package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
-import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
+import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
 
 /**
  * Implementation of Robot Pattern for the settings Site Permissions Notification sub menu.
  */
 class SettingsSubMenuSitePermissionsExceptionsRobot {
-
-    fun verifyNavigationToolBarHeader() = assertNavigationToolBarHeader()
-
-    fun verifyExceptionDefault() = assertExceptionDefault()!!
-
-    fun verifySitePermissionsExceptionSubMenuItems() {
-        verifyExceptionDefault()
+    fun verifyExceptionsEmptyList() {
+        mDevice.findObject(UiSelector().text(getStringResource(R.string.no_site_exceptions)))
+            .waitForExists(waitingTime)
+        onView(withText(R.string.no_site_exceptions)).check(matches(isDisplayed()))
     }
+
+    fun verifyExceptionCreated(url: String, shouldBeDisplayed: Boolean) {
+        if (shouldBeDisplayed) {
+            exceptionsList.waitForExists(waitingTime)
+            onView(withText(containsString(url))).check(matches(isDisplayed()))
+        } else {
+            assertTrue(
+                mDevice.findObject(UiSelector().textContains(url)).waitUntilGone(waitingTime),
+            )
+        }
+    }
+
+    fun verifyClearPermissionsDialog() {
+        onView(withText(R.string.clear_permissions)).check(matches(isDisplayed()))
+        onView(withText(R.string.confirm_clear_permissions_on_all_sites)).check(matches(isDisplayed()))
+        onView(withText(R.string.clear_permissions_positive)).check(matches(isDisplayed()))
+        onView(withText(R.string.clear_permissions_negative)).check(matches(isDisplayed()))
+    }
+
+    // Click button for resetting all of one site's permissions to default
+    fun clickClearPermissionsForOneSite() {
+        swipeToBottom()
+        onView(withText(R.string.clear_permissions))
+            .check(matches(isDisplayed()))
+            .click()
+    }
+    fun verifyClearPermissionsForOneSiteDialog() {
+        onView(withText(R.string.clear_permissions)).check(matches(isDisplayed()))
+        onView(withText(R.string.confirm_clear_permissions_site)).check(matches(isDisplayed()))
+        onView(withText(R.string.clear_permissions_positive)).check(matches(isDisplayed()))
+        onView(withText(R.string.clear_permissions_negative)).check(matches(isDisplayed()))
+    }
+
+    fun openSiteExceptionsDetails(url: String) {
+        exceptionsList.waitForExists(waitingTime)
+        onView(withText(containsString(url))).click()
+    }
+
+    fun verifyPermissionSettingSummary(setting: String, summary: String) {
+        onView(
+            allOf(
+                withText(setting),
+                hasSibling(withText(summary)),
+            ),
+        ).check(matches(isDisplayed()))
+    }
+
+    fun openChangePermissionSettingsMenu(permissionSetting: String) {
+        onView(withText(containsString(permissionSetting))).click()
+    }
+
+    // Click button for resetting all permissions for all websites
+    fun clickClearPermissionsOnAllSites() {
+        exceptionsList.waitForExists(waitingTime)
+        onView(withId(R.id.delete_all_site_permissions_button))
+            .check(matches(isDisplayed()))
+            .click()
+    }
+
+    // Click button for resetting one site permission to default
+    fun clickClearOnePermissionForOneSite() {
+        onView(withText(R.string.clear_permission))
+            .check(matches(isDisplayed()))
+            .click()
+    }
+
+    fun verifyResetPermissionDefaultForThisSiteDialog() {
+        onView(withText(R.string.clear_permission)).check(matches(isDisplayed()))
+        onView(withText(R.string.confirm_clear_permission_site)).check(matches(isDisplayed()))
+        onView(withText(R.string.clear_permissions_positive)).check(matches(isDisplayed()))
+        onView(withText(R.string.clear_permissions_negative)).check(matches(isDisplayed()))
+    }
+
+    fun clickOK() = onView(withText(R.string.clear_permissions_positive)).click()
+
+    fun clickCancel() = onView(withText(R.string.clear_permissions_negative)).click()
 
     class Transition {
         fun goBack(interact: SettingsSubMenuSitePermissionsRobot.() -> Unit): SettingsSubMenuSitePermissionsRobot.Transition {
@@ -40,10 +121,5 @@ class SettingsSubMenuSitePermissionsExceptionsRobot {
 private fun goBackButton() =
     onView(allOf(withContentDescription("Navigate up")))
 
-private fun assertNavigationToolBarHeader() {
-    onView(withText(R.string.preference_exceptions))
-        .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
-}
-
-private fun assertExceptionDefault() =
-    onView(allOf(withText(R.string.no_site_exceptions)))
+private val exceptionsList =
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/exceptions"))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsRobot.kt
@@ -139,6 +139,21 @@ class SettingsSubMenuSitePermissionsRobot {
             return SettingsSubMenuSitePermissionsCommonRobot.Transition()
         }
 
+        fun openDRMControlledContent(
+            interact: SettingsSubMenuSitePermissionsCommonRobot.() -> Unit,
+        ): SettingsSubMenuSitePermissionsCommonRobot.Transition {
+            onView(withId(R.id.recycler_view)).perform(
+                RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
+                    hasDescendant(withText("DRM-controlled content")),
+                ),
+            )
+
+            openDrmControlledContent().click()
+
+            SettingsSubMenuSitePermissionsCommonRobot().interact()
+            return SettingsSubMenuSitePermissionsCommonRobot.Transition()
+        }
+
         fun openExceptions(
             interact: SettingsSubMenuSitePermissionsExceptionsRobot.() -> Unit,
         ): SettingsSubMenuSitePermissionsExceptionsRobot.Transition {
@@ -176,6 +191,9 @@ private fun openNotification() =
 
 private fun openPersistentStorage() =
     onView(allOf(withText("Persistent Storage")))
+
+private fun openDrmControlledContent() =
+    onView(allOf(withText("DRM-controlled content")))
 
 private fun openExceptions() =
     onView(allOf(withText("Exceptions")))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SitePermissionsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SitePermissionsRobot.kt
@@ -14,37 +14,55 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
-import org.mozilla.fenix.helpers.TestHelper
-import org.mozilla.fenix.helpers.TestHelper.getPermissionAllowID
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
 
 class SitePermissionsRobot {
-    fun clickGrantAppPermissionButton() {
-        TestHelper.grantPermission()
-    }
-
-    fun clickDenyAppPermissionButton() {
-        TestHelper.denyPermission()
-    }
-
     fun verifyMicrophonePermissionPrompt(url: String) {
-        assertTrue(
-            mDevice.findObject(UiSelector().text("Allow $url to use your microphone?"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
-        assertTrue(allowPagePermissionButton.text.equals("Allow"))
+        try {
+            assertTrue(
+                mDevice.findObject(UiSelector().text("Allow $url to use your microphone?"))
+                    .waitForExists(waitingTime),
+            )
+            assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+            assertTrue(allowPagePermissionButton.text.equals("Allow"))
+        } catch (e: AssertionError) {
+            browserScreen {
+            }.openThreeDotMenu {
+            }.refreshPage {
+            }.clickStartMicrophoneButton {
+                assertTrue(
+                    mDevice.findObject(UiSelector().text("Allow $url to use your microphone?"))
+                        .waitForExists(waitingTime),
+                )
+                assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+                assertTrue(allowPagePermissionButton.text.equals("Allow"))
+            }
+        }
     }
 
     fun verifyCameraPermissionPrompt(url: String) {
-        assertTrue(
-            mDevice.findObject(UiSelector().text("Allow $url to use your camera?"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
-        assertTrue(allowPagePermissionButton.text.equals("Allow"))
+        try {
+            assertTrue(
+                mDevice.findObject(UiSelector().text("Allow $url to use your camera?"))
+                    .waitForExists(waitingTime),
+            )
+            assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+            assertTrue(allowPagePermissionButton.text.equals("Allow"))
+        } catch (e: AssertionError) {
+            browserScreen {
+            }.openThreeDotMenu {
+            }.refreshPage {
+            }.clickStartCameraButton {
+                assertTrue(
+                    mDevice.findObject(UiSelector().text("Allow $url to use your camera?"))
+                        .waitForExists(waitingTime),
+                )
+                assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+                assertTrue(allowPagePermissionButton.text.equals("Allow"))
+            }
+        }
     }
 
     fun verifyAudioVideoPermissionPrompt(url: String) {
@@ -57,22 +75,50 @@ class SitePermissionsRobot {
     }
 
     fun verifyLocationPermissionPrompt(url: String) {
-        assertTrue(
-            mDevice.findObject(UiSelector().text("Allow $url to use your location?"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
-        assertTrue(allowPagePermissionButton.text.equals("Allow"))
+        try {
+            assertTrue(
+                mDevice.findObject(UiSelector().text("Allow $url to use your location?"))
+                    .waitForExists(waitingTime),
+            )
+            assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+            assertTrue(allowPagePermissionButton.text.equals("Allow"))
+        } catch (e: AssertionError) {
+            browserScreen {
+            }.openThreeDotMenu {
+            }.refreshPage {
+            }.clickGetLocationButton {
+                assertTrue(
+                    mDevice.findObject(UiSelector().text("Allow $url to use your location?"))
+                        .waitForExists(waitingTime),
+                )
+                assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+                assertTrue(allowPagePermissionButton.text.equals("Allow"))
+            }
+        }
     }
 
     fun verifyNotificationsPermissionPrompt(url: String, blocked: Boolean = false) {
         if (!blocked) {
-            assertTrue(
-                mDevice.findObject(UiSelector().text("Allow $url to send notifications?"))
-                    .waitForExists(waitingTime),
-            )
-            assertTrue(denyPagePermissionButton.text.equals("Never"))
-            assertTrue(allowPagePermissionButton.text.equals("Always"))
+            try {
+                assertTrue(
+                    mDevice.findObject(UiSelector().text("Allow $url to send notifications?"))
+                        .waitForExists(waitingTime),
+                )
+                assertTrue(denyPagePermissionButton.text.equals("Never"))
+                assertTrue(allowPagePermissionButton.text.equals("Always"))
+            } catch (e: AssertionError) {
+                browserScreen {
+                }.openThreeDotMenu {
+                }.refreshPage {
+                }.clickOpenNotificationButton {
+                    assertTrue(
+                        mDevice.findObject(UiSelector().text("Allow $url to send notifications?"))
+                            .waitForExists(waitingTime),
+                    )
+                    assertTrue(denyPagePermissionButton.text.equals("Never"))
+                    assertTrue(allowPagePermissionButton.text.equals("Always"))
+                }
+            }
         } else {
             /* if "Never" was selected in a previous step, or if the app is not allowed,
                the Notifications permission prompt won't be displayed anymore */
@@ -80,6 +126,52 @@ class SitePermissionsRobot {
                 mDevice.findObject(UiSelector().text("Allow $url to send notifications?"))
                     .exists(),
             )
+        }
+    }
+
+    fun verifyPersistentStoragePermissionPrompt(url: String) {
+        try {
+            assertTrue(
+                mDevice.findObject(UiSelector().text("Allow $url to store data in persistent storage?"))
+                    .waitForExists(waitingTime),
+            )
+            assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+            assertTrue(allowPagePermissionButton.text.equals("Allow"))
+        } catch (e: AssertionError) {
+            browserScreen {
+            }.openThreeDotMenu {
+            }.refreshPage {
+            }.clickRequestPersistentStorageAccessButton {
+                assertTrue(
+                    mDevice.findObject(UiSelector().text("Allow $url to store data in persistent storage?"))
+                        .waitForExists(waitingTime),
+                )
+                assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+                assertTrue(allowPagePermissionButton.text.equals("Allow"))
+            }
+        }
+    }
+
+    fun verifyDRMContentPermissionPrompt(url: String) {
+        try {
+            assertTrue(
+                mDevice.findObject(UiSelector().text("Allow $url to play DRM-controlled content?"))
+                    .waitForExists(waitingTime),
+            )
+            assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+            assertTrue(allowPagePermissionButton.text.equals("Allow"))
+        } catch (e: AssertionError) {
+            browserScreen {
+            }.openThreeDotMenu {
+            }.refreshPage {
+            }.clickRequestDRMControlledContentAccessButton {
+                assertTrue(
+                    mDevice.findObject(UiSelector().text("Allow $url to play DRM-controlled content?"))
+                        .waitForExists(waitingTime),
+                )
+                assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+                assertTrue(allowPagePermissionButton.text.equals("Allow"))
+            }
         }
     }
 
@@ -94,6 +186,8 @@ class SitePermissionsRobot {
     }
 
     fun selectRememberPermissionDecision() {
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/do_not_ask_again"))
+            .waitForExists(waitingTime)
         onView(withId(R.id.do_not_ask_again))
             .check(matches(isDisplayed()))
             .click()
@@ -122,13 +216,6 @@ class SitePermissionsRobot {
         }
     }
 }
-
-// App permission prompts buttons
-private val allowSystemPermissionButton =
-    mDevice.findObject(UiSelector().resourceId(getPermissionAllowID() + ":id/permission_allow_button"))
-
-private val denySystemPermissionButton =
-    mDevice.findObject(UiSelector().resourceId(getPermissionAllowID() + ":id/permission_deny_button"))
 
 // Page permission prompts buttons
 private val allowPagePermissionButton =


### PR DESCRIPTION
Had to recreate PR https://github.com/mozilla-mobile/firefox-android/pull/1426.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1824136
https://bugzilla.mozilla.org/show_bug.cgi?id=1828663