### PR TITLE
Bug 1831119 - WIP Add optional small and medium image resource fields to Nimbus onboarding feature

### DIFF
--- a/fenix/app/onboarding.fml.yaml
+++ b/fenix/app/onboarding.fml.yaml
@@ -19,7 +19,7 @@ features:
               ordering: 10
               body: juno_onboarding_default_browser_description_nimbus
               link-text: juno_onboarding_default_browser_description_link_text
-              image-res: ic_onboarding_welcome
+              image-res-default: ic_onboarding_welcome
               primary-button-label: juno_onboarding_default_browser_positive_button
               secondary-button-label: juno_onboarding_default_browser_negative_button
 
@@ -27,7 +27,7 @@ features:
               card-type: sync-sign-in
               title: juno_onboarding_sign_in_title
               body: juno_onboarding_sign_in_description
-              image-res: ic_onboarding_sync
+              image-res-default: ic_onboarding_sync
               ordering: 20
               primary-button-label: juno_onboarding_sign_in_positive_button
               secondary-button-label: juno_onboarding_sign_in_negative_button
@@ -36,7 +36,7 @@ features:
               card-type: notification-permission
               title: juno_onboarding_enable_notifications_title_nimbus
               body: juno_onboarding_enable_notifications_description_nimbus
-              image-res: ic_notification_permission
+              image-res-default: ic_notification_permission
               ordering: 30
               primary-button-label: juno_onboarding_enable_notifications_positive_button
               secondary-button-label: juno_onboarding_enable_notifications_negative_button
@@ -76,11 +76,19 @@ objects:
           e.g. body: This is a policy link
                link-text: policy link
         default: null
-      image-res:
+      image-res-default:
         type: Image
-        description: The resource id of the image to be displayed.
+        description: The default resource id of the image to be displayed.
         # This should never be defaulted.
         default: ic_onboarding_welcome
+      image-res-small:
+        type: Option<Image>
+        description: The resource id of the 'small' image to be displayed.
+        default: null
+      image-res-medium:
+        type: Option<Image>
+        description: The resource id of the 'medium' image to be displayed.
+        default: null
       ordering:
         type: Int
         description: Used to sequence the cards.

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
@@ -30,7 +30,11 @@ class JunoOnboardingMapperTest {
 
 private val defaultBrowserPageUiData = OnboardingPageUiData(
     type = OnboardingPageUiData.Type.DEFAULT_BROWSER,
-    imageRes = R.drawable.ic_onboarding_welcome,
+    imageResources = ImageResources(
+        default = R.drawable.ic_onboarding_welcome,
+        small = R.drawable.ic_onboarding_welcome,
+        medium = R.drawable.ic_onboarding_welcome,
+    ),
     title = "default browser title",
     description = "default browser body with link text",
     linkText = "link text",
@@ -39,7 +43,7 @@ private val defaultBrowserPageUiData = OnboardingPageUiData(
 )
 private val syncPageUiData = OnboardingPageUiData(
     type = OnboardingPageUiData.Type.SYNC_SIGN_IN,
-    imageRes = R.drawable.ic_onboarding_sync,
+    imageResources = ImageResources(R.drawable.ic_onboarding_sync),
     title = "sync title",
     description = "sync body",
     primaryButtonLabel = "sync primary button text",
@@ -47,7 +51,7 @@ private val syncPageUiData = OnboardingPageUiData(
 )
 private val notificationPageUiData = OnboardingPageUiData(
     type = OnboardingPageUiData.Type.NOTIFICATION_PERMISSION,
-    imageRes = R.drawable.ic_notification_permission,
+    imageResources = ImageResources(R.drawable.ic_notification_permission),
     title = "notification title",
     description = "notification body",
     primaryButtonLabel = "notification primary button text",
@@ -56,7 +60,9 @@ private val notificationPageUiData = OnboardingPageUiData(
 
 private val defaultBrowserCardData = OnboardingCardData(
     cardType = OnboardingCardType.DEFAULT_BROWSER,
-    imageRes = R.drawable.ic_onboarding_welcome,
+    imageResDefault = R.drawable.ic_onboarding_welcome,
+    imageResSmall = R.drawable.ic_onboarding_welcome,
+    imageResMedium = R.drawable.ic_onboarding_welcome,
     title = StringHolder(null, "default browser title"),
     body = StringHolder(null, "default browser body with link text"),
     linkText = StringHolder(null, "link text"),
@@ -66,7 +72,7 @@ private val defaultBrowserCardData = OnboardingCardData(
 )
 private val syncCardData = OnboardingCardData(
     cardType = OnboardingCardType.SYNC_SIGN_IN,
-    imageRes = R.drawable.ic_onboarding_sync,
+    imageResDefault = R.drawable.ic_onboarding_sync,
     title = StringHolder(null, "sync title"),
     body = StringHolder(null, "sync body"),
     primaryButtonLabel = StringHolder(null, "sync primary button text"),
@@ -75,7 +81,7 @@ private val syncCardData = OnboardingCardData(
 )
 private val notificationCardData = OnboardingCardData(
     cardType = OnboardingCardType.NOTIFICATION_PERMISSION,
-    imageRes = R.drawable.ic_notification_permission,
+    imageResDefault = R.drawable.ic_notification_permission,
     title = StringHolder(null, "notification title"),
     body = StringHolder(null, "notification body"),
     primaryButtonLabel = StringHolder(null, "notification primary button text"),

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapper.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.onboarding.view
 
+import androidx.annotation.DrawableRes
 import org.mozilla.fenix.nimbus.OnboardingCardData
 import org.mozilla.fenix.nimbus.OnboardingCardType
 import org.mozilla.fenix.settings.SupportUtils
@@ -23,12 +24,25 @@ internal fun Collection<OnboardingCardData>.toPageUiData(showNotificationPage: B
 
 private fun OnboardingCardData.toPageUiData() = OnboardingPageUiData(
     type = cardType.toPageUiDataType(),
-    imageRes = imageRes.resourceId,
+    imageResources = ImageResources(
+        imageResDefault.resourceId,
+        imageResSmall?.resourceId,
+        imageResMedium?.resourceId,
+    ),
     title = title,
     description = body,
     linkText = linkText,
     primaryButtonLabel = primaryButtonLabel,
     secondaryButtonLabel = secondaryButtonLabel,
+)
+
+/**
+ * Stores all the available image resources for an [OnboardingCardData].
+ */
+data class ImageResources(
+    @DrawableRes val default: Int,
+    @DrawableRes val small: Int? = null,
+    @DrawableRes val medium: Int? = null,
 )
 
 private fun OnboardingCardType.toPageUiDataType() = when (this) {
@@ -78,7 +92,7 @@ private fun createOnboardingPageState(
     onNegativeButtonClick: () -> Unit,
     onUrlClick: (String) -> Unit = {},
 ): OnboardingPageState = OnboardingPageState(
-    image = onboardingPageUiData.imageRes,
+    imageResources = onboardingPageUiData.imageResources,
     title = onboardingPageUiData.title,
     description = onboardingPageUiData.description,
     linkTextState = onboardingPageUiData.linkText?.let {

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/JunoOnboardingScreen.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/JunoOnboardingScreen.kt
@@ -228,7 +228,7 @@ private fun JunoOnboardingScreenPreview() {
 private fun defaultPreviewPages() = listOf(
     OnboardingPageUiData(
         type = OnboardingPageUiData.Type.DEFAULT_BROWSER,
-        imageRes = R.drawable.ic_onboarding_welcome,
+        imageResources = ImageResources(R.drawable.ic_onboarding_welcome),
         title = stringResource(R.string.juno_onboarding_default_browser_title_nimbus),
         description = stringResource(R.string.juno_onboarding_default_browser_description_nimbus),
         linkText = stringResource(R.string.juno_onboarding_default_browser_description_link_text),
@@ -237,7 +237,7 @@ private fun defaultPreviewPages() = listOf(
     ),
     OnboardingPageUiData(
         type = OnboardingPageUiData.Type.SYNC_SIGN_IN,
-        imageRes = R.drawable.ic_onboarding_sync,
+        imageResources = ImageResources(R.drawable.ic_onboarding_sync),
         title = stringResource(R.string.juno_onboarding_sign_in_title),
         description = stringResource(R.string.juno_onboarding_sign_in_description),
         primaryButtonLabel = stringResource(R.string.juno_onboarding_sign_in_positive_button),
@@ -245,7 +245,7 @@ private fun defaultPreviewPages() = listOf(
     ),
     OnboardingPageUiData(
         type = OnboardingPageUiData.Type.NOTIFICATION_PERMISSION,
-        imageRes = R.drawable.ic_notification_permission,
+        imageResources = ImageResources(R.drawable.ic_notification_permission),
         title = stringResource(R.string.juno_onboarding_enable_notifications_title_nimbus),
         description = stringResource(R.string.juno_onboarding_enable_notifications_description_nimbus),
         primaryButtonLabel = stringResource(R.string.juno_onboarding_enable_notifications_positive_button),

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/NotificationPermissionDialogScreen.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/NotificationPermissionDialogScreen.kt
@@ -28,7 +28,7 @@ fun NotificationPermissionDialogScreen(
 ) {
     OnboardingPage(
         pageState = OnboardingPageState(
-            image = R.drawable.ic_notification_permission,
+            imageResources = ImageResources(R.drawable.ic_notification_permission),
             title = stringResource(
                 id = R.string.onboarding_home_enable_notifications_title,
                 formatArgs = arrayOf(stringResource(R.string.app_name)),

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPage.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPage.kt
@@ -107,7 +107,7 @@ fun OnboardingPage(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Image(
-                    painter = painterResource(id = pageState.image),
+                    painter = painterResource(id = pageState.imageResources.default),
                     contentDescription = null,
                     modifier = Modifier.height(imageHeight(boxWithConstraintsScope)),
                 )
@@ -237,7 +237,7 @@ private fun OnboardingPagePreview() {
     FirefoxTheme {
         OnboardingPage(
             pageState = OnboardingPageState(
-                image = R.drawable.ic_notification_permission,
+                imageResources = ImageResources(R.drawable.ic_notification_permission),
                 title = stringResource(
                     id = R.string.onboarding_home_enable_notifications_title,
                     formatArgs = arrayOf(stringResource(R.string.app_name)),

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPageState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPageState.kt
@@ -4,12 +4,10 @@
 
 package org.mozilla.fenix.onboarding.view
 
-import androidx.annotation.DrawableRes
-
 /**
  * Model containing data for [OnboardingPage].
  *
- * @param image [DrawableRes] displayed on the page.
+ * @param imageResources The [ImageResources] of the page.
  * @param title [String] title of the page.
  * @param description [String] description of the page.
  * @param linkTextState [LinkTextState] part of description text with a link.
@@ -18,7 +16,7 @@ import androidx.annotation.DrawableRes
  * @param onRecordImpressionEvent Callback for recording impression event.
  */
 data class OnboardingPageState(
-    @DrawableRes val image: Int,
+    val imageResources: ImageResources,
     val title: String,
     val description: String,
     val linkTextState: LinkTextState? = null,

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPageUiData.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPageUiData.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.onboarding.view
 
-import androidx.annotation.DrawableRes
 import org.mozilla.fenix.nimbus.OnboardingCardData
 
 /**
@@ -12,7 +11,7 @@ import org.mozilla.fenix.nimbus.OnboardingCardData
  */
 data class OnboardingPageUiData(
     val type: Type,
-    @DrawableRes val imageRes: Int,
+    val imageResources: ImageResources,
     val title: String,
     val description: String,
     val linkText: String? = null,

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/UpgradeOnboarding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/UpgradeOnboarding.kt
@@ -69,7 +69,7 @@ fun UpgradeOnboarding(
         OnboardingPage(
             pageState = when (onboardingState) {
                 UpgradeOnboardingState.Welcome -> OnboardingPageState(
-                    image = R.drawable.ic_onboarding_welcome,
+                    imageResources = ImageResources(R.drawable.ic_onboarding_welcome),
                     title = stringResource(id = R.string.onboarding_home_welcome_title_2),
                     description = stringResource(id = R.string.onboarding_home_welcome_description),
                     primaryButton = Action(
@@ -88,7 +88,7 @@ fun UpgradeOnboarding(
                     },
                 )
                 UpgradeOnboardingState.SyncSignIn -> OnboardingPageState(
-                    image = R.drawable.ic_onboarding_sync,
+                    imageResources = ImageResources(R.drawable.ic_onboarding_sync),
                     title = stringResource(id = R.string.onboarding_home_sync_title_3),
                     description = stringResource(id = R.string.onboarding_home_sync_description),
                     primaryButton = Action(

--- a/fenix/app/src/test/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
@@ -14,7 +14,7 @@ class JunoOnboardingMapperTest {
     @Test
     fun `GIVEN a default browser page WHEN mapToOnboardingPageState is called THEN creates the expected OnboardingPageState`() {
         val expected = OnboardingPageState(
-            image = R.drawable.ic_onboarding_welcome,
+            imageResources = ImageResources(R.drawable.ic_onboarding_welcome),
             title = "default browser title",
             description = "default browser body with link text",
             linkTextState = LinkTextState(
@@ -28,7 +28,7 @@ class JunoOnboardingMapperTest {
 
         val onboardingPageUiData = OnboardingPageUiData(
             type = OnboardingPageUiData.Type.DEFAULT_BROWSER,
-            imageRes = R.drawable.ic_onboarding_welcome,
+            imageResources = ImageResources(R.drawable.ic_onboarding_welcome),
             title = "default browser title",
             description = "default browser body with link text",
             linkText = "link text",
@@ -52,7 +52,7 @@ class JunoOnboardingMapperTest {
     @Test
     fun `GIVEN a sync page WHEN mapToOnboardingPageState is called THEN creates the expected OnboardingPageState`() {
         val expected = OnboardingPageState(
-            image = R.drawable.ic_onboarding_sync,
+            imageResources = ImageResources(R.drawable.ic_onboarding_sync),
             title = "sync title",
             description = "sync body",
             primaryButton = Action("sync primary button text", unitLambda),
@@ -61,7 +61,7 @@ class JunoOnboardingMapperTest {
 
         val onboardingPageUiData = OnboardingPageUiData(
             type = OnboardingPageUiData.Type.SYNC_SIGN_IN,
-            imageRes = R.drawable.ic_onboarding_sync,
+            imageResources = ImageResources(R.drawable.ic_onboarding_sync),
             title = "sync title",
             description = "sync body",
             linkText = null,
@@ -85,7 +85,7 @@ class JunoOnboardingMapperTest {
     @Test
     fun `GIVEN a notification page WHEN mapToOnboardingPageState is called THEN creates the expected OnboardingPageState`() {
         val expected = OnboardingPageState(
-            image = R.drawable.ic_notification_permission,
+            imageResources = ImageResources(R.drawable.ic_notification_permission),
             title = "notification title",
             description = "notification body",
             primaryButton = Action("notification primary button text", unitLambda),
@@ -94,7 +94,7 @@ class JunoOnboardingMapperTest {
 
         val onboardingPageUiData = OnboardingPageUiData(
             type = OnboardingPageUiData.Type.NOTIFICATION_PERMISSION,
-            imageRes = R.drawable.ic_notification_permission,
+            imageResources = ImageResources(R.drawable.ic_notification_permission),
             title = "notification title",
             description = "notification body",
             linkText = null,

--- a/fenix/app/src/test/java/org/mozilla/fenix/onboarding/view/OnboardingPageUiDataTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/onboarding/view/OnboardingPageUiDataTest.kt
@@ -53,7 +53,7 @@ class OnboardingPageUiDataTest {
 
 private val defaultBrowserPageUiData = OnboardingPageUiData(
     type = OnboardingPageUiData.Type.DEFAULT_BROWSER,
-    imageRes = R.drawable.ic_onboarding_welcome,
+    imageResources = ImageResources(R.drawable.ic_onboarding_welcome),
     title = "default browser title",
     description = "default browser body with link text",
     linkText = "link text",
@@ -63,7 +63,7 @@ private val defaultBrowserPageUiData = OnboardingPageUiData(
 
 private val syncPageUiData = OnboardingPageUiData(
     type = OnboardingPageUiData.Type.SYNC_SIGN_IN,
-    imageRes = R.drawable.ic_onboarding_sync,
+    imageResources = ImageResources(R.drawable.ic_onboarding_sync),
     title = "sync title",
     description = "sync body",
     primaryButtonLabel = "sync primary button text",
@@ -72,7 +72,7 @@ private val syncPageUiData = OnboardingPageUiData(
 
 private val notificationPageUiData = OnboardingPageUiData(
     type = OnboardingPageUiData.Type.NOTIFICATION_PERMISSION,
-    imageRes = R.drawable.ic_notification_permission,
+    imageResources = ImageResources(R.drawable.ic_notification_permission),
     title = "notification title",
     description = "notification body",
     primaryButtonLabel = "notification primary button text",


### PR DESCRIPTION
UX are providing 3 different sized images to be used for onboarding. The Nimbus onboarding feature needs to be updated to handle this. The follow-up ticket will implement using the small and medium sized images.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1831119