### PR TITLE
Bug 1810197 - Revert "Fix condition of changeExtension".

### DIFF
--- a/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
+++ b/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/DownloadUtils.kt
@@ -344,7 +344,7 @@ object DownloadUtils {
             // Compare the last segment of the extension against the mime type.
             // If there's a mismatch, discard the entire extension.
             val typeFromExt = mimeTypeMap.getMimeTypeFromExtension(filename.substringAfterLast('.'))
-            if (typeFromExt?.equals(mimeType, ignoreCase = true) != true) {
+            if (typeFromExt?.equals(mimeType, ignoreCase = true) != false) {
                 extension = mimeTypeMap.getExtensionFromMimeType(mimeType)?.let { ".$it" }
                 // Check if the extension needs to be changed
                 if (extension != null && filename.endsWith(extension, ignoreCase = true)) {

--- a/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
+++ b/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt
@@ -111,20 +111,8 @@ class DownloadUtilsTest {
         Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("zip", "application/zip")
         Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("tar.gz", "application/gzip")
 
-        // For one mimetype to multiple extensions mapping
-        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("com", "application/x-msdos-program")
-        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("exe", "application/x-msdos-program")
-        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("bat", "application/x-msdos-program")
-        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("dll", "application/x-msdos-program")
-        // Matches the last inserted extension
-        assertEquals("dll", MimeTypeMap.getSingleton().getExtensionFromMimeType("application/x-msdos-program"))
-        assertEquals("application/x-msdos-program", MimeTypeMap.getSingleton().getMimeTypeFromExtension("exe"))
-
         assertEquals("file.jpg", DownloadUtils.guessFileName(null, null, "http://example.com/file.jpg", "image/jpeg"))
-
-        // This is difference with URLUtil.guessFileName
         assertEquals("file.jpg", DownloadUtils.guessFileName(null, null, "http://example.com/file.bin", "image/jpeg"))
-
         assertEquals(
             "Caesium-wahoo-v3.6-b792615ced1b.zip",
             DownloadUtils.guessFileName(null, null, "https://download.msfjarvis.website/caesium/wahoo/beta/Caesium-wahoo-v3.6-b792615ced1b.zip", "application/zip"),
@@ -140,11 +128,6 @@ class DownloadUtilsTest {
         assertEquals("file.data", DownloadUtils.guessFileName(null, null, "http://example.com/file.data", "application/octet-stream"))
         assertEquals("file.data", DownloadUtils.guessFileName(null, null, "http://example.com/file.data", "binary/octet-stream"))
         assertEquals("file.data", DownloadUtils.guessFileName(null, null, "http://example.com/file.data", "application/unknown"))
-
-        assertEquals("file.jpg", DownloadUtils.guessFileName(null, null, "http://example.com/file.zip", "image/jpeg"))
-        // Should not change to file.dll
-        assertEquals("file.exe", DownloadUtils.guessFileName(null, null, "http://example.com/file.exe", "application/x-msdos-program"))
-        assertEquals("file.exe", DownloadUtils.guessFileName(null, null, "http://example.com/file.exe", "application/vnd.microsoft.portable-executable"))
     }
 
     @Test


### PR DESCRIPTION
The previous fix, addressed the specific issue but introduce an unwanted code path no addressing the general issue, lets revert for now until we have general solution.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1810197