### PR TITLE
Bug 1815579 - Improve performance of image loading in tab items

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ThumbnailImage.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ThumbnailImage.kt
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.compose
+
+import android.graphics.Bitmap
+import android.os.Parcelable
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
+import mozilla.components.concept.base.images.ImageLoadRequest
+import org.mozilla.fenix.components.components
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Thumbnail belonging to a [key]. Asynchronously fetches the bitmap from storage.
+ *
+ * @param key Key used to remember the thumbnail for future compositions.
+ * @param size [Dp] size of the thumbnail.
+ * @param modifier [Modifier] used to draw the image content.
+ * @param contentScale [ContentScale] used to draw image content.
+ * @param alignment [Alignment] used to draw the image content.
+ */
+@Composable
+@Suppress("LongParameterList")
+fun ThumbnailImage(
+    key: String,
+    size: Dp,
+    modifier: Modifier,
+    contentScale: ContentScale,
+    alignment: Alignment,
+    fallbackContent: @Composable () -> Unit,
+) {
+    if (inComposePreview) {
+        Box(modifier = Modifier.background(color = FirefoxTheme.colors.layer3))
+    } else {
+        val thumbnailSize = LocalDensity.current.run { size.toPx().toInt() }
+        val request = ImageLoadRequest(key, thumbnailSize)
+        val storage = components.core.thumbnailStorage
+        var state by rememberSaveable { mutableStateOf(ThumbnailImageState(null, false)) }
+        val scope = rememberCoroutineScope()
+
+        DisposableEffect(Unit) {
+            if (!state.hasLoaded) {
+                scope.launch {
+                    val thumbnailBitmap = storage.loadThumbnail(request).await()
+                    thumbnailBitmap?.prepareToDraw()
+                    state = ThumbnailImageState(
+                        bitmap = thumbnailBitmap,
+                        hasLoaded = true,
+                    )
+                }
+            }
+
+            onDispose {
+                // Recycle the bitmap to liberate the RAM. Without this, a list of [ThumbnailImage]
+                // will bloat the memory. This is a trade-off, however, as the bitmap
+                // will be re-fetched if this Composable is disposed and re-loaded.
+                state.bitmap?.recycle()
+                state = ThumbnailImageState(
+                    bitmap = null,
+                    hasLoaded = false,
+                )
+            }
+        }
+
+        if (state.bitmap == null && state.hasLoaded) {
+            fallbackContent()
+        } else {
+            state.bitmap?.let { bitmap ->
+                Image(
+                    painter = BitmapPainter(bitmap.asImageBitmap()),
+                    contentDescription = null,
+                    modifier = modifier,
+                    contentScale = contentScale,
+                    alignment = alignment,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * State wrapper for [ThumbnailImage].
+ */
+@Parcelize
+private data class ThumbnailImageState(
+    val bitmap: Bitmap?,
+    val hasLoaded: Boolean,
+) : Parcelable
+
+/**
+ * This preview does not demo anything. This is to ensure that [ThumbnailImage] does not break other previews.
+*/
+@Preview
+@Composable
+private fun ThumbnailImagePreview() {
+    FirefoxTheme {
+        ThumbnailImage(
+            key = "",
+            size = 1.dp,
+            modifier = Modifier,
+            contentScale = ContentScale.Crop,
+            alignment = Alignment.Center,
+            fallbackContent = {},
+        )
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/list/ListItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/list/ListItem.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.compose.list
 
 import android.content.res.Configuration
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -86,6 +87,7 @@ fun TextListItem(
  *
  * @param label The label in the list item.
  * @param description An optional description text below the label.
+ * @param faviconPainter Optional painter to use when fetching a new favicon is unnecessary.
  * @param onClick Called when the user clicks on the item.
  * @param url Website [url] for which the favicon will be shown.
  * @param iconPainter [Painter] used to display an [IconButton] after the list item.
@@ -96,6 +98,7 @@ fun TextListItem(
 fun FaviconListItem(
     label: String,
     description: String? = null,
+    faviconPainter: Painter? = null,
     onClick: (() -> Unit)? = null,
     url: String,
     iconPainter: Painter? = null,
@@ -107,11 +110,21 @@ fun FaviconListItem(
         description = description,
         onClick = onClick,
         beforeListAction = {
-            Favicon(
-                url = url,
-                size = ICON_SIZE,
-                modifier = Modifier.padding(horizontal = 16.dp),
-            )
+            if (faviconPainter != null) {
+                Image(
+                    painter = faviconPainter,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .size(ICON_SIZE),
+                )
+            } else {
+                Favicon(
+                    url = url,
+                    size = ICON_SIZE,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
         },
         afterListAction = {
             if (iconPainter != null && onIconClick != null) {
@@ -325,7 +338,7 @@ private fun IconListItemWithRightIconPreview() {
 )
 private fun FaviconListItemPreview() {
     FirefoxTheme {
-        Box(Modifier.background(FirefoxTheme.colors.layer1)) {
+        Column(Modifier.background(FirefoxTheme.colors.layer1)) {
             FaviconListItem(
                 label = "Favicon + right icon + clicks",
                 description = "Description text",
@@ -333,6 +346,14 @@ private fun FaviconListItemPreview() {
                 url = "",
                 iconPainter = painterResource(R.drawable.ic_menu),
                 onIconClick = { println("icon click") },
+            )
+
+            FaviconListItem(
+                label = "Favicon + painter",
+                description = "Description text",
+                faviconPainter = painterResource(id = R.drawable.ic_tab_collection),
+                onClick = { println("list item click") },
+                url = "",
             )
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.compose.tabstray
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -13,12 +14,14 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
@@ -33,6 +36,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
@@ -52,10 +56,9 @@ import mozilla.components.browser.state.state.createTab
 import mozilla.components.support.ktx.kotlin.MAX_URI_LENGTH
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.Divider
-import org.mozilla.fenix.compose.Favicon
 import org.mozilla.fenix.compose.HorizontalFadingEdgeBox
 import org.mozilla.fenix.compose.SwipeToDismiss
-import org.mozilla.fenix.compose.ThumbnailCard
+import org.mozilla.fenix.compose.TabThumbnail
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.tabstray.TabsTrayTestTag
 import org.mozilla.fenix.tabstray.ext.toDisplayTitle
@@ -146,13 +149,18 @@ fun TabGridItem(
                             .fillMaxWidth()
                             .wrapContentHeight(),
                     ) {
-                        Favicon(
-                            url = tab.content.url,
-                            size = 16.dp,
-                            modifier = Modifier
-                                .align(Alignment.CenterVertically)
-                                .padding(start = 8.dp),
-                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+
+                        tab.content.icon?.let { icon ->
+                            icon.prepareToDraw()
+                            Image(
+                                bitmap = icon.asImageBitmap(),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .align(Alignment.CenterVertically)
+                                    .size(16.dp),
+                            )
+                        }
 
                         HorizontalFadingEdgeBox(
                             modifier = Modifier
@@ -230,9 +238,8 @@ private fun Thumbnail(
                 testTag = TabsTrayTestTag.tabItemThumbnail
             },
     ) {
-        ThumbnailCard(
-            url = tab.content.url,
-            key = tab.id,
+        TabThumbnail(
+            tab = tab,
             size = LocalConfiguration.current.screenWidthDp.dp,
             modifier = Modifier.fillMaxSize(),
         )

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
@@ -41,7 +41,7 @@ import mozilla.components.browser.state.state.createTab
 import mozilla.components.support.ktx.kotlin.MAX_URI_LENGTH
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.SwipeToDismiss
-import org.mozilla.fenix.compose.ThumbnailCard
+import org.mozilla.fenix.compose.TabThumbnail
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.ext.toShortUrl
 import org.mozilla.fenix.tabstray.TabsTrayTestTag
@@ -174,9 +174,8 @@ private fun Thumbnail(
     onMediaIconClicked: ((TabSessionState) -> Unit),
 ) {
     Box {
-        ThumbnailCard(
-            url = tab.content.url,
-            key = tab.id,
+        TabThumbnail(
+            tab = tab,
             modifier = Modifier
                 .size(width = 92.dp, height = 72.dp)
                 .semantics(mergeDescendants = true) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -56,7 +56,7 @@ import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ContextualMenu
 import org.mozilla.fenix.compose.Image
 import org.mozilla.fenix.compose.MenuItem
-import org.mozilla.fenix.compose.ThumbnailCard
+import org.mozilla.fenix.compose.TabThumbnail
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.compose.inComposePreview
 import org.mozilla.fenix.home.recenttabs.RecentTab
@@ -228,9 +228,8 @@ fun RecentTabImage(
                 contentScale = ContentScale.Crop,
             )
         }
-        else -> ThumbnailCard(
-            url = tab.state.content.url,
-            key = tab.state.id,
+        else -> TabThumbnail(
+            tab = tab.state,
             modifier = modifier,
             contentScale = contentScale,
         )

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/inactivetabs/InactiveTabs.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/inactivetabs/InactiveTabs.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -101,10 +103,15 @@ fun InactiveTabsList(
                 Column {
                     inactiveTabs.forEach { tab ->
                         val tabUrl = tab.content.url.toShortUrl()
+                        val faviconPainter = tab.content.icon?.run {
+                            prepareToDraw()
+                            BitmapPainter(asImageBitmap())
+                        }
 
                         FaviconListItem(
                             label = tab.toDisplayTitle(),
                             description = tabUrl,
+                            faviconPainter = faviconPainter,
                             onClick = { onTabClick(tab) },
                             url = tabUrl,
                             iconPainter = painterResource(R.drawable.mozac_ic_close),


### PR DESCRIPTION
### Findings

#### Thumbnail bitmap retention
Thumbnail bitmaps were seemingly fetched, retained, and re-fetched. They were garbage collected when the Tabs Tray was dismissed, but violently scrolling up and down would explode the in-app memory.
  - My solution for this was to add a bitmap recycle call to `ThumbnailImage` in a `DisposableEffect` block.

#### The Favicon composable
Relying on the `Favicon` Composable when the icon was available via `TabsessionState.content.icon` was causing unnecessary icon fetches inside `TabGridItem` AND `ThumbnailCard`. 
  - I ended up needing to differentiate use cases for the original `ThumbnailCard`; one via Recent Synced Tabs (where `TabSessionState` isn't available) and one where `TabSessionState` is the driving data object. `TabThumbnail` is driven via `TabSessionState` so that the passed-in bitmap of `tab.content.icon` can be used instead of needlessly re-fetching the favicon.
  - The favicon (whether via `Favicon` or `TabsessionState.content.icon`) was also being loaded & rendered before the thumbnail was loaded AND they were existing simultaneously as the thumbnail (the thumbnail was being painted on top of the favicon). I refactored `ThumbnailImage` to have a `fallbackContent` Composable to render the favicon for a tab ONLY when the thumbnail could not be fetched. 
  - I also added an optional painter to `FaviconListitem` to cover this use case. This will aid in the performance of loading inactive tabs that have their icons still on disk.

#### Lazy list/grid composables
I noticed that some of the thumbnail fetching was built around the idea that the `LazyColumn` and `LazyGrid` Composables functioned 1:1 as a `RecyclerView`. I discovered this is not the case; Composables are NOT reused like Views are in the XML analog. We should not be coding our item Composables to take lazy loading into account but instead let their parent Composables handle this behind the scenes. I refactored the logic around fetching the thumbnails around a changing tab key string, since the key was never supposed to be changing in the first place. I also changed the bitmap `remember` to `rememberSaveable` as that will allow it to be preserved via app configuration changes. 

#### Bitmap fetching + side effect coroutines
One thing I'm not 100% certain on is using the coroutines from [side effects](https://developer.android.com/jetpack/compose/side-effects) to perform intense, time sensitive operations, like bitmap fetching in this situation. One hypothesis we had during investigation was the bitmap fetching coroutine in `LaunchedEffect` was launching _several seconds_ from when it should be. I opted to directly use `rememberCoroutineScope` instead to ensure the bitmap fetching coroutines are launched and de-scoped correctly.  

[One resource I used](https://developer.android.com/jetpack/compose/graphics/images/optimization)

### Profiles
- [Perf changes w/ 50 tabs, big fling down, big fling up](https://share.firefox.dev/3Jz8niy) (taken directly from the Firefox profiler)
- [Perf changes - open tabs tray w/ 50 tabs](https://share.firefox.dev/3NlD2RE) (taken via Android Studio profiler)

I tried to take more extensive profiles, but the tool in Android Studio was crashing in this use flow when capturing the trace.

### UI test comparison on Pixel 2
| XML time (run time, total) | Compose time before changes (run time, total) | Compose time after changes (run time, total) |
| -- | -- | -- |
| 3m 44s, 6m 51s | 3m 30s, 7m 13s | 3m 31s, 6m 39s |

### Videos (captured on Pixel 5, non-release build)
| XML (main) | Compose (main) | Compose (with changes) |
| -- | -- | -- |
| https://github.com/mozilla-mobile/firefox-android/assets/87384386/6febaae5-c6fd-4b4f-8989-11ae2e85a2a2 | https://github.com/mozilla-mobile/firefox-android/assets/87384386/64185033-4fc6-4a04-a5e1-9436c92e2a0e | https://github.com/mozilla-mobile/firefox-android/assets/87384386/87cf04ec-6923-47f3-997d-d9e82647dfa6 |





This is visual anecdotal evidence, but I still wanted to provide a "look and feel" comparison.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.
















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1815579