### PR TITLE
Bug 1823999 - Fix UNDO Snackbar for composified Tabs Tray

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFab.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFab.kt
@@ -4,18 +4,12 @@
 
 package org.mozilla.fenix.tabstray
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.invisibleToUser
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.R
@@ -31,7 +25,6 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * @param onPrivateTabsFabClicked Invoked when the fab is clicked in [Page.PrivateTabs].
  * @param onSyncedTabsFabClicked Invoked when the fab is clicked in [Page.SyncedTabs].
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun TabsTrayFab(
     tabsTrayStore: TabsTrayStore,
@@ -81,22 +74,14 @@ fun TabsTrayFab(
         }
     }
 
-    Box(
-        Modifier
-            .fillMaxSize()
-            .semantics { invisibleToUser() },
-    ) {
-        if (isInNormalMode) {
-            FloatingActionButton(
-                icon = icon,
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(16.dp),
-                contentDescription = contentDescription,
-                label = label,
-                onClick = onClick,
-            )
-        }
+    if (isInNormalMode) {
+        FloatingActionButton(
+            icon = icon,
+            modifier = Modifier.padding(bottom = 16.dp, end = 16.dp),
+            contentDescription = contentDescription,
+            label = label,
+            onClick = onClick,
+        )
     }
 }
 

--- a/fenix/app/src/main/res/layout/component_tabstray3_fab.xml
+++ b/fenix/app/src/main/res/layout/component_tabstray3_fab.xml
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <androidx.compose.ui.platform.ComposeView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom|end"
     android:elevation="99dp" />


### PR DESCRIPTION
https://user-images.githubusercontent.com/87384386/234960614-1a8a5123-58a6-4846-99f5-111ab0d635d2.mov

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-an

droid/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1823999