### PR TITLE
Bug 1825071 - Refactor BrowserIconsTest to remove Robolectric.

### DIFF
--- a/android-components/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
+++ b/android-components/components/browser/icons/src/main/java/mozilla/components/browser/icons/BrowserIcons.kt
@@ -211,7 +211,9 @@ class BrowserIcons @Suppress("LongParameterList") constructor(
     }
 
     @MainThread
-    private fun loadIntoViewInternal(
+    @VisibleForTesting
+    @Suppress("UndocumentedPublicFunction") // this is visible only for tests
+    fun loadIntoViewInternal(
         view: WeakReference<ImageView>,
         request: IconRequest,
         placeholder: Drawable?,

--- a/fenix/app/src/test/java/org/mozilla/fenix/ext/BrowserIconsTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/ext/BrowserIconsTest.kt
@@ -4,26 +4,42 @@
 
 package org.mozilla.fenix.ext
 
+import android.content.Context
 import android.widget.ImageView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.IconRequest
-import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import java.lang.ref.WeakReference
 
-@RunWith(FenixRobolectricTestRunner::class)
 class BrowserIconsTest {
     @Test
     fun loadIntoViewTest() {
-        val imageView = spyk(ImageView(testContext))
-        val icons = spyk(BrowserIcons(testContext, httpClient = GeckoViewFetchClient(testContext)))
         val myUrl = "https://mozilla.com"
-        val request = spyk(IconRequest(url = myUrl))
+        val request = IconRequest(url = myUrl)
+        val imageView = mockk<ImageView>()
+        val context = mockk<Context>()
+        val weakReference = slot<WeakReference<ImageView>>()
+
+        every { context.assets } returns mockk()
+        every { context.resources.getDimensionPixelSize(any()) } returns 100
+
+        val icons = spyk(
+            BrowserIcons(context = context, httpClient = mockk<GeckoViewFetchClient>()),
+        )
+
+        every { icons.loadIntoViewInternal(any(), any(), any(), any()) } returns mockk()
+
         icons.loadIntoView(imageView, myUrl)
+
         verify { icons.loadIntoView(imageView, request) }
+        verify { icons.loadIntoViewInternal(capture(weakReference), request, null, null) }
+        assertEquals(imageView, weakReference.captured.get())
     }
 }


### PR DESCRIPTION
Also add some additional checks.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1825071