### PR TITLE
Bug 1829531 - Fix the status bar color when the download prompt appears.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/downloads/StartDownloadDialog.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/downloads/StartDownloadDialog.kt
@@ -17,7 +17,6 @@ import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import androidx.annotation.VisibleForTesting
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.children
 import androidx.viewbinding.ViewBinding
@@ -25,8 +24,6 @@ import mozilla.components.feature.downloads.databinding.MozacDownloaderChooserPr
 import mozilla.components.feature.downloads.toMegabyteOrKilobyteString
 import mozilla.components.feature.downloads.ui.DownloaderApp
 import mozilla.components.feature.downloads.ui.DownloaderAppAdapter
-import mozilla.components.support.ktx.android.view.setNavigationBarTheme
-import mozilla.components.support.ktx.android.view.setStatusBarTheme
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.DialogScrimBinding
 import org.mozilla.fenix.databinding.StartDownloadDialogLayoutBinding
@@ -50,12 +47,6 @@ abstract class StartDownloadDialog(
 
     @VisibleForTesting
     internal var onDismiss: () -> Unit = {}
-
-    @VisibleForTesting
-    internal var initialNavigationBarColor = activity.window.navigationBarColor
-
-    @VisibleForTesting
-    internal var initialStatusBarColor = activity.window.statusBarColor
 
     /**
      * Show the download view.
@@ -89,10 +80,6 @@ abstract class StartDownloadDialog(
             elevation = activity.resources.getDimension(R.dimen.browser_fragment_download_dialog_elevation)
             visibility = View.VISIBLE
         }
-
-        activity.window.setNavigationBarTheme(ContextCompat.getColor(activity, R.color.material_scrim_color))
-        activity.window.setStatusBarTheme(ContextCompat.getColor(activity, R.color.material_scrim_color))
-
         return this
     }
 
@@ -120,9 +107,6 @@ abstract class StartDownloadDialog(
         enableSiblingsAccessibility(container?.parent as? ViewGroup)
 
         container?.visibility = View.GONE
-
-        activity.window.setNavigationBarTheme(initialNavigationBarColor)
-        activity.window.setStatusBarTheme(initialStatusBarColor)
 
         onDismiss()
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/downloads/StartDownloadDialogTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/downloads/StartDownloadDialogTest.kt
@@ -6,21 +6,16 @@ package org.mozilla.fenix.downloads
 
 import android.app.Activity
 import android.content.Context
-import android.graphics.Color
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.content.ContextCompat
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.verify
-import mozilla.components.support.ktx.android.view.setNavigationBarTheme
-import mozilla.components.support.ktx.android.view.setStatusBarTheme
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -37,20 +32,6 @@ import org.robolectric.Robolectric
 
 @RunWith(FenixRobolectricTestRunner::class)
 class StartDownloadDialogTest {
-    @Test
-    fun `WHEN the dialog is instantiated THEN cache the navigation and status bar colors`() {
-        val navigationBarColor = Color.RED
-        val statusBarColor = Color.BLUE
-        val activity: Activity = mockk {
-            every { window.navigationBarColor } returns navigationBarColor
-            every { window.statusBarColor } returns statusBarColor
-        }
-        val dialog = TestDownloadDialog(activity)
-
-        assertEquals(navigationBarColor, dialog.initialNavigationBarColor)
-        assertEquals(statusBarColor, dialog.initialStatusBarColor)
-    }
-
     @Test
     fun `WHEN the view is to be shown THEN set the scrim and other window customization bind the download values`() {
         val activity = Robolectric.buildActivity(Activity::class.java).create().get()
@@ -78,10 +59,6 @@ class StartDownloadDialogTest {
                 dialogContainer.elevation,
             )
             assertTrue(dialogContainer.isVisible)
-            verify {
-                activity.window.setNavigationBarTheme(ContextCompat.getColor(activity, R.color.material_scrim_color))
-                activity.window.setStatusBarTheme(ContextCompat.getColor(activity, R.color.material_scrim_color))
-            }
             assertEquals(dialog, fluentDialog)
         }
     }
@@ -119,10 +96,6 @@ class StartDownloadDialogTest {
             assertTrue(dialogParent.childCount == 1)
             assertTrue(dialogContainer.childCount == 0)
             assertFalse(dialogContainer.isVisible)
-            verify {
-                activity.window.setNavigationBarTheme(dialog.initialNavigationBarColor)
-                activity.window.setStatusBarTheme(dialog.initialStatusBarColor)
-            }
         }
     }
 


### PR DESCRIPTION
This should also fix the bug https://bugzilla.mozilla.org/show_bug.cgi?id=1825827 .

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1829531