### PR TITLE
Bug 1822552 - Adjust vertical padding in recently visited groups to prevent title text from being cut off at the bottom

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
@@ -179,7 +179,7 @@ private fun RecentlyVisitedHistoryGroup(
             RecentlyVisitedTitle(
                 text = recentVisit.title,
                 modifier = Modifier
-                    .padding(top = 7.dp, bottom = 2.dp)
+                    .padding(top = 4.dp, bottom = 2.dp)
                     .weight(1f)
                     .semantics {
                         testTagsAsResourceId = true


### PR DESCRIPTION
**Screenshot before:**
<img src="https://github.com/mozilla-mobile/firefox-android/assets/4525736/7582e691-d2d5-4597-891b-01d5642c89c6" width="200">

**Screenshot after:**
<img src="https://github.com/mozilla-mobile/firefox-android/assets/4525736/6775dbf1-473b-4ed0-b3e9-c15ced52af71" width="200">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1822552