### PR TITLE
Bug 1833452 - Fix app services autopublish when building Fenix/Focus

### DIFF
--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -851,20 +851,6 @@ if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcd
     apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
 }
 
-def appServicesSrcDir = null
-if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) {
-  appServicesSrcDir = gradle.getProperty('localProperties.autoPublish.application-services.dir')
-} else if (gradle.hasProperty('localProperties.branchBuild.application-services.dir')) {
-  appServicesSrcDir = gradle.getProperty('localProperties.branchBuild.application-services.dir')
-}
-if (appServicesSrcDir) {
-    if (appServicesSrcDir.startsWith("/")) {
-        apply from: "${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
-    } else {
-        apply from: "../${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
-    }
-}
-
 if (gradle.hasProperty('localProperties.autoPublish.glean.dir')) {
     ext.gleanSrcDir = gradle."localProperties.autoPublish.glean.dir"
     apply from: "../${gleanSrcDir}/build-scripts/substitute-local-glean.gradle"

--- a/fenix/settings.gradle
+++ b/fenix/settings.gradle
@@ -31,6 +31,20 @@ gradle.projectsLoaded { ->
                 }
             }
         }
+
+        def appServicesSrcDir = null
+        if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) {
+          appServicesSrcDir = gradle.getProperty('localProperties.autoPublish.application-services.dir')
+        } else if (gradle.hasProperty('localProperties.branchBuild.application-services.dir')) {
+          appServicesSrcDir = gradle.getProperty('localProperties.branchBuild.application-services.dir')
+        }
+        if (appServicesSrcDir) {
+            if (appServicesSrcDir.startsWith("/")) {
+                apply from: "${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+            } else {
+                apply from: "${rootProject.projectDir}/${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+            }
+        }
     }
 }
 

--- a/focus-android/app/build.gradle
+++ b/focus-android/app/build.gradle
@@ -614,11 +614,6 @@ if (project.hasProperty("coverage")) {
     }
 }
 
-if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) {
-    ext.appServicesSrcDir = gradle."localProperties.autoPublish.application-services.dir"
-    apply from: "../${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
-}
-
 if (gradle.hasProperty('localProperties.autoPublish.glean.dir')) {
     ext.gleanSrcDir = gradle."localProperties.autoPublish.glean.dir"
     apply from: "../${gleanSrcDir}/build-scripts/substitute-local-glean.gradle"

--- a/focus-android/settings.gradle
+++ b/focus-android/settings.gradle
@@ -29,6 +29,20 @@ gradle.projectsLoaded { ->
                 }
             }
         }
+
+        def appServicesSrcDir = null
+        if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) {
+          appServicesSrcDir = gradle.getProperty('localProperties.autoPublish.application-services.dir')
+        } else if (gradle.hasProperty('localProperties.branchBuild.application-services.dir')) {
+          appServicesSrcDir = gradle.getProperty('localProperties.branchBuild.application-services.dir')
+        }
+        if (appServicesSrcDir) {
+            if (appServicesSrcDir.startsWith("/")) {
+                apply from: "${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+            } else {
+                apply from: "${rootProject.projectDir}/${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Moved the code into `settings.gradle` and put it inside an `allprojects` block.  I'm not 100% sure what's going on but I think this applies the changes to android-components projects as well.  In any case, `./gradlew assembleDebug` now seems to pick up the local app-services code.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1833452