### PR TITLE
Bug 1836347 - Add default active and inactive colors for the PagerIndicator

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/PagerIndicator.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/PagerIndicator.kt
@@ -34,10 +34,10 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * indicators to show progress, instead of just showing the current one as active.
  *
  * @param pagerState The state object of your [HorizontalPager] to be used to observe the list's state.
- * @param modifier The modifier to apply to this layout.
  * @param pageCount The size of indicators should be displayed, defaults to [PagerState.pageCount].
  * If you are implementing a looping pager with a much larger [PagerState.pageCount]
  * than indicators should displayed, e.g. [Int.MAX_VALUE], specify you real size in this param.
+ * @param modifier The modifier to apply to this layout.
  * @param activeColor The color of the active page indicator, and the color of previous page
  * indicators in case [leaveTrail] is set to true.
  * @param inactiveColor The color of page indicators that are inactive.
@@ -47,10 +47,10 @@ import org.mozilla.fenix.theme.FirefoxTheme
 @Composable
 fun PagerIndicator(
     pagerState: PagerState,
-    modifier: Modifier = Modifier,
     pageCount: Int,
-    activeColor: Color,
-    inactiveColor: Color,
+    modifier: Modifier = Modifier,
+    activeColor: Color = FirefoxTheme.colors.indicatorActive,
+    inactiveColor: Color = FirefoxTheme.colors.indicatorInactive,
     leaveTrail: Boolean = false,
 ) {
     Row(
@@ -124,6 +124,22 @@ private fun PagerIndicatorPreview() {
                 activeColor = FirefoxTheme.colors.actionPrimary,
                 inactiveColor = FirefoxTheme.colors.actionSecondary,
                 leaveTrail = true,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = "Default colors",
+                style = FirefoxTheme.typography.caption,
+                color = FirefoxTheme.colors.textPrimary,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            PagerIndicator(
+                pagerState = rememberPagerState(1),
+                pageCount = 3,
                 modifier = Modifier.align(Alignment.CenterHorizontally),
             )
         }


### PR DESCRIPTION



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1836347