### PR TITLE
Bug 1829372 - Allow PDF files to be opened in third party apps.

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -1011,7 +1011,6 @@ class GeckoEngineSession(
                     mimeType = contentType,
                 )
                 val response = webResponse.toResponse()
-
                 notifyObservers {
                     onExternalResource(
                         url = url,
@@ -1020,6 +1019,8 @@ class GeckoEngineSession(
                         fileName = fileName.sanitizeFileName(),
                         response = response,
                         isPrivate = privateMode,
+                        openInApp = webResponse.doRequestExternalApp,
+                        skipConfirmation = webResponse.doSkipConfirmation,
                     )
                 }
             }

--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -1019,8 +1019,8 @@ class GeckoEngineSession(
                         fileName = fileName.sanitizeFileName(),
                         response = response,
                         isPrivate = privateMode,
-                        openInApp = webResponse.doRequestExternalApp,
-                        skipConfirmation = webResponse.doSkipConfirmation,
+                        openInApp = webResponse.requestExternalApp,
+                        skipConfirmation = webResponse.skipConfirmation,
                     )
                 }
             }

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -344,6 +344,8 @@ class GeckoEngineSessionTest {
             cookie = eq(null),
             userAgent = eq(null),
             isPrivate = eq(true),
+            skipConfirmation = eq(true),
+            openInApp = eq(true),
             response = captor.capture(),
         )
 
@@ -3724,6 +3726,8 @@ class GeckoEngineSessionTest {
                     cookie: String?,
                     userAgent: String?,
                     isPrivate: Boolean,
+                    skipConfirmation: Boolean,
+                    openInApp: Boolean,
                     response: Response?,
                 ) {
                     assertEquals("PDF response is always a success.", RESPONSE_CODE_SUCCESS, response!!.status)
@@ -3756,6 +3760,8 @@ class GeckoEngineSessionTest {
                     cookie: String?,
                     userAgent: String?,
                     isPrivate: Boolean,
+                    skipConfirmation: Boolean,
+                    openInApp: Boolean,
                     response: Response?,
                 ) {
                     assert(false) { "We should not notify observers." }

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -329,6 +329,8 @@ class GeckoEngineSessionTest {
         val response = WebResponse.Builder("https://download.mozilla.org/image.png")
             .addHeader(Headers.Names.CONTENT_TYPE, "image/png")
             .addHeader(Headers.Names.CONTENT_LENGTH, "42")
+            .skipConfirmation(true)
+            .requestExternalApp(true)
             .body(mock())
             .build()
 

--- a/android-components/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
+++ b/android-components/components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt
@@ -461,6 +461,8 @@ class SystemEngineViewTest {
                     cookie: String?,
                     userAgent: String?,
                     isPrivate: Boolean,
+                    skipConfirmation: Boolean,
+                    openInApp: Boolean,
                     response: Response?,
                 ) {
                     assertEquals("https://download.mozilla.org", url)

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
@@ -189,6 +189,8 @@ internal class EngineObserver(
         cookie: String?,
         userAgent: String?,
         isPrivate: Boolean,
+        skipConfirmation: Boolean,
+        openInApp: Boolean,
         response: Response?,
     ) {
         // We want to avoid negative contentLength values
@@ -204,6 +206,8 @@ internal class EngineObserver(
             userAgent,
             Environment.DIRECTORY_DOWNLOADS,
             private = isPrivate,
+            skipConfirmation = skipConfirmation,
+            openInApp = openInApp,
             response = response,
         )
 

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/content/DownloadState.kt
@@ -23,6 +23,8 @@ import java.util.UUID
  * @property filePath The file path the file was saved at.
  * @property referrerUrl The site that linked to this download.
  * @property skipConfirmation Whether or not the confirmation dialog should be shown before the download begins.
+ * @property openInApp Whether or not the file associated with this download should be opened in a
+ * third party app after downloaded successfully.
  * @property id The unique identifier of this download.
  * @property private Indicates if the download was created from a private session.
  * @property createdTime A timestamp when the download was created.
@@ -43,6 +45,7 @@ data class DownloadState(
     val destinationDirectory: String = Environment.DIRECTORY_DOWNLOADS,
     val referrerUrl: String? = null,
     val skipConfirmation: Boolean = false,
+    val openInApp: Boolean = false,
     val id: String = UUID.randomUUID().toString(),
     val sessionId: String? = null,
     val private: Boolean = false,

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -247,6 +247,9 @@ abstract class EngineSession(
          * @param contentType The type of content to be downloaded.
          * @param cookie The cookie related to request.
          * @param userAgent The user agent of the engine.
+         * @param skipConfirmation Whether or not the confirmation dialog should be shown before the download begins.
+         * @param openInApp Whether or not the associated resource should be opened in a third party
+         * app after processed successfully.
          * @param isPrivate Indicates if the download was requested from a private session.
          * @param response A response object associated with this request, when provided can be
          * used instead of performing a manual a download.
@@ -260,6 +263,8 @@ abstract class EngineSession(
             cookie: String? = null,
             userAgent: String? = null,
             isPrivate: Boolean = false,
+            skipConfirmation: Boolean = false,
+            openInApp: Boolean = false,
             response: Response? = null,
         ) = Unit
 

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -650,6 +650,8 @@ class EngineSessionTest {
                 contentType = "application/vnd.android.package-archive",
                 cookie = "PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;",
                 isPrivate = true,
+                skipConfirmation = false,
+                openInApp = false,
                 userAgent = "Components/1.0",
             )
         }
@@ -661,6 +663,8 @@ class EngineSessionTest {
             contentType = "application/vnd.android.package-archive",
             cookie = "PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;",
             isPrivate = true,
+            skipConfirmation = false,
+            openInApp = false,
             userAgent = "Components/1.0",
         )
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* * **browser-state**
+  * 🌟 Added `DownloadState`.`openInApp` to indicate whether or not the file associated with the download should be opened in a third party app after downloaded successfully, for more information see [bug 1829371](https://bugzilla.mozilla.org/show_bug.cgi?id=1829371) and [bug 1829372](https://bugzilla.mozilla.org/show_bug.cgi?id=1829372).
+
 # 113.0.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v112..releases_v113)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/releases_v113/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -168,7 +168,7 @@ abstract class BaseBrowserFragment :
     AccessibilityManager.AccessibilityStateChangeListener {
 
     private var _binding: FragmentBrowserBinding? = null
-    protected val binding get() = _binding!!
+    internal val binding get() = _binding!!
 
     private lateinit var browserFragmentStore: BrowserFragmentStore
     private lateinit var browserAnimator: BrowserAnimator
@@ -221,7 +221,7 @@ abstract class BaseBrowserFragment :
     private var initUIJob: Job? = null
     protected var webAppToolbarShouldBeVisible = true
 
-    private val sharedViewModel: SharedViewModel by activityViewModels()
+    internal val sharedViewModel: SharedViewModel by activityViewModels()
     private val homeViewModel: HomeScreenViewModel by activityViewModels()
 
     private var currentStartDownloadDialog: StartDownloadDialog? = null
@@ -577,29 +577,7 @@ abstract class BaseBrowserFragment :
         )
 
         downloadFeature.onDownloadStopped = { downloadState, _, downloadJobStatus ->
-            // If the download is just paused, don't show any in-app notification
-            if (shouldShowCompletedDownloadDialog(downloadState, downloadJobStatus)) {
-                saveDownloadDialogState(
-                    downloadState.sessionId,
-                    downloadState,
-                    downloadJobStatus,
-                )
-
-                val dynamicDownloadDialog = DynamicDownloadDialog(
-                    context = context,
-                    downloadState = downloadState,
-                    didFail = downloadJobStatus == DownloadState.Status.FAILED,
-                    tryAgain = downloadFeature::tryAgain,
-                    onCannotOpenFile = {
-                        showCannotOpenFileError(binding.dynamicSnackbarContainer, context, it)
-                    },
-                    binding = binding.viewDynamicDownloadDialog,
-                    toolbarHeight = toolbarHeight,
-                ) { sharedViewModel.downloadDialogState.remove(downloadState.sessionId) }
-
-                dynamicDownloadDialog.show()
-                browserToolbarView.expand()
-            }
+            handleOnDownloadFinished(downloadState, downloadJobStatus, downloadFeature::tryAgain)
         }
 
         resumeDownloadDialogState(
@@ -1005,7 +983,7 @@ abstract class BaseBrowserFragment :
      * Preserves current state of the [DynamicDownloadDialog] to persist through tab changes and
      * other fragments navigation.
      * */
-    private fun saveDownloadDialogState(
+    internal fun saveDownloadDialogState(
         sessionId: String?,
         downloadState: DownloadState,
         downloadJobStatus: DownloadState.Status,
@@ -1544,7 +1522,7 @@ abstract class BaseBrowserFragment :
         )
     }
 
-    private fun showCannotOpenFileError(
+    internal fun showCannotOpenFileError(
         container: ViewGroup,
         context: Context,
         downloadState: DownloadState,
@@ -1608,7 +1586,6 @@ abstract class BaseBrowserFragment :
     @VisibleForTesting
     internal fun getSwipeRefreshLayout() = binding.swipeRefresh
 
-    @VisibleForTesting
     internal fun shouldShowCompletedDownloadDialog(
         downloadState: DownloadState,
         status: DownloadState.Status,

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/DownloadUtils.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/DownloadUtils.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.browser
+
+import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.browser.state.state.content.DownloadState.Status
+import mozilla.components.feature.downloads.AbstractFetchDownloadService
+import org.mozilla.fenix.R
+import org.mozilla.fenix.downloads.DynamicDownloadDialog
+
+internal fun BaseBrowserFragment.handleOnDownloadFinished(
+    downloadState: DownloadState,
+    downloadJobStatus: Status,
+    tryAgain: (String) -> Unit,
+) {
+    // If the download is just paused, don't show any in-app notification
+    if (shouldShowCompletedDownloadDialog(downloadState, downloadJobStatus)) {
+        val safeContext = context ?: return
+        val onCannotOpenFile: (DownloadState) -> Unit = {
+            showCannotOpenFileError(binding.dynamicSnackbarContainer, safeContext, it)
+        }
+        if (downloadState.openInApp && downloadJobStatus == Status.COMPLETED) {
+            val fileWasOpened = AbstractFetchDownloadService.openFile(
+                applicationContext = safeContext.applicationContext,
+                download = downloadState,
+            )
+            if (!fileWasOpened) {
+                onCannotOpenFile(downloadState)
+            }
+        } else {
+            saveDownloadDialogState(
+                downloadState.sessionId,
+                downloadState,
+                downloadJobStatus,
+            )
+
+            val dynamicDownloadDialog = DynamicDownloadDialog(
+                context = safeContext,
+                downloadState = downloadState,
+                didFail = downloadJobStatus == Status.FAILED,
+                tryAgain = tryAgain,
+                onCannotOpenFile = onCannotOpenFile,
+                binding = binding.viewDynamicDownloadDialog,
+                toolbarHeight = resources.getDimensionPixelSize(R.dimen.browser_toolbar_height),
+            ) { sharedViewModel.downloadDialogState.remove(downloadState.sessionId) }
+
+            dynamicDownloadDialog.show()
+            browserToolbarView.expand()
+        }
+    }
+}


### PR DESCRIPTION
Depends on https://bugzilla.mozilla.org/show_bug.cgi?id=1829159
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1829371
https://bugzilla.mozilla.org/show_bug.cgi?id=1829372