### PR TITLE
Bug 1814030 - Fix cookie banner reduction UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
@@ -1,7 +1,6 @@
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -17,11 +16,10 @@ class CookieBannerReductionTest {
     val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
 
     // Bug causing flakiness https://bugzilla.mozilla.org/show_bug.cgi?id=1807440
-    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1807440")
     @SmokeTest
     @Test
     fun verifyCookieBannerReductionTest() {
-        val webSite = "voetbal24.be"
+        val webSite = "startsiden.no"
 
         homeScreen {
         }.openNavigationToolbar {
@@ -66,11 +64,10 @@ class CookieBannerReductionTest {
     }
 
     // Bug causing flakiness https://bugzilla.mozilla.org/show_bug.cgi?id=1807440
-    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1807440")
     @SmokeTest
     @Test
     fun verifyCookieBannerReductionInPrivateBrowsingTest() {
-        val webSite = "voetbal24.be"
+        val webSite = "startsiden.no"
 
         homeScreen {
         }.togglePrivateBrowsingMode()
@@ -100,7 +97,7 @@ class CookieBannerReductionTest {
 
         homeScreen {
         }.openTabDrawer {
-        }.openTab("Voetbal24") {
+        }.openTab("Startsiden.no") {
             verifyCookieBannerExists(exists = false)
         }.openThreeDotMenu {
         }.openSettings {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -1229,7 +1229,7 @@ private val currentDate = LocalDate.now()
 private val currentDay = currentDate.dayOfMonth
 private val currentMonth = currentDate.month
 private val currentYear = currentDate.year
-private val cookieBanner = itemWithResId("CybotCookiebotDialog")
+private val cookieBanner = itemWithResId("startsiden-gdpr-disclaimer")
 private val totalCookieProtectionHintMessage =
     itemContainingText(getStringResource(R.string.tcp_cfr_message))
 private val totalCookieProtectionHintLearnMoreLink =


### PR DESCRIPTION
Summary:
Decided to search and try using a different website from the [rule list](https://github.com/mozilla/cookie-banner-rules-list/blob/main/cookie-banner-rules-list.json). (Sometimes the cookie banner from`voetbal24.be` remained displayed)

While searching for another suitable website, I've noticed there were [problems with other websites as well](https://bugzilla.mozilla.org/show_bug.cgi?id=1807440#c6).

I've found `startsiden.no` in the list, tested it manually on both a physical device as well as on an emulator, the cookie banner can be identified easily (for the UI tests), the dismissal works properly, and also noticed better page loading performance compared to `voetbal24.be`

Used it in our UI tests and both tests successfully passed 150x on Firebase. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1814030