### PR TITLE
Bug 1833382 - Temporarily remove walleye for long queuing on Test Lab

### DIFF
--- a/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -40,9 +40,6 @@ gcloud:
     - model: Pixel2.arm
       version: 26
       locale: en_US
-    - model: walleye
-      version: 27
-      locale: en_US
     - model: blueline
       version: 28
       locale: en_US

--- a/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
@@ -17,9 +17,6 @@ gcloud:
     - model: Pixel2.arm
       version: 26
       locale: en_US
-    - model: walleye
-      version: 27
-      locale: en_US
     - model: dreamlte
       version: 28
       locale: en_US


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1833382
https://bugzilla.mozilla.org/show_bug.cgi?id=1833382
https://bugzilla.mozilla.org/show_bug.cgi?id=1833382