### PR TITLE
Bug 1829937 - Remove "Always" as an option for app links in private browsing

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -113,7 +113,7 @@ class SettingsAdvancedTest {
                 verifyOpenLinksInAppsButton()
                 verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
-                verifyOpenLinksInAppsView("Never")
+                verifyPrivateOpenLinksInAppsView("Never")
             }
         }
     }
@@ -169,7 +169,7 @@ class SettingsAdvancedTest {
                 verifyOpenLinksInAppsButton()
                 verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
-                verifyOpenLinksInAppsView("Never")
+                verifyPrivateOpenLinksInAppsView("Never")
             }
 
             exitMenu()
@@ -251,7 +251,7 @@ class SettingsAdvancedTest {
                 verifyOpenLinksInAppsButton()
                 verifySettingsOptionSummary("Open links in apps", "Never")
             }.openOpenLinksInAppsMenu {
-                verifyOpenLinksInAppsView("Never")
+                verifyPrivateOpenLinksInAppsView("Never")
                 clickOpenLinkInAppOption("Ask before opening")
                 verifySelectedOpenLinksInAppOption("Ask before opening")
             }.goBack {
@@ -309,55 +309,6 @@ class SettingsAdvancedTest {
             navigationToolbar {
             }.enterURLAndEnterToBrowser(defaultWebPage.url) {
                 clickPageObject(itemContainingText("Youtube link"))
-                mDevice.waitForIdle()
-                assertYoutubeAppOpens()
-            }
-        }
-    }
-
-    // Assumes Youtube is installed and enabled
-    @Test
-    fun privateBrowsingAlwaysOpenLinkInAppTest() {
-        runWithCondition(
-            // Returns the GeckoView channel set for the current version, if a feature is limited to Nightly or Beta.
-            // Once this feature lands in RC we should remove the wrapper.
-            activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.NIGHTLY ||
-                activityIntentTestRule.activity.components.core.engine.version.releaseChannel == EngineReleaseChannel.BETA,
-        ) {
-            val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
-
-            homeScreen {
-            }.togglePrivateBrowsingMode()
-
-            homeScreen {
-            }.openThreeDotMenu {
-            }.openSettings {
-                verifyOpenLinksInAppsButton()
-                verifySettingsOptionSummary("Open links in apps", "Never")
-            }.openOpenLinksInAppsMenu {
-                verifyOpenLinksInAppsView("Never")
-                clickOpenLinkInAppOption("Always")
-                verifySelectedOpenLinksInAppOption("Always")
-            }.goBack {
-                verifySettingsOptionSummary("Open links in apps", "Always")
-            }
-
-            exitMenu()
-
-            navigationToolbar {
-            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-                clickPageObject(itemContainingText("Youtube link"))
-                verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
-                clickPageObject(itemWithResIdAndText("android:id/button2", "CANCEL"))
-                waitForPageToLoad()
-                verifyUrl("youtube.com")
-            }
-
-            navigationToolbar {
-            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-                clickPageObject(itemContainingText("Youtube link"))
-                verifyPrivateBrowsingOpenLinkInAnotherAppPrompt("youtube.com")
-                clickPageObject(itemWithResIdAndText("android:id/button1", "OPEN"))
                 mDevice.waitForIdle()
                 assertYoutubeAppOpens()
             }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuOpenLinksInAppsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuOpenLinksInAppsRobot.kt
@@ -36,6 +36,16 @@ class SettingsSubMenuOpenLinksInAppsRobot {
         verifySelectedOpenLinksInAppOption(selectedOpenLinkInAppsOption)
     }
 
+    fun verifyPrivateOpenLinksInAppsView(selectedOpenLinkInAppsOption: String) {
+        assertItemWithDescriptionExists(goBackButton)
+        assertItemContainingTextExists(
+            itemContainingText(getStringResource(R.string.preferences_open_links_in_apps)),
+            itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_ask)),
+            itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_never)),
+        )
+        verifySelectedOpenLinksInAppOption(selectedOpenLinkInAppsOption)
+    }
+
     fun verifySelectedOpenLinksInAppOption(openLinkInAppsOption: String) =
         onView(
             allOf(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/OpenLinksInAppsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/OpenLinksInAppsFragment.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.settings
 import android.os.Bundle
 import androidx.preference.PreferenceFragmentCompat
 import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.utils.view.addToRadioGroup
@@ -21,6 +22,13 @@ class OpenLinksInAppsFragment : PreferenceFragmentCompat() {
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.open_links_in_apps_preferences, rootKey)
+
+        radioAlways = requirePreference(R.string.pref_key_open_links_in_apps_always)
+        radioAskBeforeOpening = requirePreference(R.string.pref_key_open_links_in_apps_ask)
+        radioNever = requirePreference(R.string.pref_key_open_links_in_apps_never)
+
+        /* only show the Always option in normal browsing mode */
+        radioAlways.isVisible = requireContext().settings().lastKnownMode == BrowsingMode.Normal
     }
 
     override fun onResume() {
@@ -31,13 +39,15 @@ class OpenLinksInAppsFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupPreferences() {
-        radioAlways = requirePreference(R.string.pref_key_open_links_in_apps_always)
-        radioAskBeforeOpening = requirePreference(R.string.pref_key_open_links_in_apps_ask)
-        radioNever = requirePreference(R.string.pref_key_open_links_in_apps_never)
-
         when (requireContext().settings().openLinksInExternalApp) {
             getString(R.string.pref_key_open_links_in_apps_always) ->
-                radioAlways.setCheckedWithoutClickListener(true)
+                if (requireContext().settings().lastKnownMode == BrowsingMode.Normal) {
+                    radioAlways.setCheckedWithoutClickListener(true)
+                    radioAskBeforeOpening.setCheckedWithoutClickListener(false)
+                } else {
+                    radioAlways.setCheckedWithoutClickListener(false)
+                    radioAskBeforeOpening.setCheckedWithoutClickListener(true)
+                }
             getString(R.string.pref_key_open_links_in_apps_ask) ->
                 radioAskBeforeOpening.setCheckedWithoutClickListener(true)
             getString(R.string.pref_key_open_links_in_apps_never) ->

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -41,7 +41,6 @@ import org.mozilla.fenix.components.settings.lazyFeatureFlagPreference
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.nimbus.CookieBannersSection
 import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.nimbus.HomeScreenSection
@@ -533,9 +532,13 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      * Get the display string for the current open links in apps setting
      */
     fun getOpenLinksInAppsString(): String =
-        when (appContext.settings().openLinksInExternalApp) {
+        when (openLinksInExternalApp) {
             appContext.getString(R.string.pref_key_open_links_in_apps_always) -> {
-                appContext.getString(R.string.preferences_open_links_in_apps_always)
+                if (lastKnownMode == BrowsingMode.Normal) {
+                    appContext.getString(R.string.preferences_open_links_in_apps_always)
+                } else {
+                    appContext.getString(R.string.preferences_open_links_in_apps_ask)
+                }
             }
             appContext.getString(R.string.pref_key_open_links_in_apps_ask) -> {
                 appContext.getString(R.string.preferences_open_links_in_apps_ask)

--- a/fenix/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -21,6 +21,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
@@ -932,5 +933,28 @@ class SettingsTest {
     @Test
     fun `GIVEN unset user preferences THEN https-only is disabled for private tabs`() {
         assertFalse(settings.shouldUseHttpsOnlyInPrivateTabsOnly)
+    }
+
+    @Test
+    fun `GIVEN open links in apps setting THEN return the correct display string`() {
+        settings.openLinksInExternalApp = "pref_key_open_links_in_apps_always"
+        settings.lastKnownMode = BrowsingMode.Normal
+        assertEquals(settings.getOpenLinksInAppsString(), "Always")
+
+        settings.openLinksInExternalApp = "pref_key_open_links_in_apps_ask"
+        assertEquals(settings.getOpenLinksInAppsString(), "Ask before opening")
+
+        settings.openLinksInExternalApp = "pref_key_open_links_in_apps_never"
+        assertEquals(settings.getOpenLinksInAppsString(), "Never")
+
+        settings.openLinksInExternalApp = "pref_key_open_links_in_apps_always"
+        settings.lastKnownMode = BrowsingMode.Private
+        assertEquals(settings.getOpenLinksInAppsString(), "Ask before opening")
+
+        settings.openLinksInExternalApp = "pref_key_open_links_in_apps_ask"
+        assertEquals(settings.getOpenLinksInAppsString(), "Ask before opening")
+
+        settings.openLinksInExternalApp = "pref_key_open_links_in_apps_never"
+        assertEquals(settings.getOpenLinksInAppsString(), "Never")
     }
 }


### PR DESCRIPTION
Right now even if the user set "Open links in apps" as "Always" we still prompt the user in private browsing in order to protect user's policy.  To reflect this behaviour in settings, removing "Always" as an option in private browsing.

If the user set the option to "Always", in private browsing mode the "Open links in apps" setting will still say "Ask before opening".

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1829937