### PR TITLE
Bug 1833118 - WIP Disabled resource optimization

### DIFF
--- a/fenix/gradle.properties
+++ b/fenix/gradle.properties
@@ -19,6 +19,10 @@ org.gradle.jvmargs=-Xmx7g -Xms2g -XX:MaxMetaspaceSize=6g
 kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=false
+# Disable the default resource optimization flag else linking 'image' resources via Nimbus is not
+# possible in the current implementation.
+# Note: This flag will be removed in version 8.0 of the Android Gradle Plugin.
+android.enableResourceOptimizations=false
 
 # Enables copying of Jetpack Benchmark results from the device to the build directory.
 android.enableAdditionalTestOutput=true


### PR DESCRIPTION
### Overview
Nimbus experimenter requires an image `resource` ID is used for certain configurations. The app accesses the provided image as a regular `resource`.

### Problem
Gradle is optimizing the application `resources`, creating a flat directory structure and generating an alias for each image (for most use cases this isn't an issue). Therefore, the ID provided by the experimenter is _unknown_ to the app **&** each image density will have a different ID. 

<img width="718" alt="optimized res dir" src="https://github.com/mozilla-mobile/firefox-android/assets/1833156/6d5999e6-36f8-4bb8-8a0c-761d48f2f493">

### Proposed solution
The optimization is done by the Android Gradle Plugin, by default `enableResourceOptimizations` is enabled for version 7 of Gradle. This flag can be set to `false`. There are downsides to disabling the optimization:

1. it affects _all_ resources
2. results in a slightly larger apk size
3. is deprecated from Android Gradle Plugin 8.0 (a different flag is available)

I am unable to find an alternative approach that allows a more targeted approach that affects only the experimenter files. **Would appreciate any other suggestions that folks may have.**

<img width="809" alt="disabled optimize res dir" src="https://github.com/mozilla-mobile/firefox-android/assets/1833156/9ce347a7-933b-4473-9d1a-97158449f703">

### apk size comparison

- Approx 2 MB more when disabling the `resource` optimization

<img width="1641" alt="image optimization apk comparison" src="https://github.com/mozilla-mobile/firefox-android/assets/1833156/add33490-6266-4c0a-ba74-beaf39725ea7">

### Alternative solution
The implementation is updated to decided which images to display based on the card type. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
7. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
8. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
9. Click on `View task in Taskcluster` in the new `DETAILS` section.
10. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1833118