### PR TITLE
Bug 1837568 - Revert commits causing keyboard visibility problems in UI tests

### DIFF
--- a/fenix/app/src/androidTest/assets/pages/password.html
+++ b/fenix/app/src/androidTest/assets/pages/password.html
@@ -6,7 +6,7 @@
 </head>
 
 <body aria-label="body">
-<h2>Login Form</h2>
+
 <form method="GET" action="passwordsubmit.html">
 <p>Username: <input id="username" type="text" value="test@example.com"></p>
 <p>Password: <input id="password" type="password" value="verysecret"></p>

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
@@ -15,7 +15,6 @@ import androidx.test.uiautomator.UiSelector
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.helpers.FeatureSettingsHelper.Companion.settings
 import org.mozilla.fenix.helpers.TestHelper.appContext
-import org.mozilla.fenix.helpers.TestHelper.hideSoftKeyboard
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.onboarding.FenixOnboarding
 
@@ -32,7 +31,6 @@ class HomeActivityTestRule(
     initialTouchMode: Boolean = false,
     launchActivity: Boolean = true,
     private val skipOnboarding: Boolean = false,
-    private val hideSoftKeyboard: Boolean = false,
 ) : ActivityTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity),
     FeatureSettingsHelper by FeatureSettingsHelperDelegate() {
 
@@ -42,7 +40,6 @@ class HomeActivityTestRule(
     constructor(
         initialTouchMode: Boolean = false,
         launchActivity: Boolean = true,
-        hideSoftKeyboard: Boolean = false,
         skipOnboarding: Boolean = false,
         isHomeOnboardingDialogEnabled: Boolean = settings.showHomeOnboardingDialog &&
             FenixOnboarding(appContext).userHasBeenOnboarded(),
@@ -58,7 +55,7 @@ class HomeActivityTestRule(
         isOpenInAppBannerEnabled: Boolean = settings.shouldShowOpenInAppBanner,
         etpPolicy: ETPPolicy = getETPPolicy(settings),
         tabsTrayRewriteEnabled: Boolean = false,
-    ) : this(initialTouchMode, launchActivity, hideSoftKeyboard, skipOnboarding) {
+    ) : this(initialTouchMode, launchActivity, skipOnboarding) {
         this.isHomeOnboardingDialogEnabled = isHomeOnboardingDialogEnabled
         this.isPocketEnabled = isPocketEnabled
         this.isJumpBackInCFREnabled = isJumpBackInCFREnabled
@@ -90,7 +87,6 @@ class HomeActivityTestRule(
         super.beforeActivityLaunched()
         setLongTapTimeout(3000)
         applyFlagUpdates()
-        if (hideSoftKeyboard) { hideSoftKeyboard() }
         if (skipOnboarding) { skipOnboardingBeforeLaunch() }
     }
 
@@ -115,13 +111,11 @@ class HomeActivityTestRule(
         fun withDefaultSettingsOverrides(
             initialTouchMode: Boolean = false,
             launchActivity: Boolean = true,
-            hideSoftKeyboard: Boolean = false,
             skipOnboarding: Boolean = false,
             tabsTrayRewriteEnabled: Boolean = false,
         ) = HomeActivityTestRule(
             initialTouchMode = initialTouchMode,
             launchActivity = launchActivity,
-            hideSoftKeyboard = hideSoftKeyboard,
             skipOnboarding = skipOnboarding,
             tabsTrayRewriteEnabled = tabsTrayRewriteEnabled,
             isJumpBackInCFREnabled = false,
@@ -145,7 +139,6 @@ class HomeActivityTestRule(
 class HomeActivityIntentTestRule internal constructor(
     initialTouchMode: Boolean = false,
     launchActivity: Boolean = true,
-    private val hideSoftKeyboard: Boolean = false,
     private val skipOnboarding: Boolean = false,
 ) : IntentsTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity),
     FeatureSettingsHelper by FeatureSettingsHelperDelegate() {
@@ -155,7 +148,6 @@ class HomeActivityIntentTestRule internal constructor(
     constructor(
         initialTouchMode: Boolean = false,
         launchActivity: Boolean = true,
-        hideSoftKeyboard: Boolean = false,
         skipOnboarding: Boolean = false,
         isHomeOnboardingDialogEnabled: Boolean = settings.showHomeOnboardingDialog &&
             FenixOnboarding(appContext).userHasBeenOnboarded(),
@@ -171,7 +163,7 @@ class HomeActivityIntentTestRule internal constructor(
         isOpenInAppBannerEnabled: Boolean = settings.shouldShowOpenInAppBanner,
         etpPolicy: ETPPolicy = getETPPolicy(settings),
         tabsTrayRewriteEnabled: Boolean = false,
-    ) : this(initialTouchMode, launchActivity, hideSoftKeyboard, skipOnboarding) {
+    ) : this(initialTouchMode, launchActivity, skipOnboarding) {
         this.isHomeOnboardingDialogEnabled = isHomeOnboardingDialogEnabled
         this.isPocketEnabled = isPocketEnabled
         this.isJumpBackInCFREnabled = isJumpBackInCFREnabled
@@ -218,7 +210,6 @@ class HomeActivityIntentTestRule internal constructor(
         super.beforeActivityLaunched()
         setLongTapTimeout(3000)
         applyFlagUpdates()
-        if (hideSoftKeyboard) { hideSoftKeyboard() }
         if (skipOnboarding) { skipOnboardingBeforeLaunch() }
     }
 
@@ -265,13 +256,11 @@ class HomeActivityIntentTestRule internal constructor(
         fun withDefaultSettingsOverrides(
             initialTouchMode: Boolean = false,
             launchActivity: Boolean = true,
-            hideSoftKeyboard: Boolean = false,
             skipOnboarding: Boolean = false,
             tabsTrayRewriteEnabled: Boolean = false,
         ) = HomeActivityIntentTestRule(
             initialTouchMode = initialTouchMode,
             launchActivity = launchActivity,
-            hideSoftKeyboard = hideSoftKeyboard,
             skipOnboarding = skipOnboarding,
             tabsTrayRewriteEnabled = tabsTrayRewriteEnabled,
             isJumpBackInCFREnabled = false,

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -26,7 +26,6 @@ import android.os.storage.StorageVolume
 import android.provider.Settings
 import android.util.Log
 import android.view.View
-import android.view.accessibility.AccessibilityWindowInfo
 import androidx.annotation.RequiresApi
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.test.espresso.Espresso
@@ -485,19 +484,5 @@ object TestHelper {
     fun bringAppToForeground() {
         mDevice.pressRecentApps()
         mDevice.findObject(UiSelector().resourceId("$packageName:id/container")).waitForExists(waitingTime)
-    }
-
-    fun isSoftKeyboardVisible(): Boolean {
-        mDevice.waitForIdle()
-        for (window in InstrumentationRegistry.getInstrumentation().uiAutomation.windows) {
-            if (window.type == AccessibilityWindowInfo.TYPE_INPUT_METHOD) {
-                return true
-            }
-        }
-        return false
-    }
-
-    fun hideSoftKeyboard() {
-        mDevice.executeShellCommand("settings put secure show_ime_with_hard_keyboard 0")
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -12,8 +12,6 @@ import kotlinx.coroutines.runBlocking
 import mozilla.appservices.places.BookmarkRoot
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -28,7 +26,6 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.clickSnackbarButton
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
-import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
 import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.ui.robots.bookmarksMenu
@@ -153,11 +150,11 @@ class BookmarksTest {
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
             ) {
                 clickAddFolderButton()
-                assertTrue(isKeyboardVisible())
+                verifyKeyboardVisible()
                 addNewFolderName(bookmarksFolderName)
                 saveNewFolder()
                 verifyFolderTitle(bookmarksFolderName)
-                assertFalse(isKeyboardVisible())
+                verifyKeyboardHidden()
             }
         }
     }
@@ -170,7 +167,7 @@ class BookmarksTest {
             clickAddFolderButton()
             addNewFolderName(bookmarksFolderName)
             navigateUp()
-            assertFalse(isKeyboardVisible())
+            verifyKeyboardHidden()
             verifyBookmarkFolderIsNotCreated(bookmarksFolderName)
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -28,7 +28,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.clickSnackbarButton
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
-import org.mozilla.fenix.helpers.TestHelper.isSoftKeyboardVisible
+import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
 import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.ui.robots.bookmarksMenu
@@ -153,11 +153,11 @@ class BookmarksTest {
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
             ) {
                 clickAddFolderButton()
-                assertTrue(isSoftKeyboardVisible())
+                assertTrue(isKeyboardVisible())
                 addNewFolderName(bookmarksFolderName)
                 saveNewFolder()
                 verifyFolderTitle(bookmarksFolderName)
-                assertFalse(isSoftKeyboardVisible())
+                assertFalse(isKeyboardVisible())
             }
         }
     }
@@ -170,7 +170,7 @@ class BookmarksTest {
             clickAddFolderButton()
             addNewFolderName(bookmarksFolderName)
             navigateUp()
-            assertFalse(isSoftKeyboardVisible())
+            assertFalse(isKeyboardVisible())
             verifyBookmarkFolderIsNotCreated(bookmarksFolderName)
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
@@ -21,7 +21,7 @@ import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.clickSnackbarButton
-import org.mozilla.fenix.helpers.TestHelper.isSoftKeyboardVisible
+import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.verifySnackBarText
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -361,7 +361,7 @@ class ComposeTabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabButtonShortcutsMenu {
         }.openNewPrivateTabFromShortcutsMenu {
-            assertTrue(isSoftKeyboardVisible())
+            assertTrue(isKeyboardVisible())
             verifyFocusedNavigationToolbar()
             // dismiss search dialog
             homeScreen { }.pressBack()
@@ -372,7 +372,7 @@ class ComposeTabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabButtonShortcutsMenu {
         }.openTabFromShortcutsMenu {
-            assertTrue(isSoftKeyboardVisible())
+            assertTrue(isKeyboardVisible())
             verifyFocusedNavigationToolbar()
             // dismiss search dialog
             homeScreen { }.pressBack()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
@@ -10,7 +10,6 @@ import androidx.test.uiautomator.UiDevice
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
@@ -21,7 +20,6 @@ import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.clickSnackbarButton
-import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.verifySnackBarText
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -361,7 +359,7 @@ class ComposeTabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabButtonShortcutsMenu {
         }.openNewPrivateTabFromShortcutsMenu {
-            assertTrue(isKeyboardVisible())
+            verifyKeyboardVisible()
             verifyFocusedNavigationToolbar()
             // dismiss search dialog
             homeScreen { }.pressBack()
@@ -372,7 +370,7 @@ class ComposeTabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabButtonShortcutsMenu {
         }.openTabFromShortcutsMenu {
-            assertTrue(isKeyboardVisible())
+            verifyKeyboardVisible()
             verifyFocusedNavigationToolbar()
             // dismiss search dialog
             homeScreen { }.pressBack()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.ui
 
 import android.os.Build
-import android.view.View
 import android.view.autofill.AutofillManager
 import androidx.core.net.toUri
 import okhttp3.mockwebserver.MockWebServer
@@ -14,23 +13,20 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.MatcherHelper
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
-import org.mozilla.fenix.helpers.TestHelper.isSoftKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
-import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.helpers.TestHelper.restartApp
 import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
-import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.clearTextFieldItem
 import org.mozilla.fenix.ui.robots.clickPageObject
@@ -49,7 +45,7 @@ class LoginsTest {
 
     @get:Rule
     val activityTestRule =
-        HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true, hideSoftKeyboard = true)
+        HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
 
     @Before
     fun setUp() {
@@ -136,22 +132,12 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(saveLoginTest.url) {
-            verifyPageContent("Login Form")
             clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    clickSubmitLoginButton()
-                }
-            }
+            verifySaveLoginPromptIsDisplayed()
             // Click save to save the login
             clickPageObject(itemWithText("Save"))
+        }
+        browserScreen {
         }.openThreeDotMenu {
         }.openSettings {
             scrollToElementByText("Logins and passwords")
@@ -175,28 +161,10 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            waitForPageToLoad()
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), userName)
             setPageObjectText(itemWithResId("password"), password)
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                if (isSoftKeyboardVisible() && !itemWithText("Save").exists()) {
-                    mDevice.pressBack()
-                }
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), userName)
-                    setPageObjectText(itemWithResId("password"), password)
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
             mDevice.waitForIdle()
         }.openThreeDotMenu {
@@ -217,21 +185,7 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(saveLoginTest.url) {
-            verifyPageContent("Login Form")
             clickSubmitLoginButton()
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                if (isSoftKeyboardVisible() && !itemWithText("Save").exists()) {
-                    mDevice.pressBack()
-                }
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    clickSubmitLoginButton()
-                }
-            }
             // Don't save the login, add to exceptions
             clickPageObject(itemWithText("Never save"))
             mDevice.waitForIdle()
@@ -260,20 +214,8 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(saveLoginTest.url) {
-            verifyPageContent("Login Form")
             clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    clickSubmitLoginButton()
-                }
-            }
+            verifySaveLoginPromptIsDisplayed()
             // Click Save to save the login
             clickPageObject(itemWithText("Save"))
         }.openNavigationToolbar {
@@ -281,20 +223,7 @@ class LoginsTest {
             enterPassword("test")
             mDevice.waitForIdle()
             clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    enterPassword("test")
-                    mDevice.waitForIdle()
-                    clickSubmitLoginButton()
-                }
-            }
+            verifySaveLoginPromptIsDisplayed()
             // Click Update to change the saved password
             clickPageObject(itemWithText("Update"))
         }.openThreeDotMenu {
@@ -312,6 +241,7 @@ class LoginsTest {
         }
     }
 
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1816066")
     @SmokeTest
     @Test
     fun verifyMultipleLoginsSelectionsTest() {
@@ -323,42 +253,15 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), firstUser)
             setPageObjectText(itemWithResId("password"), firstPass)
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), firstUser)
-                    setPageObjectText(itemWithResId("password"), firstPass)
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
             setPageObjectText(itemWithResId("username"), secondUser)
             setPageObjectText(itemWithResId("password"), secondPass)
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), secondUser)
-                    setPageObjectText(itemWithResId("password"), secondPass)
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
             clearTextFieldItem(itemWithResId("username"))
             clickSuggestedLoginsButton()
@@ -382,25 +285,12 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "mozilla")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -423,25 +313,12 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "mozilla")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -473,25 +350,12 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "mozilla")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -513,25 +377,12 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "mozilla")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -555,25 +406,12 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "mozilla")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -597,20 +435,7 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.url) {
-            verifyPageContent("Login Form")
             clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    clickSubmitLoginButton()
-                }
-            }
             clickPageObject(itemWithText("Save"))
             mDevice.waitForIdle()
         }.openThreeDotMenu {
@@ -644,7 +469,8 @@ class LoginsTest {
         }.openLoginsAndPasswordSubMenu {
         }.openSaveLoginsAndPasswordsOptions {
             clickNeverSaveOption()
-        }.goBack {}
+        }.goBack {
+        }
 
         exitMenu()
 
@@ -661,24 +487,10 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "mozilla")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
         }.openTabDrawer {
             closeTab()
@@ -698,7 +510,8 @@ class LoginsTest {
             verifyAutofillInFirefoxToggle(true)
             clickAutofillInFirefoxOption()
             verifyAutofillInFirefoxToggle(false)
-        }.goBack {}
+        }.goBack {
+        }
 
         exitMenu()
 
@@ -728,22 +541,10 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "mozilla")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
         }.openTabDrawer {
             closeTab()
@@ -776,41 +577,15 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstLoginPage.url) {
-            verifyPageContent("Login Form")
             clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    clickSubmitLoginButton()
-                }
-            }
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(secondLoginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "android")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
         }.openThreeDotMenu {
         }.openSettings {
@@ -848,41 +623,15 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstLoginPage.url) {
-            verifyPageContent("Login Form")
             clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    clickSubmitLoginButton()
-                }
-            }
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(secondLoginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "android")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
         }.openThreeDotMenu {
         }.openSettings {
@@ -912,6 +661,7 @@ class LoginsTest {
         }
     }
 
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1815650")
     @Test
     fun verifyLastUsedLoginSortingOptionTest() {
         val firstLoginPage = TestAssetHelper.getSaveLoginAsset(mockWebServer)
@@ -920,41 +670,15 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstLoginPage.url) {
-            verifyPageContent("Login Form")
             clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    clickSubmitLoginButton()
-                }
-            }
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(secondLoginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "mozilla")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
         }.openThreeDotMenu {
         }.openSettings {
@@ -964,26 +688,12 @@ class LoginsTest {
             clickSavedLoginsChevronIcon()
             verifyLoginsSortingOptions()
             clickLastUsedSortingOption()
-            registerAndCleanupIdlingResources(
-                ViewVisibilityIdlingResource(
-                    activityTestRule.activity.findViewById(R.id.webAddressView),
-                    View.VISIBLE,
-                ),
-            ) {
-                verifySortedLogin(activityTestRule, 0, originWebsite)
-                verifySortedLogin(activityTestRule, 1, firstLoginPage.url.authority.toString())
-            }
+            verifySortedLogin(activityTestRule, 0, originWebsite)
+            verifySortedLogin(activityTestRule, 1, firstLoginPage.url.authority.toString())
         }.goBack {
         }.openSavedLogins {
-            registerAndCleanupIdlingResources(
-                ViewVisibilityIdlingResource(
-                    activityTestRule.activity.findViewById(R.id.webAddressView),
-                    View.VISIBLE,
-                ),
-            ) {
-                verifySortedLogin(activityTestRule, 0, originWebsite)
-                verifySortedLogin(activityTestRule, 1, firstLoginPage.url.authority.toString())
-            }
+            verifySortedLogin(activityTestRule, 0, originWebsite)
+            verifySortedLogin(activityTestRule, 1, firstLoginPage.url.authority.toString())
         }
 
         restartApp(activityTestRule)
@@ -993,15 +703,8 @@ class LoginsTest {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
         }.openSavedLogins {
-            registerAndCleanupIdlingResources(
-                ViewVisibilityIdlingResource(
-                    activityTestRule.activity.findViewById(R.id.webAddressView),
-                    View.VISIBLE,
-                ),
-            ) {
-                verifySortedLogin(activityTestRule, 0, originWebsite)
-                verifySortedLogin(activityTestRule, 1, firstLoginPage.url.authority.toString())
-            }
+            verifySortedLogin(activityTestRule, 0, originWebsite)
+            verifySortedLogin(activityTestRule, 1, firstLoginPage.url.authority.toString())
         }
     }
 
@@ -1013,42 +716,17 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstLoginPage.url) {
-            verifyPageContent("Login Form")
             clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    clickSubmitLoginButton()
-                }
-            }
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(secondLoginPage.toUri()) {
-            verifyPageContent("Login Form")
             setPageObjectText(itemWithResId("username"), "mozilla")
             setPageObjectText(itemWithResId("password"), "firefox")
-            clickSubmitLoginButton()
-            // Retry actions to be removed when https://bugzilla.mozilla.org/show_bug.cgi?id=1812426 is fixed
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1833609
-            try {
-                verifySaveLoginPromptIsDisplayed()
-            } catch (e: AssertionError) {
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    verifyPageContent("Login Form")
-                    setPageObjectText(itemWithResId("username"), "mozilla")
-                    setPageObjectText(itemWithResId("password"), "firefox")
-                    clickSubmitLoginButton()
-                }
-            }
+            clickPageObject(itemWithResId("submit"))
+            verifySaveLoginPromptIsDisplayed()
             clickPageObject(itemWithText("Save"))
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
@@ -1103,7 +781,7 @@ class LoginsTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            clickPageObject(itemWithResId("username"))
+            clickPageObject(MatcherHelper.itemWithResId("username"))
             clickSuggestedLoginsButton()
             verifySuggestedUserName("mozilla")
             clickPageObject(itemWithResIdAndText("$packageName:id/username", "mozilla"))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
@@ -14,7 +14,7 @@ import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper.isSoftKeyboardVisible
+import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.verifyDarkThemeApplied
 import org.mozilla.fenix.helpers.TestHelper.verifyLightThemeApplied
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -135,7 +135,7 @@ class OnboardingTest {
         }.openSearch {
             verifyScanButton()
             verifySearchEngineButton()
-            assertTrue(isSoftKeyboardVisible())
+            assertTrue(isKeyboardVisible())
         }.dismissSearchBar {
             verifyStartBrowsingButton()
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
@@ -5,7 +5,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
@@ -14,7 +13,6 @@ import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.verifyDarkThemeApplied
 import org.mozilla.fenix.helpers.TestHelper.verifyLightThemeApplied
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -135,7 +133,7 @@ class OnboardingTest {
         }.openSearch {
             verifyScanButton()
             verifySearchEngineButton()
-            assertTrue(isKeyboardVisible())
+            verifyKeyboardVisibility()
         }.dismissSearchBar {
             verifyStartBrowsingButton()
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -19,7 +19,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
-import org.mozilla.fenix.helpers.TestHelper.isSoftKeyboardVisible
+import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.runWithCondition
 import org.mozilla.fenix.helpers.TestHelper.setTextToClipBoard
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -198,7 +198,7 @@ class SettingsSearchTest {
         }.goBack {
         }.goBack {
         }.openSearch {
-            assertTrue(isSoftKeyboardVisible())
+            assertTrue(isKeyboardVisible())
             clickSearchEngineShortcutButton()
             verifyEnginesListShortcutContains(activityTestRule, searchEngine)
             changeDefaultSearchEngine(activityTestRule, searchEngine)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -3,7 +3,6 @@ package org.mozilla.fenix.ui
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
@@ -19,7 +18,6 @@ import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
-import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.runWithCondition
 import org.mozilla.fenix.helpers.TestHelper.setTextToClipBoard
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -198,7 +196,7 @@ class SettingsSearchTest {
         }.goBack {
         }.goBack {
         }.openSearch {
-            assertTrue(isKeyboardVisible())
+            verifyKeyboardVisibility()
             clickSearchEngineShortcutButton()
             verifyEnginesListShortcutContains(activityTestRule, searchEngine)
             changeDefaultSearchEngine(activityTestRule, searchEngine)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -32,7 +32,7 @@ import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.assertYoutubeAppOpens
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
-import org.mozilla.fenix.helpers.TestHelper.isSoftKeyboardVisible
+import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -140,7 +140,7 @@ class SmokeTest {
         for (searchEngine in enginesList) {
             homeScreen {
             }.openSearch {
-                assertTrue(isSoftKeyboardVisible())
+                assertTrue(isKeyboardVisible())
                 clickSearchEngineShortcutButton()
                 verifySearchEngineList(activityTestRule)
                 changeDefaultSearchEngine(activityTestRule, searchEngine)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -16,7 +16,6 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.mediasession.MediaSession
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -32,7 +31,6 @@ import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.assertYoutubeAppOpens
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
-import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -140,7 +138,7 @@ class SmokeTest {
         for (searchEngine in enginesList) {
             homeScreen {
             }.openSearch {
-                assertTrue(isKeyboardVisible())
+                verifyKeyboardVisibility()
                 clickSearchEngineShortcutButton()
                 verifySearchEngineList(activityTestRule)
                 changeDefaultSearchEngine(activityTestRule, searchEngine)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -9,7 +9,6 @@ import androidx.test.uiautomator.UiDevice
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -17,7 +16,6 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -346,7 +344,7 @@ class TabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabButtonShortcutsMenu {
         }.openNewPrivateTabFromShortcutsMenu {
-            assertTrue(isKeyboardVisible())
+            verifyKeyboardVisible()
             verifyFocusedNavigationToolbar()
             // dismiss search dialog
             homeScreen { }.pressBack()
@@ -357,7 +355,7 @@ class TabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabButtonShortcutsMenu {
         }.openTabFromShortcutsMenu {
-            assertTrue(isKeyboardVisible())
+            verifyKeyboardVisible()
             verifyFocusedNavigationToolbar()
             // dismiss search dialog
             homeScreen { }.pressBack()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -17,7 +17,7 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper.isSoftKeyboardVisible
+import org.mozilla.fenix.helpers.TestHelper.isKeyboardVisible
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -346,7 +346,7 @@ class TabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabButtonShortcutsMenu {
         }.openNewPrivateTabFromShortcutsMenu {
-            assertTrue(isSoftKeyboardVisible())
+            assertTrue(isKeyboardVisible())
             verifyFocusedNavigationToolbar()
             // dismiss search dialog
             homeScreen { }.pressBack()
@@ -357,7 +357,7 @@ class TabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabButtonShortcutsMenu {
         }.openTabFromShortcutsMenu {
-            assertTrue(isSoftKeyboardVisible())
+            assertTrue(isKeyboardVisible())
             verifyFocusedNavigationToolbar()
             // dismiss search dialog
             homeScreen { }.pressBack()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -30,6 +30,7 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
@@ -114,6 +115,10 @@ class BookmarksRobot {
             itemWithResId("$packageName:id/bookmarkParentFolderSelector"),
         )
     }
+
+    fun verifyKeyboardHidden() = assertKeyboardVisibility(isExpectedToBeVisible = false)
+
+    fun verifyKeyboardVisible() = assertKeyboardVisibility(isExpectedToBeVisible = true)
 
     fun verifyShareOverlay() = assertShareOverlay()
 
@@ -498,6 +503,14 @@ private fun assertUndoDeleteSnackBarButton() =
 
 private fun assertSnackBarText(text: String) =
     snackBarText().check(matches(withText(containsString(text))))
+
+private fun assertKeyboardVisibility(isExpectedToBeVisible: Boolean) =
+    assertEquals(
+        isExpectedToBeVisible,
+        mDevice
+            .executeShellCommand("dumpsys input_method | grep mInputShown")
+            .contains("mInputShown=true"),
+    )
 
 private fun assertShareOverlay() =
     onView(withId(R.id.shareWrapper)).check(matches(isDisplayed()))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -55,8 +55,6 @@ import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
-import org.mozilla.fenix.helpers.TestHelper.hideSoftKeyboard
-import org.mozilla.fenix.helpers.TestHelper.isSoftKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.TestHelper.waitForObjects
@@ -323,8 +321,7 @@ class BrowserRobot {
     fun clickSubmitLoginButton() {
         clickPageObject(itemWithResId("submit"))
         itemWithResId("submit").waitUntilGone(waitingTime)
-        // Sometimes the page will start reloading, we need to wait for it to stop
-        waitForPageToLoad()
+        mDevice.waitForIdle(waitingTimeLong)
     }
 
     fun enterPassword(password: String) {
@@ -558,15 +555,10 @@ class BrowserRobot {
         }
     }
 
-    fun verifySaveLoginPromptIsDisplayed() {
-        mDevice.waitForIdle()
-        // Sometimes the keyboard will still be displayed and covers the prompt
-        hideSoftKeyboard()
-
+    fun verifySaveLoginPromptIsDisplayed() =
         assertItemWithResIdExists(
             itemWithResId("$packageName:id/feature_prompt_login_fragment"),
         )
-    }
 
     fun verifySaveLoginPromptIsNotDisplayed() =
         assertItemWithResIdExists(
@@ -879,10 +871,6 @@ class BrowserRobot {
 
     class Transition {
         fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
-            // In some cases the keyboard will unexpectedly cover the toolbar
-            if (isSoftKeyboardVisible()) {
-                hideSoftKeyboard()
-            }
             mDevice.waitForIdle(waitingTime)
             threeDotButton().perform(click())
 
@@ -1139,7 +1127,7 @@ fun homeScreenButton() = onView(withContentDescription(R.string.browser_toolbar_
 private fun threeDotButton() = onView(withContentDescription("Menu"))
 
 private fun tabsCounter() =
-    mDevice.findObject(By.res("$packageName:id/mozac_browser_toolbar_browser_actions"))
+    mDevice.findObject(By.res("$packageName:id/counter_root"))
 
 private val progressBar =
     itemWithResId("$packageName:id/mozac_browser_toolbar_progress")

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -50,6 +50,7 @@ import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.Matchers
+import org.junit.Assert
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
@@ -208,6 +209,7 @@ class HomeScreenRobot {
     fun verifyDefaultSearchEngine(searchEngine: String) = verifySearchEngineIcon(searchEngine)
     fun verifyTabCounter(numberOfOpenTabs: String) =
         assertItemWithResIdAndTextExists(tabCounter(numberOfOpenTabs))
+    fun verifyKeyboardVisible() = assertKeyboardVisibility(isExpectedToBeVisible = true)
 
     fun verifyWallpaperImageApplied(isEnabled: Boolean) {
         if (isEnabled) {
@@ -579,8 +581,7 @@ class HomeScreenRobot {
         fun openSearch(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
             navigationToolbar.waitForExists(waitingTime)
             navigationToolbar.click()
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/search_wrapper"))
-                .waitForExists(waitingTime)
+            mDevice.waitForIdle()
 
             SearchRobot().interact()
             return SearchRobot.Transition()
@@ -876,6 +877,14 @@ private fun homeScreenList() =
             .resourceId("$packageName:id/sessionControlRecyclerView")
             .scrollable(true),
     ).setAsVerticalList()
+
+private fun assertKeyboardVisibility(isExpectedToBeVisible: Boolean) =
+    Assert.assertEquals(
+        isExpectedToBeVisible,
+        mDevice
+            .executeShellCommand("dumpsys input_method | grep mInputShown")
+            .contains("mInputShown=true"),
+    )
 
 private fun assertFocusedNavigationToolbar() =
     onView(allOf(withHint("Search or enter address")))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -35,8 +35,6 @@ import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
-import org.mozilla.fenix.helpers.TestHelper.hideSoftKeyboard
-import org.mozilla.fenix.helpers.TestHelper.isSoftKeyboardVisible
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
@@ -162,9 +160,6 @@ class NavigationToolbarRobot {
         }
 
         fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
-            if (isSoftKeyboardVisible()) {
-                hideSoftKeyboard()
-            }
             mDevice.waitNotNull(Until.findObject(By.res("$packageName:id/mozac_browser_toolbar_menu")), waitingTime)
             threeDotButton().click()
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -30,6 +30,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
@@ -177,6 +178,7 @@ class SearchRobot {
         assertSearchEnginePrompt(rule, searchEngineName)
     fun verifySearchBarEmpty() = assertSearchBarEmpty()
 
+    fun verifyKeyboardVisibility() = assertKeyboardVisibility(isExpectedToBeVisible = true)
     fun verifySearchEngineList(rule: ComposeTestRule) = rule.assertSearchEngineList()
     fun verifySearchEngineIcon(expectedText: String) {
         onView(withContentDescription(expectedText))
@@ -440,6 +442,18 @@ private fun assertSearchBarEmpty() =
 fun searchScreen(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
     SearchRobot().interact()
     return SearchRobot.Transition()
+}
+
+private fun assertKeyboardVisibility(isExpectedToBeVisible: Boolean): () -> Unit = {
+    searchWrapper().waitForExists(waitingTime)
+
+    assertEquals(
+        "Keyboard not shown",
+        isExpectedToBeVisible,
+        mDevice
+            .executeShellCommand("dumpsys input_method | grep mInputShown")
+            .contains("mInputShown=true"),
+    )
 }
 
 private fun ComposeTestRule.assertSearchEngineList() {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.kt
@@ -42,10 +42,7 @@ import org.mozilla.fenix.helpers.ext.waitNotNull
  */
 
 class SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot {
-    fun verifySecurityPromptForLogins() =
-        onView(withText("Secure your logins and passwords"))
-            .inRoot(RootMatchers.DEFAULT)
-            .check(matches(isDisplayed()))
+    fun verifySecurityPromptForLogins() = assertSavedLoginsView()
 
     fun verifyEmptySavedLoginsListView() {
         onView(withText(getStringResource(R.string.preferences_passwords_saved_logins_description_empty_text)))
@@ -66,10 +63,7 @@ class SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot {
         assertSavedLoginAppears()
     }
 
-    fun tapSetupLater() =
-        onView(withText("Later"))
-            .inRoot(RootMatchers.DEFAULT)
-            .perform(ViewActions.click())
+    fun tapSetupLater() = onView(withText("Later")).perform(ViewActions.click())
 
     fun clickAddLoginButton() =
         itemContainingText(getStringResource(R.string.preferences_logins_add_login)).click()
@@ -198,6 +192,10 @@ class SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot {
 
 private fun goBackButton() =
     onView(CoreMatchers.allOf(ViewMatchers.withContentDescription("Navigate up")))
+
+private fun assertSavedLoginsView() =
+    onView(withText("Secure your logins and passwords"))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertSavedLoginAppears() =
     onView(withText("https://accounts.google.com"))


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816066