### PR TITLE
Bug 1817999 - Support nullable bookmark interactor

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/library/LibrarySiteItemView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/LibrarySiteItemView.kt
@@ -68,19 +68,19 @@ class LibrarySiteItemView @JvmOverloads constructor(
         }
     }
 
-    fun <T> setSelectionInteractor(item: T, holder: SelectionHolder<T>, interactor: SelectionInteractor<T>) {
+    fun <T> setSelectionInteractor(item: T, holder: SelectionHolder<T>, interactor: SelectionInteractor<T>?) {
         setOnClickListener {
             val selected = holder.selectedItems
             when {
-                selected.isEmpty() -> interactor.open(item)
-                item in selected -> interactor.deselect(item)
-                else -> interactor.select(item)
+                selected.isEmpty() -> interactor?.open(item)
+                item in selected -> interactor?.deselect(item)
+                else -> interactor?.select(item)
             }
         }
 
         setOnLongClickListener {
             if (holder.selectedItems.isEmpty()) {
-                interactor.select(item)
+                interactor?.select(item)
                 true
             } else {
                 false
@@ -89,9 +89,9 @@ class LibrarySiteItemView @JvmOverloads constructor(
 
         iconView.setOnClickListener {
             if (item in holder.selectedItems) {
-                interactor.deselect(item)
+                interactor?.deselect(item)
             } else {
-                interactor.select(item)
+                interactor?.select(item)
             }
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -18,7 +18,7 @@ import org.mozilla.fenix.library.LibrarySiteItemView
 import org.mozilla.fenix.library.bookmarks.viewholders.BookmarkNodeViewHolder
 import org.mozilla.fenix.library.bookmarks.viewholders.BookmarkSeparatorViewHolder
 
-class BookmarkAdapter(private val emptyView: View, private val interactor: BookmarkViewInteractor) :
+class BookmarkAdapter(private val emptyView: View, private val interactor: BookmarkViewInteractor?) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     @VisibleForTesting var tree: List<BookmarkNode> = listOf()

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListener.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListener.kt
@@ -14,7 +14,7 @@ import org.mozilla.fenix.R
 class BookmarkDeselectNavigationListener(
     private val navController: NavController,
     private val viewModel: BookmarksSharedViewModel,
-    private val bookmarkInteractor: BookmarkViewInteractor,
+    private val bookmarkInteractor: BookmarkViewInteractor?,
 ) : NavController.OnDestinationChangedListener, DefaultLifecycleObserver {
 
     override fun onResume(owner: LifecycleOwner) {
@@ -31,7 +31,7 @@ class BookmarkDeselectNavigationListener(
     override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {
         if (destination.id != R.id.bookmarkFragment || differentFromSelectedFolder(arguments)) {
             // TODO this is currently called when opening the bookmark menu. Fix this if possible
-            bookmarkInteractor.onAllBookmarksDeselected()
+            bookmarkInteractor?.onAllBookmarksDeselected()
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -67,8 +67,8 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
     private lateinit var bookmarkStore: BookmarkFragmentStore
     private lateinit var bookmarkView: BookmarkView
     private var _bookmarkInteractor: BookmarkFragmentInteractor? = null
-    private val bookmarkInteractor: BookmarkFragmentInteractor
-        get() = _bookmarkInteractor!!
+    private val bookmarkInteractor: BookmarkFragmentInteractor?
+        get() = _bookmarkInteractor
 
     private val sharedViewModel: BookmarksSharedViewModel by activityViewModels()
     private val desktopFolders by lazy { DesktopFolders(requireContext(), showMobileRoot = false) }
@@ -171,7 +171,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
             val currentRoot = loadBookmarkNode(currentGuid)
 
             if (isActive && currentRoot != null) {
-                bookmarkInteractor.onBookmarksChanged(currentRoot)
+                bookmarkInteractor?.onBookmarksChanged(currentRoot)
             }
         }
     }
@@ -204,7 +204,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
     override fun onMenuItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.bookmark_search -> {
-                bookmarkInteractor.onSearch()
+                bookmarkInteractor?.onSearch()
                 true
             }
             R.id.close_bookmarks -> {
@@ -285,7 +285,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
         loadBookmarkNode(currentGuid)
             ?.let { node ->
                 val rootNode = node - pendingBookmarksToDelete
-                bookmarkInteractor.onBookmarksChanged(rootNode)
+                bookmarkInteractor?.onBookmarksChanged(rootNode)
             }
     }
 
@@ -420,7 +420,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
         pendingBookmarksToDelete.addAll(selected)
         val selectedFolder = sharedViewModel.selectedFolder ?: return
         val bookmarkTree = selectedFolder - pendingBookmarksToDelete
-        bookmarkInteractor.onBookmarksChanged(bookmarkTree)
+        bookmarkInteractor?.onBookmarksChanged(bookmarkTree)
     }
 
     private suspend fun undoPendingDeletion(selected: Set<BookmarkNode>) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -120,7 +120,7 @@ interface BookmarkViewInteractor : SelectionInteractor<BookmarkNode> {
 
 class BookmarkView(
     container: ViewGroup,
-    val interactor: BookmarkViewInteractor,
+    val interactor: BookmarkViewInteractor?,
     private val navController: NavController,
 ) : LibraryPageView(container), UserInteractionHandler {
 
@@ -143,7 +143,7 @@ class BookmarkView(
             navController.navigate(NavGraphDirections.actionGlobalTurnOnSync())
         }
         binding.swipeRefresh.setOnRefreshListener {
-            interactor.onRequestSync()
+            interactor?.onRequestSync()
         }
     }
 
@@ -152,7 +152,7 @@ class BookmarkView(
         if (state.mode != mode) {
             mode = state.mode
             if (mode is BookmarkFragmentState.Mode.Normal || mode is BookmarkFragmentState.Mode.Selecting) {
-                interactor.onSelectionModeSwitch(mode)
+                interactor?.onSelectionModeSwitch(mode)
             }
         }
 
@@ -183,11 +183,11 @@ class BookmarkView(
     override fun onBackPressed(): Boolean {
         return when (mode) {
             is BookmarkFragmentState.Mode.Selecting -> {
-                interactor.onAllBookmarksDeselected()
+                interactor?.onAllBookmarksDeselected()
                 true
             }
             else -> {
-                interactor.onBackPressed()
+                interactor?.onBackPressed()
                 true
             }
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolder.kt
@@ -30,7 +30,7 @@ import org.mozilla.fenix.utils.Do
  */
 class BookmarkNodeViewHolder(
     private val containerView: LibrarySiteItemView,
-    private val interactor: BookmarkViewInteractor,
+    private val interactor: BookmarkViewInteractor?,
 ) : RecyclerView.ViewHolder(containerView) {
 
     var item: BookmarkNode? = null
@@ -40,14 +40,14 @@ class BookmarkNodeViewHolder(
         menu = BookmarkItemMenu(containerView.context) { menuItem ->
             val item = this.item ?: return@BookmarkItemMenu
             Do exhaustive when (menuItem) {
-                BookmarkItemMenu.Item.Edit -> interactor.onEditPressed(item)
-                BookmarkItemMenu.Item.Copy -> interactor.onCopyPressed(item)
-                BookmarkItemMenu.Item.Share -> interactor.onSharePressed(item)
-                BookmarkItemMenu.Item.OpenInNewTab -> interactor.onOpenInNormalTab(item)
-                BookmarkItemMenu.Item.OpenInPrivateTab -> interactor.onOpenInPrivateTab(item)
-                BookmarkItemMenu.Item.OpenAllInNewTabs -> interactor.onOpenAllInNewTabs(item)
-                BookmarkItemMenu.Item.OpenAllInPrivateTabs -> interactor.onOpenAllInPrivateTabs(item)
-                BookmarkItemMenu.Item.Delete -> interactor.onDelete(setOf(item))
+                BookmarkItemMenu.Item.Edit -> interactor?.onEditPressed(item)
+                BookmarkItemMenu.Item.Copy -> interactor?.onCopyPressed(item)
+                BookmarkItemMenu.Item.Share -> interactor?.onSharePressed(item)
+                BookmarkItemMenu.Item.OpenInNewTab -> interactor?.onOpenInNormalTab(item)
+                BookmarkItemMenu.Item.OpenInPrivateTab -> interactor?.onOpenInPrivateTab(item)
+                BookmarkItemMenu.Item.OpenAllInNewTabs -> interactor?.onOpenAllInNewTabs(item)
+                BookmarkItemMenu.Item.OpenAllInPrivateTabs -> interactor?.onOpenAllInPrivateTabs(item)
+                BookmarkItemMenu.Item.Delete -> interactor?.onDelete(setOf(item))
             }
         }
 

--- a/fenix/detekt-baseline.xml
+++ b/fenix/detekt-baseline.xml
@@ -704,7 +704,7 @@
     <ID>UndocumentedPublicFunction:ImageButton.kt$fun ImageButton.removeAndDisable()</ID>
     <ID>UndocumentedPublicFunction:ImageButton.kt$fun ImageButton.showAndEnable()</ID>
     <ID>UndocumentedPublicFunction:IntentReceiverActivity.kt$IntentReceiverActivity$fun processIntent(intent: Intent)</ID>
-    <ID>UndocumentedPublicFunction:LibrarySiteItemView.kt$LibrarySiteItemView$fun &lt;T&gt; setSelectionInteractor(item: T, holder: SelectionHolder&lt;T&gt;, interactor: SelectionInteractor&lt;T&gt;)</ID>
+    <ID>UndocumentedPublicFunction:LibrarySiteItemView.kt$LibrarySiteItemView$fun &lt;T&gt; setSelectionInteractor(item: T, holder: SelectionHolder&lt;T&gt;, interactor: SelectionInteractor&lt;T&gt;?)</ID>
     <ID>UndocumentedPublicFunction:LibrarySiteItemView.kt$LibrarySiteItemView$fun attachMenu(menuController: MenuController)</ID>
     <ID>UndocumentedPublicFunction:LibrarySiteItemView.kt$LibrarySiteItemView$fun loadFavicon(url: String)</ID>
     <ID>UndocumentedPublicFunction:LocaleAdapter.kt$LocaleAdapter$fun updateData(localeList: List&lt;Locale&gt;, selectedLocale: Locale)</ID>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817999