### PR TITLE
Bug 1830011 - New Delete browsing data on quit tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/Matchers.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/Matchers.kt
@@ -7,8 +7,10 @@ package org.mozilla.fenix.helpers
 import android.graphics.Bitmap
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers
 import junit.framework.AssertionFailedError
 import org.hamcrest.CoreMatchers.not
@@ -69,4 +71,22 @@ fun ViewInteraction.isVisibleForUser(): Boolean {
     }
 
     return true
+}
+
+fun atPosition(position: Int, itemMatcher: Matcher<View?>): Matcher<View?>? {
+    return object : BoundedMatcher<View?, RecyclerView>(
+        RecyclerView::class.java,
+    ) {
+        override fun describeTo(description: Description) {
+            description.appendText("has item at position $position: ")
+            itemMatcher.describeTo(description)
+        }
+
+        override fun matchesSafely(view: RecyclerView): Boolean {
+            val viewHolder = view.findViewHolderForAdapterPosition(position)
+                ?: // has no item on such position
+                return false
+            return itemMatcher.matches(viewHolder.itemView)
+        }
+    }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeleteBrowsingDataOnQuitTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeleteBrowsingDataOnQuitTest.kt
@@ -1,0 +1,252 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
+
+import android.Manifest
+import androidx.core.net.toUri
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.rule.GrantPermissionRule
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.R
+import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.MatcherHelper
+import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestAssetHelper.getStorageTestAsset
+import org.mozilla.fenix.helpers.TestHelper
+import org.mozilla.fenix.helpers.TestHelper.exitMenu
+import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.TestHelper.restartApp
+import org.mozilla.fenix.helpers.TestHelper.setNetworkEnabled
+import org.mozilla.fenix.ui.robots.clickPageObject
+import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.navigationToolbar
+
+/**
+ *  Tests for verifying the Settings for:
+ *  Delete Browsing Data on quit
+ *
+ */
+class SettingsDeleteBrowsingDataOnQuitTest {
+    /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
+    private lateinit var mockWebServer: MockWebServer
+
+    @get:Rule
+    val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
+
+    // Automatically allows app permissions, avoiding a system dialog showing up.
+    @get:Rule
+    val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.RECORD_AUDIO,
+    )
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun deleteBrowsingDataOnQuitSettingsItemsTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingDataOnQuit {
+            verifyNavigationToolBarHeader()
+            verifyDeleteBrowsingOnQuitEnabled(false)
+            verifyDeleteBrowsingOnQuitButtonSummary()
+            verifyDeleteBrowsingOnQuitEnabled(false)
+            clickDeleteBrowsingOnQuitButtonSwitch()
+            verifyDeleteBrowsingOnQuitEnabled(true)
+            verifyAllTheCheckBoxesText()
+            verifyAllTheCheckBoxesChecked(true)
+        }.goBack {
+            verifySettingsOptionSummary("Delete browsing data on quit", "On")
+        }.goBack {
+        }.openThreeDotMenu {
+            verifyQuitButtonExists()
+            pressBack()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser("test".toUri()) {
+        }.openThreeDotMenu {
+            verifyQuitButtonExists()
+        }
+    }
+
+    @Test
+    fun deleteOpenTabsOnQuitTest() {
+        val testPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingDataOnQuit {
+            clickDeleteBrowsingOnQuitButtonSwitch()
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage.url) {
+        }.goToHomescreen {
+        }.openThreeDotMenu {
+            clickQuit()
+            restartApp(activityTestRule)
+        }
+        navigationToolbar {
+        }.openTabTray {
+            verifyNoOpenTabsInNormalBrowsing()
+        }
+    }
+
+    @Test
+    fun deleteHistoryAndSiteStorageOnQuitTest() {
+        val storageWritePage =
+            getStorageTestAsset(mockWebServer, "storage_write.html")
+        val storageCheckPage =
+            getStorageTestAsset(mockWebServer, "storage_check.html")
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingDataOnQuit {
+            clickDeleteBrowsingOnQuitButtonSwitch()
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(storageWritePage.url) {
+            clickPageObject(MatcherHelper.itemWithText("Set cookies"))
+            verifyPageContent("Values written to storage")
+        }.goToHomescreen {
+        }.openThreeDotMenu {
+            clickQuit()
+            restartApp(activityTestRule)
+        }
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openHistory {
+            verifyEmptyHistoryView()
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(storageCheckPage.url) {
+            verifyPageContent("Session storage empty")
+            verifyPageContent("Local storage empty")
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(storageWritePage.url) {
+            verifyPageContent("No cookies set")
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun deleteDownloadsOnQuitTest() {
+        val downloadTestPage = "https://storage.googleapis.com/mobile_test_assets/test_app/downloads.html"
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingDataOnQuit {
+            clickDeleteBrowsingOnQuitButtonSwitch()
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
+        }.clickDownloadLink("smallZip.zip") {
+            verifyDownloadPrompt("smallZip.zip")
+        }.clickDownload {
+            verifyDownloadNotificationPopup()
+        }.closeCompletedDownloadPrompt {
+        }.goToHomescreen {
+        }.openThreeDotMenu {
+            clickQuit()
+            mDevice.waitForIdle()
+        }
+        restartApp(activityTestRule)
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openDownloadsManager {
+            verifyEmptyDownloadsList()
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun deleteSitePermissionsOnQuitTest() {
+        val testPage = "https://mozilla-mobile.github.io/testapp/permissions"
+        val testPageSubstring = "https://mozilla-mobile.github.io:443"
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingDataOnQuit {
+            clickDeleteBrowsingOnQuitButtonSwitch()
+            exitMenu()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage.toUri()) {
+            waitForPageToLoad()
+        }.clickStartMicrophoneButton {
+            verifyMicrophonePermissionPrompt(testPageSubstring)
+            selectRememberPermissionDecision()
+        }.clickPagePermissionButton(false) {
+            verifyPageContent("Microphone not allowed")
+        }.goToHomescreen {
+        }.openThreeDotMenu {
+            clickQuit()
+            mDevice.waitForIdle()
+        }
+        restartApp(activityTestRule)
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage.toUri()) {
+            waitForPageToLoad()
+        }.clickStartMicrophoneButton {
+            verifyMicrophonePermissionPrompt(testPageSubstring)
+        }
+    }
+
+    @Test
+    fun deleteCachedFilesOnQuitTest() {
+        val pocketTopArticles = TestHelper.getStringResource(R.string.pocket_pinned_top_articles)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingDataOnQuit {
+            clickDeleteBrowsingOnQuitButtonSwitch()
+            exitMenu()
+        }
+        homeScreen {
+            verifyExistingTopSitesTabs(pocketTopArticles)
+        }.openTopSiteTabWithTitle(pocketTopArticles) {
+            waitForPageToLoad()
+        }.goToHomescreen {
+        }.openThreeDotMenu {
+            clickQuit()
+            mDevice.waitForIdle()
+        }
+        // disabling wifi to prevent downloads in the background
+        setNetworkEnabled(enabled = false)
+        restartApp(activityTestRule)
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser("about:cache".toUri()) {
+            verifyNetworkCacheIsEmpty("memory")
+            verifyNetworkCacheIsEmpty("disk")
+        }
+        setNetworkEnabled(enabled = true)
+    }
+}

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeleteBrowsingDataTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeleteBrowsingDataTest.kt
@@ -30,8 +30,6 @@ import org.mozilla.fenix.ui.robots.settingsScreen
 /**
  *  Tests for verifying the Settings for:
  *  Delete Browsing Data
- *  Delete Browsing Data on quit
- *
  */
 
 class SettingsDeleteBrowsingDataTest {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataOnQuitRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataOnQuitRobot.kt
@@ -7,15 +7,19 @@ package org.mozilla.fenix.ui.robots
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.withChild
+import androidx.test.espresso.matcher.ViewMatchers.withClassName
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withParentIndex
 import androidx.test.espresso.matcher.ViewMatchers.withResourceName
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.assertIsChecked
+import org.mozilla.fenix.helpers.atPosition
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.isChecked
 
@@ -24,32 +28,70 @@ import org.mozilla.fenix.helpers.isChecked
  */
 class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
 
-    fun verifyNavigationToolBarHeader() = assertNavigationToolBarHeader()
+    fun verifyNavigationToolBarHeader() =
+        onView(
+            allOf(
+                withId(R.id.navigationToolbar),
+                withChild(withText(R.string.preferences_delete_browsing_data_on_quit)),
+            ),
+        )
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    fun verifyDeleteBrowsingOnQuitButton() = assertDeleteBrowsingOnQuitButton()
+    fun verifyDeleteBrowsingOnQuitEnabled(enabled: Boolean) =
+        deleteBrowsingOnQuitButton.assertIsChecked(enabled)
 
-    fun verifyDeleteBrowsingOnQuitButtonSummary() = assertDeleteBrowsingOnQuitButtonSummary()
+    fun verifyDeleteBrowsingOnQuitButtonSummary() =
+        onView(
+            withText(R.string.preference_summary_delete_browsing_data_on_quit_2),
+        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    fun verifyDeleteBrowsingOnQuitButtonSwitchDefault() = assertDeleteBrowsingOnQuitButtonSwitchDefault()
+    fun clickDeleteBrowsingOnQuitButtonSwitch() = onView(withResourceName("switch_widget")).click()
 
-    fun clickDeleteBrowsingOnQuitButtonSwitchDefaultChange() = verifyDeleteBrowsingOnQuitButtonSwitchDefault().click()
+    fun verifyAllTheCheckBoxesText() {
+        openTabsCheckbox
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    fun verifyAllTheCheckBoxesText() = assertAllOptionsAndCheckBoxes()
+        browsingDataCheckbox
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    fun verifyAllTheCheckBoxesChecked() = assertAllCheckBoxesAreChecked()
+        cookiesCheckbox
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    fun verifyDeleteBrowsingDataOnQuitSubMenuItems() {
-        verifyDeleteBrowsingOnQuitButton()
-        verifyDeleteBrowsingOnQuitButtonSummary()
-        verifyDeleteBrowsingOnQuitButtonSwitchDefault()
-        clickDeleteBrowsingOnQuitButtonSwitchDefaultChange()
-        verifyAllTheCheckBoxesText()
-        verifyAllTheCheckBoxesChecked()
+        onView(withText(R.string.preferences_delete_browsing_data_cookies_subtitle))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+        cachedFilesCheckbox
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+        onView(withText(R.string.preferences_delete_browsing_data_cached_files_subtitle))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+        sitePermissionsCheckbox
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
+
+    fun verifyAllTheCheckBoxesChecked(checked: Boolean) {
+        for (index in 2..7) {
+            onView(withId(R.id.recycler_view))
+                .check(
+                    matches(
+                        atPosition(
+                            index,
+                            hasDescendant(
+                                allOf(
+                                    withResourceName(containsString("checkbox")),
+                                    isChecked(checked),
+                                ),
+                            ),
+                        ),
+                    ),
+                )
+        }
     }
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
-            goBackButton().click()
+            goBackButton.click()
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()
@@ -57,57 +99,21 @@ class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
     }
 }
 
-private fun goBackButton() = onView(withContentDescription("Navigate up"))
+private val goBackButton = onView(withContentDescription("Navigate up"))
 
-private fun assertNavigationToolBarHeader() = onView(
-    allOf(
-        withId(R.id.navigationToolbar),
-        withChild(withText(R.string.preferences_delete_browsing_data_on_quit)),
-    ),
-)
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private val deleteBrowsingOnQuitButton =
+    onView(withClassName(containsString("android.widget.Switch")))
 
-private fun deleteBrowsingOnQuitButton() = onView(
-    allOf(
-        withParentIndex(0),
-        withChild(withText(R.string.preferences_delete_browsing_data_on_quit)),
-    ),
-)
-
-private fun assertDeleteBrowsingOnQuitButton() = deleteBrowsingOnQuitButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun assertDeleteBrowsingOnQuitButtonSummary() = onView(
-    withText(R.string.preference_summary_delete_browsing_data_on_quit_2),
-)
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun assertDeleteBrowsingOnQuitButtonSwitchDefault() = onView(withResourceName("switch_widget"))
-    .check(matches(isChecked(false)))
-
-private fun assertAllOptionsAndCheckBoxes() {
+private val openTabsCheckbox =
     onView(withText(R.string.preferences_delete_browsing_data_tabs_title_2))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
+private val browsingDataCheckbox =
     onView(withText(R.string.preferences_delete_browsing_data_browsing_data_title))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    onView(withText(R.string.preferences_delete_browsing_data_cookies))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private val cookiesCheckbox = onView(withText(R.string.preferences_delete_browsing_data_cookies))
 
-    onView(withText(R.string.preferences_delete_browsing_data_cookies_subtitle))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
+private val cachedFilesCheckbox =
     onView(withText(R.string.preferences_delete_browsing_data_cached_files))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    onView(withText(R.string.preferences_delete_browsing_data_cached_files_subtitle))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
+private val sitePermissionsCheckbox =
     onView(withText(R.string.preferences_delete_browsing_data_site_permissions))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
-private fun assertAllCheckBoxesAreChecked() {
-    // Only verifying the options, checkboxes default value can't be verified due to issue #9471
-}

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -38,6 +38,7 @@ import org.mozilla.fenix.helpers.MatcherHelper.checkedItemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
@@ -59,6 +60,14 @@ class ThreeDotMenuMainRobot {
     fun verifyEditBookmarkButton() = assertEditBookmarkButton()
     fun verifyCloseAllTabsButton() = assertCloseAllTabsButton()
     fun verifyReaderViewAppearance(visible: Boolean) = assertReaderViewAppearanceButton(visible)
+
+    fun verifyQuitButtonExists() {
+        // Need to double swipe the menu, to make this button visible.
+        // In case it reaches the end, the second swipe is no-op.
+        expandMenu()
+        expandMenu()
+        assertItemContainingTextExists(itemWithText("Quit"))
+    }
 
     fun expandMenu() {
         onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeUp())
@@ -155,6 +164,11 @@ class ThreeDotMenuMainRobot {
                 }
             }
         }
+    }
+
+    fun clickQuit() {
+        expandMenu()
+        onView(withText("Quit")).click()
     }
 
     class Transition {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1830011