### PR TITLE
Bug 1837509 - Compose Top Sites should work with wallpapers

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesViewHolder.kt
@@ -8,10 +8,11 @@ import android.view.View
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.LifecycleOwner
-import mozilla.components.lib.state.ext.observeAsComposableState
+import mozilla.components.lib.state.ext.observeAsState
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
+import org.mozilla.fenix.wallpapers.WallpaperState
 
 /**
  * View holder for top sites.
@@ -30,11 +31,13 @@ class TopSitesViewHolder(
     @Composable
     override fun Content() {
         val topSites =
-            components.appStore.observeAsComposableState { state -> state.topSites }.value
-                ?: emptyList()
+            components.appStore.observeAsState(emptyList()) { state -> state.topSites }.value
+        val wallpaperState = components.appStore
+            .observeAsState(WallpaperState.default) { state -> state.wallpaperState }.value
 
         TopSites(
             topSites = topSites,
+            topSiteColors = TopSiteColors.colors(wallpaperState = wallpaperState),
             onTopSiteClick = { topSite ->
                 interactor.onSelectTopSite(topSite, topSites.indexOf(topSite))
             },


### PR DESCRIPTION
To test this with actual wallpapers in a debug build, you'll need to create a file `.wallpaper_url` file in the top-level of Fenix, and it should include the URL of the server as contents:

https://assets.mozilla.net/mobile-wallpapers/android


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1837509