### PR TITLE
Bug 1828493 - Fix UI discrepancies of Compose tab items

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
@@ -84,7 +84,7 @@ fun TabGridItem(
     onClick: (tab: TabSessionState) -> Unit,
     onLongClick: (tab: TabSessionState) -> Unit,
 ) {
-    val tabBorderModifier = if (isSelected && !multiSelectionEnabled) {
+    val tabBorderModifier = if (isSelected) {
         Modifier.border(
             4.dp,
             FirefoxTheme.colors.borderAccent,

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -22,6 +23,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -159,6 +161,13 @@ private fun Thumbnail(
         )
 
         if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .size(width = 92.dp, height = 72.dp)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(FirefoxTheme.colors.layerAccentNonOpaque),
+            )
+
             Card(
                 modifier = Modifier
                     .size(size = 40.dp)


### PR DESCRIPTION
This PR focuses on the last two points of the ticket:

1. Entering multi-select mode makes the selected tab become non-highlighted
2. Each multi-selected item has a dark gradient overlaying the hero image

Regarding the dark gradient/purple overlay that is applied on each of the selected items, this was pre-existing. The issue fixed here is that it was only applied for the `TabGridItem`. This PR aims to fix that, applying it to the `TabListItem` thumbnail.

Videos for reference:
| Keep highlighted stroke on selected tab | Apply purple overlay on list items |
| ---------------------------------------- | --------------------------------- |
| <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/aa3770da-62d0-4e69-b31e-d7f570d5d712"> | <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/7012a228-6786-4c2a-ac30-b3c2cda37664"> |


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
