### PR TITLE
Bug 1834698 - [MozillaOnline] Change text for "Data Collection" in Chinese only in Mozillaonline builds

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -55,7 +55,11 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        showToolbar(getString(R.string.preferences_data_collection))
+        if (Config.channel.isMozillaOnline) {
+            showToolbar(getString(R.string.preferences_mozonline_data_collection))
+        } else {
+            showToolbar(getString(R.string.preferences_data_collection))
+        }
         updateStudiesSection()
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -156,6 +156,12 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
+
+        if (Config.channel.isMozillaOnline) {
+            requirePreference<Preference>(R.string.pref_key_data_choices).apply {
+                title = context.getString(R.string.preferences_mozonline_data_collection)
+            }
+        }
     }
 
     @SuppressLint("RestrictedApi")

--- a/fenix/app/src/main/res/values-zh-rCN/mozonline_strings.xml
+++ b/fenix/app/src/main/res/values-zh-rCN/mozonline_strings.xml
@@ -33,6 +33,9 @@
     <!-- Default title for pinned meituan top site that links to 58 home page  -->
     <string name="default_top_site_meituan">美团</string>
 
+    <!-- Preference for data collection -->
+    <string name="preferences_mozonline_data_collection">改善用户体验</string>
+
     <!-- FxA server switch-->
     <!-- Switch Preference for domestic China/global fxa server -->
     <string name="preferences_allow_domestic_china_fxa_server">使用本地服务</string>

--- a/fenix/app/src/main/res/values/mozonline_strings.xml
+++ b/fenix/app/src/main/res/values/mozonline_strings.xml
@@ -32,6 +32,9 @@
     <!-- Default title for pinned meituan top site that links to 58 home page  -->
     <string name="default_top_site_meituan">meituan</string>
 
+    <!-- Preference for data collection -->
+    <string name="preferences_mozonline_data_collection">Data collection</string>
+
     <!-- FxA server switch-->
     <!-- Switch Preference for domestic China/global fxa server -->
     <string name="preferences_allow_domestic_china_fxa_server">Use domestic China service</string>


### PR DESCRIPTION
Due to [Bug 1834415](https://bugzilla.mozilla.org/show_bug.cgi?id=1834415), and special requirement for MozillaOnline builds, change the text of "Data Collection" in Chinese that will only affect MozillaOnline builds.

Change from "数据收集"(data collection) to "改善用户体验" (user experience improvement), suggested by authorities.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1834698