### PR TITLE
Bug 1827650 - Disable checkboxes when deletion in progress.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
@@ -123,6 +123,15 @@ class DeleteBrowsingDataFragment : Fragment(R.layout.fragment_delete_browsing_da
         }
     }
 
+    private fun updateCheckboxes(deleteInProgress: Boolean = false) {
+        runIfFragmentIsAttached {
+            getCheckboxes().forEach {
+                it.isEnabled = !deleteInProgress
+                binding.deleteData.alpha = if (!deleteInProgress) ENABLED_ALPHA else DISABLED_ALPHA
+            }
+        }
+    }
+
     private fun askToDelete() {
         runIfFragmentIsAttached {
             AlertDialog.Builder(requireContext()).apply {
@@ -170,6 +179,7 @@ class DeleteBrowsingDataFragment : Fragment(R.layout.fragment_delete_browsing_da
 
     private fun startDeletion() {
         updateDeleteButton(deleteInProgress = true)
+        updateCheckboxes(deleteInProgress = true)
         binding.progressBar.visibility = View.VISIBLE
         binding.deleteBrowsingDataWrapper.isEnabled = false
         binding.deleteBrowsingDataWrapper.isClickable = false
@@ -178,6 +188,7 @@ class DeleteBrowsingDataFragment : Fragment(R.layout.fragment_delete_browsing_da
 
     private fun finishDeletion() {
         updateDeleteButton(deleteInProgress = false)
+        updateCheckboxes(deleteInProgress = false)
         val popAfter = binding.openTabsItem.isChecked
         binding.progressBar.visibility = View.GONE
         binding.deleteBrowsingDataWrapper.isEnabled = true


### PR DESCRIPTION
Previously when deleting browsing data, while the deletion was in progress, the user could still check the boxes and press the "Delete browsing data" button, triggering the dialog that lead to the app crashing. This patch aims to disable interaction with the checkboxes while a deletion is in progress.


https://github.com/mozilla-mobile/firefox-android/assets/32488956/07836355-01f3-4472-ad5c-470f08675c22


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
