### PR TITLE
Bug 1820545 - Refactor isActiveUser method to remove test intermittency.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/ReEngagementNotificationWorker.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/ReEngagementNotificationWorker.kt
@@ -37,8 +37,9 @@ class ReEngagementNotificationWorker(
 
     override fun doWork(): Result {
         val settings = applicationContext.settings()
+        val isActiveUser = isActiveUser(settings.lastBrowseActivity, System.currentTimeMillis())
 
-        if (isActiveUser(settings) || !settings.shouldShowReEngagementNotification()) {
+        if (isActiveUser || !settings.shouldShowReEngagementNotification()) {
             return Result.success()
         }
 
@@ -136,8 +137,8 @@ class ReEngagementNotificationWorker(
         }
 
         @VisibleForTesting
-        internal fun isActiveUser(settings: Settings): Boolean {
-            if (System.currentTimeMillis() - settings.lastBrowseActivity > INACTIVE_USER_THRESHOLD) {
+        internal fun isActiveUser(lastBrowseActivity: Long, currentTimeMillis: Long): Boolean {
+            if (currentTimeMillis - lastBrowseActivity > INACTIVE_USER_THRESHOLD) {
                 return false
             }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/onboarding/ReEngagementNotificationWorkerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/onboarding/ReEngagementNotificationWorkerTest.kt
@@ -4,8 +4,8 @@
 
 package org.mozilla.fenix.onboarding
 
-import io.mockk.spyk
 import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
@@ -24,21 +24,22 @@ class ReEngagementNotificationWorkerTest {
 
     @Test
     fun `GIVEN last browser activity THEN determine if the user is active correctly`() {
-        val localSetting = spyk(settings)
+        val now = System.currentTimeMillis()
+        val fourHoursAgo = now - Settings.FOUR_HOURS_MS
+        val oneDayAgo = now - Settings.ONE_DAY_MS
 
-        localSetting.lastBrowseActivity = System.currentTimeMillis()
-        assert(ReEngagementNotificationWorker.isActiveUser(localSetting))
+        assertTrue(ReEngagementNotificationWorker.isActiveUser(now, now))
+        assertTrue(ReEngagementNotificationWorker.isActiveUser(fourHoursAgo, now))
 
-        localSetting.lastBrowseActivity = System.currentTimeMillis() - Settings.FOUR_HOURS_MS
-        assert(ReEngagementNotificationWorker.isActiveUser(localSetting))
+        // test inactive user threshold
+        assertTrue(ReEngagementNotificationWorker.isActiveUser(oneDayAgo, now))
+        assertFalse(ReEngagementNotificationWorker.isActiveUser(oneDayAgo - 1, now))
+        assertTrue(ReEngagementNotificationWorker.isActiveUser(oneDayAgo + 1, now))
 
-        localSetting.lastBrowseActivity = System.currentTimeMillis() - Settings.ONE_DAY_MS
-        assertFalse(ReEngagementNotificationWorker.isActiveUser(localSetting))
+        // test default value
+        assertFalse(ReEngagementNotificationWorker.isActiveUser(0, now))
 
-        localSetting.lastBrowseActivity = 0
-        assertFalse(ReEngagementNotificationWorker.isActiveUser(localSetting))
-
-        localSetting.lastBrowseActivity = -1000
-        assertFalse(ReEngagementNotificationWorker.isActiveUser(localSetting))
+        // test unlikely value
+        assertFalse(ReEngagementNotificationWorker.isActiveUser(-1000, now))
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1820545