### PR TITLE
Bug 1831197 - Temporarily use Redfin (Pixel5) during Firebase Test Lab disruption

### DIFF
--- a/android-components/automation/taskcluster/androidTest/flank-arm.yml
+++ b/android-components/automation/taskcluster/androidTest/flank-arm.yml
@@ -19,8 +19,8 @@ gcloud:
   performance-metrics: true
 
   device:
-   - model: Pixel2.arm
-     version: 28
+   - model: redfin
+     version: 30
      locale: en_US
 
 flank:

--- a/fenix/automation/taskcluster/androidTest/flank-arm-beta.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-beta.yml
@@ -29,7 +29,7 @@ gcloud:
     - class org.mozilla.fenix.ui.NoNetworkAccessStartupTests#noNetworkConnectionStartupTest
 
   device:
-    - model: Pixel2.arm
+    - model: redfin
       version: 30
       locale: en_US
 

--- a/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -37,8 +37,8 @@ gcloud:
     - class org.mozilla.fenix.ui.BookmarksTest#addBookmarkTest
 
   device:
-    - model: Pixel2.arm
-      version: 26
+    - model: redfin
+      version: 30
       locale: en_US
     - model: walleye
       version: 27

--- a/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
@@ -14,8 +14,8 @@ gcloud:
     clearPackageData: true
 
   device:
-    - model: Pixel2.arm
-      version: 26
+    - model: redfin
+      version: 30
       locale: en_US
     - model: walleye
       version: 27

--- a/fenix/automation/taskcluster/androidTest/flank-arm-screenshots-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-screenshots-tests.yml
@@ -23,7 +23,7 @@ gcloud:
    - package org.mozilla.fenix.screenshots
 
   device:
-   - model: Pixel2.arm
+   - model: redfin
      version: 30
      locale: en_US
 

--- a/fenix/automation/taskcluster/androidTest/flank-arm-start-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-start-test.yml
@@ -29,7 +29,7 @@ gcloud:
    - class org.mozilla.fenix.ui.NoNetworkAccessStartupTests#noNetworkConnectionStartupTest
 
   device:
-   - model: Pixel2.arm
+   - model: redfin
      version: 30
      locale: en_US
 

--- a/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -23,13 +23,13 @@ gcloud:
     - notPackage org.mozilla.fenix.syncintegration
 
   device:
-    - model: Pixel2.arm
+    - model: redfin
       version: 30
       locale: en_US
 
 flank:
   project: GOOGLE_PROJECT
-  max-test-shards: 100
+  max-test-shards: 50
   num-test-runs: 1
   output-style: compact
   full-junit-result: true

--- a/focus-android/automation/taskcluster/androidTest/flank-arm-beta.yml
+++ b/focus-android/automation/taskcluster/androidTest/flank-arm-beta.yml
@@ -24,7 +24,7 @@ gcloud:
     - class org.mozilla.focus.activity.EraseBrowsingDataTest#deleteHistoryOnRestartTest
   
   device:
-    - model: Pixel2.arm
+    - model: redfin
       version: 30
       locale: en_US
 

--- a/focus-android/automation/taskcluster/androidTest/flank-arm-start-test.yml
+++ b/focus-android/automation/taskcluster/androidTest/flank-arm-start-test.yml
@@ -24,7 +24,7 @@ gcloud:
     - class org.mozilla.focus.activity.EraseBrowsingDataTest#deleteHistoryOnRestartTest
 
   device:
-    - model: Pixel2.arm
+    - model: redfin
       version: 30
       locale: en_US
 

--- a/focus-android/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/focus-android/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -24,7 +24,7 @@ gcloud:
     - package org.mozilla.focus.privacy
 
   device:
-    - model: Pixel2.arm
+    - model: redfin
       version: 30
       locale: en_US
 

--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -205,7 +205,7 @@ tasks:
             commands:
                 - [wget, {artifact-reference: '<signed-apk-debug-apk/public/build/fenix/arm64-v8a/target.apk>'}, '-O', app.apk]
                 - [wget, {artifact-reference: '<signed-apk-android-test/public/build/fenix/noarch/target.apk>'}, '-O', android-test.apk]
-                - [automation/taskcluster/androidTest/ui-test.sh, arm64-v8a, app.apk, android-test.apk, '100']
+                - [automation/taskcluster/androidTest/ui-test.sh, arm64-v8a, app.apk, android-test.apk, '50']
         treeherder:
             platform: 'fenix-ui-test/opt'
             symbol: fenix-debug(ui-test-arm)


### PR DESCRIPTION
https://status.firebase.google.com

`redfin` is marked as high-capacity at API Level `30`

Test of a Pixel 5 (Physical ARM) `redfin` from `Pixel2.arm`.

---- 

CI Run: 

Focus: ✅ 
Fenix: 🔴 Looks like there's significant failures on the Pixel 5 in common calls, would require tinkering. 

---

https://bugzilla.mozilla.org/show_bug.cgi?id=1831197
https://bugzilla.mozilla.org/show_bug.cgi?id=1831197
https://bugzilla.mozilla.org/show_bug.cgi?id=1831197
https://bugzilla.mozilla.org/show_bug.cgi?id=1831197
https://bugzilla.mozilla.org/show_bug.cgi?id=1831197
https://bugzilla.mozilla.org/show_bug.cgi?id=1831197