### PR TITLE
Bug 1820122 - Do not run gradle 'test' in external-gradle-dependencies-fenix

### DIFF
--- a/taskcluster/android_taskgraph/transforms/external_gradle_dependencies.py
+++ b/taskcluster/android_taskgraph/transforms/external_gradle_dependencies.py
@@ -106,7 +106,7 @@ def _get_gradle_task_names(gradle_project):
     if gradle_project == "focus":
         gradle_tasks_name.extend(["assembleFocusDebug", "assembleAndroidTest", "testFocusDebugUnitTest", "lint"])
     elif gradle_project == "fenix":
-        gradle_tasks_name.extend(["assemble", "assembleAndroidTest", "testClasses", "test", "lint"])
+        gradle_tasks_name.extend(["assemble", "assembleAndroidTest", "testClasses", "lint"])
     else:
         lint_task_name = "lint" if gradle_project in ("tooling-lint", "samples-browser") else "lintRelease"
         gradle_tasks_name.extend(["assemble", "assembleAndroidTest", "test", lint_task_name])


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1820122