### PR TITLE
Bug 1829600 - Create new "No internet connection" and "Address not found" UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BrowsingErrorPagesTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BrowsingErrorPagesTest.kt
@@ -11,10 +11,12 @@ import org.junit.Test
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.setNetworkEnabled
 import org.mozilla.fenix.ui.robots.browserScreen
+import org.mozilla.fenix.ui.robots.clickPageObject
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
 /**
@@ -110,6 +112,19 @@ class BrowsingErrorPagesTest {
         }.refreshPage {
             waitForPageToLoad()
             verifyPageContent("Example Domain")
+        }
+    }
+
+    @Test
+    fun addressNotFoundErrorMessageTest() {
+        val url = "ww.example.com"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(url.toUri()) {
+            waitForPageToLoad()
+            verifyAddressNotFoundErrorMessage()
+            clickPageObject(itemWithResId("errorTryAgain"))
+            verifyAddressNotFoundErrorMessage()
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BrowsingErrorPagesTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BrowsingErrorPagesTest.kt
@@ -127,4 +127,24 @@ class BrowsingErrorPagesTest {
             verifyAddressNotFoundErrorMessage()
         }
     }
+
+    @Test
+    fun noInternetConnectionErrorMessageTest() {
+        val url = "www.example.com"
+
+        setNetworkEnabled(false)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(url.toUri()) {
+            verifyNoInternetConnectionErrorMessage()
+        }
+
+        setNetworkEnabled(true)
+
+        browserScreen {
+            clickPageObject(itemWithResId("errorTryAgain"))
+            waitForPageToLoad()
+            verifyPageContent("Example Domain")
+        }
+    }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -805,6 +805,13 @@ class BrowserRobot {
         assertItemWithResIdExists(itemWithResId("errorTryAgain"))
     }
 
+    fun verifyAddressNotFoundErrorMessage() {
+        assertItemContainingTextExists(
+            itemContainingText(getStringResource(R.string.mozac_browser_errorpages_unknown_host_title)),
+        )
+        assertItemWithResIdExists(itemWithResId("errorTryAgain"))
+    }
+
     class Transition {
         fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
             mDevice.waitForIdle(waitingTime)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -812,6 +812,13 @@ class BrowserRobot {
         assertItemWithResIdExists(itemWithResId("errorTryAgain"))
     }
 
+    fun verifyNoInternetConnectionErrorMessage() {
+        assertItemContainingTextExists(
+            itemContainingText(getStringResource(R.string.mozac_browser_errorpages_no_internet_title)),
+        )
+        assertItemWithResIdExists(itemWithResId("errorTryAgain"))
+    }
+
     class Transition {
         fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
             mDevice.waitForIdle(waitingTime)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -799,8 +799,6 @@ class BrowserRobot {
     fun verifyConnectionErrorMessage() {
         assertItemContainingTextExists(
             itemContainingText(getStringResource(R.string.mozac_browser_errorpages_connection_failure_title)),
-            itemContainingText("The site could be temporarily unavailable or too busy. Try again in a few moments."),
-            itemContainingText("If you are unable to load any pages, check your device’s data or Wi-Fi connection."),
         )
         assertItemWithResIdExists(itemWithResId("errorTryAgain"))
     }


### PR DESCRIPTION
Bug 1829600 - Create new "No internet connection" and "Address not found" UI tests

✅ Both tests successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1829600