### PR TITLE
Bug 1796305 - Address lint unused resources

### DIFF
--- a/android-components/components/browser/errorpages/build.gradle
+++ b/android-components/components/browser/errorpages/build.gradle
@@ -15,13 +15,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    lint {
-        // Lint reports (falsely) a bunch of unused resources for this project. Those resources
-        // are references from Kotlin code and it looks like Android lint can't see those references
-        // yet. Let's disable this check and retry once a newer SDK is available.
-        disable 'UnusedResources'
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/addons/build.gradle
+++ b/android-components/components/feature/addons/build.gradle
@@ -38,9 +38,6 @@ android {
     lint {
         warningsAsErrors true
         abortOnError true
-
-        // https://github.com/mozilla-mobile/android-components/issues/10642
-        disable 'UnusedResources'
     }
 
     buildFeatures {

--- a/android-components/components/ui/icons/build.gradle
+++ b/android-components/components/ui/icons/build.gradle
@@ -12,11 +12,6 @@ android {
         targetSdkVersion config.targetSdkVersion
     }
 
-    lint {
-        // All icons are unused in this module.
-        disable 'UnusedResources'
-    }
-
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
As now Fenix and AC are in the same repo, `lint` can see the resources been used.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1796305