### PR TITLE
Bug 1833655 - Bump pull-request-labeler action to 1.0.5

### DIFF
--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.actor != 'github-actions[bot]' && github.actor != 'dependabot[bot]' && github.actor != 'MickeyMoz'
     steps:
       - name: Pull Request Labeler
-        uses: gabrielluong/pull-request-labeler@1.0.4
+        uses: gabrielluong/pull-request-labeler@1.0.5
         if: github.repository == 'mozilla-mobile/firefox-android'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adjusts how the action was fetching the pull request number which doesn't expose a `number` property for the [pull_request_review](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request_review) event compare to the [pull_request](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request) event. This will ensure that we will mark the PR as approved or changes needed when a pull request review is submitted.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1833655