### PR TITLE
Revert "Bug 1821724 - For Portrait mode, align the Pocket column with the column title  "

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLarge.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLarge.kt
@@ -28,9 +28,6 @@ import androidx.compose.ui.unit.sp
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.theme.FirefoxTheme
 
-const val ITEM_WIDTH = 328
-const val ITEM_HEIGHT = 116
-
 /**
  * Default layout of a large tab shown in a list taking String arguments for title and caption.
  * Has the following structure:
@@ -141,7 +138,7 @@ fun ListItemTabSurface(
     onClick: (() -> Unit)? = null,
     tabDetails: @Composable () -> Unit,
 ) {
-    var modifier = Modifier.size(ITEM_WIDTH.dp, ITEM_HEIGHT.dp)
+    var modifier = Modifier.size(328.dp, 116.dp)
     if (onClick != null) modifier = modifier.then(Modifier.clickable { onClick() })
 
     Card(

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLargePlaceholder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLargePlaceholder.kt
@@ -46,7 +46,7 @@ fun ListItemTabLargePlaceholder(
 ) {
     Card(
         modifier = Modifier
-            .size(ITEM_WIDTH.dp, ITEM_HEIGHT.dp)
+            .size(328.dp, 116.dp)
             .clickable { onClick() },
         shape = RoundedCornerShape(8.dp),
         backgroundColor = FirefoxTheme.colors.layer2,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -6,7 +6,6 @@
 
 package org.mozilla.fenix.home.pocket
 
-import android.content.res.Configuration
 import android.graphics.Rect
 import android.net.Uri
 import androidx.annotation.FloatRange
@@ -40,7 +39,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
@@ -69,7 +67,6 @@ import mozilla.components.service.pocket.PocketStory.PocketSponsoredStoryShim
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.ClickableSubstringLink
 import org.mozilla.fenix.compose.EagerFlingBehavior
-import org.mozilla.fenix.compose.ITEM_WIDTH
 import org.mozilla.fenix.compose.ListItemTabLarge
 import org.mozilla.fenix.compose.ListItemTabLargePlaceholder
 import org.mozilla.fenix.compose.ListItemTabSurface
@@ -274,20 +271,12 @@ fun PocketStories(
     val listState = rememberLazyListState()
     val flingBehavior = EagerFlingBehavior(lazyRowState = listState)
 
-    val configuration = LocalConfiguration.current
-    val screenWidth = configuration.screenWidthDp.dp
-
-    val endPadding =
-        remember { mutableStateOf(endPadding(configuration, screenWidth, contentPadding)) }
-    // Force recomposition as padding is not consistently updated when orientation has changed.
-    endPadding.value = endPadding(configuration, screenWidth, contentPadding)
-
     LazyRow(
         modifier = Modifier.semantics {
             testTagsAsResourceId = true
             testTag = "pocket.stories"
         },
-        contentPadding = PaddingValues(start = contentPadding, end = endPadding.value),
+        contentPadding = PaddingValues(horizontal = contentPadding),
         state = listState,
         flingBehavior = flingBehavior,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -340,16 +329,6 @@ fun PocketStories(
         }
     }
 }
-
-private fun endPadding(configuration: Configuration, screenWidth: Dp, contentPadding: Dp) =
-    if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-        alignColumnToTitlePadding(screenWidth = screenWidth, contentPadding = contentPadding)
-    } else {
-        contentPadding
-    }
-
-private fun alignColumnToTitlePadding(screenWidth: Dp, contentPadding: Dp) =
-    screenWidth - (ITEM_WIDTH.dp + contentPadding)
 
 /**
  * Add a callback for when this Composable is "shown" on the screen.


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-android#2312
https://bugzilla.mozilla.org/show_bug.cgi?id=1821724