### PR TITLE
Bug 1837378 - New system notification settings UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
@@ -91,7 +91,7 @@ class MediaNotificationTest {
         mDevice.openNotification()
 
         notificationShade {
-            verifySystemNotificationGone(videoTestPage.title)
+            verifySystemNotificationDoesNotExist(videoTestPage.title)
         }
 
         // close notification shade before the next test
@@ -125,7 +125,7 @@ class MediaNotificationTest {
         mDevice.openNotification()
 
         notificationShade {
-            verifySystemNotificationGone(audioTestPage.title)
+            verifySystemNotificationDoesNotExist(audioTestPage.title)
         }
 
         // close notification shade before the next test
@@ -162,7 +162,7 @@ class MediaNotificationTest {
         mDevice.openNotification()
 
         notificationShade {
-            verifySystemNotificationGone("A site is playing media")
+            verifySystemNotificationDoesNotExist("A site is playing media")
         }
 
         // close notification shade before and go back to regular mode before the next test

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -13,7 +13,10 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.navigationToolbar
+import org.mozilla.fenix.ui.robots.notificationShade
 
 /**
  *  Tests for verifying the the privacy and security section of the Settings menu
@@ -142,6 +145,42 @@ class SettingsPrivacyTest {
             verifySitePermissionOption("Cross-site cookies", "Ask to allow")
             verifySitePermissionOption("DRM-controlled content", "Ask to allow")
             verifySitePermissionOption("Exceptions")
+        }
+    }
+
+    @Test
+    fun verifyNotificationsSettingsTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        // Clear all existing notifications
+        notificationShade {
+            mDevice.openNotification()
+            clearNotifications()
+        }
+
+        homeScreen {
+        }.togglePrivateBrowsingMode()
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.openNotificationShade {
+            verifySystemNotificationExists("Close private tabs")
+        }.closeNotificationTray {
+        }.openThreeDotMenu {
+        }.openSettings {
+            verifySettingsOptionSummary("Notifications", "Allowed")
+        }.openSettingsSubMenuNotifications {
+            verifyAllSystemNotificationsToggleState(true)
+            verifyPrivateBrowsingSystemNotificationsToggleState(true)
+            clickPrivateBrowsingSystemNotificationsToggle()
+            verifyPrivateBrowsingSystemNotificationsToggleState(false)
+            clickAllSystemNotificationsToggle()
+            verifyAllSystemNotificationsToggleState(false)
+        }.goBack {
+            verifySettingsOptionSummary("Notifications", "Not allowed")
+        }.goBackToBrowser {
+        }.openNotificationShade {
+            verifySystemNotificationDoesNotExist("Close private tabs")
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
@@ -51,7 +51,7 @@ class NotificationRobot {
         cancelAll()
     }
 
-    fun verifySystemNotificationGone(notificationMessage: String) {
+    fun verifySystemNotificationDoesNotExist(notificationMessage: String) {
         mDevice.waitNotNull(
             Until.gone(text(notificationMessage)),
             waitingTime,
@@ -127,6 +127,13 @@ class NotificationRobot {
 
             HomeScreenRobot().interact()
             return HomeScreenRobot.Transition()
+        }
+
+        fun closeNotificationTray(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            mDevice.pressBack()
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SystemSettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SystemSettingsRobot.kt
@@ -7,7 +7,9 @@ package org.mozilla.fenix.ui.robots
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.uiautomator.UiSelector
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndDescription
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.mDevice
@@ -21,6 +23,26 @@ class SystemSettingsRobot {
     fun verifyMakeDefaultBrowser() {
         Intents.intended(hasAction(SettingsRobot.DEFAULT_APPS_SETTINGS_ACTION))
     }
+
+    fun verifyAllSystemNotificationsToggleState(enabled: Boolean) {
+        if (enabled) {
+            assertTrue(allSystemSettingsNotificationsToggle.isChecked)
+        } else {
+            assertFalse(allSystemSettingsNotificationsToggle.isChecked)
+        }
+    }
+
+    fun verifyPrivateBrowsingSystemNotificationsToggleState(enabled: Boolean) {
+        if (enabled) {
+            assertTrue(privateBrowsingSystemSettingsNotificationsToggle.isChecked)
+        } else {
+            assertFalse(privateBrowsingSystemSettingsNotificationsToggle.isChecked)
+        }
+    }
+
+    fun clickPrivateBrowsingSystemNotificationsToggle() = privateBrowsingSystemSettingsNotificationsToggle.click()
+
+    fun clickAllSystemNotificationsToggle() = allSystemSettingsNotificationsToggle.click()
 
     class Transition {
         // Difficult to know where this will go
@@ -46,3 +68,15 @@ private fun assertSystemNotificationsView() {
             .waitForExists(waitingTime),
     )
 }
+
+private val allSystemSettingsNotificationsToggle =
+    mDevice.findObject(
+        UiSelector().resourceId("com.android.settings:id/switch_bar")
+            .childSelector(
+                UiSelector()
+                    .resourceId("com.android.settings:id/switch_widget")
+                    .index(1),
+            ),
+    )
+private val privateBrowsingSystemSettingsNotificationsToggle =
+    itemWithResIdAndDescription("com.android.settings:id/switchWidget", "Private browsing session")


### PR DESCRIPTION
Bug 1837378 - New system notification settings UI tests

Both tests successfully passed 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1837378