### PR TITLE
Bug 1831336 - WIP Incorporate the new Nimbus experimenter PNG image resources in OnboardingPage

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPage.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPage.kt
@@ -107,7 +107,11 @@ fun OnboardingPage(
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Image(
-                    painter = painterResource(id = pageState.image),
+                    painter = painterResource(
+                        id = pageState.imageResources.resourceIdForScreenSize(
+                            boxWithConstraintsScope,
+                        ),
+                    ),
                     contentDescription = null,
                     modifier = Modifier.height(imageHeight(boxWithConstraintsScope)),
                 )
@@ -231,13 +235,23 @@ private fun imageHeight(boxWithConstraintsScope: BoxWithConstraintsScope): Dp {
     return boxWithConstraintsScope.maxHeight.times(imageHeightRatio)
 }
 
+/**
+ * @return the relevant image resource for the given screen size.
+ */
+private fun ImageResources.resourceIdForScreenSize(boxWithConstraintsScope: BoxWithConstraintsScope) =
+    when {
+        boxWithConstraintsScope.maxHeight <= 550.dp -> small ?: default
+        boxWithConstraintsScope.maxHeight <= 650.dp -> medium ?: default
+        else -> default
+    }
+
 @LightDarkPreview
 @Composable
 private fun OnboardingPagePreview() {
     FirefoxTheme {
         OnboardingPage(
             pageState = OnboardingPageState(
-                image = R.drawable.ic_notification_permission,
+                imageResources = ImageResources(R.drawable.ic_notification_permission),
                 title = stringResource(
                     id = R.string.onboarding_home_enable_notifications_title,
                     formatArgs = arrayOf(stringResource(R.string.app_name)),


### PR DESCRIPTION
Depends on https://github.com/mozilla-mobile/firefox-android/pull/1906, https://github.com/mozilla-mobile/firefox-android/pull/1895

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1831336