### PR TITLE
Bug 1837451 - Refactor FocusDependencies into a plugin using composite build

### DIFF
--- a/focus-android/build.gradle
+++ b/focus-android/build.gradle
@@ -34,7 +34,7 @@ buildscript {
     }
 
     // Variables in plugins {} aren't directly supported. Hack around it by setting an
-    // intermediate variable which can pull from FocusDependencies.kt and be used later.
+    // intermediate variable which can pull from FocusDependenciesPlugin.kt and be used later.
     ext {
         detekt_plugin = FocusVersions.detekt_version
         python_envs_plugin = FocusVersions.python_envs_plugin_version

--- a/focus-android/plugins/focusdependencies/build.gradle
+++ b/focus-android/plugins/focusdependencies/build.gradle
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+plugins {
+    id "org.gradle.kotlin.kotlin-dsl" version "2.4.1"
+}
+
+repositories {
+    mavenCentral()
+}
+
+gradlePlugin {
+    plugins.register("FocusDependenciesPlugin") {
+        id = "FocusDependenciesPlugin"
+        implementationClass = "FocusDependenciesPlugin"
+    }
+}

--- a/focus-android/plugins/focusdependencies/settings.gradle
+++ b/focus-android/plugins/focusdependencies/settings.gradle
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Prevents gradle builds from looking for a root settings.gradle

--- a/focus-android/plugins/focusdependencies/src/main/java/FocusDependenciesPlugin.kt
+++ b/focus-android/plugins/focusdependencies/src/main/java/FocusDependenciesPlugin.kt
@@ -2,8 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+
 // If you ever need to force a toolchain rebuild (taskcluster) then edit the following comment.
 // FORCE REBUILD 2023-05-05
+
+class FocusDependenciesPlugin : Plugin<Settings> {
+    override fun apply(settings: Settings) = Unit
+}
 
 object FocusVersions {
     object Adjust {

--- a/focus-android/settings.gradle
+++ b/focus-android/settings.gradle
@@ -5,10 +5,12 @@
 pluginManagement {
     includeBuild("../android-components/plugins/publicsuffixlist")
     includeBuild("../android-components/plugins/dependencies")
+    includeBuild("./plugins/focusdependencies")
 }
 
 plugins {
     id 'mozac.DependenciesPlugin'
+    id 'FocusDependenciesPlugin'
 }
 
 apply from: file('../shared-settings.gradle')

--- a/taskcluster/android_taskgraph/transforms/external_gradle_dependencies.py
+++ b/taskcluster/android_taskgraph/transforms/external_gradle_dependencies.py
@@ -69,8 +69,10 @@ def _get_build_gradle_paths(gradle_project):
     ]
 
     # Make sure we rebuild the cache when Fenix or Focus dependencies are changed
-    if gradle_project in ("focus", "fenix"):
+    if gradle_project == "fenix":
         file_list.append(f"{project_dir}/buildSrc/src/main/java/*Dependencies.kt")
+    elif gradle_project == "focus":
+        file_list.append(f"{project_dir}/plugins/focusdependencies/src/main/java/FocusDependenciesPlugin.kt")
 
     return file_list
 

--- a/taskcluster/ci/external-gradle-dependencies/kind.yml
+++ b/taskcluster/ci/external-gradle-dependencies/kind.yml
@@ -65,7 +65,7 @@ tasks:
                 - githubLintDetektDetails
             resources:
                 # TODO: Make focus lint tasks use their own gradle deps tasks
-                - focus-android/buildSrc/src/main/java/FocusDependencies.kt
+                - focus-android/plugins/focusdependencies/src/main/java/FocusDependenciesPlugin.kt
 
     lint-fenix:
         treeherder:


### PR DESCRIPTION



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1837451