### PR TITLE
Bug 1836778 - Add Support for Printing in GeckoEngineSession

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -278,6 +278,29 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.requestPrintContent]
+     */
+    override fun requestPrintContent() {
+        geckoSession.didPrintPageContent().then(
+            { finishedPrinting ->
+                if (finishedPrinting == true) {
+                    notifyObservers {
+                        onPrintFinish()
+                    }
+                }
+                GeckoResult<Void>()
+            },
+            { throwable ->
+                logger.error("Printing failed.", throwable)
+                notifyObservers {
+                    onPrintException(true, throwable)
+                }
+                GeckoResult()
+            },
+        )
+    }
+
+    /**
      * See [EngineSession.stopLoading]
      */
     override fun stopLoading() {

--- a/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -106,6 +106,10 @@ class SystemEngineSession(
         throw UnsupportedOperationException("PDF support is not available in this engine")
     }
 
+    override fun requestPrintContent() {
+        throw UnsupportedOperationException("Print support is not available in this engine")
+    }
+
     /**
      * See [EngineSession.stopLoading]
      */

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -1057,6 +1057,30 @@ sealed class EngineAction : BrowserAction() {
     ) : EngineAction(), ActionWithTab
 
     /**
+     * Indicates the given [tabId] is to print the page content.
+     */
+    data class PrintContentAction(
+        override val tabId: String,
+    ) : EngineAction(), ActionWithTab
+
+    /**
+     * Indicates the given [tabId] completed printing the page content.
+     */
+    data class PrintContentCompletedAction(
+        override val tabId: String,
+    ) : EngineAction(), ActionWithTab
+
+    /**
+     * Indicates the given [tabId] was unable to print the page content.
+     * [isPrint] indicates if it is in response to a print (true) or PDF saving (false).
+     */
+    data class PrintContentExceptionAction(
+        override val tabId: String,
+        val isPrint: Boolean,
+        val throwable: Throwable,
+    ) : EngineAction(), ActionWithTab
+
+    /**
      * Navigates back in the tab with the given [tabId].
      */
     data class SaveToPdfAction(

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
@@ -435,6 +435,14 @@ internal class EngineObserver(
         store.dispatch(EngineAction.SaveToPdfExceptionAction(tabId, throwable))
     }
 
+    override fun onPrintFinish() {
+        store.dispatch(EngineAction.PrintContentCompletedAction(tabId))
+    }
+
+    override fun onPrintException(isPrint: Boolean, throwable: Throwable) {
+        store.dispatch(EngineAction.PrintContentExceptionAction(tabId, isPrint, throwable))
+    }
+
     override fun onCheckForFormData(containsFormData: Boolean) {
         store.dispatch(ContentAction.UpdateHasFormDataAction(tabId, containsFormData))
     }

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddleware.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/EngineDelegateMiddleware.kt
@@ -42,6 +42,7 @@ internal class EngineDelegateMiddleware(
             is EngineAction.ToggleDesktopModeAction -> toggleDesktopMode(context.store, action)
             is EngineAction.ExitFullScreenModeAction -> exitFullScreen(context.store, action)
             is EngineAction.SaveToPdfAction -> saveToPdf(context.store, action)
+            is EngineAction.PrintContentAction -> printContent(context.store, action)
             is EngineAction.ClearDataAction -> clearData(context.store, action)
             is EngineAction.PurgeHistoryAction -> purgeHistory(context.state)
             else -> next(action)
@@ -140,6 +141,14 @@ internal class EngineDelegateMiddleware(
     ) = scope.launch {
         getEngineSessionOrDispatch(store, action)
             ?.requestPdfToDownload()
+    }
+
+    private fun printContent(
+        store: Store<BrowserState, BrowserAction>,
+        action: EngineAction.PrintContentAction,
+    ) = scope.launch {
+        getEngineSessionOrDispatch(store, action)
+            ?.requestPrintContent()
     }
 
     private fun clearData(

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/EngineStateReducer.kt
@@ -61,6 +61,9 @@ internal object EngineStateReducer {
         is EngineAction.ToggleDesktopModeAction,
         is EngineAction.ExitFullScreenModeAction,
         is EngineAction.SaveToPdfAction,
+        is EngineAction.PrintContentAction,
+        is EngineAction.PrintContentCompletedAction,
+        is EngineAction.PrintContentExceptionAction,
         is EngineAction.KillEngineSessionAction,
         is EngineAction.ClearDataAction,
         -> {

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -84,6 +84,7 @@ class EngineObserverTest {
                 notifyObservers { onNavigationStateChange(true, true) }
             }
             override fun requestPdfToDownload() = Unit
+            override fun requestPrintContent() = Unit
             override fun loadUrl(
                 url: String,
                 parent: EngineSession?,
@@ -139,6 +140,7 @@ class EngineObserverTest {
             override fun purgeHistory() {}
             override fun loadData(data: String, mimeType: String, encoding: String) {}
             override fun requestPdfToDownload() = Unit
+            override fun requestPrintContent() = Unit
             override fun loadUrl(
                 url: String,
                 parent: EngineSession?,
@@ -196,6 +198,7 @@ class EngineObserverTest {
             ) {}
             override fun loadData(data: String, mimeType: String, encoding: String) {}
             override fun requestPdfToDownload() = Unit
+            override fun requestPrintContent() = Unit
             override fun findAll(text: String) {}
             override fun findNext(forward: Boolean) {}
             override fun clearFindMatches() {}

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -284,6 +284,19 @@ abstract class EngineSession(
         fun onSaveToPdfException(throwable: Throwable) = Unit
 
         /**
+         * Event to indicate that printing finished.
+         */
+        fun onPrintFinish() = Unit
+
+        /**
+         * Event to indicate that an exception was thrown while preparing to print or save as pdf.
+         *
+         * @param isPrint true for a true print error or false for a Save as PDF error.
+         * @param throwable The exception throwable. Usually a GeckoPrintException.
+         */
+        fun onPrintException(isPrint: Boolean, throwable: Throwable) = Unit
+
+        /**
          * Event to indicate that this session needs to be checked for form data.
          *
          * @param containsFormData Indicates if the session has form data.
@@ -726,6 +739,13 @@ abstract class EngineSession(
      * A typical implementation would have the same flow that feeds into [EngineSession.Observer.onExternalResource].
      */
     abstract fun requestPdfToDownload()
+
+    /**
+     * Requests the [EngineSession] to print the current session's contents.
+     *
+     * This will open the Android Print Spooler.
+     */
+    abstract fun requestPrintContent()
 
     /**
      * Stops loading the current session.

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -949,6 +949,8 @@ open class DummyEngineSession : EngineSession() {
 
     override fun requestPdfToDownload() {}
 
+    override fun requestPrintContent() {}
+
     override fun stopLoading() {}
 
     override fun reload(flags: LoadUrlFlags) {}

--- a/android-components/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/android-components/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -432,6 +432,35 @@ class SessionUseCases(
         }
     }
 
+    /**
+     * A use case for requesting a given tab to print it's content.
+     */
+    class PrintContentUseCase internal constructor(
+        private val store: BrowserStore,
+    ) {
+        /**
+         * Request that Android print the current [tabId].
+         *
+         * The same caveats in the [SaveToPdfUseCase] apply here because the Engine makes a PDF prior
+         * to sending the print request on to the Android print spooler. This means the session should
+         * have been painted first to successfully make a PDF.
+         *
+         * ⚠️ Make sure to have a middleware that handles the [EngineAction.PrintContentExceptionAction]`
+         * to handle print errors. Handling [EngineAction.PrintContentCompletedAction] is only necessary for
+         * telemetry or if any extra actions need to be completed.
+         *
+         */
+        operator fun invoke(
+            tabId: String? = store.state.selectedTabId,
+        ) {
+            if (tabId == null) {
+                return
+            }
+
+            store.dispatch(EngineAction.PrintContentAction(tabId))
+        }
+    }
+
     val loadUrl: DefaultLoadUrlUseCase by lazy { DefaultLoadUrlUseCase(store, onNoTab) }
     val loadData: LoadDataUseCase by lazy { LoadDataUseCase(store, onNoTab) }
     val reload: ReloadUrlUseCase by lazy { ReloadUrlUseCase(store) }
@@ -442,6 +471,7 @@ class SessionUseCases(
     val requestDesktopSite: RequestDesktopSiteUseCase by lazy { RequestDesktopSiteUseCase(store) }
     val exitFullscreen: ExitFullScreenUseCase by lazy { ExitFullScreenUseCase(store) }
     val saveToPdf: SaveToPdfUseCase by lazy { SaveToPdfUseCase(store) }
+    val printContent: PrintContentUseCase by lazy { PrintContentUseCase(store) }
     val crashRecovery: CrashRecoveryUseCase by lazy { CrashRecoveryUseCase(store) }
     val purgeHistory: PurgeHistoryUseCase by lazy { PurgeHistoryUseCase(store) }
     val updateLastAccess: UpdateLastAccessUseCase by lazy { UpdateLastAccessUseCase(store) }

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/DefaultComponents.kt
@@ -316,6 +316,9 @@ open class DefaultComponents(private val applicationContext: Context) {
             SimpleBrowserMenuItem("Save to PDF") {
                 sessionUseCases.saveToPdf.invoke()
             },
+            SimpleBrowserMenuItem("Print") {
+                sessionUseCases.printContent.invoke()
+            },
             SimpleBrowserMenuItem("Restore after crash") {
                 sessionUseCases.crashRecovery.invoke()
             },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ permalink: /changelog/
 
 * **feature-pwa**
   * Adds `WebAppContentFeature` to set the "display" mode from the web app manifest on the `EngineSession`.
+* **browser-engine-gecko**:
+  * Added support for Printing on the Engine.
+* **concept-engine**:
+  * Added new `requestPrintContent` API in `Engine`. This is currently only supported in the Gecko Engine.
 
 # 115.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v114..releases_v115)


### PR DESCRIPTION
This bug adds an option to print the current page's content using the Android Print Spooler via GeckoView with status on the Engine in AC.

GeckoView bug [1837426](https://bugzilla.mozilla.org/show_bug.cgi?id=1837426) adds in the new `didPrintPageContent` to the GeckoView API first.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.
















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1836778