### PR TITLE
Bug 1833851 — Remove context param from FeatureHolder in Focus

### DIFF
--- a/focus-android/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/cfr/CfrMiddleware.kt
@@ -39,7 +39,7 @@ class CfrMiddleware(private val appContext: Context) : Middleware<BrowserState, 
         next: (BrowserAction) -> Unit,
         action: BrowserAction,
     ) {
-        onboardingConfig = onboardingFeature.value(context = appContext)
+        onboardingConfig = onboardingFeature.value()
         if (onboardingConfig.isCfrEnabled) {
             next(action)
             showCookieBannerCfr(action)

--- a/focus-android/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/navigation/MainActivityNavigation.kt
@@ -103,7 +103,7 @@ class MainActivityNavigation(
     }
 
     private fun showStartBrowsingCfr() {
-        val onboardingConfig = FocusNimbus.features.onboarding.value(activity)
+        val onboardingConfig = FocusNimbus.features.onboarding.value()
         if (
             onboardingConfig.isCfrEnabled &&
             !activity.settings.isFirstRun &&
@@ -121,7 +121,7 @@ class MainActivityNavigation(
     @Suppress("MagicNumber")
     private fun showPromoteSearchWidgetDialogOrBrandedSnackbar() {
         val onboardingFeature = FocusNimbus.features.onboarding
-        val onboardingConfig = onboardingFeature.value(activity)
+        val onboardingConfig = onboardingFeature.value()
 
         val clearBrowsingSessions = activity.components.settings.getClearBrowsingSessions()
         activity.components.settings.addClearBrowsingSessions(1)

--- a/focus-android/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -223,7 +223,7 @@ class Settings(
     var isNewOnboardingEnable: Boolean
         get() = preferences.getBoolean(
             getPreferenceKey(R.string.new_onboarding_enabled),
-            FocusNimbus.features.onboarding.value(context).isEnabled,
+            FocusNimbus.features.onboarding.value().isEnabled,
         )
         set(value) {
             preferences.edit()
@@ -459,7 +459,7 @@ class Settings(
     var isCookieBannerEnable: Boolean
         get() = preferences.getBoolean(
             getPreferenceKey(R.string.pref_key_cookie_banner_enabled),
-            FocusNimbus.features.cookieBanner.value(context).isCookieHandlingEnabled,
+            FocusNimbus.features.cookieBanner.value().isCookieHandlingEnabled,
         )
         set(value) {
             preferences.edit()

--- a/focus-android/app/src/test/java/org/mozilla/focus/cfr/CfrMiddlewareTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/cfr/CfrMiddlewareTest.kt
@@ -39,7 +39,7 @@ class CfrMiddlewareTest {
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
-        onboardingExperiment = FocusNimbus.features.onboarding.value(testContext)
+        onboardingExperiment = FocusNimbus.features.onboarding.value()
     }
 
     @Test


### PR DESCRIPTION
Fixes [Bug 1833851](https://bugzilla.mozilla.org/show_bug.cgi?id=1833851).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1833851