### PR TITLE
Bug 1836364 - Add a dialog for handling FedCM showAccountListPrompt

### DIFF
--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Level
 import mozilla.components.concept.engine.prompt.PromptRequest.Authentication.Method
 import mozilla.components.concept.engine.prompt.PromptRequest.TimeSelection.Type
+import mozilla.components.concept.identitycredential.Account
 import mozilla.components.concept.identitycredential.Provider
 import mozilla.components.concept.storage.Address
 import mozilla.components.concept.storage.CreditCardEntry
@@ -122,6 +123,18 @@ sealed class PromptRequest(
         data class SelectProvider(
             val providers: List<Provider>,
             val onConfirm: (Provider) -> Unit,
+            override val onDismiss: () -> Unit,
+        ) : IdentityCredential(onDismiss), Dismissible
+
+        /**
+         * Value type that represents Identity Credential request for selecting an [Account] prompt.
+         * @property accounts A list of accounts which the user could select from.
+         * @property onConfirm callback to let the page know the user selected an account.
+         * @property onDismiss callback to let the page know the user dismissed the dialog.
+         */
+        data class SelectAccount(
+            val accounts: List<Account>,
+            val onConfirm: (Account) -> Unit,
             override val onDismiss: () -> Unit,
         ) : IdentityCredential(onDismiss), Dismissible
     }

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/identitycredential/Account.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/identitycredential/Account.kt
@@ -9,15 +9,17 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 /**
- * Represents an Identity credential provider:
- * @property id An identifier for this [Provider].
- * @property icon An icon of the provider, normally the logo of the brand.
- * @property name The name of this [Provider].
+ * Represents an Identity credential account:
+ * @property id An identifier for this [Account].
+ * @property email The email associated to this [Account].
+ * @property name The name of this [Account].
+ * @property icon An icon for the [Account], normally the profile picture
  */
 @SuppressLint("ParcelCreator")
 @Parcelize
-data class Provider(
+data class Account(
     val id: Int,
-    val icon: String?,
+    val email: String,
     val name: String,
+    val icon: String?,
 ) : Parcelable

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -72,6 +72,7 @@ import mozilla.components.feature.prompts.facts.emitCreditCardSaveShownFact
 import mozilla.components.feature.prompts.facts.emitSuccessfulAddressAutofillFormDetectedFact
 import mozilla.components.feature.prompts.facts.emitSuccessfulCreditCardAutofillFormDetectedFact
 import mozilla.components.feature.prompts.file.FilePicker
+import mozilla.components.feature.prompts.identitycredential.SelectAccountDialogFragment
 import mozilla.components.feature.prompts.identitycredential.SelectProviderDialogFragment
 import mozilla.components.feature.prompts.login.LoginDelegate
 import mozilla.components.feature.prompts.login.LoginExceptions
@@ -179,7 +180,8 @@ class PromptFeature private constructor(
     // This set of weak references of fragments is only used for dismissing all prompts on navigation.
     // For all other code only `activePrompt` is tracked for now.
     @VisibleForTesting(otherwise = PRIVATE)
-    internal val activePromptsToDismiss = Collections.newSetFromMap(WeakHashMap<PromptDialogFragment, Boolean>())
+    internal val activePromptsToDismiss =
+        Collections.newSetFromMap(WeakHashMap<PromptDialogFragment, Boolean>())
 
     constructor(
         activity: Activity,
@@ -881,6 +883,15 @@ class PromptFeature private constructor(
                 )
             }
 
+            is PromptRequest.IdentityCredential.SelectAccount -> {
+                SelectAccountDialogFragment.newInstance(
+                    sessionId = session.id,
+                    promptRequestUID = promptRequest.uid,
+                    shouldDismissOnLoad = true,
+                    accounts = promptRequest.accounts,
+                )
+            }
+
             else -> throw InvalidParameterException("Not valid prompt request type $promptRequest")
         }
 
@@ -942,6 +953,7 @@ class PromptFeature private constructor(
             is SelectAddress,
             is Share,
             is PromptRequest.IdentityCredential.SelectProvider,
+            is PromptRequest.IdentityCredential.SelectAccount,
             -> true
             is Alert, is TextPrompt, is Confirm, is Repost, is Popup -> promptAbuserDetector.shouldShowMoreDialogs
         }

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/BasicAccountsAdapter.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/BasicAccountsAdapter.kt
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.identitycredential
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.concept.identitycredential.Account
+import mozilla.components.feature.prompts.R
+import mozilla.components.support.ktx.kotlin.base64PngToBitmap
+
+private object AccountItemDiffCallback : DiffUtil.ItemCallback<Account>() {
+    override fun areItemsTheSame(oldItem: Account, newItem: Account) =
+        oldItem.id == newItem.id
+
+    override fun areContentsTheSame(oldItem: Account, newItem: Account) =
+        oldItem == newItem
+}
+
+/**
+ * RecyclerView adapter for displaying account items.
+ */
+internal class BasicAccountAdapter(
+    private val onAccountSelected: (Account) -> Unit,
+) : ListAdapter<Account, AccountViewHolder>(AccountItemDiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AccountViewHolder {
+        val view = LayoutInflater
+            .from(parent.context)
+            .inflate(
+                R.layout.mozac_feature_prompts_identity_crendential_account_item,
+                parent,
+                false,
+            )
+        return AccountViewHolder(view, onAccountSelected)
+    }
+
+    override fun onBindViewHolder(holder: AccountViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+/**
+ * View holder for a account item.
+ */
+internal class AccountViewHolder(
+    itemView: View,
+    private val onAccountSelected: (Account) -> Unit,
+) : RecyclerView.ViewHolder(itemView), View.OnClickListener {
+    internal lateinit var account: Account
+
+    init {
+        itemView.setOnClickListener(this)
+    }
+
+    fun bind(item: Account) {
+        account = item
+
+        itemView.findViewById<TextView>(R.id.fedcm_account_name).text = item.name
+
+        account.icon?.let {
+            itemView.findViewById<ImageView>(R.id.fedcm_account_icon)
+                .setImageBitmap(it.base64PngToBitmap())
+        }
+    }
+
+    override fun onClick(v: View?) {
+        onAccountSelected(account)
+    }
+}

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/SelectAccountDialogFragment.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/SelectAccountDialogFragment.kt
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.identitycredential
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.concept.identitycredential.Account
+import mozilla.components.concept.identitycredential.Provider
+import mozilla.components.feature.prompts.R
+import mozilla.components.feature.prompts.dialog.KEY_PROMPT_UID
+import mozilla.components.feature.prompts.dialog.KEY_SESSION_ID
+import mozilla.components.feature.prompts.dialog.KEY_SHOULD_DISMISS_ON_LOAD
+import mozilla.components.feature.prompts.dialog.PromptDialogFragment
+import mozilla.components.support.utils.ext.getParcelableArrayListCompat
+import mozilla.components.ui.widgets.withCenterAlignedButtons
+
+private const val KEY_ACCOUNTS = "KEY_ACCOUNTS"
+
+/**
+ * A Federated Credential Management dialog for selecting an account.
+ */
+internal class SelectAccountDialogFragment : PromptDialogFragment() {
+    private lateinit var listAdapter: BasicAccountAdapter
+
+    internal val accounts: List<Account> by lazy {
+        safeArguments.getParcelableArrayListCompat(KEY_ACCOUNTS, Account::class.java) ?: emptyList()
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+        AlertDialog.Builder(requireContext())
+            .setCancelable(true)
+            .setTitle(R.string.mozac_feature_prompts_identity_credentials_choose_account)
+            .setView(createDialogContentView())
+            .create()
+            .withCenterAlignedButtons()
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        feature?.onCancel(sessionId, promptRequestUID)
+    }
+
+    @SuppressLint("InflateParams")
+    internal fun createDialogContentView(): View {
+        val view = LayoutInflater.from(requireContext())
+            .inflate(R.layout.mozac_feature_prompts_choose_identity_account_dialog, null)
+
+        setupRecyclerView(view)
+        return view
+    }
+
+    private fun setupRecyclerView(view: View) {
+        listAdapter = BasicAccountAdapter(this::onAccountChange)
+        view.findViewById<RecyclerView>(R.id.recyclerView).apply {
+            layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
+            adapter = listAdapter
+        }
+        listAdapter.submitList(accounts)
+    }
+
+    /**
+     * Called when a new [Provider] is selected by the user.
+     */
+    @VisibleForTesting
+    internal fun onAccountChange(account: Account) {
+        feature?.onConfirm(sessionId, promptRequestUID, account)
+        dismiss()
+    }
+
+    companion object {
+        fun newInstance(
+            sessionId: String,
+            promptRequestUID: String,
+            accounts: List<Account>,
+            shouldDismissOnLoad: Boolean,
+        ) = SelectAccountDialogFragment().apply {
+            arguments = (arguments ?: Bundle()).apply {
+                putString(KEY_SESSION_ID, sessionId)
+                putString(KEY_PROMPT_UID, promptRequestUID)
+                putBoolean(KEY_SHOULD_DISMISS_ON_LOAD, shouldDismissOnLoad)
+                putParcelableArrayList(KEY_ACCOUNTS, ArrayList(accounts))
+            }
+        }
+    }
+}

--- a/android-components/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_choose_identity_account_dialog.xml
+++ b/android-components/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_choose_identity_account_dialog.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.recyclerview.widget.RecyclerView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        tools:listitem="@layout/mozac_feature_prompts_color_item" />

--- a/android-components/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_identity_crendential_account_item.xml
+++ b/android-components/components/feature/prompts/src/main/res/layout/mozac_feature_prompts_identity_crendential_account_item.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/item"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/fedcm_account_icon"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:contentDescription="@string/mozac_feature_prompts_account_picture"/>
+
+    <TextView
+        android:id="@+id/fedcm_account_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toEndOf="@id/fedcm_account_icon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginStart="4dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:gravity="center_vertical|center_horizontal"
+        android:lines="1"
+        android:padding="8dp"
+        android:minHeight="?android:attr/listPreferredItemHeightLarge"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+        tools:text="rune-stellar-ambert.glitch.me" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-components/components/feature/prompts/src/main/res/values/strings.xml
+++ b/android-components/components/feature/prompts/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="mozac_feature_prompts_choose_a_color">Choose a color</string>
     <!-- Title of the Identity Credential provider dialog choose. -->
     <string name="mozac_feature_prompts_identity_credentials_choose_provider">Choose a login provider</string>
+    <!-- Title of an account picker dialog for identity credentials. -->
+    <string name="mozac_feature_prompts_identity_credentials_choose_account">Choose an account</string>
     <!-- Text of a confirm button in dialog requesting to open a new window. -->
     <string name="mozac_feature_prompts_allow">Allow</string>
     <!-- Text of a negative button in dialog requesting to open a new window. -->
@@ -130,4 +132,8 @@
     <string name="mozac_feature_prompts_collapse_address_content_description">Collapse suggested addresses</string>
     <!-- Text for the manage addresses button. -->
     <string name="mozac_feature_prompts_manage_address">Manage addresses</string>
+
+    <!-- Federated Credential Management prompts -->
+    <!--Content description for the Account picture in the Select Account FedCM prompt -->
+    <string name="mozac_feature_prompts_account_picture">Account picture</string>
 </resources>

--- a/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -6,9 +6,12 @@
 
 package mozilla.components.support.ktx.kotlin
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.InetAddresses
 import android.net.Uri
 import android.os.Build
+import android.util.Base64
 import android.util.Patterns
 import android.webkit.URLUtil
 import androidx.core.net.toUri
@@ -49,6 +52,9 @@ const val MAX_URI_LENGTH = 25000
 
 private const val FILE_PREFIX = "file://"
 private const val MAX_VALID_PORT = 65_535
+
+// Prefix for a valid image URI string
+private const val PNG_URI_PREFIX = "data:image/png;base64,"
 
 /**
  * Shortens URLs to be more user friendly.
@@ -404,4 +410,23 @@ fun String.last4Digits(): String {
  */
 fun String.trimmed(): String {
     return this.take(MAX_URI_LENGTH)
+}
+
+/**
+ * Returns a bitmap from the base64 representation of a PNG.
+ * Returns null if the string is not a valid base64 representation of a PNG
+ */
+fun String.base64PngToBitmap(): Bitmap? = base64ToBitmap(PNG_URI_PREFIX)
+
+/**
+ * Returns a bitmap from its base64 representation.
+ * Returns null if the string is not a valid base64 representation of a bitmap
+ * @param prefix the prefix expected for the string to be considered a valid base64 bitmap string
+ */
+private fun String.base64ToBitmap(prefix: String): Bitmap? {
+    if (!startsWith(prefix)) {
+        return null
+    }
+    val raw = Base64.decode(substring(PNG_URI_PREFIX.length), Base64.DEFAULT)
+    return BitmapFactory.decodeByteArray(raw, 0, raw.size)
 }

--- a/android-components/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/android-components/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Ignore
@@ -519,6 +520,18 @@ class StringTest {
         assertEquals("mozilla.org", ("m.mozilla.org").stripCommonSubdomains())
         assertEquals("mozilla.org", ("mobile.mozilla.org").stripCommonSubdomains())
         assertEquals("random.mozilla.org", ("random.mozilla.org").stripCommonSubdomains())
+    }
+
+    @Test
+    fun `given an invalid base64 image string when converting it into bitmap then the result is null`() {
+        val invalidBase64BitmapString = "aa"
+        assertNull(invalidBase64BitmapString.base64PngToBitmap())
+    }
+
+    @Test
+    fun `given a valid base64 png string when converting it into bitmap then the result is not null and no exception is thrown`() {
+        val validBase64BitmapString = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAABfGlDQ1BpY2MAACiRfZE9SMNAHMVfU0UpLQ52EFHIUJ0siIo4ahWKUCHUCq06mFz6BU0akhQXR8G14ODHYtXBxVlXB1dBEPwAcXF1UnSREv+XFFrEeHDcj3f3HnfvAKFRYZrVNQ5oum2mkwkxm1sVe14RwjDCiCEiM8uYk6QUfMfXPQJ8vYvzLP9zf46ImrcYEBCJZ5lh2sQbxNObtsF5nzjKSrJKfE48ZtIFiR+5rnj8xrnossAzo2YmPU8cJRaLHax0MCuZGvEUcUzVdMoXsh6rnLc4a5Uaa92TvzCc11eWuU5zCEksYgkSRCiooYwKbMRp1UmxkKb9hI9/0PVL5FLIVQYjxwKq0CC7fvA/+N2tVZic8JLCCaD7xXE+RoCeXaBZd5zvY8dpngDBZ+BKb/urDWDmk/R6W4sdAX3bwMV1W1P2gMsdYODJkE3ZlYI0hUIBeD+jb8oB/bdAaM3rrbWP0wcgQ12lboCDQ2C0SNnrPu/u7ezt3zOt/n4AYeJyoPRouWIAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAZQTFRF33Fi////EyzH0AAAAAF0Uk5ToeE3SxgAAAABYktHRAH/Ai3eAAAACXBIWXMAAA3XAAAN1wFCKJt4AAAAB3RJTUUH5wYVEDYOXZDMlQAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjMtMDYtMjFUMTY6NTQ6MDErMDA6MDAxTfjQAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDIzLTA2LTIxVDE2OjU0OjAxKzAwOjAwQBBAbAAAAABJRU5ErkJggg=="
+        assertNotNull(validBase64BitmapString.base64PngToBitmap())
     }
 
     private infix fun String.shortenedShouldBecome(expect: String) {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1836364