### PR TITLE
Bug 1831197 - Temporarily use X86 Pixel2 during Firebase Test Lab disruption (May, 2023)

### DIFF
--- a/android-components/automation/taskcluster/androidTest/flank-arm.yml
+++ b/android-components/automation/taskcluster/androidTest/flank-arm.yml
@@ -19,7 +19,7 @@ gcloud:
   performance-metrics: true
 
   device:
-   - model: Pixel2.arm
+   - model: Pixel2
      version: 28
      locale: en_US
 

--- a/fenix/automation/taskcluster/androidTest/flank-arm-beta.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-beta.yml
@@ -29,7 +29,7 @@ gcloud:
     - class org.mozilla.fenix.ui.NoNetworkAccessStartupTests#noNetworkConnectionStartupTest
 
   device:
-    - model: Pixel2.arm
+    - model: Pixel2
       version: 30
       locale: en_US
 

--- a/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -37,7 +37,7 @@ gcloud:
     - class org.mozilla.fenix.ui.BookmarksTest#addBookmarkTest
 
   device:
-    - model: Pixel2.arm
+    - model: Pixel2
       version: 26
       locale: en_US
     - model: walleye

--- a/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
@@ -14,7 +14,7 @@ gcloud:
     clearPackageData: true
 
   device:
-    - model: Pixel2.arm
+    - model: Pixel2
       version: 26
       locale: en_US
     - model: walleye

--- a/fenix/automation/taskcluster/androidTest/flank-arm-screenshots-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-screenshots-tests.yml
@@ -23,7 +23,7 @@ gcloud:
    - package org.mozilla.fenix.screenshots
 
   device:
-   - model: Pixel2.arm
+   - model: Pixel2
      version: 30
      locale: en_US
 

--- a/fenix/automation/taskcluster/androidTest/flank-arm-start-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-start-test.yml
@@ -29,7 +29,7 @@ gcloud:
    - class org.mozilla.fenix.ui.NoNetworkAccessStartupTests#noNetworkConnectionStartupTest
 
   device:
-   - model: Pixel2.arm
+   - model: Pixel2
      version: 30
      locale: en_US
 

--- a/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -23,7 +23,7 @@ gcloud:
     - notPackage org.mozilla.fenix.syncintegration
 
   device:
-    - model: Pixel2.arm
+    - model: Pixel2
       version: 30
       locale: en_US
 

--- a/focus-android/automation/taskcluster/androidTest/flank-arm-beta.yml
+++ b/focus-android/automation/taskcluster/androidTest/flank-arm-beta.yml
@@ -24,7 +24,7 @@ gcloud:
     - class org.mozilla.focus.activity.EraseBrowsingDataTest#deleteHistoryOnRestartTest
   
   device:
-    - model: Pixel2.arm
+    - model: Pixel2
       version: 30
       locale: en_US
 

--- a/focus-android/automation/taskcluster/androidTest/flank-arm-start-test.yml
+++ b/focus-android/automation/taskcluster/androidTest/flank-arm-start-test.yml
@@ -24,7 +24,7 @@ gcloud:
     - class org.mozilla.focus.activity.EraseBrowsingDataTest#deleteHistoryOnRestartTest
 
   device:
-    - model: Pixel2.arm
+    - model: Pixel2
       version: 30
       locale: en_US
 

--- a/focus-android/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/focus-android/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -24,7 +24,7 @@ gcloud:
     - package org.mozilla.focus.privacy
 
   device:
-    - model: Pixel2.arm
+    - model: Pixel2
       version: 30
       locale: en_US
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1831197