### PR TITLE
Bug 1834692 - [MozillaOnline] Disable "isMarketingTelemetryEnabled" no matter what users click in privacy pop window in MozillaOnline builds

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentDisplayHelper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/mozonline/PrivacyContentDisplayHelper.kt
@@ -58,7 +58,6 @@ fun showPrivacyPopWindow(context: Context, activity: Activity) {
             context.getString(R.string.privacy_notice_positive_button),
         ) { _, _ ->
             context.settings().shouldShowPrivacyPopWindow = false
-            context.settings().isMarketingTelemetryEnabled = true
             context.components.analytics.metrics.start(MetricServiceType.Marketing)
             // Now that the privacy notice is accepted, application initialization can continue.
             context.application.initialize()
@@ -69,7 +68,6 @@ fun showPrivacyPopWindow(context: Context, activity: Activity) {
             context.getString(R.string.privacy_notice_neutral_button_2),
         ) { _, _ ->
             context.settings().shouldShowPrivacyPopWindow = false
-            context.settings().isMarketingTelemetryEnabled = false
             context.settings().isTelemetryEnabled = false
             context.components.analytics.metrics.start(MetricServiceType.Marketing)
             // Now that the privacy notice is accepted, application initialization can continue.


### PR DESCRIPTION
Since we have hided marketing data collection preference in MozillaOnline builds in [Bug 1832003](https://bugzilla.mozilla.org/show_bug.cgi?id=1832003), we should keep it as false. Also we don't really use adjust in MozillaOnline builds so this data won't be valid anyway.

It defaults to false in MozillaOnline builds, so I just remove the re-assignment lines in privacy pop window.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1834692