### PR TITLE
Bug 1830112 - Display full text in compose button when large font

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/button/Button.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/button/Button.kt
@@ -19,11 +19,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.theme.FirefoxTheme
+
+const val DEFAULT_MAX_LINES = 2
 
 /**
  * Base component for buttons.
@@ -44,6 +48,9 @@ private fun Button(
     tint: Color,
     onClick: () -> Unit,
 ) {
+    // Required to detect if font increased due to accessibility.
+    val fontScale: Float = LocalConfiguration.current.fontScale
+
     androidx.compose.material.Button(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
@@ -65,9 +72,10 @@ private fun Button(
 
         Text(
             text = text,
+            textAlign = TextAlign.Center,
             color = textColor,
             style = FirefoxTheme.typography.button,
-            maxLines = 1,
+            maxLines = if (fontScale > 1.0f) Int.MAX_VALUE else DEFAULT_MAX_LINES,
         )
     }
 }


### PR DESCRIPTION
When using the compose button and the size of the font is set to largest for accessibility purposes, the font should not cut if it doesn't fit. Instead, the button accommodates the entirety of the text.

<img src="https://user-images.githubusercontent.com/32488956/235623613-1d98b0e5-5b83-46d1-b606-9b7640215160.png" width = "50%">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1830112