### PR TITLE
Bug 1837059 - Remove stray GMS reference for annotation

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/readermode/ReaderModeController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/readermode/ReaderModeController.kt
@@ -7,8 +7,8 @@ package org.mozilla.fenix.browser.readermode
 import android.view.View
 import android.widget.Button
 import android.widget.RadioButton
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
-import com.google.android.gms.common.util.VisibleForTesting
 import mozilla.components.feature.readerview.ReaderViewFeature
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.fenix.R


### PR DESCRIPTION
This was likely automatically imported by mistake

<!-- Do not add anything below this line -->

Used by GitHub Actions.

https://bugzilla.mozilla.org/show_bug.cgi?id=1837059