### PR TITLE
Bug 1830849 - Add image resource field to Nimbus onboarding feature

### DIFF
--- a/fenix/app/onboarding.fml.yaml
+++ b/fenix/app/onboarding.fml.yaml
@@ -19,6 +19,7 @@ features:
               ordering: 10
               body: juno_onboarding_default_browser_description_nimbus
               link-text: juno_onboarding_default_browser_description_link_text
+              image-res: ic_onboarding_welcome
               primary-button-label: juno_onboarding_default_browser_positive_button
               secondary-button-label: juno_onboarding_default_browser_negative_button
 
@@ -26,6 +27,7 @@ features:
               card-type: sync-sign-in
               title: juno_onboarding_sign_in_title
               body: juno_onboarding_sign_in_description
+              image-res: ic_onboarding_sync
               ordering: 20
               primary-button-label: juno_onboarding_sign_in_positive_button
               secondary-button-label: juno_onboarding_sign_in_negative_button
@@ -34,6 +36,7 @@ features:
               card-type: notification-permission
               title: juno_onboarding_enable_notifications_title_nimbus
               body: juno_onboarding_enable_notifications_description_nimbus
+              image-res: ic_notification_permission
               ordering: 30
               primary-button-label: juno_onboarding_enable_notifications_positive_button
               secondary-button-label: juno_onboarding_enable_notifications_negative_button
@@ -73,6 +76,11 @@ objects:
           e.g. body: This is a policy link
                link-text: policy link
         default: null
+      image-res:
+        type: Image
+        description: The resource id of the image to be displayed.
+        # This should never be defaulted.
+        default: ic_onboarding_welcome
       ordering:
         type: Int
         description: Used to sequence the cards.

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
@@ -56,6 +56,7 @@ private val notificationPageUiData = OnboardingPageUiData(
 
 private val defaultBrowserCardData = OnboardingCardData(
     cardType = OnboardingCardType.DEFAULT_BROWSER,
+    imageRes = R.drawable.ic_onboarding_welcome,
     title = StringHolder(null, "default browser title"),
     body = StringHolder(null, "default browser body with link text"),
     linkText = StringHolder(null, "link text"),
@@ -65,6 +66,7 @@ private val defaultBrowserCardData = OnboardingCardData(
 )
 private val syncCardData = OnboardingCardData(
     cardType = OnboardingCardType.SYNC_SIGN_IN,
+    imageRes = R.drawable.ic_onboarding_sync,
     title = StringHolder(null, "sync title"),
     body = StringHolder(null, "sync body"),
     primaryButtonLabel = StringHolder(null, "sync primary button text"),
@@ -73,6 +75,7 @@ private val syncCardData = OnboardingCardData(
 )
 private val notificationCardData = OnboardingCardData(
     cardType = OnboardingCardType.NOTIFICATION_PERMISSION,
+    imageRes = R.drawable.ic_notification_permission,
     title = StringHolder(null, "notification title"),
     body = StringHolder(null, "notification body"),
     primaryButtonLabel = StringHolder(null, "notification primary button text"),

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapper.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.onboarding.view
 
-import org.mozilla.fenix.R
 import org.mozilla.fenix.nimbus.OnboardingCardData
 import org.mozilla.fenix.nimbus.OnboardingCardType
 import org.mozilla.fenix.settings.SupportUtils
@@ -22,36 +21,20 @@ internal fun Collection<OnboardingCardData>.toPageUiData(showNotificationPage: B
     }.sortedBy { it.ordering }
         .map { it.toPageUiData() }
 
-private fun OnboardingCardData.toPageUiData(): OnboardingPageUiData {
-    return when (cardType) {
-        OnboardingCardType.DEFAULT_BROWSER -> OnboardingPageUiData(
-            type = OnboardingPageUiData.Type.DEFAULT_BROWSER,
-            imageRes = R.drawable.ic_onboarding_welcome,
-            title = title,
-            description = body,
-            linkText = linkText,
-            primaryButtonLabel = primaryButtonLabel,
-            secondaryButtonLabel = secondaryButtonLabel,
-        )
+private fun OnboardingCardData.toPageUiData() = OnboardingPageUiData(
+    type = cardType.toPageUiDataType(),
+    imageRes = imageRes.resourceId,
+    title = title,
+    description = body,
+    linkText = linkText,
+    primaryButtonLabel = primaryButtonLabel,
+    secondaryButtonLabel = secondaryButtonLabel,
+)
 
-        OnboardingCardType.SYNC_SIGN_IN -> OnboardingPageUiData(
-            type = OnboardingPageUiData.Type.SYNC_SIGN_IN,
-            imageRes = R.drawable.ic_onboarding_sync,
-            title = title,
-            description = body,
-            primaryButtonLabel = primaryButtonLabel,
-            secondaryButtonLabel = secondaryButtonLabel,
-        )
-
-        OnboardingCardType.NOTIFICATION_PERMISSION -> OnboardingPageUiData(
-            type = OnboardingPageUiData.Type.NOTIFICATION_PERMISSION,
-            imageRes = R.drawable.ic_notification_permission,
-            title = title,
-            description = body,
-            primaryButtonLabel = primaryButtonLabel,
-            secondaryButtonLabel = secondaryButtonLabel,
-        )
-    }
+private fun OnboardingCardType.toPageUiDataType() = when (this) {
+    OnboardingCardType.DEFAULT_BROWSER -> OnboardingPageUiData.Type.DEFAULT_BROWSER
+    OnboardingCardType.SYNC_SIGN_IN -> OnboardingPageUiData.Type.SYNC_SIGN_IN
+    OnboardingCardType.NOTIFICATION_PERMISSION -> OnboardingPageUiData.Type.NOTIFICATION_PERMISSION
 }
 
 /**


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1830849