### PR TITLE
Bug 1807081 - Add OLED black theme, for nightly testing only

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -21,6 +21,11 @@ object FeatureFlags {
     val customExtensionCollectionFeature = Config.channel.isNightlyOrDebug || Config.channel.isBeta
 
     /**
+     * Enables the user to select an "OLED Black" theme.
+     */
+    val blackTheme = Config.channel.isNightlyOrDebug
+
+    /**
      * Pull-to-refresh allows you to pull the web content down far enough to have the page to
      * reload.
      */

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -562,7 +562,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                     AppCompatDelegate.MODE_NIGHT_NO,
                 )
             }
-            settings.shouldUseDarkTheme -> {
+            settings.shouldUseDarkTheme || settings.shouldUseBlackTheme -> {
                 AppCompatDelegate.setDefaultNightMode(
                     AppCompatDelegate.MODE_NIGHT_YES,
                 )

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -563,7 +563,7 @@ class Core(
             (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
                 Configuration.UI_MODE_NIGHT_YES
         return when {
-            context.settings().shouldUseDarkTheme -> PreferredColorScheme.Dark
+            context.settings().shouldUseDarkTheme || context.settings().shouldUseBlackTheme -> PreferredColorScheme.Dark
             context.settings().shouldUseLightTheme -> PreferredColorScheme.Light
             inDark -> PreferredColorScheme.Dark
             else -> PreferredColorScheme.Light

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
@@ -40,6 +40,7 @@ import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.ext.name
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.settings.SupportUtils
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.view.ViewHolder
 
 @SuppressLint("ClickableViewAccessibility")
@@ -100,7 +101,8 @@ class TopSiteItemViewHolder(
             flow.map { state -> state.wallpaperState }
                 .ifChanged()
                 .collect { currentState ->
-                    var backgroundColor = ContextCompat.getColor(view.context, R.color.fx_mobile_layer_color_2)
+                    val colorResourceId = ThemeManager.resolveAttribute(R.attr.layer2, view.context)
+                    var backgroundColor = ContextCompat.getColor(view.context, colorResourceId)
 
                     currentState.runIfWallpaperCardColorsAreAvailable { cardColorLight, cardColorDark ->
                         backgroundColor = if (view.context.isSystemInDarkTheme()) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -31,6 +31,7 @@ import org.mozilla.fenix.utils.view.addToRadioGroup
 class CustomizationFragment : PreferenceFragmentCompat() {
     private lateinit var radioLightTheme: RadioButtonPreference
     private lateinit var radioDarkTheme: RadioButtonPreference
+    private lateinit var radioBlackTheme: RadioButtonPreference
     private lateinit var radioAutoBatteryTheme: RadioButtonPreference
     private lateinit var radioFollowDeviceTheme: RadioButtonPreference
 
@@ -48,6 +49,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
     private fun setupPreferences() {
         bindFollowDeviceTheme()
         bindDarkTheme()
+        bindBlackTheme()
         bindLightTheme()
         bindAutoBatteryTheme()
         setupRadioGroups()
@@ -59,6 +61,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         addToRadioGroup(
             radioLightTheme,
             radioDarkTheme,
+            radioBlackTheme,
             if (SDK_INT >= Build.VERSION_CODES.P) {
                 radioFollowDeviceTheme
             } else {
@@ -95,6 +98,14 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         }
     }
 
+    private fun bindBlackTheme() {
+        radioBlackTheme = requirePreference(R.string.pref_key_black_theme)
+        radioBlackTheme.onClickListener {
+            setNewTheme(AppCompatDelegate.MODE_NIGHT_YES)
+        }
+        radioBlackTheme.isVisible = FeatureFlags.blackTheme
+    }
+
     private fun bindFollowDeviceTheme() {
         radioFollowDeviceTheme = requirePreference(R.string.pref_key_follow_device_theme)
         if (SDK_INT >= Build.VERSION_CODES.P) {
@@ -105,8 +116,9 @@ class CustomizationFragment : PreferenceFragmentCompat() {
     }
 
     private fun setNewTheme(mode: Int) {
-        if (AppCompatDelegate.getDefaultNightMode() == mode) return
-        AppCompatDelegate.setDefaultNightMode(mode)
+        if (AppCompatDelegate.getDefaultNightMode() != mode) {
+            AppCompatDelegate.setDefaultNightMode(mode)
+        }
         activity?.recreate()
         with(requireComponents.core) {
             engine.settings.preferredColorScheme = getPreferredColorScheme()

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -125,7 +125,11 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setStyle(STYLE_NO_TITLE, R.style.TabTrayDialogStyle)
+        if (requireContext().settings().shouldUseBlackTheme) {
+            setStyle(STYLE_NO_TITLE, R.style.NormalBlackTheme_TabTrayDialogStyle)
+        } else {
+            setStyle(STYLE_NO_TITLE, R.style.TabTrayDialogStyle)
+        }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabViewHolder.kt
@@ -19,6 +19,7 @@ import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.selection.SelectionHolder
 import org.mozilla.fenix.tabstray.TabsTrayInteractor
 import org.mozilla.fenix.tabstray.TabsTrayStore
+import org.mozilla.fenix.theme.ThemeManager
 import kotlin.math.max
 
 sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -95,6 +96,9 @@ sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(item
         itemView: View,
         featureName: String,
     ) : AbstractBrowserTabViewHolder(itemView, imageLoader, store, selectionHolder, featureName) {
+
+        private val nonSelectedColorId = ThemeManager.resolveAttribute(R.attr.layer1, itemView.context)
+
         override val thumbnailSize: Int
             get() = max(
                 itemView.resources.getDimensionPixelSize(R.dimen.tab_tray_list_item_thumbnail_height),
@@ -105,7 +109,7 @@ sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(item
             val color = if (showAsSelected) {
                 R.color.fx_mobile_layer_color_accent_opaque
             } else {
-                R.color.fx_mobile_layer_color_1
+                nonSelectedColorId
             }
             itemView.setBackgroundColor(
                 ContextCompat.getColor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
@@ -24,6 +24,7 @@ import org.mozilla.fenix.tabstray.TabsTrayState.Mode
 import org.mozilla.fenix.tabstray.TabsTrayState.Mode.Select
 import org.mozilla.fenix.tabstray.TabsTrayStore
 import org.mozilla.fenix.tabstray.ext.showWithTheme
+import org.mozilla.fenix.theme.ThemeManager
 
 /**
  * A binding that shows/hides the multi-select banner of the selected count of tabs.
@@ -51,6 +52,11 @@ class SelectionBannerBinding(
      * A holder of views that will be used by having their [View.setVisibility] modified.
      */
     class VisibilityModifier(vararg val views: View)
+
+    private val nonSelectModeColorId = ThemeManager.resolveAttribute(
+        R.attr.layer1,
+        backgroundView.context,
+    )
 
     private var isPreviousModeSelect = false
 
@@ -114,7 +120,7 @@ class SelectionBannerBinding(
             val colorResource = if (isSelectMode) {
                 R.color.fx_mobile_layer_color_accent
             } else {
-                R.color.fx_mobile_layer_color_1
+                nonSelectModeColorId
             }
 
             val color = ContextCompat.getColor(backgroundView.context, colorResource)

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/ext/BrowserMenu.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/ext/BrowserMenu.kt
@@ -9,17 +9,16 @@ import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import mozilla.components.browser.menu.BrowserMenu
 import org.mozilla.fenix.R
+import org.mozilla.fenix.theme.ThemeManager
 
 /**
  * Invokes [BrowserMenu.show] and applies the default theme color background.
  */
 fun BrowserMenu.showWithTheme(view: View) {
     show(view).also { popupMenu ->
+        val color = ThemeManager.resolveAttribute(R.attr.layer2, view.context)
         (popupMenu.contentView as? CardView)?.setCardBackgroundColor(
-            ContextCompat.getColor(
-                view.context,
-                R.color.fx_mobile_layer_color_2,
-            ),
+            ContextCompat.getColor(view.context, color),
         )
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
@@ -28,6 +28,7 @@ import org.mozilla.fenix.ext.settings
 enum class Theme {
     Light,
     Dark,
+    Black,
     Private,
     ;
 
@@ -48,7 +49,11 @@ enum class Theme {
             ) {
                 Private
             } else if (isSystemInDarkTheme()) {
-                Dark
+                if (LocalContext.current.settings().shouldUseBlackTheme) {
+                    Black
+                } else {
+                    Dark
+                }
             } else {
                 Light
             }
@@ -68,6 +73,7 @@ fun FirefoxTheme(
     val colors = when (theme) {
         Theme.Light -> lightColorPalette
         Theme.Dark -> darkColorPalette
+        Theme.Black -> blackColorPalette
         Theme.Private -> privateColorPalette
     }
 
@@ -217,6 +223,17 @@ private val lightColorPalette = FirefoxColors(
     borderAccent = PhotonColors.Ink20,
     borderDisabled = PhotonColors.DarkGrey90A40,
     borderWarning = PhotonColors.Red70,
+)
+
+private val blackColorPalette = darkColorPalette.copy(
+    layer1 = PhotonColors.Black,
+    layer2 = PhotonColors.DarkGrey90,
+    layer3 = PhotonColors.DarkGrey80,
+    layer4Start = PhotonColors.Black,
+    layer4Center = PhotonColors.Black,
+    layer4End = PhotonColors.Black,
+    actionTertiary = PhotonColors.DarkGrey80,
+    borderPrimary = PhotonColors.DarkGrey70,
 )
 
 private val privateColorPalette = darkColorPalette.copy(

--- a/fenix/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
@@ -23,9 +23,11 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
+import org.mozilla.fenix.ext.settings
 
 abstract class ThemeManager {
 
+    protected abstract val activity: Activity
     abstract var currentTheme: BrowsingMode
 
     /**
@@ -33,7 +35,11 @@ abstract class ThemeManager {
      */
     @get:StyleRes
     val currentThemeResource get() = when (currentTheme) {
-        BrowsingMode.Normal -> R.style.NormalTheme
+        BrowsingMode.Normal -> if (activity.settings().shouldUseBlackTheme) {
+            R.style.NormalBlackTheme
+        } else {
+            R.style.NormalTheme
+        }
         BrowsingMode.Private -> R.style.PrivateTheme
     }
 
@@ -117,7 +123,7 @@ abstract class ThemeManager {
 
 class DefaultThemeManager(
     currentTheme: BrowsingMode,
-    private val activity: Activity,
+    override val activity: Activity,
 ) : ThemeManager() {
     override var currentTheme: BrowsingMode = currentTheme
         set(value) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -553,6 +553,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = false,
     )
 
+    var shouldUseBlackTheme by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_black_theme),
+        default = false,
+    )
+
     var shouldFollowDeviceTheme by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_follow_device_theme),
         default = false,

--- a/fenix/app/src/main/res/drawable/home_bottom_bar_background.xml
+++ b/fenix/app/src/main/res/drawable/home_bottom_bar_background.xml
@@ -5,8 +5,8 @@
 
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 <item>
-    <shape>
-        <solid android:color="@color/fx_mobile_layer_color_1" />
+    <shape>.
+        <solid android:color="?attr/layer1" />
     </shape>
 </item>
 <item android:bottom="-2dp" android:left="-2dp" android:right="-2dp">

--- a/fenix/app/src/main/res/drawable/home_bottom_bar_background_top.xml
+++ b/fenix/app/src/main/res/drawable/home_bottom_bar_background_top.xml
@@ -6,7 +6,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 <item>
     <shape>
-        <solid android:color="@color/fx_mobile_layer_color_1" />
+        <solid android:color="?attr/layer1" />
     </shape>
 </item>
 <item android:top="-2dp" android:left="-2dp" android:right="-2dp">

--- a/fenix/app/src/main/res/drawable/swipe_delete_background.xml
+++ b/fenix/app/src/main/res/drawable/swipe_delete_background.xml
@@ -4,5 +4,5 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/fx_mobile_layer_color_3" />
+    <solid android:color="?attr/layer3" />
 </shape>

--- a/fenix/app/src/main/res/layout/component_tabstray2.xml
+++ b/fenix/app/src/main/res/layout/component_tabstray2.xml
@@ -9,7 +9,7 @@
     style="@style/BottomSheetModal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:backgroundTint="@color/fx_mobile_layer_color_1"
+    android:backgroundTint="?attr/layer1"
     app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
     tools:ignore="MozMultipleConstraintLayouts">
 
@@ -29,7 +29,7 @@
         android:id="@+id/info_banner"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/fx_mobile_layer_color_1"
+        android:background="?attr/layer1"
         android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@+id/topBar" />
 
@@ -37,7 +37,7 @@
         android:id="@+id/topBar"
         android:layout_width="match_parent"
         android:layout_height="80dp"
-        android:background="@color/fx_mobile_layer_color_1"
+        android:background="?attr/layer1"
         android:importantForAccessibility="no"
         app:layout_constraintTop_toBottomOf="@+id/handle" />
 
@@ -78,7 +78,7 @@
         android:id="@+id/tab_layout"
         android:layout_width="0dp"
         android:layout_height="80dp"
-        android:background="@color/fx_mobile_layer_color_1"
+        android:background="?attr/layer1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/handle"
         app:layout_constraintWidth_percent="0.5"

--- a/fenix/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/fenix/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -25,7 +25,7 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:importantForAccessibility="yes"
-        app:cardBackgroundColor="@color/fx_mobile_layer_color_2"
+        app:cardBackgroundColor="?attr/layer2"
         app:cardCornerRadius="@dimen/tab_tray_grid_item_border_radius"
         app:cardElevation="0dp"
         app:strokeColor="@color/fx_mobile_border_color_primary"

--- a/fenix/app/src/main/res/values-night-v23/styles.xml
+++ b/fenix/app/src/main/res/values-night-v23/styles.xml
@@ -14,6 +14,6 @@
         <item name="android:windowLightStatusBar">false</item>
 
         <!-- Style the navigation bar -->
-        <item name="android:navigationBarColor">@color/fx_mobile_layer_color_1</item>
+        <item name="android:navigationBarColor">?attr/layer1</item>
     </style>
 </resources>

--- a/fenix/app/src/main/res/values-v27/styles.xml
+++ b/fenix/app/src/main/res/values-v27/styles.xml
@@ -48,6 +48,6 @@
     <style name="TabTrayDialogStyle" parent="TabTrayDialogStyleBase">
         <item name="android:navigationBarDividerColor">@android:color/transparent</item>
         <item name="android:windowLightNavigationBar">@bool/theme_is_light</item>
-        <item name="android:navigationBarColor">@color/fx_mobile_layer_color_1</item>
+        <item name="android:navigationBarColor">?attr/layer1</item>
     </style>
 </resources>

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -132,6 +132,7 @@
     <!-- Theme Settings -->
     <string name="pref_key_light_theme" translatable="false">pref_key_light_theme</string>
     <string name="pref_key_dark_theme" translatable="false">pref_key_dark_theme</string>
+    <string name="pref_key_black_theme" translatable="false">pref_key_black_theme</string>
     <string name="pref_key_auto_battery_theme" translatable="false">pref_key_auto_battery_theme</string>
     <string name="pref_key_follow_device_theme" translatable="false">pref_key_follow_device_theme</string>
 

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -679,6 +679,8 @@
     <string name="preference_light_theme">Light</string>
     <!-- Preference for using dark theme -->
     <string name="preference_dark_theme">Dark</string>
+    <!-- Preference for using black theme -->
+    <string name="preference_black_theme">Black</string>
     <!-- Preference for using using dark or light theme automatically set by battery -->
     <string name="preference_auto_battery_theme">Set by Battery Saver</string>
     <!-- Preference for using following device theme -->

--- a/fenix/app/src/main/res/values/styles.xml
+++ b/fenix/app/src/main/res/values/styles.xml
@@ -12,7 +12,7 @@
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
         <item name="android:progressBarStyleHorizontal">@style/progressBarStyleHorizontal</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:windowBackground">@color/fx_mobile_layer_color_1</item>
+        <item name="android:windowBackground">?attr/layer1</item>
         <item name="android:colorEdgeEffect">@color/accent_normal_theme</item>
         <item name="android:colorAccent">@color/fx_mobile_text_color_primary</item>
         <item name="android:textColorPrimary">@color/state_list_text_color</item>
@@ -93,9 +93,9 @@
         <item name="neutral">@color/neutral_normal_theme</item>
         <item name="neutralFaded">@color/neutral_faded_normal_theme</item>
         <item name="accentUsedOnDarkBackground">@color/fx_mobile_text_color_accent</item>
-        <item name="toolbarStartGradient">@color/fx_mobile_layer_color_1</item>
-        <item name="toolbarCenterGradient">@color/fx_mobile_layer_color_1</item>
-        <item name="toolbarEndGradient">@color/fx_mobile_layer_color_1</item>
+        <item name="toolbarStartGradient">?attr/layer1</item>
+        <item name="toolbarCenterGradient">?attr/layer1</item>
+        <item name="toolbarEndGradient">?attr/layer1</item>
         <item name="fillLinkFromClipboard">@color/fill_link_from_clipboard_normal_theme</item>
         <item name="syncDisconnected">@color/sync_disconnected_icon_fill_normal_theme</item>
         <item name="syncDisconnectedBackground">@color/sync_disconnected_background_normal_theme</item>
@@ -114,20 +114,28 @@
         <!-- Shared widget colors -->
         <item name="mozac_primary_text_color">@color/fx_mobile_text_color_primary</item>
         <item name="mozac_caption_text_color">@color/fx_mobile_text_color_secondary</item>
-        <item name="mozac_widget_favicon_background_color">@color/fx_mobile_layer_color_2</item>
+        <item name="mozac_widget_favicon_background_color">?attr/layer2</item>
         <item name="mozac_widget_favicon_border_color">@color/fx_mobile_border_color_primary</item>
 
         <!-- Drawables -->
         <item name="fenixLogo">@drawable/ic_logo_wordmark_normal</item>
         <item name="fenixWordmarkText">@drawable/ic_wordmark_text_normal</item>
         <item name="fenixWordmarkLogo">@drawable/ic_wordmark_logo</item>
-        <item name="homeBackground">@color/fx_mobile_layer_color_1</item>
+        <item name="homeBackground">?attr/layer1</item>
         <item name="bottomBarBackground">@drawable/home_bottom_bar_background</item>
         <item name="bottomBarBackgroundTop">@drawable/home_bottom_bar_background_top</item>
         <item name="privateBrowsingButtonBackground">@android:color/transparent</item>
         <item name="privateBrowsingButtonAccent">@color/fx_mobile_text_color_primary</item>
 
         <item name="tabCounterTintColor">?attr/textPrimary</item>
+    </style>
+
+    <!-- A black theme derived from the normal activity theme -->
+    <style name="NormalBlackTheme" parent="NormalTheme">
+        <item name="android:windowBackground">@color/photonBlack</item>
+        <item name="layer1">@color/photonBlack</item>
+        <item name="layer2">@color/photonDarkGrey90</item>
+        <item name="layer3">@color/fx_mobile_layer_color_3</item>
     </style>
 
     <!-- A theme derived from the normal activity theme, but to look and behave like a dialog -->
@@ -661,11 +669,20 @@
 
     <!-- Tab Tray does not present a private theme, so it needs to be separate from other bottom sheet styles -->
     <style name="TabTrayDialogStyleBase" parent="BottomSheetBase">
+        <item name="layer1">@color/fx_mobile_layer_color_1</item>
+        <item name="layer2">@color/fx_mobile_layer_color_2</item>
+        <item name="layer3">@color/fx_mobile_layer_color_3</item>
         <item name="bottomSheetStyle">@style/BottomSheetModal</item>
-        <item name="android:colorBackground">@color/fx_mobile_layer_color_1</item>
+        <item name="android:colorBackground">?attr/layer1</item>
     </style>
 
     <style name="TabTrayDialogStyle" parent="TabTrayDialogStyleBase" />
+
+    <!-- Inherit some layers from NormalBlackTheme when in Black theme -->
+    <style name="NormalBlackTheme.TabTrayDialogStyle" parent="TabTrayDialogStyle">
+        <item name="layer1">@color/photonBlack</item>
+        <item name="layer2">@color/photonBlack</item>
+    </style>
 
     <!-- Stuff to make the bottom sheet with round top borders -->
     <style name="BottomSheetShapeAppearance" parent="ShapeAppearance.MaterialComponents.LargeComponent">

--- a/fenix/app/src/main/res/xml/customization_preferences.xml
+++ b/fenix/app/src/main/res/xml/customization_preferences.xml
@@ -17,6 +17,10 @@
             android:defaultValue="false"
             android:key="@string/pref_key_dark_theme"
             android:title="@string/preference_dark_theme" />
+        <org.mozilla.fenix.settings.RadioButtonPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_black_theme"
+            android:title="@string/preference_black_theme" />
 
         <org.mozilla.fenix.settings.RadioButtonPreference
             android:defaultValue="false"


### PR DESCRIPTION
Implemented a solution to this bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1807081
Based on this PR: https://github.com/mozilla-mobile/fenix/pull/27789

This defines and adds a "pure black"/"true black"/"OLED black" theme to Fenix.

Here are some screenshots:

![IMAGE 2023-05-09 06:40:24](https://github.com/mozilla-mobile/firefox-android/assets/10657588/03fb0407-3c0a-4938-8c7e-95e8d01c04d2)
![IMAGE 2023-05-09 06:40:27](https://github.com/mozilla-mobile/firefox-android/assets/10657588/1c94ad0c-ae7b-4a9d-9f37-0382af3e2c5d)

This issue hasn't seen any input from UX yet, but internal folks have expressed interest in the past. This fix effects only Nightly users, who can help generate feedback and inform UX decisions on the matter.

This would also help developers add pure black options to other parts of the stack, like Reader Mode and GeckoView, which would rely on the settings added in this PR.

Originally https://github.com/mozilla-mobile/firefox-android/pull/1909, but that PR filled up with auto-comments based off of commit messages it seems I don't have the ability to fix. This PR ought to be cleaner.

Thank you to @fice-t for writing 99% of the original code; I just cleaned up a couple of small pieces and ported it over to this repo.

Tagging @gabrielluong because you ran this idea past Product and UX originally.

Tagging @csadilek because you shut down the original PR, for continuity's sake.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807081