### PR TITLE
Bug 1836887 - Remove telemetry probes expired in v116

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -2266,26 +2266,6 @@ metrics:
     metadata:
       tags:
         - Notifications
-  shared_prefs_uuid:
-    type: uuid
-    lifetime: ping
-    description: |
-      A UUID stored in Shared Preferences used to analyze technical differences
-      between storage mechanisms in Android, specifically the Glean DB and
-      Shared Preferences.
-    send_in_pings:
-      - metrics
-    notification_emails:
-      - android-probes@mozilla.com
-      - raphael@mozilla.com
-      - fbertsch@mozilla.com
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1822119
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1822119
-    data_sensitivity:
-      - technical
-    expires: 116
 
 customize_home:
   most_visited_sites:
@@ -9472,23 +9452,6 @@ private_browsing_shortcut_cfr:
     notification_emails:
       - android-probes@mozilla.com
     expires: 122
-
-server_knobs:
-  validation:
-    disabled: true
-    type: event
-    description: |
-      Temporary metric recorded at the same time as
-      "tabs_tray.new_tab_tapped" to validate that the Glean Server Knobs
-      functionality is working correctly.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1823682
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1823682#c2
-    notification_emails:
-      - android-probes@mozilla.com
-      - brosa@mozilla.com
-    expires: 116
 
 pull_to_refresh_in_browser:
   enabled:

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -719,12 +719,6 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
             searchWidgetInstalled.set(settings.searchWidgetInstalled)
 
-            if (settings.sharedPrefsUUID.isEmpty()) {
-                settings.sharedPrefsUUID = sharedPrefsUuid.generateAndSet().toString()
-            } else {
-                sharedPrefsUuid.set(UUID.fromString(settings.sharedPrefsUUID))
-            }
-
             val openTabsCount = settings.openTabsCount
             hasOpenTabs.set(openTabsCount > 0)
             if (openTabsCount > 0) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -33,11 +33,6 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
                     context.components.analytics.metrics.start(MetricServiceType.Data)
                 } else {
                     context.components.analytics.metrics.stop(MetricServiceType.Data)
-
-                    // Reset the Shared Prefs UUID on opt-out since we're investigating cases of
-                    // unexpected client ID regeneration. Telemetry data collection opt-out is
-                    // expected to reset the client ID.
-                    context.settings().sharedPrefsUUID = ""
                 }
                 // Reset experiment identifiers on both opt-in and opt-out; it's likely
                 // that in future we will need to pass in the new telemetry client_id

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -28,7 +28,6 @@ import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.GleanMetrics.Collections
 import org.mozilla.fenix.GleanMetrics.Events
-import org.mozilla.fenix.GleanMetrics.ServerKnobs
 import org.mozilla.fenix.GleanMetrics.TabsTray
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
@@ -476,9 +475,6 @@ class DefaultTabsTrayController(
             TabsTray.newPrivateTabTapped.record(NoExtras())
         } else {
             TabsTray.newTabTapped.record(NoExtras())
-
-            // Temporary recording for validating the Glean Server Knobs functionality.
-            ServerKnobs.validation.record(NoExtras())
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -220,16 +220,6 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = "",
     )
 
-    /**
-     * A UUID stored in Shared Preferences used to analyze technical differences
-     * between storage mechanisms in Android, specifically the Glean DB and
-     * Shared Preferences.
-     */
-    var sharedPrefsUUID by stringPreference(
-        appContext.getPreferenceKey(R.string.pref_key_shared_prefs_uuid),
-        default = "",
-    )
-
     var currentWallpaperName by stringPreference(
         appContext.getPreferenceKey(R.string.pref_key_current_wallpaper),
         default = Wallpaper.Default.name,

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -342,7 +342,6 @@
     <string name="pref_key_custom_sponsored_stories_site_id" translatable="false">pref_key_custom_sponsored_stories_site_id</string>
     <string name="pref_key_custom_sponsored_stories_country" translatable="false">pref_key_custom_sponsored_stories_country</string>
     <string name="pref_key_custom_sponsored_stories_city" translatable="false">pref_key_custom_sponsored_stories_city</string>
-    <string name="pref_key_shared_prefs_uuid" translatable="false">pref_key_shared_prefs_uuid</string>
     <string name="pref_key_enable_compose_top_sites" translatable="false">pref_key_enable_compose_top_sites</string>
 
     <!-- Growth Data -->

--- a/fenix/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
@@ -148,9 +148,6 @@ class FenixApplicationTest {
         assertTrue(settings.contileContextId.isEmpty())
         assertNull(TopSites.contextId.testGetValue())
 
-        assertTrue(settings.sharedPrefsUUID.isEmpty())
-        assertNull(Metrics.sharedPrefsUuid.testGetValue())
-
         application.setStartupMetrics(browserStore, settings, browsersCache, mozillaProductDetector)
 
         // Verify that browser defaults metrics are set.
@@ -195,14 +192,6 @@ class FenixApplicationTest {
         assertNotNull(TopSites.contextId.testGetValue())
         assertEquals(contextId, settings.contileContextId)
 
-        // Verify that setStartupMetrics() creates `the Metrics.sharedPrefsUuid`
-        // Glean metric and that it stores the value in shared preferences at
-        // settings.sharedPrefsUUID. Subsequent calls load the UUID value from
-        // shared preferences rather than generating a new one.
-        val sharedPrefsUUIDMetricValue = Metrics.sharedPrefsUuid.testGetValue()!!.toString()
-        assertNotNull(Metrics.sharedPrefsUuid.testGetValue())
-        assertEquals(sharedPrefsUUIDMetricValue, settings.sharedPrefsUUID)
-
         // Verify that search engine defaults are NOT set. This test does
         // not mock most of the objects telemetry is collected from.
         assertNull(SearchDefaultEngine.code.testGetValue())
@@ -213,9 +202,6 @@ class FenixApplicationTest {
 
         assertEquals(contextId, TopSites.contextId.testGetValue()!!.toString())
         assertEquals(contextId, settings.contileContextId)
-
-        assertEquals(sharedPrefsUUIDMetricValue, Metrics.sharedPrefsUuid.testGetValue()!!.toString())
-        assertEquals(sharedPrefsUUIDMetricValue, settings.sharedPrefsUUID)
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1836887