### PR TITLE
Bug 1822755 - increase padding around `Powered by Pocket` section from home screen 

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -491,31 +492,29 @@ fun PoweredByPocketHeader(
     val linkStartIndex = text.indexOf(link)
     val linkEndIndex = linkStartIndex + link.length
 
-    Column(
-        modifier = modifier.semantics {
-            testTagsAsResourceId = true
-            testTag = "pocket.header"
-        },
-        horizontalAlignment = Alignment.CenterHorizontally,
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp)
+            .semantics(mergeDescendants = true) {
+                testTagsAsResourceId = true
+                testTag = "pocket.header"
+            },
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(
-            Modifier
-                .fillMaxWidth()
-                .semantics(mergeDescendants = true) {},
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                painter = painterResource(id = R.drawable.pocket_vector),
-                contentDescription = null,
-                // Apply the red tint in code. Otherwise the image is black and white.
-                tint = Color(0xFFEF4056),
-            )
+        Icon(
+            painter = painterResource(id = R.drawable.pocket_vector),
+            contentDescription = null,
+            // Apply the red tint in code. Otherwise the image is black and white.
+            tint = Color(0xFFEF4056),
+        )
 
-            Spacer(modifier = Modifier.width(16.dp))
+        Spacer(modifier = Modifier.width(16.dp))
 
-            val onClickLabel = stringResource(id = R.string.a11y_action_label_pocket_learn_more)
-            Column(
-                Modifier.semantics(mergeDescendants = true) {
+        val onClickLabel = stringResource(id = R.string.a11y_action_label_pocket_learn_more)
+        Column(
+            modifier = Modifier
+                .semantics(mergeDescendants = true) {
                     role = Role.Button
                     onClick(label = onClickLabel) {
                         onLearnMoreClicked(
@@ -524,38 +523,37 @@ fun PoweredByPocketHeader(
                         false
                     }
                 },
-            ) {
-                Text(
-                    text = stringResource(
-                        R.string.pocket_stories_feature_title_2,
-                        LocalContext.current.getString(R.string.pocket_product_name),
-                    ),
-                    modifier = Modifier.semantics {
-                        testTagsAsResourceId = true
-                        testTag = "pocket.header.title"
-                    },
-                    color = textColor,
-                    style = FirefoxTheme.typography.caption,
-                )
+        ) {
+            Text(
+                text = stringResource(
+                    R.string.pocket_stories_feature_title_2,
+                    LocalContext.current.getString(R.string.pocket_product_name),
+                ),
+                modifier = Modifier.semantics {
+                    testTagsAsResourceId = true
+                    testTag = "pocket.header.title"
+                },
+                color = textColor,
+                style = FirefoxTheme.typography.caption,
+            )
 
-                Box(
-                    modifier = modifier.semantics {
-                        testTagsAsResourceId = true
-                        testTag = "pocket.header.subtitle"
-                    },
+            Box(
+                modifier = modifier.semantics {
+                    testTagsAsResourceId = true
+                    testTag = "pocket.header.subtitle"
+                },
+            ) {
+                ClickableSubstringLink(
+                    text = text,
+                    textColor = textColor,
+                    linkTextColor = linkTextColor,
+                    linkTextDecoration = TextDecoration.Underline,
+                    clickableStartIndex = linkStartIndex,
+                    clickableEndIndex = linkEndIndex,
                 ) {
-                    ClickableSubstringLink(
-                        text = text,
-                        textColor = textColor,
-                        linkTextColor = linkTextColor,
-                        linkTextDecoration = TextDecoration.Underline,
-                        clickableStartIndex = linkStartIndex,
-                        clickableEndIndex = linkEndIndex,
-                    ) {
-                        onLearnMoreClicked(
-                            "https://www.mozilla.org/en-US/firefox/pocket/?$POCKET_FEATURE_UTM_KEY_VALUE",
-                        )
-                    }
+                    onLearnMoreClicked(
+                        "https://www.mozilla.org/en-US/firefox/pocket/?$POCKET_FEATURE_UTM_KEY_VALUE",
+                    )
                 }
             }
         }


### PR DESCRIPTION
The PR fixes accessibility in the `powered by pocket `  section in the home page 

### Fix description
increase the tap area of the parent widget

### Issue snapshot
![WhatsApp Image 2023-03-23 at 21 11 52](https://user-images.githubusercontent.com/35276272/227341454-6ccc2a8f-62c9-4631-81e9-fec472c5d918.jpeg)



### Demo after fix

https://www.loom.com/share/2c1f5ed381eb45deacba73deeefa55f8


### Pull Request checklist
- [x] **Quality:** This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog:** This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features

### After merge
 - Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
 - Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1822755