### PR TITLE
Bug 1833698 - Test verbose Flank logging for extra duration information

### DIFF
--- a/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -31,5 +31,5 @@ flank:
   project: GOOGLE_PROJECT
   max-test-shards: 100
   num-test-runs: 1
-  output-style: compact
+  output-style: verbose
   full-junit-result: true

--- a/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -31,5 +31,5 @@ flank:
   project: GOOGLE_PROJECT
   max-test-shards: 100
   num-test-runs: 1
-  output-style: verbose
+  output-style: single
   full-junit-result: true


### PR DESCRIPTION
`s/compact/verbose` test
https://bugzilla.mozilla.org/show_bug.cgi?id=1833698
https://bugzilla.mozilla.org/show_bug.cgi?id=1833698