### PR TITLE
Bug 1826453 - Refactor tab page button click metrics

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabLayoutMediator.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabLayoutMediator.kt
@@ -9,13 +9,10 @@ import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayout
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.base.feature.LifecycleAwareFeature
-import mozilla.telemetry.glean.private.NoExtras
-import org.mozilla.fenix.GleanMetrics.TabsTray
 import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.tabstray.TrayPagerAdapter.Companion.POSITION_NORMAL_TABS
 import org.mozilla.fenix.tabstray.TrayPagerAdapter.Companion.POSITION_PRIVATE_TABS
 import org.mozilla.fenix.tabstray.TrayPagerAdapter.Companion.POSITION_SYNCED_TABS
-import org.mozilla.fenix.utils.Do
 
 /**
  * Selected the selected pager depending on the [BrowserStore] state and synchronizes user actions
@@ -82,12 +79,6 @@ internal class TabLayoutObserver(
         }
 
         interactor.onTrayPositionSelected(tab.position, animate)
-
-        Do exhaustive when (Page.positionToPage(tab.position)) {
-            Page.NormalTabs -> TabsTray.normalModeTapped.record(NoExtras())
-            Page.PrivateTabs -> TabsTray.privateModeTapped.record(NoExtras())
-            Page.SyncedTabs -> TabsTray.syncedModeTapped.record(NoExtras())
-        }
     }
 
     override fun onTabUnselected(tab: TabLayout.Tab) = Unit

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -266,8 +266,16 @@ class DefaultTabsTrayController(
     }
 
     override fun handleTrayScrollingToPosition(position: Int, smoothScroll: Boolean) {
+        val page = Page.positionToPage(position)
+
+        when (page) {
+            Page.NormalTabs -> TabsTray.normalModeTapped.record(NoExtras())
+            Page.PrivateTabs -> TabsTray.privateModeTapped.record(NoExtras())
+            Page.SyncedTabs -> TabsTray.syncedModeTapped.record(NoExtras())
+        }
+
         selectTabPosition(position, smoothScroll)
-        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(position)))
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(page))
     }
 
     /**

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
@@ -1066,6 +1066,33 @@ class DefaultTabsTrayControllerTest {
         assertEquals("1", snapshot.single().extra?.getValue("tab_count"))
     }
 
+    @Test
+    fun `WHEN the normal tabs page button is clicked THEN report the metric`() {
+        assertNull(TabsTray.normalModeTapped.testGetValue())
+
+        createController().handleTrayScrollingToPosition(Page.NormalTabs.ordinal, false)
+
+        assertNotNull(TabsTray.normalModeTapped.testGetValue())
+    }
+
+    @Test
+    fun `WHEN the private tabs page button is clicked THEN report the metric`() {
+        assertNull(TabsTray.privateModeTapped.testGetValue())
+
+        createController().handleTrayScrollingToPosition(Page.PrivateTabs.ordinal, false)
+
+        assertNotNull(TabsTray.privateModeTapped.testGetValue())
+    }
+
+    @Test
+    fun `WHEN the synced tabs page button is clicked THEN report the metric`() {
+        assertNull(TabsTray.syncedModeTapped.testGetValue())
+
+        createController().handleTrayScrollingToPosition(Page.SyncedTabs.ordinal, false)
+
+        assertNotNull(TabsTray.syncedModeTapped.testGetValue())
+    }
+
     private fun createController(
         navigateToHomeAndDeleteSession: (String) -> Unit = { },
         selectTabPosition: (Int, Boolean) -> Unit = { _, _ -> },

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/TabLayoutObserverTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/TabLayoutObserverTest.kt
@@ -12,13 +12,10 @@ import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.middleware.CaptureActionsMiddleware
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.GleanMetrics.TabsTray
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @RunWith(FenixRobolectricTestRunner::class) // for gleanTestRule
@@ -40,34 +37,28 @@ class TabLayoutObserverTest {
         val observer = TabLayoutObserver(interactor)
         val tab = mockk<TabLayout.Tab>()
         every { tab.position } returns 1
-        assertNull(TabsTray.privateModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         store.waitUntilIdle()
 
         verify { interactor.onTrayPositionSelected(1, false) }
-        assertNotNull(TabsTray.privateModeTapped.testGetValue())
 
         every { tab.position } returns 0
-        assertNull(TabsTray.normalModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         store.waitUntilIdle()
 
         verify { interactor.onTrayPositionSelected(0, true) }
-        assertNotNull(TabsTray.normalModeTapped.testGetValue())
 
         every { tab.position } returns 2
-        assertNull(TabsTray.syncedModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         store.waitUntilIdle()
 
         verify { interactor.onTrayPositionSelected(2, true) }
-        assertNotNull(TabsTray.syncedModeTapped.testGetValue())
     }
 
     @Test
@@ -75,16 +66,13 @@ class TabLayoutObserverTest {
         val observer = TabLayoutObserver(interactor)
         val tab = mockk<TabLayout.Tab>()
         every { tab.position } returns 1
-        assertNull(TabsTray.privateModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         verify { interactor.onTrayPositionSelected(1, false) }
-        assertNotNull(TabsTray.privateModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         verify { interactor.onTrayPositionSelected(1, true) }
-        assertNotNull(TabsTray.privateModeTapped.testGetValue())
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1826453