### PR TITLE
Bug 1814992 - Add `SyncedTabsList` to `TabsTray`

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,6 +29,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.browser.storage.sync.TabEntry
 import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppState
@@ -38,7 +37,10 @@ import org.mozilla.fenix.compose.Divider
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.tabstray.ext.isNormalTab
 import org.mozilla.fenix.tabstray.inactivetabs.InactiveTabsList
+import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsList
+import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsListItem
 import org.mozilla.fenix.theme.FirefoxTheme
+import mozilla.components.browser.storage.sync.Tab as SyncTab
 
 /**
  * Top-level UI for displaying the Tabs Tray feature.
@@ -62,6 +64,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * close dialog's enable button.
  * @param onInactiveTabClick Invoked when the user clicks on an inactive tab.
  * @param onInactiveTabClose Invoked when the user clicks on an inactive tab's close button.
+ * @param onSyncedTabClick Invoked when the user clicks on a synced tab.
  */
 @OptIn(ExperimentalPagerApi::class, ExperimentalComposeUiApi::class)
 @Suppress("LongMethod", "LongParameterList")
@@ -85,6 +88,7 @@ fun TabsTray(
     onEnableInactiveTabAutoCloseClick: () -> Unit,
     onInactiveTabClick: (TabSessionState) -> Unit,
     onInactiveTabClose: (TabSessionState) -> Unit,
+    onSyncedTabClick: (SyncTab) -> Unit,
 ) {
     val selectedTabId = browserStore
         .observeAsComposableState { state -> state.selectedTabId }.value
@@ -197,11 +201,13 @@ fun TabsTray(
                         )
                     }
                     Page.SyncedTabs -> {
-                        Text(
-                            text = "Synced tabs",
-                            modifier = Modifier.padding(all = 16.dp),
-                            color = FirefoxTheme.colors.textPrimary,
-                            style = FirefoxTheme.typography.body1,
+                        val syncedTabs = tabsTrayStore
+                            .observeAsComposableState { state -> state.syncedTabs }.value ?: emptyList()
+
+                        SyncedTabsList(
+                            syncedTabs = syncedTabs,
+                            taskContinuityEnabled = true,
+                            onTabClick = onSyncedTabClick,
                         )
                     }
                 }
@@ -222,6 +228,7 @@ private fun TabsTrayPreview() {
             tabCount = 7,
             isPrivate = true,
         ),
+        syncedTabs = generateFakeSyncedTabsList(),
     )
 }
 
@@ -262,9 +269,11 @@ private fun TabsTrayPrivateTabsPreview() {
 private fun TabsTraySyncedTabsPreview() {
     TabsTrayPreviewRoot(
         selectedPage = Page.SyncedTabs,
+        syncedTabs = generateFakeSyncedTabsList(deviceCount = 3),
     )
 }
 
+@Suppress("LongMethod", "LongParameterList")
 @Composable
 private fun TabsTrayPreviewRoot(
     displayTabsInGrid: Boolean = true,
@@ -274,6 +283,7 @@ private fun TabsTrayPreviewRoot(
     normalTabs: List<TabSessionState> = emptyList(),
     inactiveTabs: List<TabSessionState> = emptyList(),
     privateTabs: List<TabSessionState> = emptyList(),
+    syncedTabs: List<SyncedTabsListItem> = emptyList(),
     inactiveTabsExpanded: Boolean = false,
     showInactiveTabsAutoCloseDialog: Boolean = false,
 ) {
@@ -281,6 +291,7 @@ private fun TabsTrayPreviewRoot(
     val normalTabsState = remember { normalTabs.toMutableStateList() }
     val inactiveTabsState = remember { inactiveTabs.toMutableStateList() }
     val privateTabsState = remember { privateTabs.toMutableStateList() }
+    val syncedTabsState = remember { syncedTabs.toMutableStateList() }
     var inactiveTabsExpandedState by remember { mutableStateOf(inactiveTabsExpanded) }
     var showInactiveTabsAutoCloseDialogState by remember { mutableStateOf(showInactiveTabsAutoCloseDialog) }
 
@@ -302,6 +313,7 @@ private fun TabsTrayPreviewRoot(
             inactiveTabs = inactiveTabsState,
             normalTabs = normalTabsState,
             privateTabs = privateTabsState,
+            syncedTabs = syncedTabsState,
         ),
     )
 
@@ -347,6 +359,7 @@ private fun TabsTrayPreviewRoot(
             },
             onInactiveTabClick = {},
             onInactiveTabClose = inactiveTabsState::remove,
+            onSyncedTabClick = {},
         )
     }
 }
@@ -361,3 +374,26 @@ private fun generateFakeTabsList(tabCount: Int = 10, isPrivate: Boolean = false)
             ),
         )
     }
+
+private fun generateFakeSyncedTabsList(deviceCount: Int = 1): List<SyncedTabsListItem> =
+    List(deviceCount) { index ->
+        SyncedTabsListItem.DeviceSection(
+            displayName = "Device $index",
+            tabs = listOf(
+                generateFakeSyncedTab("Mozilla", "www.mozilla.org"),
+                generateFakeSyncedTab("Google", "www.google.com"),
+                generateFakeSyncedTab("", "www.google.com"),
+            ),
+        )
+    }
+
+private fun generateFakeSyncedTab(tabName: String, tabUrl: String): SyncedTabsListItem.Tab =
+    SyncedTabsListItem.Tab(
+        tabName.ifEmpty { tabUrl },
+        tabUrl,
+        SyncTab(
+            history = listOf(TabEntry(tabName, tabUrl, null)),
+            active = 0,
+            lastUsed = 0L,
+        ),
+    )

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -252,6 +252,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                         },
                         onInactiveTabClick = tabsTrayInteractor::onInactiveTabClicked,
                         onInactiveTabClose = tabsTrayInteractor::onInactiveTabClosed,
+                        onSyncedTabClick = tabsTrayInteractor::onSyncedTabClicked,
                     )
                 }
             }


### PR DESCRIPTION
Note: the business logic for the FAB has yet to land via https://github.com/mozilla-mobile/firefox-android/pull/1562, so any syncs during testing will need to be manual syncs via Settings.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1814992