### PR TITLE
Bug 1832001 - [MozillaOnline] Update Privacy pop window content in MozillaOnline builds

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentDisplayHelper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentDisplayHelper.kt
@@ -25,30 +25,15 @@ fun showPrivacyPopWindow(context: Context, activity: Activity) {
 
     // Use hyperlinks to display details about privacy
     val messageClickable1 = context.getString(R.string.privacy_notice_clickable1)
-    val messageClickable2 = context.getString(R.string.privacy_notice_clickable2)
-    val messageClickable3 = context.getString(R.string.privacy_notice_clickable3)
+
     val messageSpannable = SpannableString(content)
 
     val clickableSpan1 = PrivacyContentSpan(Position.POS1, context)
-    val clickableSpan2 = PrivacyContentSpan(Position.POS2, context)
-    val clickableSpan3 = PrivacyContentSpan(Position.POS3, context)
 
     messageSpannable.setSpan(
         clickableSpan1,
         content.indexOf(messageClickable1),
         content.indexOf(messageClickable1) + messageClickable1.length,
-        Spanned.SPAN_INCLUSIVE_INCLUSIVE,
-    )
-    messageSpannable.setSpan(
-        clickableSpan2,
-        content.indexOf(messageClickable2),
-        content.indexOf(messageClickable2) + messageClickable2.length,
-        Spanned.SPAN_INCLUSIVE_INCLUSIVE,
-    )
-    messageSpannable.setSpan(
-        clickableSpan3,
-        content.indexOf(messageClickable3),
-        content.indexOf(messageClickable3) + messageClickable3.length,
         Spanned.SPAN_INCLUSIVE_INCLUSIVE,
     )
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentSpan.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentSpan.kt
@@ -12,14 +12,10 @@ import android.view.View
 
 object Position {
     const val POS1 = 1
-    const val POS2 = 2
-    const val POS3 = 3
 }
 
 object ADDR {
-    const val URL1 = "https://www.mozilla.org/en-US/MPL/"
-    const val URL2 = "https://www.mozilla.org/en-US/foundation/trademarks/policy/"
-    const val URL3 = "https://www.mozilla.org/zh-CN/privacy/firefox/"
+    const val URL1 = "https://www.firefox.com.cn/about/privacy/firefox-android/"
 }
 
 class PrivacyContentSpan(var pos: Int, var context: Context) :
@@ -35,8 +31,6 @@ class PrivacyContentSpan(var pos: Int, var context: Context) :
         val addr = Bundle()
         when (pos) {
             Position.POS1 -> addr.putString("url", ADDR.URL1)
-            Position.POS2 -> addr.putString("url", ADDR.URL2)
-            Position.POS3 -> addr.putString("url", ADDR.URL3)
         }
         engineViewIntent.putExtras(addr)
         context.startActivity(engineViewIntent)

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -12,6 +12,7 @@ import androidx.core.net.toUri
 import mozilla.components.support.ktx.android.content.appVersionName
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.BuildConfig
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customtabs.EXTRA_IS_SANDBOX_CUSTOM_TAB
@@ -96,6 +97,9 @@ object SupportUtils {
     fun getMozillaPageUrl(page: MozillaPage, locale: Locale = Locale.getDefault()): String {
         val path = page.path
         val langTag = getLanguageTag(locale)
+        if (Config.channel.isMozillaOnline && page == MozillaPage.PRIVATE_NOTICE) {
+            return "https://www.firefox.com.cn/about/privacy/firefox-android/"
+        }
         return "https://www.mozilla.org/$langTag/$path"
     }
 

--- a/fenix/app/src/main/res/values-zh-rCN/mozonline_strings.xml
+++ b/fenix/app/src/main/res/values-zh-rCN/mozonline_strings.xml
@@ -4,17 +4,13 @@
     <!-- Privacy Notice title-->
     <string name="privacy_notice_title">关于您的权利</string>
     <!-- Privacy Notice content-->
-    <string name="privacy_notice_content">Mozilla Firefox 是一款自由开源软件，由来自世界各地成千上万的社区志愿者共同完成。以下几点您应该了解：
-    \n\n•Firefox 提供给您时依照的条款为 Mozilla 公共许可证（MPL）。这表示您可以使用、复制和向他人分发 Firefox。我们也非常欢迎您按自己的需要修改 Firefox 的源代码。Mozilla 公共许可证还授予您分发您自己修改过的软件版本的权利。
-    \n•您没有获得 Mozilla 基金会或其他任何一方的商标权利或许可，这包括但不限于 Firefox 的名称或标志。有关商标的其他信息在：这里。
-    \n•Firefox 的一些功能（例如崩溃报告器）使您可以向 Mozilla 提供反馈。提交反馈的同时，您授权 Mozilla 使用反馈信息改进产品、在其网站上发布反馈信息，以及分发反馈内容。
-    \n•关于我们如何使用您通过 Firefox 提交给 Mozilla 的个人信息和反馈，请参见 Firefox 隐私权政策。</string>
+    <string name="privacy_notice_content">在使用本应用前，请仔细阅读我们的个人信息保护政策。本政策帮助您了解我们为什么，以及如何收集、存储、使用、保护您的个人信息，您可以点击阅读完整内容，以便进一步了解。
+    \n根据《常⻅类型移动互联网应用程序必要个人信息范围规定》，火狐浏览器中国版属于“浏览器类”，基本功能服务为“浏览互联网信息资源”，无须个人信息，即可使用基本功能服务。
+    \n您同意个人信息保护政策，仅代表您已了解本应用提供的功能，以及功能运行所需的必要个人信息，并不代表您已同意我们收集非必要个人信息。对于非必要的个人信息处理，会在您使用服务的过程中单独征求您的同意。如果您拒绝我们收集非必要个人信息，并不会影响您使用基本功能服务。
+    \n您同意个人信息保护政策，个人信息相关权限并不会默认开启，我们会在您使用到相应功能时，另行弹窗再次征得您的同意后开启。权限开启后您还可以随时通过设备设置关闭权限。您不同意开启权限，不会影响其他非相关功能的正常使用。
+    \n点击同意即代表您已阅读并同意我们的个人信息保护政策。</string>
     <!-- Privacy Notice clickable-->
-    <string name="privacy_notice_clickable1">Mozilla 公共许可证（MPL）</string>
-    <!-- Privacy Notice clickable-->
-    <string name="privacy_notice_clickable2">这里</string>
-    <!-- Privacy Notice clickable-->
-    <string name="privacy_notice_clickable3">Firefox 隐私权政策</string>
+    <string name="privacy_notice_clickable1">阅读完整内容</string>
     <!-- Privacy Notice positive button-->
     <string name="privacy_notice_positive_button">同意并继续</string>
     <!-- Privacy Notice neutral button-->

--- a/fenix/app/src/main/res/values/mozonline_strings.xml
+++ b/fenix/app/src/main/res/values/mozonline_strings.xml
@@ -4,17 +4,13 @@
     <!-- Privacy Notice title-->
     <string name="privacy_notice_title">About your rights</string>
     <!-- Privacy Notice content-->
-    <string name="privacy_notice_content">Mozilla Firefox is free and open source software, built by a community of thousands from all over the world. There are a few things you should know:
-    \n\n•Firefox is made available to you under the terms of the Mozilla Public License. This means you may use, copy and distribute Firefox to others. You are also welcome to modify the source code of Firefox as you want to meet your needs. The Mozilla Public License also gives you the right to distribute your modified versions.
-    \n•You are not granted any trademark rights or licenses to the trademarks of the Mozilla Foundation or any party, including without limitation the Firefox name or logo. Additional information on trademarks may be found here.
-    \n•Some features in Firefox, such as the Crash Reporter, give you the option to provide feedback to Mozilla. By choosing to submit feedback, you give Mozilla permission to use the feedback to improve its products, to publish the feedback on its websites, and to distribute the feedback.
-    \n•How we use your personal information and feedback submitted to Mozilla through Firefox is described in the Firefox Privacy Policy.</string>
+    <string name="privacy_notice_content">Before using this application, please carefully read our Personal Information Protection Policy. This policy helps you understand why and how we collect, store, use, and protect your personal information. You can click on Read Full Content for further information.
+    \nAccording to the "Regulations on the Scope of Necessary Personal Information for Common Types of Mobile Internet Applications," the Chinese version of Firefox browser belongs to the "browser category," with its basic function being "browsing Internet information resources." No personal information is required to use the basic functions.
+    \nBy agreeing to the Personal Information Protection Policy, you acknowledge that you understand the functions provided by the application and the necessary personal information required for the functioning, but this does not mean you agree to our collection of non-essential personal information. For non-essential personal information processing, we will seek your consent separately during your use of the service. Refusing to provide non-essential personal information will not affect your use of basic functions.
+    \nWhen you agree to the Personal Information Protection Policy, the related permissions will not be enabled by default. We will enable these permissions after obtaining your consent through a separate pop-up when you use the corresponding functions. You can also close the permissions at any time through device settings. If you disagree with enabling permissions, it will not affect the normal use of other unrelated functions.
+    \nClicking "agree" indicates that you have read and agreed to our Personal Information Protection Policy.</string>
     <!-- Privacy Notice clickable-->
-    <string name="privacy_notice_clickable1">Mozilla Public License</string>
-    <!-- Privacy Notice clickable-->
-    <string name="privacy_notice_clickable2">found here</string>
-    <!-- Privacy Notice clickable-->
-    <string name="privacy_notice_clickable3">Firefox Privacy Policy</string>
+    <string name="privacy_notice_clickable1">Read Full Content</string>
     <!-- Privacy Notice positive button-->
     <string name="privacy_notice_positive_button">Agree and Continue</string>
     <!-- Privacy Notice neutral button-->


### PR DESCRIPTION
Due to the requirement from authorities in China, there will be several PR about MozillaOnline builds modifications in the next few days.

This PR updates the content of privacy pop window content and change the link of privacy notice. We have confirmed the content of the new pop window and the privacy notice (specifically for MozillaOnline builds) with legal through emails.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1832001