### PR TITLE
Bug 1830045 - New search bookmarks UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -344,18 +344,21 @@ object TestHelper {
 
     // Permission allow dialogs differ on various Android APIs
     fun grantSystemPermission() {
+        val whileUsingTheAppPermissionButton: UiObject =
+            mDevice.findObject(UiSelector().textContains("While using the app"))
+
+        val allowPermissionButton: UiObject =
+            mDevice.findObject(
+                UiSelector()
+                    .textContains("Allow")
+                    .className("android.widget.Button"),
+            )
+
         if (Build.VERSION.SDK_INT >= 23) {
-            if (mDevice.findObject(UiSelector().textContains("While using the app")).waitForExists(
-                    waitingTimeShort,
-                )
-            ) {
-                mDevice.findObject(UiSelector().textContains("While using the app")).click()
-            } else {
-                mDevice.findObject(
-                    UiSelector()
-                        .textContains("Allow")
-                        .className("android.widget.Button"),
-                ).click()
+            if (whileUsingTheAppPermissionButton.waitForExists(waitingTimeShort)) {
+                whileUsingTheAppPermissionButton.click()
+            } else if (allowPermissionButton.waitForExists(waitingTimeShort)) {
+                allowPermissionButton.click()
             }
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -6,7 +6,6 @@
 
 package org.mozilla.fenix.ui.robots
 
-import android.os.Build
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
@@ -45,6 +44,7 @@ import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
+import org.mozilla.fenix.helpers.TestHelper.grantSystemPermission
 import org.mozilla.fenix.helpers.TestHelper.isPackageInstalled
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
@@ -70,25 +70,10 @@ class SearchRobot {
     // Device or AVD requires a Google Services Android OS installation
     fun startVoiceSearch() {
         voiceSearchButton.click()
+        grantSystemPermission()
 
-        // Accept runtime permission (API 30) for Google Voice
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
-            val allowPermission = mDevice.findObject(
-                UiSelector().text(
-                    when {
-                        Build.VERSION.SDK_INT == Build.VERSION_CODES.R -> "Allow all the time"
-                        else -> "While using the app"
-                    },
-                ),
-            )
-
-            if (allowPermission.exists()) {
-                allowPermission.click()
-            }
-
-            if (isPackageInstalled(Constants.PackageName.GOOGLE_QUICK_SEARCH)) {
-                Intents.intended(IntentMatchers.hasAction(SPEECH_RECOGNITION))
-            }
+        if (isPackageInstalled(Constants.PackageName.GOOGLE_QUICK_SEARCH)) {
+            Intents.intended(IntentMatchers.hasAction(SPEECH_RECOGNITION))
         }
     }
 


### PR DESCRIPTION
Created new search bookmarks related UI tests based on our [manual tests](https://testrail.stage.mozaws.net/index.php?/suites/view/3192&group_by=cases:section_id&group_id=274060&group_order=asc).
All tests successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1830045