### PR TITLE
Bug 1829213 - Update Save To PDF Telemetry and checkForPdfViewer Option

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -264,6 +264,10 @@ class GeckoEngineSession(
                     )
                 }
 
+                notifyObservers {
+                    onSaveToPdfComplete()
+                }
+
                 GeckoResult()
             },
             { throwable ->
@@ -608,6 +612,37 @@ class GeckoEngineSession(
                     onCheckForFormDataException(throwable)
                 }
                 GeckoResult<Boolean>()
+            },
+        )
+    }
+
+    /**
+     * Checks if a PDF viewer is being used on the current page or not via GeckoView session.
+     */
+    override fun checkForPdfViewer(
+        onResult: (Boolean) -> Unit,
+        onException: (Throwable) -> Unit,
+    ) {
+        geckoSession.isPdfJs.then(
+            { response ->
+                if (response == null) {
+                    logger.error(
+                        "Invalid value: No result from GeckoView if a PDF viewer is used.",
+                    )
+                    onException(
+                        IllegalStateException(
+                            "Invalid value: No result from GeckoView if a PDF viewer is used.",
+                        ),
+                    )
+                    return@then GeckoResult()
+                }
+                onResult(response)
+                GeckoResult<Boolean>()
+            },
+            { throwable ->
+                logger.error("Checking for PDF viewer failed.", throwable)
+                onException(throwable)
+                GeckoResult()
             },
         )
     }

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -2449,6 +2449,30 @@ class GeckoEngineSessionTest {
     }
 
     @Test
+    fun `checkForPdfViewer should correctly process a GV response`() {
+        val engineSession = GeckoEngineSession(
+            mock(),
+            geckoSessionProvider = geckoSessionProvider,
+        )
+        var onResultCalled = false
+        var onExceptionCalled = false
+
+        val ruleResult = GeckoResult<Boolean>()
+        whenever(geckoSession.isPdfJs).thenReturn(ruleResult)
+
+        engineSession.checkForPdfViewer(
+            onResult = { onResultCalled = true },
+            onException = { onExceptionCalled = true },
+        )
+
+        ruleResult.complete(true)
+        shadowOf(getMainLooper()).idle()
+
+        assertTrue(onResultCalled)
+        assertFalse(onExceptionCalled)
+    }
+
+    @Test
     fun containsFormData() {
         val engineSession = GeckoEngineSession(runtime = mock(), geckoSessionProvider = geckoSessionProvider)
         var formData = false

--- a/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -409,6 +409,16 @@ class SystemEngineSession(
         }
     }
 
+    /**
+     * Checks for if PDF Viewer is used.
+     */
+    override fun checkForPdfViewer(
+        onResult: (Boolean) -> Unit,
+        onException: (Throwable) -> Unit,
+    ) {
+        throw UnsupportedOperationException("Checking for PDF viewer is not available in this engine")
+    }
+
     override fun hasCookieBannerRuleForSession(
         onResult: (Boolean) -> Unit,
         onException: (Throwable) -> Unit,

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -1088,6 +1088,13 @@ sealed class EngineAction : BrowserAction() {
     ) : EngineAction(), ActionWithTab
 
     /**
+     * Indicates the given [tabId] was successful in generating a requested PDF page.
+     */
+    data class SaveToPdfCompleteAction(
+        override val tabId: String,
+    ) : EngineAction(), ActionWithTab
+
+    /**
      * Indicates the given [tabId] was unable to generate a requested save to PDF page.
      */
     data class SaveToPdfExceptionAction(

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
@@ -443,6 +443,10 @@ internal class EngineObserver(
         store.dispatch(EngineAction.PrintContentExceptionAction(tabId, isPrint, throwable))
     }
 
+    override fun onSaveToPdfComplete() {
+        store.dispatch(EngineAction.SaveToPdfCompleteAction(tabId))
+    }
+
     override fun onCheckForFormData(containsFormData: Boolean) {
         store.dispatch(ContentAction.UpdateHasFormDataAction(tabId, containsFormData))
     }

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
@@ -45,7 +45,9 @@ internal object EngineStateReducer {
         is EngineAction.OptimizedLoadUrlTriggeredAction -> {
             state
         }
-        is EngineAction.SaveToPdfExceptionAction -> {
+        is EngineAction.SaveToPdfExceptionAction,
+        is EngineAction.SaveToPdfCompleteAction,
+        -> {
             throw IllegalStateException(
                 "You need to add a middleware to handle this action in your BrowserStore. ($action)",
             )

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -72,6 +72,10 @@ class EngineObserverTest {
                 onResult: (Boolean) -> Unit,
                 onException: (Throwable) -> Unit,
             ) {}
+            override fun checkForPdfViewer(
+                onResult: (Boolean) -> Unit,
+                onException: (Throwable) -> Unit,
+            ) {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -133,6 +137,10 @@ class EngineObserverTest {
                 onResult: (Boolean) -> Unit,
                 onException: (Throwable) -> Unit,
             ) {}
+            override fun checkForPdfViewer(
+                onResult: (Boolean) -> Unit,
+                onException: (Throwable) -> Unit,
+            ) {}
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}
@@ -187,6 +195,10 @@ class EngineObserverTest {
             override fun updateTrackingProtection(policy: TrackingProtectionPolicy) {}
             override fun toggleDesktopMode(enable: Boolean, reload: Boolean) {}
             override fun hasCookieBannerRuleForSession(
+                onResult: (Boolean) -> Unit,
+                onException: (Throwable) -> Unit,
+            ) {}
+            override fun checkForPdfViewer(
                 onResult: (Boolean) -> Unit,
                 onException: (Throwable) -> Unit,
             ) {}

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -297,6 +297,11 @@ abstract class EngineSession(
         fun onPrintException(isPrint: Boolean, throwable: Throwable) = Unit
 
         /**
+         * Event to indicate that the PDF was successfully generated.
+         */
+        fun onSaveToPdfComplete() = Unit
+
+        /**
          * Event to indicate that this session needs to be checked for form data.
          *
          * @param containsFormData Indicates if the session has form data.
@@ -814,6 +819,16 @@ abstract class EngineSession(
      * @param onError callback invoked if there was an error getting the response.
      */
     abstract fun hasCookieBannerRuleForSession(onResult: (Boolean) -> Unit, onException: (Throwable) -> Unit)
+
+    /**
+     * Checks if the current session is using a PDF viewer.
+     *
+     * @param onSuccess callback invoked if the engine API returned a valid response. Please note
+     * that the response can be null - which can indicate a bug, a miscommunication
+     * or other unexpected failure.
+     * @param onError callback invoked if there was an error getting the response.
+     */
+    abstract fun checkForPdfViewer(onResult: (Boolean) -> Unit, onException: (Throwable) -> Unit)
 
     /**
      * Finds and highlights all occurrences of the provided String and highlights them asynchronously.

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -970,6 +970,11 @@ open class DummyEngineSession : EngineSession() {
         onException: (Throwable) -> Unit,
     ) {}
 
+    override fun checkForPdfViewer(
+        onResult: (Boolean) -> Unit,
+        onException: (Throwable) -> Unit,
+    ) {}
+
     override fun findAll(text: String) {}
 
     override fun findNext(forward: Boolean) {}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ permalink: /changelog/
   * Adds `WebAppContentFeature` to set the "display" mode from the web app manifest on the `EngineSession`.
 * **browser-engine-gecko**:
   * Added support for Printing on the Engine.
+  * Add support for `checkForPdfViewer` API for checking whether a PDF viewer is loaded on the current session or not.
 * **concept-engine**:
   * Added new `requestPrintContent` API in `Engine`. This is currently only supported in the Gecko Engine.
 

--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -485,10 +485,18 @@ events:
     type: event
     description: |
       A user tapped the save to pdf option in the share sheet.
+    extra_keys:
+      source:
+        type: string
+        description: |
+          A string that indicates the type of document of pdf, non-pdf or unknown. 
+          The default is unknown.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/3709
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1829213
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/27257
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1829213#c4
     data_sensitivity:
       - interaction
     notification_emails:
@@ -500,12 +508,49 @@ events:
   save_to_pdf_failure:
     type: event
     description: |
-      A user tapped the save pdf but an error ocurred
+      A user tapped the save pdf but an error occurred
       and the process failed.
+    extra_keys:
+      source:
+        type: string
+        description: |
+          A string that indicates the type of document of pdf, non-pdf or unknown. 
+          The default is unknown.
+      reason:
+        type: string
+        description: |
+          An error occurred while setting up for saving a PDF.
+          Default option is unknown, other options are no_settings_service, no_settings, 
+          no_canonical_context, no_activity_context_delegate, no_activity_context, 
+          no_print_delegate, and io_error.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/27635
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1829213
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/27661#issuecomment-1300505370
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1829213#c4
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 122
+    metadata:
+      tags:
+        - Sharing
+  save_to_pdf_completed:
+    type: event
+    description: |
+      Saving to PDF successfully generated a PDF.
+    extra_keys:
+      source:
+        type: string
+        description: |
+          A string that indicates the type of document of pdf, non-pdf or unknown. 
+          The default is unknown.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1829213
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1829213#c4
     data_sensitivity:
       - technical
     notification_emails:

--- a/fenix/app/src/main/java/org/mozilla/fenix/share/SaveToPDFMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/SaveToPDFMiddleware.kt
@@ -7,16 +7,30 @@ package org.mozilla.fenix.share
 import android.content.Context
 import android.widget.Toast
 import android.widget.Toast.LENGTH_LONG
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.EngineAction
+import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
-import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.R
 import org.mozilla.gecko.util.ThreadUtils
+import org.mozilla.geckoview.GeckoSession
+import org.mozilla.geckoview.GeckoSession.GeckoPrintException.ERROR_NO_ACTIVITY_CONTEXT
+import org.mozilla.geckoview.GeckoSession.GeckoPrintException.ERROR_NO_ACTIVITY_CONTEXT_DELEGATE
+import org.mozilla.geckoview.GeckoSession.GeckoPrintException.ERROR_NO_PRINT_DELEGATE
+import org.mozilla.geckoview.GeckoSession.GeckoPrintException.ERROR_PRINT_SETTINGS_SERVICE_NOT_AVAILABLE
+import org.mozilla.geckoview.GeckoSession.GeckoPrintException.ERROR_UNABLE_TO_CREATE_PRINT_SETTINGS
+import org.mozilla.geckoview.GeckoSession.GeckoPrintException.ERROR_UNABLE_TO_RETRIEVE_CANONICAL_BROWSING_CONTEXT
+import java.io.IOException
+import java.lang.Exception
 
 /**
  * [BrowserAction] middleware reacting in response to Save to PDF related [Action]s.
@@ -24,6 +38,7 @@ import org.mozilla.gecko.util.ThreadUtils
  */
 class SaveToPDFMiddleware(
     private val context: Context,
+    private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main),
 ) : Middleware<BrowserState, BrowserAction> {
 
     override fun invoke(
@@ -31,15 +46,154 @@ class SaveToPDFMiddleware(
         next: (BrowserAction) -> Unit,
         action: BrowserAction,
     ) {
-        if (action is EngineAction.SaveToPdfExceptionAction) {
-            // See https://github.com/mozilla-mobile/fenix/issues/27649 for more details,
-            // why a Toast is used here.
-            ThreadUtils.runOnUiThread {
-                Toast.makeText(context, R.string.unable_to_save_to_pdf_error, LENGTH_LONG).show()
+        when (action) {
+            is EngineAction.SaveToPdfAction -> {
+                postTelemetryTapped(ctx.state.findTab(action.tabId))
+                // Continue to generate the PDF, passing through here to add telemetry
+                next(action)
             }
-            Events.saveToPdfFailure.record(NoExtras())
-        } else {
-            next(action)
+
+            is EngineAction.SaveToPdfCompleteAction -> {
+                postTelemetryCompleted(ctx.state.findTab(action.tabId))
+            }
+
+            is EngineAction.SaveToPdfExceptionAction -> {
+                // See https://github.com/mozilla-mobile/fenix/issues/27649 for more details,
+                // why a Toast is used here.
+                ThreadUtils.runOnUiThread {
+                    Toast.makeText(context, R.string.unable_to_save_to_pdf_error, LENGTH_LONG).show()
+                }
+
+                postTelemetryFailed(ctx.state.findTab(action.tabId), action.throwable)
+            }
+            else -> {
+                next(action)
+            }
+        }
+    }
+
+    /**
+     * Use to generate failure extra reasons for Save To PDF failure telemetry.
+     *
+     * @param exception - A given exception that will be properly labeled for telemetry posting.
+     * @return processed failure reason to send in telemetry.
+     */
+    /* package */ @VisibleForTesting
+    fun telemetryErrorReason(exception: Exception): String {
+        var failureMsg = "unknown"
+        // Requiring information from GeckoView isn't a good practice,
+        // follow-up to improve this is bug 1838719
+        if (exception is GeckoSession.GeckoPrintException) {
+            when (exception.code) {
+                ERROR_PRINT_SETTINGS_SERVICE_NOT_AVAILABLE -> failureMsg = "no_settings_service"
+                ERROR_UNABLE_TO_CREATE_PRINT_SETTINGS -> failureMsg = "no_settings"
+                ERROR_UNABLE_TO_RETRIEVE_CANONICAL_BROWSING_CONTEXT -> failureMsg = "no_canonical_context"
+                ERROR_NO_ACTIVITY_CONTEXT_DELEGATE -> failureMsg = "no_activity_context_delegate"
+                ERROR_NO_ACTIVITY_CONTEXT -> failureMsg = "no_activity_context"
+                ERROR_NO_PRINT_DELEGATE -> failureMsg = "no_print_delegate"
+            }
+        }
+        if (exception is IOException) {
+            failureMsg = "io_error"
+        }
+        return failureMsg
+    }
+
+    /**
+     * Use to generate extra sources for Save To PDF telemetry.
+     *
+     * @param isPdfViewer - If the page has a PDF viewer or not.
+     * @return processed page source type to send in telemetry.
+     */
+    /* package */ @VisibleForTesting
+    fun telemetrySource(isPdfViewer: Boolean?): String {
+        val source = when (isPdfViewer) {
+            null -> "unknown"
+            true -> "pdf"
+            false -> "non-pdf"
+        }
+        return source
+    }
+
+    /**
+     * Indicates the Save As PDF action was requested and posts telemetry via Glean.
+     *
+     * @param tab - tab state to use for page source category
+     */
+    private fun postTelemetryTapped(tab: TabSessionState?) {
+        mainScope.launch {
+            tab?.engineState?.engineSession?.checkForPdfViewer(
+                onResult = { isPdf ->
+                    Events.saveToPdfTapped.record(
+                        Events.SaveToPdfTappedExtra(
+                            source = telemetrySource(isPdf),
+                        ),
+                    )
+                },
+                onException = {
+                    Events.saveToPdfTapped.record(
+                        Events.SaveToPdfTappedExtra(
+                            source = telemetrySource(null),
+                        ),
+                    )
+                },
+            )
+        }
+    }
+
+    /**
+     * Indicates the Save As PDF action completed and generated a PDF and posts telemetry via Glean.
+     *
+     * @param tab - tab state to use for page source category
+     */
+    private fun postTelemetryCompleted(tab: TabSessionState?) {
+        mainScope.launch {
+            tab?.engineState?.engineSession?.checkForPdfViewer(
+                onResult = { isPdf ->
+                    Events.saveToPdfCompleted.record(
+                        Events.SaveToPdfCompletedExtra(
+                            source = telemetrySource(isPdf),
+                        ),
+                    )
+                },
+                onException = {
+                    Events.saveToPdfCompleted.record(
+                        Events.SaveToPdfCompletedExtra(
+                            source = telemetrySource(null),
+                        ),
+                    )
+                },
+            )
+        }
+    }
+
+    /**
+     * Indicates the Save As PDF action failed and the reason for failure and posts telemetry via Glean.
+     *
+     * @param tab - tab state to use for page source category
+     * @param throwable - failure state to use for failure reason category
+     */
+    private fun postTelemetryFailed(tab: TabSessionState?, throwable: Throwable) {
+        val telFailureReason = telemetryErrorReason(throwable as Exception)
+        mainScope.launch {
+            tab?.engineState?.engineSession?.checkForPdfViewer(
+                onResult = { isPdf ->
+                    Events.saveToPdfFailure.record(
+                        Events.SaveToPdfFailureExtra(
+                            source = telemetrySource(isPdf),
+                            reason = telFailureReason,
+                        ),
+                    )
+                },
+                onException = {
+                    Events.saveToPdfFailure.record(
+                        Events.SaveToPdfFailureExtra(
+                            source = telemetrySource(null),
+                            reason = telFailureReason,
+                        ),
+                    )
+                },
+            )
         }
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -146,7 +146,6 @@ class DefaultShareController(
     }
 
     override fun handleSaveToPDF(tabId: String?) {
-        Events.saveToPdfTapped.record(NoExtras())
         handleShareClosed()
         saveToPdfUseCase.invoke(tabId)
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/share/SaveToPDFMiddlewareTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/share/SaveToPDFMiddlewareTest.kt
@@ -3,20 +3,29 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.share
-
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
 import mozilla.components.browser.state.action.EngineAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.EngineSession
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.geckoview.GeckoSession
+import java.io.IOException
 
 @RunWith(FenixRobolectricTestRunner::class)
 class SaveToPDFMiddlewareTest {
@@ -27,15 +36,193 @@ class SaveToPDFMiddlewareTest {
     @get:Rule
     val mainCoroutineTestRule = MainCoroutineRule()
 
-    @Test
-    fun `GIVEN a save to pdf request WHEN it fails THEN telemetry is sent`() = runTestOnMain {
-        val middleware = SaveToPDFMiddleware(testContext)
-        val browserStore = BrowserStore(middleware = listOf(middleware))
+    // Only ERROR_PRINT_SETTINGS_SERVICE_NOT_AVAILABLE is available for testing
+    class MockGeckoPrintException() : GeckoSession.GeckoPrintException()
 
-        browserStore.dispatch(EngineAction.SaveToPdfExceptionAction("14", RuntimeException("reader save to pdf failed")))
+    @Test
+    fun `GIVEN a save to pdf request WHEN it fails unexpectedly THEN unknown failure telemetry is sent`() = runTestOnMain {
+        val exceptionToThrow = RuntimeException("reader save to pdf failed")
+        val middleware = SaveToPDFMiddleware(testContext)
+        val mockEngineSession: EngineSession = mockk<EngineSession>().apply {
+            every {
+                checkForPdfViewer(any(), any())
+            } answers {
+                secondArg<(Throwable) -> Unit>().invoke(exceptionToThrow)
+            }
+        }
+        val browserStore = BrowserStore(
+            middleware = listOf(middleware),
+            initialState = BrowserState(
+                tabs = listOf(
+                    createTab(
+                        url = "https://mozilla.org",
+                        id = "14",
+                        engineSession = mockEngineSession,
+                    ),
+                ),
+            ),
+        )
+        browserStore.dispatch(
+            EngineAction.SaveToPdfExceptionAction("14", exceptionToThrow),
+        )
         browserStore.waitUntilIdle()
         testScheduler.advanceUntilIdle()
+        val response = Events.saveToPdfFailure.testGetValue()?.firstOrNull()
+        assertNotNull(response)
+        val reason = response?.extra?.get("reason")
+        assertEquals("unknown", reason)
+        val source = response?.extra?.get("source")
+        assertEquals("unknown", source)
+    }
 
-        assertNotNull(Events.saveToPdfFailure.testGetValue())
+    @Test
+    fun `GIVEN a save to pdf request WHEN it fails due to io THEN io failure telemetry is sent`() = runTestOnMain {
+        val exceptionToThrow = IOException()
+        val middleware = SaveToPDFMiddleware(testContext)
+        val mockEngineSession: EngineSession = mockk<EngineSession>().apply {
+            every {
+                checkForPdfViewer(any(), any())
+            } answers {
+                secondArg<(Throwable) -> Unit>().invoke(exceptionToThrow)
+            }
+        }
+        val browserStore = BrowserStore(
+            middleware = listOf(middleware),
+            initialState = BrowserState(
+                tabs = listOf(
+                    createTab(
+                        url = "https://mozilla.org",
+                        id = "14",
+                        engineSession = mockEngineSession,
+                    ),
+                ),
+            ),
+        )
+        browserStore.dispatch(EngineAction.SaveToPdfExceptionAction("14", exceptionToThrow))
+        browserStore.waitUntilIdle()
+        testScheduler.advanceUntilIdle()
+        val response = Events.saveToPdfFailure.testGetValue()?.firstOrNull()
+        assertNotNull(response)
+        val reason = response?.extra?.get("reason")
+        assertEquals("io_error", reason)
+        val source = response?.extra?.get("source")
+        assertEquals("unknown", source)
+    }
+
+    @Test
+    fun `GIVEN a save to pdf request WHEN it fails due to print exception THEN print exception failure telemetry is sent`() = runTestOnMain {
+        val exceptionToThrow = MockGeckoPrintException()
+        val middleware = SaveToPDFMiddleware(testContext)
+        val mockEngineSession: EngineSession = mockk<EngineSession>().apply {
+            every {
+                checkForPdfViewer(any(), any())
+            } answers {
+                secondArg<(Throwable) -> Unit>().invoke(exceptionToThrow)
+            }
+        }
+        val browserStore = BrowserStore(
+            middleware = listOf(middleware),
+            initialState = BrowserState(
+                tabs = listOf(
+                    createTab(
+                        url = "https://mozilla.org",
+                        id = "14",
+                        engineSession = mockEngineSession,
+                    ),
+                ),
+            ),
+        )
+        browserStore.dispatch(EngineAction.SaveToPdfExceptionAction("14", exceptionToThrow))
+        browserStore.waitUntilIdle()
+        testScheduler.advanceUntilIdle()
+        val response = Events.saveToPdfFailure.testGetValue()?.firstOrNull()
+        assertNotNull(response)
+        val reason = response?.extra?.get("reason")
+        assertEquals("no_settings_service", reason)
+        val source = response?.extra?.get("source")
+        assertEquals("unknown", source)
+    }
+
+    @Test
+    fun `GIVEN a save to pdf request WHEN it completes THEN completed telemetry is sent`() = runTestOnMain {
+        val middleware = SaveToPDFMiddleware(testContext)
+        val mockEngineSession: EngineSession = mockk<EngineSession>().apply {
+            every {
+                checkForPdfViewer(any(), any())
+            } answers {
+                firstArg<(Boolean) -> Unit>().invoke(false)
+            }
+        }
+        val browserStore = BrowserStore(
+            middleware = listOf(middleware),
+            initialState = BrowserState(
+                tabs = listOf(
+                    createTab(
+                        url = "https://mozilla.org",
+                        id = "14",
+                        engineSession = mockEngineSession,
+                    ),
+                ),
+            ),
+        )
+        browserStore.dispatch(EngineAction.SaveToPdfCompleteAction("14"))
+        browserStore.waitUntilIdle()
+        testScheduler.advanceUntilIdle()
+        val response = Events.saveToPdfCompleted.testGetValue()
+        assertNotNull(response)
+        val source = response?.firstOrNull()?.extra?.get("source")
+        assertEquals("non-pdf", source)
+    }
+
+    @Test
+    fun `GIVEN a save to pdf request WHEN it the action begins THEN tapped telemetry is sent`() = runTestOnMain {
+        val middleware = SaveToPDFMiddleware(testContext)
+        val mockEngineSession: EngineSession = mockk<EngineSession>().apply {
+            every {
+                checkForPdfViewer(any(), any())
+            } answers {
+                firstArg<(Boolean) -> Unit>().invoke(false)
+            }
+        }
+        val browserStore = BrowserStore(
+            middleware = listOf(middleware),
+            initialState = BrowserState(
+                tabs = listOf(
+                    createTab(
+                        url = "https://mozilla.org",
+                        id = "14",
+                        engineSession = mockEngineSession,
+                    ),
+                ),
+            ),
+        )
+        browserStore.dispatch(EngineAction.SaveToPdfAction("14"))
+        browserStore.waitUntilIdle()
+        testScheduler.advanceUntilIdle()
+        val response = Events.saveToPdfTapped.testGetValue()
+        assertNotNull(response)
+        val source = response?.firstOrNull()?.extra?.get("source")
+        assertEquals("non-pdf", source)
+    }
+
+    @Test
+    fun `GIVEN a save as pdf exception THEN should calculate the correct failure reason for telemetry`() = runTestOnMain {
+        val mockContext: Context = mock()
+        val middleware = SaveToPDFMiddleware(mockContext)
+        val noSettingsService = middleware.telemetryErrorReason(MockGeckoPrintException())
+        assertEquals("no_settings_service", noSettingsService)
+        val ioException = middleware.telemetryErrorReason(IOException())
+        assertEquals("io_error", ioException)
+        val other = middleware.telemetryErrorReason(Exception())
+        assertEquals("unknown", other)
+    }
+
+    @Test
+    fun `GIVEN a save as pdf page type THEN should calculate the correct page source for telemetry`() = runTestOnMain {
+        val mockContext: Context = mock()
+        val middleware = SaveToPDFMiddleware(mockContext)
+        assertEquals("pdf", middleware.telemetrySource(isPdfViewer = true))
+        assertEquals("non-pdf", middleware.telemetrySource(isPdfViewer = false))
+        assertEquals("unknown", middleware.telemetrySource(isPdfViewer = null))
     }
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
@@ -265,7 +265,7 @@ class ShareControllerTest {
     }
 
     @Test
-    fun `WHEN handleSaveToPDF THEN send telemetry, close the dialog and save the page to pdf`() {
+    fun `WHEN handleSaveToPDF close the dialog and save the page to pdf`() {
         val testController = DefaultShareController(
             context = mockk(),
             shareSubject = shareSubject,
@@ -286,8 +286,6 @@ class ShareControllerTest {
             saveToPdfUseCase.invoke("tabID")
             dismiss(ShareController.Result.DISMISSED)
         }
-
-        assertNotNull(Events.saveToPdfTapped.testGetValue())
     }
 
     @Test


### PR DESCRIPTION
* Adds `checkForPdfJs` to determine if page is a PDF.js page or not
* Adjusts save_to_pdf_failure to have extras of pdf, non-pdf, or unknown
* Adjusts save_to_pdf_failure to have extras of failure reason
* Adjusts save_to_pdf_tapped to have extras of pdf, non-pdf, or unknown
* Adds save_to_pdf_completed with extras of pdf, non-pdf, or unknown



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.























### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1829213