### PR TITLE
Bug 1796331 - Added @Throws for AutofillCreditCardsAddressesStorage 

### DIFF
--- a/android-components/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
+++ b/android-components/components/service/sync-autofill/src/main/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorage.kt
@@ -10,6 +10,7 @@ import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.withContext
+import kotlin.jvm.Throws
 import mozilla.appservices.autofill.AutofillApiException.NoSuchRecord
 import mozilla.components.concept.storage.Address
 import mozilla.components.concept.storage.CreditCard
@@ -115,6 +116,7 @@ class AutofillCreditCardsAddressesStorage(
         conn.getStorage().updateCreditCard(guid, updatableCreditCardFields.into())
     }
 
+    @Throws(NoSuchRecord::class)
     override suspend fun getCreditCard(guid: String): CreditCard? = withContext(coroutineContext) {
         try {
             conn.getStorage().getCreditCard(guid).into()
@@ -140,6 +142,7 @@ class AutofillCreditCardsAddressesStorage(
             conn.getStorage().addAddress(addressFields.into()).into()
         }
 
+    @Throws(NoSuchRecord::class)
     override suspend fun getAddress(guid: String): Address? = withContext(coroutineContext) {
         try {
             conn.getStorage().getAddress(guid).into()


### PR DESCRIPTION
In this issue they requested us to add throws annotation to the required methods in AutofillCreditCardsAddressesStorage.

There are only 2 methods on which throws annotation could be applied, those methods already had try and catch block in it.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1796331