### PR TITLE
Bug 1816004 - Remove unused saveToPDF feature flags

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -63,11 +63,6 @@ object FeatureFlags {
     const val composeTopSites = false
 
     /**
-     * Enables the save to PDF feature.
-     */
-    const val saveToPDF = true
-
-    /**
      * Enables the notification pre permission prompt.
      */
     const val notificationPrePermissionPromptEnabled = true

--- a/fenix/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -10,7 +10,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDialogFragment
-import androidx.core.view.isVisible
 import androidx.fragment.app.clearFragmentResult
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
@@ -23,7 +22,6 @@ import mozilla.components.browser.state.selector.findTabOrCustomTab
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.feature.accounts.push.SendTabUseCases
 import mozilla.components.feature.share.RecentAppsStorage
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.databinding.FragmentShareBinding
@@ -116,19 +114,14 @@ class ShareFragment : AppCompatDialogFragment() {
         }
         shareToAppsView = ShareToAppsView(binding.appsShareLayout, shareInteractor)
 
-        if (FeatureFlags.saveToPDF) {
-            binding.dividerLineAppsShareAndPdfSection.isVisible = true
-            binding.savePdf.apply {
-                isVisible = true
-                setContent {
-                    FirefoxTheme(theme = Theme.getTheme(allowPrivateTheme = false)) {
-                        SaveToPDFItem {
-                            shareInteractor.onSaveToPDF(tabId = args.sessionId)
-                        }
-                    }
+        binding.savePdf.setContent {
+            FirefoxTheme(theme = Theme.getTheme(allowPrivateTheme = false)) {
+                SaveToPDFItem {
+                    shareInteractor.onSaveToPDF(tabId = args.sessionId)
                 }
             }
         }
+
         return binding.root
     }
 

--- a/fenix/app/src/main/res/layout/fragment_share.xml
+++ b/fenix/app/src/main/res/layout/fragment_share.xml
@@ -56,7 +56,6 @@
 
         <View
             android:id="@+id/divider_line_apps_share_and_pdf_section"
-            android:visibility="gone"
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:layout_marginTop="8dp"
@@ -64,7 +63,6 @@
             app:layout_constraintTop_toBottomOf="@id/appsShareLayout" />
 
         <androidx.compose.ui.platform.ComposeView
-            android:visibility="gone"
             android:id="@+id/save_pdf"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Rebased of https://github.com/mozilla-mobile/firefox-android/pull/1799

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1816004