### PR TITLE
 Bug 1832008  - [MozillaOnline] Export firefox account personal info and save the file

### DIFF
--- a/fenix/app/src/main/res/values-zh-rCN/mozonline_strings.xml
+++ b/fenix/app/src/main/res/values-zh-rCN/mozonline_strings.xml
@@ -44,5 +44,7 @@
     <!-- Homescreen menu button -->
     <!-- Browser menu button that opens the account setting page -->
     <string name="browser_menu_manage_account_and_devices">管理账户和设备</string>
+
+    <string name="preferences_export_account_info">导出个人信息</string>
 </resources>
 

--- a/fenix/app/src/main/res/values/mozonline_strings.xml
+++ b/fenix/app/src/main/res/values/mozonline_strings.xml
@@ -43,4 +43,6 @@
     <!-- Homescreen menu button -->
     <!-- Browser menu button that opens the account setting page -->
     <string name="browser_menu_manage_account_and_devices">Manage Account and Devices</string>
+    
+    <string name="preferences_export_account_info">Export Account Info</string>
 </resources>

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -44,6 +44,7 @@
     <string name="pref_key_your_rights" translatable="false">pref_key_your_rights</string>
     <string name="pref_key_account" translatable="false">pref_key_account</string>
     <string name="pref_key_sign_in" translatable="false">pref_key_sign_in</string>
+    <string name="pref_key_export_account_info" translatable="false">pref_key_export_account_info</string>
     <string name="pref_key_account_auth_error" translatable="false">pref_key_account_auth_error</string>
     <string name="pref_key_allow_domestic_china_fxa_server" translatable="false">pref_key_allow_domestic_china_fxa_server</string>
     <string name="pref_key_sync_debug" translatable="false">pref_key_sync_debug</string>

--- a/fenix/app/src/main/res/xml/account_settings_preferences.xml
+++ b/fenix/app/src/main/res/xml/account_settings_preferences.xml
@@ -60,5 +60,9 @@
             android:key="@string/pref_key_sync_address"
             android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_address" />
+
+        <Preference
+            android:key="@string/pref_key_export_account_info"
+            android:title="@string/preferences_export_account_info" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Due to the requirement from authorities in China, there will be several PR about MozillaOnline builds modifications in the next few days.

This PR export the firefox account personal info (email, displayName, avatar, device) as a txt file and save it.

https://bugzilla.mozilla.org/show_bug.cgi?id=1832008
https://bugzilla.mozilla.org/show_bug.cgi?id=1832008
https://bugzilla.mozilla.org/show_bug.cgi?id=1832008
https://bugzilla.mozilla.org/show_bug.cgi?id=1832008
https://bugzilla.mozilla.org/show_bug.cgi?id=1832008