### PR TITLE
Bug 1816517 - Add functionality for the three-dot button in the tabs tray page indicator

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
@@ -29,6 +29,7 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.rememberPagerState
 import mozilla.components.browser.state.selector.normalTabs
+import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.TabSessionState
@@ -75,6 +76,11 @@ import mozilla.components.browser.storage.sync.Tab as SyncTab
  * the multi select banner.
  * @param onShareSelectedTabsClick Invoked when the user clicks on the share button from the
  * multi select banner.
+ * @param onShareAllTabsClick Invoked when the user clicks on the share all tabs banner menu item.
+ * @param onTabSettingsClick Invoked when the user clicks on the tab settings banner menu item.
+ * @param onRecentlyClosedClick Invoked when the user clicks on the recently closed banner menu item.
+ * @param onAccountSettingsClick Invoked when the user clicks on the account settings banner menu item.
+ * @param onDeleteAllTabsClick Invoked when the user clicks on the close all tabs banner menu item.
  */
 @OptIn(ExperimentalPagerApi::class)
 @Suppress("LongMethod", "LongParameterList", "ComplexMethod")
@@ -102,9 +108,16 @@ fun TabsTray(
     onSyncedTabClick: (SyncTab) -> Unit,
     onSaveToCollectionClick: () -> Unit,
     onShareSelectedTabsClick: () -> Unit,
+    onShareAllTabsClick: () -> Unit,
+    onTabSettingsClick: () -> Unit,
+    onRecentlyClosedClick: () -> Unit,
+    onAccountSettingsClick: () -> Unit,
+    onDeleteAllTabsClick: () -> Unit,
 ) {
     val normalTabCount = browserStore
         .observeAsComposableState { state -> state.normalTabs.size }.value ?: 0
+    val privateTabCount = browserStore
+        .observeAsComposableState { state -> state.privateTabs.size }.value ?: 0
     val multiselectMode = tabsTrayStore
         .observeAsComposableState { state -> state.mode }.value ?: TabsTrayState.Mode.Normal
     val selectedPage = tabsTrayStore
@@ -141,11 +154,18 @@ fun TabsTray(
                 selectMode = multiselectMode,
                 selectedPage = selectedPage,
                 normalTabCount = normalTabCount,
+                privateTabCount = privateTabCount,
                 isInDebugMode = isInDebugMode,
                 onTabPageIndicatorClicked = onTabPageClick,
                 onExitSelectModeClick = { tabsTrayStore.dispatch(TabsTrayAction.ExitSelectMode) },
                 onSaveToCollectionClick = onSaveToCollectionClick,
                 onShareSelectedTabsClick = onShareSelectedTabsClick,
+                onEnterMultiselectModeClick = { tabsTrayStore.dispatch(TabsTrayAction.EnterSelectMode) },
+                onShareAllTabsClick = onShareAllTabsClick,
+                onTabSettingsClick = onTabSettingsClick,
+                onRecentlyClosedClick = onRecentlyClosedClick,
+                onAccountSettingsClick = onAccountSettingsClick,
+                onDeleteAllTabsClick = onDeleteAllTabsClick,
             )
         }
 
@@ -500,6 +520,11 @@ private fun TabsTrayPreviewRoot(
             onSyncedTabClick = {},
             onSaveToCollectionClick = {},
             onShareSelectedTabsClick = {},
+            onShareAllTabsClick = {},
+            onTabSettingsClick = {},
+            onRecentlyClosedClick = {},
+            onAccountSettingsClick = {},
+            onDeleteAllTabsClick = {},
         )
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
@@ -81,6 +81,9 @@ import mozilla.components.browser.storage.sync.Tab as SyncTab
  * @param onRecentlyClosedClick Invoked when the user clicks on the recently closed banner menu item.
  * @param onAccountSettingsClick Invoked when the user clicks on the account settings banner menu item.
  * @param onDeleteAllTabsClick Invoked when the user clicks on the close all tabs banner menu item.
+ * @param onBookmarkSelectedTabsClick Invoked when the user clicks on the bookmark banner menu item.
+ * @param onDeleteSelectedTabsClick Invoked when the user clicks on the close selected tabs banner menu item.
+ * @param onForceSelectedTabsAsInactiveClick Invoked when the user clicks on the make inactive banner menu item.
  */
 @OptIn(ExperimentalPagerApi::class)
 @Suppress("LongMethod", "LongParameterList", "ComplexMethod")
@@ -113,6 +116,9 @@ fun TabsTray(
     onRecentlyClosedClick: () -> Unit,
     onAccountSettingsClick: () -> Unit,
     onDeleteAllTabsClick: () -> Unit,
+    onBookmarkSelectedTabsClick: () -> Unit,
+    onDeleteSelectedTabsClick: () -> Unit,
+    onForceSelectedTabsAsInactiveClick: () -> Unit,
 ) {
     val normalTabCount = browserStore
         .observeAsComposableState { state -> state.normalTabs.size }.value ?: 0
@@ -166,6 +172,9 @@ fun TabsTray(
                 onRecentlyClosedClick = onRecentlyClosedClick,
                 onAccountSettingsClick = onAccountSettingsClick,
                 onDeleteAllTabsClick = onDeleteAllTabsClick,
+                onBookmarkSelectedTabsClick = onBookmarkSelectedTabsClick,
+                onDeleteSelectedTabsClick = onDeleteSelectedTabsClick,
+                onForceSelectedTabsAsInactiveClick = onForceSelectedTabsAsInactiveClick,
             )
         }
 
@@ -525,6 +534,9 @@ private fun TabsTrayPreviewRoot(
             onRecentlyClosedClick = {},
             onAccountSettingsClick = {},
             onDeleteAllTabsClick = {},
+            onDeleteSelectedTabsClick = {},
+            onBookmarkSelectedTabsClick = {},
+            onForceSelectedTabsAsInactiveClick = {},
         )
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayBanner.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayBanner.kt
@@ -74,6 +74,9 @@ private val ICON_SIZE = 24.dp
  * @param onRecentlyClosedClick Invoked when the user clicks on the recently closed tabs menu item.
  * @param onAccountSettingsClick Invoked when the user clicks on the account settings menu item.
  * @param onDeleteAllTabsClick Invoked when user interacts with the close all tabs menu item.
+ * @param onDeleteSelectedTabsClick Invoked when user interacts with the close menu item.
+ * @param onBookmarkSelectedTabsClick Invoked when user interacts with the bookmark menu item.
+ * @param onForceSelectedTabsAsInactiveClick Invoked when user interacts with the make inactive menu item.
  */
 @Suppress("LongParameterList")
 @Composable
@@ -93,6 +96,9 @@ fun TabsTrayBanner(
     onRecentlyClosedClick: () -> Unit,
     onAccountSettingsClick: () -> Unit,
     onDeleteAllTabsClick: () -> Unit,
+    onDeleteSelectedTabsClick: () -> Unit,
+    onBookmarkSelectedTabsClick: () -> Unit,
+    onForceSelectedTabsAsInactiveClick: () -> Unit,
 ) {
     if (selectMode is TabsTrayState.Mode.Select) {
         MultiSelectBanner(
@@ -101,6 +107,9 @@ fun TabsTrayBanner(
             onExitSelectModeClick = onExitSelectModeClick,
             onSaveToCollectionsClick = onSaveToCollectionClick,
             onShareSelectedTabs = onShareSelectedTabsClick,
+            onBookmarkSelectedTabsClick = onBookmarkSelectedTabsClick,
+            onCloseSelectedTabsClick = onDeleteSelectedTabsClick,
+            onMakeSelectedTabsInactive = onForceSelectedTabsAsInactiveClick,
         )
     } else {
         SingleSelectBanner(
@@ -350,8 +359,11 @@ private fun NormalTabsTabIcon(normalTabCount: Int) {
  * @param onExitSelectModeClick Invoked when the user clicks on exit select mode button.
  * @param onSaveToCollectionsClick Invoked when the user clicks on the save to collection button.
  * @param onShareSelectedTabs Invoked when the user clicks on the share button.
+ * @param onBookmarkSelectedTabsClick Invoked when user interacts with the bookmark menu item.
+ * @param onCloseSelectedTabsClick Invoked when user interacts with the close menu item.
+ * @param onMakeSelectedTabsInactive Invoked when user interacts with the make inactive menu item.
  */
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LongParameterList")
 @Composable
 private fun MultiSelectBanner(
     selectedTabCount: Int,
@@ -359,21 +371,27 @@ private fun MultiSelectBanner(
     onExitSelectModeClick: () -> Unit,
     onSaveToCollectionsClick: () -> Unit,
     onShareSelectedTabs: () -> Unit,
+    onBookmarkSelectedTabsClick: () -> Unit,
+    onCloseSelectedTabsClick: () -> Unit,
+    onMakeSelectedTabsInactive: () -> Unit,
 ) {
     var showMenu by remember { mutableStateOf(false) }
     val menuItems = mutableListOf(
         MenuItem(
             title = stringResource(R.string.tab_tray_multiselect_menu_item_bookmark),
-        ) {},
+            onClick = onBookmarkSelectedTabsClick,
+        ),
         MenuItem(
             title = stringResource(R.string.tab_tray_multiselect_menu_item_close),
-        ) {},
+            onClick = onCloseSelectedTabsClick,
+        ),
     )
     if (shouldShowInactiveButton) {
         menuItems.add(
             MenuItem(
                 title = stringResource(R.string.inactive_tabs_menu_item),
-            ) {},
+                onClick = onMakeSelectedTabsInactive,
+            ),
         )
     }
 
@@ -508,6 +526,9 @@ private fun TabsTrayBannerPreviewRoot(
                 onRecentlyClosedClick = {},
                 onAccountSettingsClick = {},
                 onDeleteAllTabsClick = {},
+                onBookmarkSelectedTabsClick = {},
+                onDeleteSelectedTabsClick = {},
+                onForceSelectedTabsAsInactiveClick = {},
             )
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -275,6 +275,9 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                                 private = tabsTrayStore.state.selectedPage == Page.PrivateTabs,
                             )
                         },
+                        onDeleteSelectedTabsClick = tabsTrayInteractor::onDeleteSelectedTabsClicked,
+                        onBookmarkSelectedTabsClick = tabsTrayInteractor::onBookmarkSelectedTabsClicked,
+                        onForceSelectedTabsAsInactiveClick = tabsTrayInteractor::onForceSelectedTabsAsInactiveClicked,
                     )
                 }
             }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -260,6 +260,21 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                         onSyncedTabClick = tabsTrayInteractor::onSyncedTabClicked,
                         onSaveToCollectionClick = tabsTrayInteractor::onAddSelectedTabsToCollectionClicked,
                         onShareSelectedTabsClick = tabsTrayInteractor::onShareSelectedTabs,
+                        onShareAllTabsClick = {
+                            TabsTray.shareAllTabs.record(NoExtras())
+                            navigationInteractor.onShareTabsOfTypeClicked(
+                                private = tabsTrayStore.state.selectedPage == Page.PrivateTabs,
+                            )
+                        },
+                        onTabSettingsClick = navigationInteractor::onTabSettingsClicked,
+                        onRecentlyClosedClick = navigationInteractor::onOpenRecentlyClosedClicked,
+                        onAccountSettingsClick = navigationInteractor::onAccountSettingsClicked,
+                        onDeleteAllTabsClick = {
+                            TabsTray.closeAllTabs.record(NoExtras())
+                            navigationInteractor.onCloseAllTabsClicked(
+                                private = tabsTrayStore.state.selectedPage == Page.PrivateTabs,
+                            )
+                        },
                     )
                 }
             }


### PR DESCRIPTION
Added functionality for the tabs tray banner three-dot button.

| Normal mode | Multi select mode |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/35462038/236197977-c3f483da-9987-4ac2-8f06-90c607e61823.mp4" /> | <video src="https://user-images.githubusercontent.com/35462038/236198002-2c1d7e9b-27a4-4c44-9b1a-137914c113c4.mp4" /> |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816517
https://bugzilla.mozilla.org/show_bug.cgi?id=1816558