### PR TITLE
Revert "Bug 1807307 - Disable LeakCanary in CI debug APKs used for UI fuzzy testing"

### DIFF
--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -342,13 +342,6 @@ tasks:
                   key: firebaseToken
                   path: .firebase_token.json
                   json: true
-            dummy-secrets:
-                - content: |
-                    <?xml version="1.0" encoding="utf-8"?>
-                    <resources>
-                        <string name="leak_canary_test_class_name">org.mozilla.fenix.DebugFenixApplication</string>
-                    </resources>
-                  path: app/src/main/res/values/leakcanary.xml
             pre-commands:
                 - ["cd", "fenix"]
             commands:


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-android#2213

There seems to be some parsing error with the xml file we added, but I'm unsure why because this worked for a previous run [here](https://github.com/mozilla-mobile/firefox-android/compare/0f3a144cd25bf00a5773b4afc73d63ac4ca6e962..0f684f66d0d323c5f71fd8b4773c5f4516287a68). Backing it out while I investigate because I need to more time.

```
[task 2023-05-29T09:33:49.180Z] Traceback (most recent call last):
[task 2023-05-29T09:33:49.182Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 74, in repl
[task 2023-05-29T09:33:49.183Z]     task_id = dependencies[dependency]
[task 2023-05-29T09:33:49.184Z] KeyError: '?xml version="1.0" encoding="utf-8"?>\n<resources>\n    <string name="leak_canary_test_class_name">org.mozilla.fenix.DebugFenixApplication<'
[task 2023-05-29T09:33:49.185Z] 
[task 2023-05-29T09:33:49.185Z] During handling of the above exception, another exception occurred:
[task 2023-05-29T09:33:49.185Z] 
[task 2023-05-29T09:33:49.185Z] Traceback (most recent call last):
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/main.py", line 841, in main
[task 2023-05-29T09:33:49.185Z]     args.command(vars(args))
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/main.py", line 638, in decision
[task 2023-05-29T09:33:49.185Z]     taskgraph_decision(options)
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/decision.py", line 118, in taskgraph_decision
[task 2023-05-29T09:33:49.185Z]     write_artifact("task-graph.json", tgg.morphed_task_graph.to_json())
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 221, in morphed_task_graph
[task 2023-05-29T09:33:49.185Z]     return self._run_until("morphed_task_graph")
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 423, in _run_until
[task 2023-05-29T09:33:49.185Z]     k, v = next(self._run)
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/generator.py", line 397, in _run
[task 2023-05-29T09:33:49.185Z]     optimized_task_graph, label_to_taskid = optimize_task_graph(
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/optimize/base.py", line 84, in optimize_task_graph
[task 2023-05-29T09:33:49.185Z]     get_subgraph(
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/optimize/base.py", line 380, in get_subgraph
[task 2023-05-29T09:33:49.185Z]     task.task = resolve_task_references(
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 91, in resolve_task_references
[task 2023-05-29T09:33:49.185Z]     return _recurse(
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 28, in _recurse
[task 2023-05-29T09:33:49.185Z]     return recurse(val)
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 24, in recurse
[task 2023-05-29T09:33:49.185Z]     return {k: recurse(v) for k, v in val.items()}
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 24, in <dictcomp>
[task 2023-05-29T09:33:49.185Z]     return {k: recurse(v) for k, v in val.items()}
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 24, in recurse
[task 2023-05-29T09:33:49.185Z]     return {k: recurse(v) for k, v in val.items()}
[task 2023-05-29T09:33:49.185Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 24, in <dictcomp>
[task 2023-05-29T09:33:49.185Z]     return {k: recurse(v) for k, v in val.items()}
[task 2023-05-29T09:33:49.186Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 18, in recurse
[task 2023-05-29T09:33:49.186Z]     return [recurse(v) for v in val]
[task 2023-05-29T09:33:49.186Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 18, in <listcomp>
[task 2023-05-29T09:33:49.186Z]     return [recurse(v) for v in val]
[task 2023-05-29T09:33:49.186Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 23, in recurse
[task 2023-05-29T09:33:49.186Z]     return param_fn(val[param_key])
[task 2023-05-29T09:33:49.186Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 89, in artifact_reference
[task 2023-05-29T09:33:49.186Z]     return ARTIFACT_REFERENCE_PATTERN.sub(repl, val)
[task 2023-05-29T09:33:49.186Z]   File "/builds/worker/.local/lib/python3.8/site-packages/taskgraph/util/parameterization.py", line 76, in repl
[task 2023-05-29T09:33:49.186Z]     raise KeyError(
[task 2023-05-29T09:33:49.186Z] KeyError: 'task \'ui-test-apk-fenix-robo-arm-debug\' has no dependency named \'?xml version="1.0" encoding="utf-8"?>\n<resources>\n    <string name="leak_canary_test_class_name">org.mozilla.fenix.DebugFenixApplication<\''
```