### PR TITLE
Bug 1831602 - Convert two UI tests to support composified Tabs Tray

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
@@ -77,6 +77,11 @@ interface FeatureSettingsHelper {
      */
     var isOpenInAppBannerEnabled: Boolean
 
+    /**
+     * Enable or disable the Tabs Tray to Compose rewrite.
+     */
+    var tabsTrayRewriteEnabled: Boolean
+
     fun applyFlagUpdates()
 
     fun resetAllFeatureFlags()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelperDelegate.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelperDelegate.kt
@@ -37,6 +37,7 @@ class FeatureSettingsHelperDelegate : FeatureSettingsHelper {
         isCookieBannerReductionDialogEnabled = !settings.userOptOutOfReEngageCookieBannerDialog,
         isOpenInAppBannerEnabled = settings.shouldShowOpenInAppBanner,
         etpPolicy = getETPPolicy(settings),
+        tabsTrayRewriteEnabled = settings.enableTabsTrayToCompose,
     )
 
     /**
@@ -64,6 +65,7 @@ class FeatureSettingsHelperDelegate : FeatureSettingsHelper {
     override var isCookieBannerReductionDialogEnabled: Boolean by updatedFeatureFlags::isCookieBannerReductionDialogEnabled
     override var isOpenInAppBannerEnabled: Boolean by updatedFeatureFlags::isOpenInAppBannerEnabled
     override var etpPolicy: ETPPolicy by updatedFeatureFlags::etpPolicy
+    override var tabsTrayRewriteEnabled: Boolean by updatedFeatureFlags::tabsTrayRewriteEnabled
 
     override fun applyFlagUpdates() {
         applyFeatureFlags(updatedFeatureFlags)
@@ -89,6 +91,7 @@ class FeatureSettingsHelperDelegate : FeatureSettingsHelper {
         settings.deleteSitePermissions = featureFlags.isDeleteSitePermissionsEnabled
         settings.userOptOutOfReEngageCookieBannerDialog = !featureFlags.isCookieBannerReductionDialogEnabled
         settings.shouldShowOpenInAppBanner = featureFlags.isOpenInAppBannerEnabled
+        settings.enableTabsTrayToCompose = featureFlags.tabsTrayRewriteEnabled
         setETPPolicy(featureFlags.etpPolicy)
     }
 }
@@ -108,6 +111,7 @@ private data class FeatureFlags(
     var isCookieBannerReductionDialogEnabled: Boolean,
     var isOpenInAppBannerEnabled: Boolean,
     var etpPolicy: ETPPolicy,
+    var tabsTrayRewriteEnabled: Boolean,
 )
 
 internal fun getETPPolicy(settings: Settings): ETPPolicy {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
@@ -8,6 +8,7 @@ package org.mozilla.fenix.helpers
 
 import android.content.Intent
 import android.view.ViewConfiguration.getLongPressTimeout
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiSelector
@@ -16,6 +17,8 @@ import org.mozilla.fenix.helpers.FeatureSettingsHelper.Companion.settings
 import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.onboarding.FenixOnboarding
+
+typealias HomeActivityComposeTestRule = AndroidComposeTestRule<HomeActivityTestRule, HomeActivity>
 
 /**
  * A [org.junit.Rule] to handle shared test set up for tests on [HomeActivity].
@@ -51,6 +54,7 @@ class HomeActivityTestRule(
         isCookieBannerReductionDialogEnabled: Boolean = !settings.userOptOutOfReEngageCookieBannerDialog,
         isOpenInAppBannerEnabled: Boolean = settings.shouldShowOpenInAppBanner,
         etpPolicy: ETPPolicy = getETPPolicy(settings),
+        tabsTrayRewriteEnabled: Boolean = false,
     ) : this(initialTouchMode, launchActivity, skipOnboarding) {
         this.isHomeOnboardingDialogEnabled = isHomeOnboardingDialogEnabled
         this.isPocketEnabled = isPocketEnabled
@@ -64,6 +68,7 @@ class HomeActivityTestRule(
         this.isCookieBannerReductionDialogEnabled = isCookieBannerReductionDialogEnabled
         this.isOpenInAppBannerEnabled = isOpenInAppBannerEnabled
         this.etpPolicy = etpPolicy
+        this.tabsTrayRewriteEnabled = tabsTrayRewriteEnabled
     }
 
     /**
@@ -107,10 +112,12 @@ class HomeActivityTestRule(
             initialTouchMode: Boolean = false,
             launchActivity: Boolean = true,
             skipOnboarding: Boolean = false,
+            tabsTrayRewriteEnabled: Boolean = false,
         ) = HomeActivityTestRule(
             initialTouchMode = initialTouchMode,
             launchActivity = launchActivity,
             skipOnboarding = skipOnboarding,
+            tabsTrayRewriteEnabled = tabsTrayRewriteEnabled,
             isJumpBackInCFREnabled = false,
             isPWAsPromptEnabled = false,
             isTCPCFREnabled = false,
@@ -155,6 +162,7 @@ class HomeActivityIntentTestRule internal constructor(
         isCookieBannerReductionDialogEnabled: Boolean = !settings.userOptOutOfReEngageCookieBannerDialog,
         isOpenInAppBannerEnabled: Boolean = settings.shouldShowOpenInAppBanner,
         etpPolicy: ETPPolicy = getETPPolicy(settings),
+        tabsTrayRewriteEnabled: Boolean = false,
     ) : this(initialTouchMode, launchActivity, skipOnboarding) {
         this.isHomeOnboardingDialogEnabled = isHomeOnboardingDialogEnabled
         this.isPocketEnabled = isPocketEnabled
@@ -168,6 +176,7 @@ class HomeActivityIntentTestRule internal constructor(
         this.isCookieBannerReductionDialogEnabled = isCookieBannerReductionDialogEnabled
         this.isOpenInAppBannerEnabled = isOpenInAppBannerEnabled
         this.etpPolicy = etpPolicy
+        this.tabsTrayRewriteEnabled = tabsTrayRewriteEnabled
     }
 
     private val longTapUserPreference = getLongPressTimeout()
@@ -248,10 +257,12 @@ class HomeActivityIntentTestRule internal constructor(
             initialTouchMode: Boolean = false,
             launchActivity: Boolean = true,
             skipOnboarding: Boolean = false,
+            tabsTrayRewriteEnabled: Boolean = false,
         ) = HomeActivityIntentTestRule(
             initialTouchMode = initialTouchMode,
             launchActivity = launchActivity,
             skipOnboarding = skipOnboarding,
+            tabsTrayRewriteEnabled = tabsTrayRewriteEnabled,
             isJumpBackInCFREnabled = false,
             isPWAsPromptEnabled = false,
             isTCPCFREnabled = false,

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
@@ -1,0 +1,382 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
+
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.RetryTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.navigationToolbar
+
+/**
+ *  Tests for verifying basic functionality of tabbed browsing
+ *
+ *  Including:
+ *  - Opening a tab
+ *  - Opening a private tab
+ *  - Verifying tab list
+ *  - Closing all tabs
+ *  - Close tab
+ *  - Swipe to close tab (temporarily disabled)
+ *  - Undo close tab
+ *  - Close private tabs persistent notification
+ *  - Empty tab tray state
+ *  - Tab tray details
+ *  - Shortcut context menu navigation
+ */
+
+class ComposeTabbedBrowsingTest {
+    private lateinit var mDevice: UiDevice
+    private lateinit var mockWebServer: MockWebServer
+
+    @get:Rule(order = 0)
+    val composeTestRule =
+        AndroidComposeTestRule(
+            HomeActivityTestRule.withDefaultSettingsOverrides(
+                tabsTrayRewriteEnabled = true,
+            ),
+        ) { it.activity }
+
+    @Rule(order = 1)
+    @JvmField
+    val retryTestRule = RetryTestRule(3)
+
+    @Before
+    fun setUp() {
+        mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun openNewTabTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+            mDevice.waitForIdle()
+            verifyTabCounter("1")
+        }.openComposeTabDrawer(composeTestRule) {
+            verifyNormalBrowsingButtonIsSelected()
+            verifyExistingOpenTabs("Test_Page_1")
+            closeTab()
+        }
+        homeScreen {
+        }.openComposeTabDrawer(composeTestRule) {
+            verifyNoOpenTabsInNormalBrowsing()
+        }.openNewTab {
+        }.submitQuery(defaultWebPage.url.toString()) {
+            mDevice.waitForIdle()
+            verifyTabCounter("1")
+        }.openComposeTabDrawer(composeTestRule) {
+            verifyNormalBrowsingButtonIsSelected()
+            verifyExistingOpenTabs("Test_Page_1")
+        }
+    }
+
+    @Test
+    fun openNewPrivateTabTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.togglePrivateBrowsingMode()
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+            mDevice.waitForIdle()
+            verifyTabCounter("1")
+        }.openComposeTabDrawer(composeTestRule) {
+            verifyPrivateTabsList()
+            verifyPrivateBrowsingButtonIsSelected()
+        }.toggleToNormalTabs {
+            verifyNoOpenTabsInNormalBrowsing()
+        }.toggleToPrivateTabs {
+            verifyPrivateTabsList()
+        }
+    }
+
+    @Ignore("Being converted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832606")
+    @Test
+    fun closeAllTabsTest() {
+//        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+//
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+//        }.openTabDrawer {
+//            verifyExistingTabList()
+//        }.openTabsListThreeDotMenu {
+//            verifyCloseAllTabsButton()
+//            verifyShareTabButton()
+//            verifySelectTabs()
+//        }.closeAllTabs {
+//            verifyTabCounter("0")
+//        }
+//
+//        // Repeat for Private Tabs
+//        homeScreen {
+//        }.togglePrivateBrowsingMode()
+//
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+//        }.openTabDrawer {
+//            verifyPrivateModeSelected()
+//            verifyExistingTabList()
+//        }.openTabsListThreeDotMenu {
+//            verifyCloseAllTabsButton()
+//        }.closeAllTabs {
+//            verifyTabCounter("0")
+//        }
+    }
+
+    @Ignore("Being converted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832617")
+    @Test
+    fun closeTabTest() {
+//        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+//
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(genericURL.url) {
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//            closeTab()
+//        }
+//        homeScreen {
+//            verifyTabCounter("0")
+//        }.openNavigationToolbar {
+//        }.enterURLAndEnterToBrowser(genericURL.url) {
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//            swipeTabRight("Test_Page_1")
+//        }
+//        homeScreen {
+//            verifyTabCounter("0")
+//        }.openNavigationToolbar {
+//        }.enterURLAndEnterToBrowser(genericURL.url) {
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//            swipeTabLeft("Test_Page_1")
+//        }
+//        homeScreen {
+//            verifyTabCounter("0")
+//        }
+    }
+
+    @Ignore("Being converted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832608")
+    @Test
+    fun verifyUndoSnackBarTest() {
+        // disabling these features because they interfere with the snackbar visibility
+//        activityTestRule.applySettingsExceptions {
+//            it.isPocketEnabled = false
+//            it.isRecentTabsFeatureEnabled = false
+//        }
+//
+//        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+//
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(genericURL.url) {
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//            closeTab()
+//            verifySnackBarText("Tab closed")
+//            snackBarButtonClick("UNDO")
+//        }
+//
+//        browserScreen {
+//            verifyTabCounter("1")
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//        }
+    }
+
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1829838")
+    // Try converting in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832609
+    @Test
+    fun closePrivateTabTest() {
+//        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+//
+//        homeScreen { }.togglePrivateBrowsingMode()
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(genericURL.url) {
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//            verifyCloseTabsButton("Test_Page_1")
+//            closeTab()
+//        }
+//        homeScreen {
+//            verifyTabCounter("0")
+//        }.openNavigationToolbar {
+//        }.enterURLAndEnterToBrowser(genericURL.url) {
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//            swipeTabRight("Test_Page_1")
+//        }
+//        homeScreen {
+//            verifyTabCounter("0")
+//        }.openNavigationToolbar {
+//        }.enterURLAndEnterToBrowser(genericURL.url) {
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//            swipeTabLeft("Test_Page_1")
+//        }
+//        homeScreen {
+//            verifyTabCounter("0")
+//        }
+    }
+
+    @Ignore("Being converted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832610")
+    @Test
+    fun verifyPrivateTabUndoSnackBarTest() {
+//        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+//
+//        homeScreen { }.togglePrivateBrowsingMode()
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(genericURL.url) {
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//            verifyCloseTabsButton("Test_Page_1")
+//            closeTab()
+//            verifySnackBarText("Private tab closed")
+//            snackBarButtonClick("UNDO")
+//        }
+//
+//        browserScreen {
+//            verifyTabCounter("1")
+//        }.openTabDrawer {
+//            verifyExistingOpenTabs("Test_Page_1")
+//            verifyPrivateModeSelected()
+//        }
+    }
+
+    @Ignore("Being converted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832611")
+    @Test
+    fun closePrivateTabsNotificationTest() {
+//        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+//
+//        homeScreen {
+//        }.togglePrivateBrowsingMode()
+//
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+//            mDevice.openNotification()
+//        }
+//
+//        notificationShade {
+//            verifyPrivateTabsNotification()
+//        }.clickClosePrivateTabsNotification {
+//            verifyHomeScreen()
+//        }
+    }
+
+    @Ignore("Being converted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832612")
+    @Test
+    fun verifyTabTrayNotShowingStateHalfExpanded() {
+//        navigationToolbar {
+//        }.openTabTray {
+//            verifyNoOpenTabsInNormalBrowsing()
+//            // With no tabs opened the state should be STATE_COLLAPSED.
+//            verifyBehaviorState(BottomSheetBehavior.STATE_COLLAPSED)
+//            // Need to ensure the halfExpandedRatio is very small so that when in STATE_HALF_EXPANDED
+//            // the tabTray will actually have a very small height (for a very short time) akin to being hidden.
+//            verifyHalfExpandedRatio()
+//        }.clickTopBar {
+//        }.waitForTabTrayBehaviorToIdle {
+//            // Touching the topBar would normally advance the tabTray to the next state.
+//            // We don't want that.
+//            verifyBehaviorState(BottomSheetBehavior.STATE_COLLAPSED)
+//        }.advanceToHalfExpandedState {
+//        }.waitForTabTrayBehaviorToIdle {
+//            // TabTray should not be displayed in STATE_HALF_EXPANDED.
+//            // When advancing to this state it should immediately be hidden.
+//            verifyTabTrayIsClosed()
+//        }
+    }
+
+    @Ignore("Being converted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832613")
+    @Test
+    fun verifyEmptyTabTray() {
+//        navigationToolbar {
+//        }.openTabTray {
+//            verifyNormalBrowsingButtonIsSelected(true)
+//            verifyPrivateBrowsingButtonIsSelected(false)
+//            verifySyncedTabsButtonIsSelected(false)
+//            verifyNoOpenTabsInNormalBrowsing()
+//            verifyNormalBrowsingNewTabButton()
+//            verifyTabTrayOverflowMenu(true)
+//            verifyEmptyTabsTrayMenuButtons()
+//        }
+    }
+
+    @Ignore("Being converted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832615")
+    @Test
+    fun verifyOpenTabDetails() {
+//        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+//
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+//        }.openTabDrawer {
+//            verifyNormalBrowsingButtonIsSelected(true)
+//            verifyPrivateBrowsingButtonIsSelected(false)
+//            verifySyncedTabsButtonIsSelected(false)
+//            verifyTabTrayOverflowMenu(true)
+//            verifyTabsTrayCounter()
+//            verifyExistingTabList()
+//            verifyNormalBrowsingNewTabButton()
+//            verifyOpenedTabThumbnail()
+//            verifyExistingOpenTabs(defaultWebPage.title)
+//            verifyCloseTabsButton(defaultWebPage.title)
+//        }.openTab(defaultWebPage.title) {
+//            verifyUrl(defaultWebPage.url.toString())
+//            verifyTabCounter("1")
+//        }
+    }
+
+    @Ignore("Being converted in: https://bugzilla.mozilla.org/show_bug.cgi?id=1832616")
+    @Test
+    fun verifyContextMenuShortcuts() {
+//        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+//
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+//        }.openTabButtonShortcutsMenu {
+//            verifyTabButtonShortcutMenuItems()
+//        }.closeTabFromShortcutsMenu {
+//        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+//        }.openTabButtonShortcutsMenu {
+//        }.openNewPrivateTabFromShortcutsMenu {
+//            verifyKeyboardVisible()
+//            verifyFocusedNavigationToolbar()
+//            // dismiss search dialog
+//            homeScreen { }.pressBack()
+//            verifyCommonMythsLink()
+//            verifyNavigationToolbar()
+//        }
+//        navigationToolbar {
+//        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+//        }.openTabButtonShortcutsMenu {
+//        }.openTabFromShortcutsMenu {
+//            verifyKeyboardVisible()
+//            verifyFocusedNavigationToolbar()
+//            // dismiss search dialog
+//            homeScreen { }.pressBack()
+//            verifyHomeWordmark()
+//            verifyNavigationToolbar()
+//        }
+    }
+}

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("TooManyFunctions")
+
+package org.mozilla.fenix.ui.robots
+
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
+import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.tabstray.TabsTrayTestTag
+
+/**
+ * Implementation of Robot Pattern for the Tabs Tray.
+ */
+class ComposeTabDrawerRobot(private val composeTestRule: HomeActivityComposeTestRule) {
+
+    fun verifyNormalBrowsingButtonIsSelected(isSelected: Boolean = true) {
+        if (isSelected) {
+            composeTestRule.normalBrowsingButton().assertIsSelected()
+        } else {
+            composeTestRule.normalBrowsingButton().assertIsNotSelected()
+        }
+    }
+
+    fun verifyPrivateBrowsingButtonIsSelected(isSelected: Boolean = true) {
+        if (isSelected) {
+            composeTestRule.privateBrowsingButton().assertIsSelected()
+        } else {
+            composeTestRule.privateBrowsingButton().assertIsNotSelected()
+        }
+    }
+
+    fun verifyExistingOpenTabs(vararg titles: String) {
+        titles.forEach { title ->
+            tabItem(title).assertExists()
+        }
+    }
+
+    fun verifyNormalTabsList() {
+        composeTestRule.normalTabsList().assertExists()
+    }
+
+    fun verifyPrivateTabsList() {
+        composeTestRule.privateTabsList().assertExists()
+    }
+
+    fun verifySyncedTabsList() {
+        composeTestRule.syncedTabsList().assertExists()
+    }
+
+    fun verifyNoOpenTabsInNormalBrowsing() {
+        composeTestRule.emptyNormalTabsList().assertExists()
+    }
+
+    fun verifyNoOpenTabsInPrivateBrowsing() {
+        composeTestRule.emptyPrivateTabsList().assertExists()
+    }
+
+    /**
+     * Closes a tab when there is only one tab open.
+     */
+    fun closeTab() {
+        composeTestRule.closeTabButton().performClick()
+    }
+
+    /**
+     * Obtains the tab with the provided [title]
+     */
+    private fun tabItem(title: String) = composeTestRule.onNodeWithText(title)
+
+    class Transition(private val composeTestRule: HomeActivityComposeTestRule) {
+
+        fun openNewTab(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
+            mDevice.waitForIdle()
+
+            composeTestRule.tabsTrayFab().performClick()
+            SearchRobot().interact()
+            return SearchRobot.Transition()
+        }
+
+        fun toggleToNormalTabs(interact: ComposeTabDrawerRobot.() -> Unit): Transition {
+            composeTestRule.normalBrowsingButton().performClick()
+            ComposeTabDrawerRobot(composeTestRule).interact()
+            return Transition(composeTestRule)
+        }
+
+        fun toggleToPrivateTabs(interact: ComposeTabDrawerRobot.() -> Unit): Transition {
+            composeTestRule.privateBrowsingButton().performClick()
+            ComposeTabDrawerRobot(composeTestRule).interact()
+            return Transition(composeTestRule)
+        }
+    }
+}
+
+/**
+ * Obtains the root Tabs Tray.
+ */
+private fun ComposeTestRule.tabsTray() = onNodeWithTag(TabsTrayTestTag.tabsTray)
+
+/**
+ * Obtains the Tabs Tray FAB.
+ */
+private fun ComposeTestRule.tabsTrayFab() = onNodeWithTag(TabsTrayTestTag.fab)
+
+/**
+ * Obtains the normal browsing page button of the Tabs Tray banner.
+ */
+private fun ComposeTestRule.normalBrowsingButton() = onNodeWithTag(TabsTrayTestTag.normalTabsPageButton)
+
+/**
+ * Obtains the private browsing page button of the Tabs Tray banner.
+ */
+private fun ComposeTestRule.privateBrowsingButton() = onNodeWithTag(TabsTrayTestTag.privateTabsPageButton)
+
+/**
+ * Obtains the normal tabs list.
+ */
+private fun ComposeTestRule.normalTabsList() = onNodeWithTag(TabsTrayTestTag.normalTabsList)
+
+/**
+ * Obtains the private tabs list.
+ */
+private fun ComposeTestRule.privateTabsList() = onNodeWithTag(TabsTrayTestTag.privateTabsList)
+
+/**
+ * Obtains the synced tabs list.
+ */
+private fun ComposeTestRule.syncedTabsList() = onNodeWithTag(TabsTrayTestTag.syncedTabsList)
+
+/**
+ * Obtains the empty normal tabs list.
+ */
+private fun ComposeTestRule.emptyNormalTabsList() = onNodeWithTag(TabsTrayTestTag.emptyNormalTabsList)
+
+/**
+ * Obtains the empty private tabs list.
+ */
+private fun ComposeTestRule.emptyPrivateTabsList() = onNodeWithTag(TabsTrayTestTag.emptyPrivateTabsList)
+
+/**
+ * Obtains an open tab's close button when there's only one tab open.
+ */
+private fun ComposeTestRule.closeTabButton() = onNodeWithTag(TabsTrayTestTag.tabItemClose)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -57,6 +57,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.Constants.LISTS_MAXSWIPES
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
+import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.assertCheckedItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
@@ -80,6 +81,7 @@ import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.helpers.withBitmapDrawable
+import org.mozilla.fenix.tabstray.TabsTrayTestTag
 import org.mozilla.fenix.utils.Settings
 
 /**
@@ -548,6 +550,15 @@ class HomeScreenRobot {
 
             TabDrawerRobot().interact()
             return TabDrawerRobot.Transition()
+        }
+
+        fun openComposeTabDrawer(composeTestRule: HomeActivityComposeTestRule, interact: ComposeTabDrawerRobot.() -> Unit): ComposeTabDrawerRobot.Transition {
+            mDevice.waitForIdle(waitingTime)
+            onView(withId(R.id.tab_button)).click()
+            composeTestRule.onNodeWithTag(TabsTrayTestTag.tabsTray).assertExists()
+
+            ComposeTabDrawerRobot(composeTestRule).interact()
+            return ComposeTabDrawerRobot.Transition(composeTestRule)
         }
 
         fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/button/FloatingActionButton.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/button/FloatingActionButton.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
@@ -47,7 +46,7 @@ fun FloatingActionButton(
 ) {
     FloatingActionButton(
         onClick = onClick,
-        modifier = Modifier.testTag("button.fab").then(modifier),
+        modifier = modifier,
         backgroundColor = FirefoxTheme.colors.actionPrimary,
         contentColor = FirefoxTheme.colors.textActionPrimary,
     ) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -49,6 +50,7 @@ import org.mozilla.fenix.compose.Favicon
 import org.mozilla.fenix.compose.HorizontalFadingEdgeBox
 import org.mozilla.fenix.compose.ThumbnailCard
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.tabstray.TabsTrayTestTag
 import org.mozilla.fenix.tabstray.ext.toDisplayTitle
 import org.mozilla.fenix.theme.FirefoxTheme
 
@@ -156,7 +158,8 @@ fun TabGridItem(
                             modifier = Modifier
                                 .clickable { onCloseClick(tab) }
                                 .size(24.dp)
-                                .align(Alignment.CenterVertically),
+                                .align(Alignment.CenterVertically)
+                                .testTag(TabsTrayTestTag.tabItemClose),
                         )
                     }
                 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -35,6 +36,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.ThumbnailCard
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.ext.toShortUrl
+import org.mozilla.fenix.tabstray.TabsTrayTestTag
 import org.mozilla.fenix.tabstray.ext.toDisplayTitle
 import org.mozilla.fenix.theme.FirefoxTheme
 
@@ -116,7 +118,9 @@ fun TabListItem(
         if (!multiSelectionEnabled) {
             IconButton(
                 onClick = { onCloseClick(tab) },
-                modifier = Modifier.size(size = 48.dp),
+                modifier = Modifier
+                    .size(size = 48.dp)
+                    .testTag(TabsTrayTestTag.tabItemClose),
             ) {
                 Icon(
                     painter = painterResource(id = R.drawable.mozac_ic_close),

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import mozilla.components.browser.state.selector.normalTabs
@@ -154,7 +155,8 @@ fun TabsTray(
         modifier = Modifier
             .fillMaxSize()
             .then(shapeModifier)
-            .background(FirefoxTheme.colors.layer1),
+            .background(FirefoxTheme.colors.layer1)
+            .testTag(TabsTrayTestTag.tabsTray),
     ) {
         Box(modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection())) {
             TabsTrayBanner(
@@ -304,6 +306,7 @@ private fun NormalTabsPage(
             displayTabsInGrid = displayTabsInGrid,
             selectedTabId = selectedTabId,
             selectionMode = selectionMode,
+            modifier = Modifier.testTag(TabsTrayTestTag.normalTabsList),
             onTabClose = onTabClose,
             onTabMediaClick = onTabMediaClick,
             onTabClick = onTabClick,
@@ -338,6 +341,7 @@ private fun PrivateTabsPage(
             displayTabsInGrid = displayTabsInGrid,
             selectedTabId = selectedTabId,
             selectionMode = selectionMode,
+            modifier = Modifier.testTag(TabsTrayTestTag.privateTabsList),
             onTabClose = onTabClose,
             onTabMediaClick = onTabMediaClick,
             onTabClick = onTabClick,
@@ -365,15 +369,23 @@ private fun SyncedTabsPage(
 
 @Composable
 private fun EmptyTabPage(isPrivate: Boolean) {
-    Box(modifier = Modifier.fillMaxSize()) {
+    val testTag: String
+    val emptyTextId: Int
+    if (isPrivate) {
+        testTag = TabsTrayTestTag.emptyPrivateTabsList
+        emptyTextId = R.string.no_private_tabs_description
+    } else {
+        testTag = TabsTrayTestTag.emptyNormalTabsList
+        emptyTextId = R.string.no_open_tabs_description
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(testTag),
+    ) {
         Text(
-            text = stringResource(
-                id = if (isPrivate) {
-                    R.string.no_private_tabs_description
-                } else {
-                    R.string.no_open_tabs_description
-                },
-            ),
+            text = stringResource(id = emptyTextId),
             modifier = Modifier
                 .align(Alignment.TopCenter)
                 .padding(top = 80.dp),

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayBanner.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayBanner.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -173,7 +174,9 @@ private fun SingleSelectBanner(
                     Tab(
                         selected = selectedPage == Page.NormalTabs,
                         onClick = { onTabPageIndicatorClicked(Page.NormalTabs) },
-                        modifier = Modifier.fillMaxHeight(),
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .testTag(TabsTrayTestTag.normalTabsPageButton),
                         selectedContentColor = selectedColor,
                         unselectedContentColor = inactiveColor,
                     ) {
@@ -183,7 +186,9 @@ private fun SingleSelectBanner(
                     Tab(
                         selected = selectedPage == Page.PrivateTabs,
                         onClick = { onTabPageIndicatorClicked(Page.PrivateTabs) },
-                        modifier = Modifier.fillMaxHeight(),
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .testTag(TabsTrayTestTag.privateTabsPageButton),
                         icon = {
                             Icon(
                                 painter = painterResource(id = R.drawable.ic_private_browsing),
@@ -197,7 +202,9 @@ private fun SingleSelectBanner(
                     Tab(
                         selected = selectedPage == Page.SyncedTabs,
                         onClick = { onTabPageIndicatorClicked(Page.SyncedTabs) },
-                        modifier = Modifier.fillMaxHeight(),
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .testTag(TabsTrayTestTag.syncedTabsPageButton),
                         icon = {
                             Icon(
                                 painter = painterResource(id = R.drawable.ic_synced_tabs),

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFab.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFab.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -77,7 +78,9 @@ fun TabsTrayFab(
     if (isInNormalMode) {
         FloatingActionButton(
             icon = icon,
-            modifier = Modifier.padding(bottom = 16.dp, end = 16.dp),
+            modifier = Modifier
+                .padding(bottom = 16.dp, end = 16.dp)
+                .testTag(TabsTrayTestTag.fab),
             contentDescription = contentDescription,
             label = label,
             onClick = onClick,

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTabLayouts.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTabLayouts.kt
@@ -53,6 +53,7 @@ fun TabLayout(
     displayTabsInGrid: Boolean,
     selectedTabId: String?,
     selectionMode: TabsTrayState.Mode,
+    modifier: Modifier = Modifier,
     onTabClose: (TabSessionState) -> Unit,
     onTabMediaClick: (TabSessionState) -> Unit,
     onTabClick: (TabSessionState) -> Unit,
@@ -74,6 +75,7 @@ fun TabLayout(
             selectedTabId = selectedTabId,
             selectedTabIndex = selectedTabIndex,
             selectionMode = selectionMode,
+            modifier = modifier,
             onTabClose = onTabClose,
             onTabMediaClick = onTabMediaClick,
             onTabClick = onTabClick,
@@ -86,6 +88,7 @@ fun TabLayout(
             selectedTabId = selectedTabId,
             selectedTabIndex = selectedTabIndex,
             selectionMode = selectionMode,
+            modifier = modifier,
             onTabClose = onTabClose,
             onTabMediaClick = onTabMediaClick,
             onTabClick = onTabClick,
@@ -102,6 +105,7 @@ private fun TabGrid(
     selectedTabId: String?,
     selectedTabIndex: Int,
     selectionMode: TabsTrayState.Mode,
+    modifier: Modifier = Modifier,
     onTabClose: (TabSessionState) -> Unit,
     onTabMediaClick: (TabSessionState) -> Unit,
     onTabClick: (TabSessionState) -> Unit,
@@ -114,7 +118,7 @@ private fun TabGrid(
 
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = MIN_COLUMN_WIDTH_DP.dp),
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         state = state,
     ) {
         header?.let {
@@ -152,6 +156,7 @@ private fun TabList(
     selectedTabId: String?,
     selectedTabIndex: Int,
     selectionMode: TabsTrayState.Mode,
+    modifier: Modifier = Modifier,
     onTabClose: (TabSessionState) -> Unit,
     onTabMediaClick: (TabSessionState) -> Unit,
     onTabClick: (TabSessionState) -> Unit,
@@ -163,7 +168,7 @@ private fun TabList(
     val isInMultiSelectMode = selectionMode is TabsTrayState.Mode.Select
 
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         state = state,
     ) {
         header?.let {

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTestTag.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTestTag.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+internal object TabsTrayTestTag {
+    const val tabsTray = "tabstray"
+
+    // Tabs Tray Banner
+    private const val bannerTestTagRoot = "$tabsTray.banner"
+    const val normalTabsPageButton = "$bannerTestTagRoot.normalTabsPageButton"
+    const val privateTabsPageButton = "$bannerTestTagRoot.privateTabsPageButton"
+    const val syncedTabsPageButton = "$bannerTestTagRoot.syncedTabsPageButton"
+
+    // FAB
+    const val fab = "$tabsTray.fab"
+
+    // Tab lists
+    private const val tabListTestTagRoot = "$tabsTray.tabList"
+    const val normalTabsList = "$tabListTestTagRoot.normal"
+    const val privateTabsList = "$tabListTestTagRoot.private"
+    const val syncedTabsList = "$tabListTestTagRoot.synced"
+
+    const val emptyNormalTabsList = "$normalTabsList.empty"
+    const val emptyPrivateTabsList = "$privateTabsList.empty"
+
+    // Tab items
+    private const val tabItemRoot = "$tabsTray.tabItem"
+    const val tabItemClose = "$tabItemRoot.close"
+}


### PR DESCRIPTION
Rather than rewrite the existing logic inside of [`TabDrawerRobot`](https://searchfox.org/mozilla-mobile/source/firefox-android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt) and [`TabbedBrowsingTest`](https://searchfox.org/mozilla-mobile/source/firefox-android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt), I created an intermediary `ComposeTabbedBrowsingTest` and `ComposeTabDrawerRobot` to perform the conversion, so that there aren’t breaking changes in 15+ files AND the two suites of tests can live in tandem until the switch-over happens.

In `ComposeTabDrawerRobot`, I opted for extension functions to obtain the Composables, as that would allow the logic of test tags, etc., to live in one unified place and could be used by both `ComposeTabDrawerRobot` and `ComposeTabDrawerRobot.Transition`. These extension functions, at-large, currently do not live in their own file, as calls to those Composables should, ideally, only happen within the `ComposeTabDrawerRobot` file.

The ignored tests will be handled in follow-up tickets. See this [meta](https://bugzilla.mozilla.org/show_bug.cgi?id=1810775), section 4.5, for the full list.

I also created a Kotlin object, `TabsTrayTestTag`, to contain all of the test tags in a central location and so the test tag naming can feed off of each other.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1831602