### PR TITLE
Bug 1836317 - Add an interactor function for handling top site long clicks

### DIFF
--- a/android-components/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSite.kt
+++ b/android-components/components/feature/top-sites/src/main/java/mozilla/components/feature/top/sites/TopSite.kt
@@ -12,6 +12,7 @@ sealed class TopSite {
     abstract val title: String?
     abstract val url: String
     abstract val createdAt: Long?
+    abstract val type: String
 
     /**
      * This top site was added as a default by the application.
@@ -20,12 +21,14 @@ sealed class TopSite {
      * @property title The title of the top site.
      * @property url The URL of the top site.
      * @property createdAt The optional date the top site was added.
+     * @property type The type name of the top site.
      */
     data class Default(
         override val id: Long?,
         override val title: String?,
         override val url: String,
         override val createdAt: Long?,
+        override val type: String = "DEFAULT",
     ) : TopSite()
 
     /**
@@ -35,12 +38,14 @@ sealed class TopSite {
      * @property title The title of the top site.
      * @property url The URL of the top site.
      * @property createdAt The optional date the top site was added.
+     * @property type The type name of the top site.
      */
     data class Pinned(
         override val id: Long?,
         override val title: String?,
         override val url: String,
         override val createdAt: Long?,
+        override val type: String = "PINNED",
     ) : TopSite()
 
     /**
@@ -50,12 +55,14 @@ sealed class TopSite {
      * @property title The title of the top site.
      * @property url The URL of the top site.
      * @property createdAt The optional date the top site was added.
+     * @property type The type name of the top site.
      */
     data class Frecent(
         override val id: Long?,
         override val title: String?,
         override val url: String,
         override val createdAt: Long?,
+        override val type: String = "FRECENT",
     ) : TopSite()
 
     /**
@@ -68,6 +75,7 @@ sealed class TopSite {
      * @property imageUrl The image URL of the top site.
      * @property impressionUrl The URL that needs to be fired when the top site is displayed.
      * @property createdAt The optional date the top site was added.
+     * @property type The type name of the top site.
      */
     data class Provided(
         override val id: Long?,
@@ -77,5 +85,6 @@ sealed class TopSite {
         val imageUrl: String,
         val impressionUrl: String,
         override val createdAt: Long?,
+        override val type: String = "PROVIDED",
     ) : TopSite()
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/ext/TopSite.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ext/TopSite.kt
@@ -8,16 +8,6 @@ import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.settings.SupportUtils
 
 /**
- * Returns the type name of the [TopSite].
- */
-fun TopSite.name(): String = when (this) {
-    is TopSite.Default -> "DEFAULT"
-    is TopSite.Frecent -> "FRECENT"
-    is TopSite.Pinned -> "PINNED"
-    is TopSite.Provided -> "PROVIDED"
-}
-
-/**
  * Returns a sorted list of [TopSite] with the default Google top site always appearing
  * as the first item.
  */

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -131,6 +131,11 @@ interface SessionControlController {
     fun handleSponsorPrivacyClicked()
 
     /**
+     * @see [TopSiteInteractor.onTopSiteLongClicked]
+     */
+    fun handleTopSiteLongClicked(topSite: TopSite)
+
+    /**
      * @see [CollectionInteractor.onToggleCollectionExpanded]
      */
     fun handleToggleCollectionExpanded(collection: TabCollection, expand: Boolean)
@@ -410,6 +415,10 @@ class DefaultSessionControlController(
             newTab = true,
             from = BrowserDirection.FromHome,
         )
+    }
+
+    override fun handleTopSiteLongClicked(topSite: TopSite) {
+        TopSites.longPress.record(TopSites.LongPressExtra(topSite.type))
     }
 
     @VisibleForTesting

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -181,6 +181,14 @@ interface TopSiteInteractor {
      * "Our sponsors & your privacy" top site menu item.
      */
     fun onSponsorPrivacyClicked()
+
+    /**
+     * Handles long click event for the given top site. Called when an user long clicks on a top
+     * site.
+     *
+     * @param topSite The top site that was long clicked.
+     */
+    fun onTopSiteLongClicked(topSite: TopSite)
 }
 
 interface MessageCardInteractor {
@@ -291,6 +299,10 @@ class SessionControlInteractor(
 
     override fun onSponsorPrivacyClicked() {
         controller.handleSponsorPrivacyClicked()
+    }
+
+    override fun onTopSiteLongClicked(topSite: TopSite) {
+        controller.handleTopSiteLongClicked(topSite)
     }
 
     override fun showWallpapersOnboardingDialog(state: WallpaperState): Boolean {

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
@@ -37,7 +37,6 @@ import org.mozilla.fenix.ext.bitmapForUrl
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.isSystemInDarkTheme
 import org.mozilla.fenix.ext.loadIntoView
-import org.mozilla.fenix.ext.name
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.view.ViewHolder
@@ -54,7 +53,7 @@ class TopSiteItemViewHolder(
 
     init {
         itemView.setOnLongClickListener {
-            TopSites.longPress.record(TopSites.LongPressExtra(topSite.name()))
+            interactor.onTopSiteLongClicked(topSite)
 
             val topSiteMenu = TopSiteItemMenu(
                 context = view.context,

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -1052,6 +1052,25 @@ class DefaultSessionControlControllerTest {
     }
 
     @Test
+    fun `WHEN top site long clicked is called THEN report the top site long click telemetry`() {
+        assertNull(TopSites.longPress.testGetValue())
+
+        val topSite = TopSite.Provided(
+            id = 1L,
+            title = "Mozilla",
+            url = "mozilla.org",
+            clickUrl = "",
+            imageUrl = "",
+            impressionUrl = "",
+            createdAt = 0,
+        )
+
+        createController().handleTopSiteLongClicked(topSite)
+
+        assertEquals(topSite.type, TopSites.longPress.testGetValue()!!.single().extra!!["type"])
+    }
+
+    @Test
     fun `WHEN handleOpenInPrivateTabClicked is called with a TopSite#Provided site THEN Event#TopSiteOpenContileInPrivateTab is reported`() {
         val topSite = TopSite.Provided(
             id = 1L,

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import mozilla.components.feature.tab.collections.Tab
 import mozilla.components.feature.tab.collections.TabCollection
+import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.service.pocket.PocketStory
 import org.junit.Before
 import org.junit.Test
@@ -219,6 +220,13 @@ class SessionControlInteractorTest {
     fun `WHEN onSponsorPrivacyClicked is called THEN handleSponsorPrivacyClicked is called`() {
         interactor.onSponsorPrivacyClicked()
         verify { controller.handleSponsorPrivacyClicked() }
+    }
+
+    @Test
+    fun `WHEN a top site is long clicked THEN the click is handled`() {
+        val topSite: TopSite = mockk()
+        interactor.onTopSiteLongClicked(topSite)
+        verify { controller.handleTopSiteLongClicked(topSite) }
     }
 
     @Test


### PR DESCRIPTION




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1836317