### PR TITLE
Bug 1821593 - Avoid metric recording errors for extensions lists.

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -7052,6 +7052,31 @@ addons:
     metadata:
       tags:
         - WebExtensions
+  installed_addons_extra:
+    type: string_list
+    description: |
+      A list of all installed add-ons on the device.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/8920
+      - https://github.com/mozilla-mobile/fenix/issues/19923
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1821593
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/11080
+      - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
+      - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
+      - https://github.com/mozilla-mobile/fenix/pull/21788#issuecomment-950022224
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - cgordon@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - WebExtensions
   enabled_addons:
     type: string_list
     description: |
@@ -7061,6 +7086,31 @@ addons:
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/8920
       - https://github.com/mozilla-mobile/fenix/issues/19923
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/11080
+      - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
+      - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
+      - https://github.com/mozilla-mobile/fenix/pull/21316#issuecomment-944615938
+      - https://github.com/mozilla-mobile/fenix/pull/25405#issuecomment-1139058237
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 116
+    metadata:
+      tags:
+        - WebExtensions
+  enabled_addons_extra:
+    type: string_list
+    description: |
+      A list of all enabled add-ons on the device.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/8920
+      - https://github.com/mozilla-mobile/fenix/issues/19923
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1821593
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11080
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -741,14 +741,22 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
             val installedAddonSize = settings.installedAddonsCount
             Addons.hasInstalledAddons.set(installedAddonSize > 0)
+            val installedAddonsList = settings.installedAddonsList.split(',').map {
+                it.take(50)
+            }
+
             if (installedAddonSize > 0) {
-                Addons.installedAddons.set(settings.installedAddonsList.split(','))
+                Addons.installedAddons.set(installedAddonsList)
             }
 
             val enabledAddonSize = settings.enabledAddonsCount
             Addons.hasEnabledAddons.set(enabledAddonSize > 0)
+            val enabledAddonsList = settings.enabledAddonsList.split(',').map {
+                it.take(50)
+            }
+
             if (enabledAddonSize > 0) {
-                Addons.enabledAddons.set(settings.enabledAddonsList.split(','))
+                Addons.enabledAddons.set(enabledAddonsList)
             }
 
             val desktopBookmarksSize = settings.desktopBookmarksSize

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -746,7 +746,8 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             }
 
             if (installedAddonSize > 0) {
-                Addons.installedAddons.set(installedAddonsList)
+                Addons.installedAddons.set(installedAddonsList.take(20))
+                Addons.installedAddonsExtra.set(installedAddonsList.subList(20, 39))
             }
 
             val enabledAddonSize = settings.enabledAddonsCount
@@ -756,7 +757,8 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             }
 
             if (enabledAddonSize > 0) {
-                Addons.enabledAddons.set(enabledAddonsList)
+                Addons.enabledAddons.set(enabledAddonsList.take(20))
+                Addons.enabledAddonsExtra.set(enabledAddonsList.subList(20, 39))
             }
 
             val desktopBookmarksSize = settings.desktopBookmarksSize


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821593