### PR TITLE
Bug 1831545 - WIP Add should display field to the onboarding manifest and add to mapping filter

### DIFF
--- a/fenix/app/onboarding.fml.yaml
+++ b/fenix/app/onboarding.fml.yaml
@@ -81,6 +81,10 @@ objects:
         description: The resource id of the image to be displayed.
         # This should never be defaulted.
         default: ic_onboarding_welcome
+      should-display:
+        type: Boolean
+        description: If true, the card should be displayed.
+        default: true
       ordering:
         type: Int
         description: Used to sequence the cards.

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
@@ -26,6 +26,15 @@ class JunoOnboardingMapperTest {
         val expected = listOf(defaultBrowserPageUiData, syncPageUiData)
         assertEquals(expected, unsortedAllKnownCardData.toPageUiData(false))
     }
+
+    @Test
+    fun cardShouldBeDisplayedFalse_pagesToDisplay_returnsSortedListOfConvertedPagesWithoutThatCard() {
+        val expected = listOf(defaultBrowserPageUiData, syncPageUiData, notificationPageUiData)
+
+        val cards = unsortedAllKnownCardData.plus(defaultBrowserCardData(false))
+
+        assertEquals(expected, cards.toPageUiData(true))
+    }
 }
 
 private val defaultBrowserPageUiData = OnboardingPageUiData(
@@ -54,7 +63,7 @@ private val notificationPageUiData = OnboardingPageUiData(
     secondaryButtonLabel = "notification secondary button text",
 )
 
-private val defaultBrowserCardData = OnboardingCardData(
+private fun defaultBrowserCardData(shouldDisplay: Boolean = true) = OnboardingCardData(
     cardType = OnboardingCardType.DEFAULT_BROWSER,
     imageRes = R.drawable.ic_onboarding_welcome,
     title = StringHolder(null, "default browser title"),
@@ -63,6 +72,7 @@ private val defaultBrowserCardData = OnboardingCardData(
     primaryButtonLabel = StringHolder(null, "default browser primary button text"),
     secondaryButtonLabel = StringHolder(null, "default browser secondary button text"),
     ordering = 10,
+    shouldDisplay = shouldDisplay,
 )
 private val syncCardData = OnboardingCardData(
     cardType = OnboardingCardType.SYNC_SIGN_IN,
@@ -86,5 +96,5 @@ private val notificationCardData = OnboardingCardData(
 private val unsortedAllKnownCardData = listOf(
     syncCardData,
     notificationCardData,
-    defaultBrowserCardData,
+    defaultBrowserCardData(),
 )

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapper.kt
@@ -12,13 +12,14 @@ import org.mozilla.fenix.settings.SupportUtils
  * Returns a list of all the required Nimbus 'cards' that have been converted to [OnboardingPageUiData].
  */
 internal fun Collection<OnboardingCardData>.toPageUiData(showNotificationPage: Boolean): List<OnboardingPageUiData> =
-    filter {
-        if (it.cardType == OnboardingCardType.NOTIFICATION_PERMISSION) {
-            showNotificationPage
-        } else {
-            true
-        }
-    }.sortedBy { it.ordering }
+    filter { it.shouldDisplay }
+        .filter {
+            if (it.cardType == OnboardingCardType.NOTIFICATION_PERMISSION) {
+                showNotificationPage
+            } else {
+                true
+            }
+        }.sortedBy { it.ordering }
         .map { it.toPageUiData() }
 
 private fun OnboardingCardData.toPageUiData() = OnboardingPageUiData(


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1831545