### PR TITLE
Bug 1829864 - Revert "Bug 1805651 - Update taskgraph to 5.1.0 and use index-path-regexes"

### DIFF
--- a/taskcluster/android_taskgraph/__init__.py
+++ b/taskcluster/android_taskgraph/__init__.py
@@ -27,7 +27,7 @@ def register(graph_config):
     Import all modules that are siblings of this one, triggering decorators in
     the process.
     """
-    _import_modules(["job", "routes", "target_tasks", "worker_types", "release_promotion"])
+    _import_modules(["job", "routes", "target_tasks", "worker_types", "release_promotion", "morph"])
 
 
 def _import_modules(modules):

--- a/taskcluster/android_taskgraph/morph.py
+++ b/taskcluster/android_taskgraph/morph.py
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+
+from taskgraph.morph import _SCOPE_SUMMARY_REGEXPS
+
+# TODO Bug 1805651: let taskgraph allow us to specify this route
+_SCOPE_SUMMARY_REGEXPS.append(
+    re.compile(r"(index:insert-task:mobile\.v3.[^.]*\.).*")
+)

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -177,8 +177,6 @@ taskgraph:
             name: firefox-android
     cached-task-prefix: mobile.v2.firefox-android
     decision-parameters: 'android_taskgraph:get_decision_parameters'
-    index-path-regexes:
-        - 'mobile\.v3.[^.]*\.).*'
 
 workers:
     aliases:

--- a/taskcluster/requirements.in
+++ b/taskcluster/requirements.in
@@ -3,4 +3,4 @@
 
 mozilla-version
 redo
-taskcluster-taskgraph >= 5.1.0
+taskcluster-taskgraph >= 3.2.0

--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -277,9 +277,9 @@ slugid==2.0.0 \
     --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297 \
     --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c
     # via taskcluster-taskgraph
-taskcluster-taskgraph==5.1.0 \
-    --hash=sha256:12d1fa73c9149400458018d78d1c2a33912f290283c16bfaf9bd356051a11dc7 \
-    --hash=sha256:93df9c2a2f94411a88788f79fbcc51576003a8d7795af70b195f123ff3886777
+taskcluster-taskgraph==5.0.1 \
+    --hash=sha256:8e48532d183f781910556d1b134c0765f451548bd52820cbca26e94f4564311d \
+    --hash=sha256:a7b9fc3e27d1f96089b4d106b7404d55affed98ad278dd8759d81875350de320
     # via -r requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-android#1703 until we fix the regression in taskgraph.

https://bugzilla.mozilla.org/show_bug.cgi?id=1829864
https://bugzilla.mozilla.org/show_bug.cgi?id=1805651
https://bugzilla.mozilla.org/show_bug.cgi?id=1805651
https://bugzilla.mozilla.org/show_bug.cgi?id=1805651