### PR TITLE
Bug 1830870 - Fix disabled tab closing UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -10,7 +10,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -141,7 +140,6 @@ class TabbedBrowsingTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1830870")
     @Test
     fun closeTabTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -199,7 +197,6 @@ class TabbedBrowsingTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1829838")
     @Test
     fun closePrivateTabTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -15,10 +15,13 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.GeneralLocation
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.swipeLeft
+import androidx.test.espresso.action.ViewActions.swipeRight
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -38,11 +41,13 @@ import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matcher
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
+import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndDescription
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
@@ -125,20 +130,62 @@ class TabDrawerRobot {
         }
 
     fun swipeTabRight(title: String) {
-        var retries = 0 // number of retries before failing, will stop at 2
-        while (!tabItem(title).waitUntilGone(waitingTimeShort) && retries < 3
-        ) {
-            tab(title).swipeRight(3)
-            retries++
+        for (i in 1..RETRY_COUNT) {
+            try {
+                onView(
+                    allOf(
+                        withId(R.id.tab_item),
+                        hasDescendant(
+                            allOf(
+                                withId(R.id.mozac_browser_tabstray_title),
+                                withText(title),
+                            ),
+                        ),
+                    ),
+                ).perform(swipeRight())
+                assertTrue(
+                    itemWithResIdContainingText(
+                        "$packageName:id/mozac_browser_tabstray_title",
+                        title,
+                    ).waitUntilGone(waitingTimeShort),
+                )
+
+                break
+            } catch (e: AssertionError) {
+                if (i == RETRY_COUNT) {
+                    throw e
+                }
+            }
         }
     }
 
     fun swipeTabLeft(title: String) {
-        var retries = 0 // number of retries before failing, will stop at 2
-        while (!tabItem(title).waitUntilGone(waitingTimeShort) && retries < 3
-        ) {
-            tab(title).swipeLeft(3)
-            retries++
+        for (i in 1..RETRY_COUNT) {
+            try {
+                onView(
+                    allOf(
+                        withId(R.id.tab_item),
+                        hasDescendant(
+                            allOf(
+                                withId(R.id.mozac_browser_tabstray_title),
+                                withText(title),
+                            ),
+                        ),
+                    ),
+                ).perform(swipeLeft())
+                assertTrue(
+                    itemWithResIdContainingText(
+                        "$packageName:id/mozac_browser_tabstray_title",
+                        title,
+                    ).waitUntilGone(waitingTimeShort),
+                )
+
+                break
+            } catch (e: AssertionError) {
+                if (i == RETRY_COUNT) {
+                    throw e
+                }
+            }
         }
     }
 
@@ -566,10 +613,6 @@ private fun assertSyncedTabsButtonIsSelected(isSelected: Boolean) {
 
 private val tabsList =
     UiScrollable(UiSelector().className("androidx.recyclerview.widget.RecyclerView"))
-
-// This Espresso tab selector is used for actions that UIAutomator doesn't handle very well: swipe and long-tap
-private fun tab(title: String) =
-    mDevice.findObject(UiSelector().textContains(title))
 
 // This tab selector is used for actions that involve waiting and asserting the existence of the view
 private fun tabItem(title: String) =


### PR DESCRIPTION
Fixes [1830870](https://bugzilla.mozilla.org/show_bug.cgi?id=1830870) and [1829838](https://bugzilla.mozilla.org/show_bug.cgi?id=1829838)

Summary:
The problems were caused when trying to close a tab using the swipe gesture, UI Automator sometimes fails to perform the swipe action, so I've switched to Espresso.

Both tests successfully ran 100x **without** the retryRule on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1830870