### PR TITLE
Bug 1838485 - Refactor some firefox-android compiler option setting

### DIFF
--- a/android-components/build.gradle
+++ b/android-components/build.gradle
@@ -227,9 +227,6 @@ subprojects {
                 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
                     kotlinOptions {
                         jvmTarget = "17"
-                        freeCompilerArgs += [
-                            "-opt-in=kotlin.RequiresOptIn"
-                        ]
                     }
                 }
             }

--- a/android-components/build.gradle
+++ b/android-components/build.gradle
@@ -145,6 +145,12 @@ subprojects {
     }
 
     afterEvaluate {
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlin {
+                jvmToolchain(17)
+            }
+        }
+
         if (it.hasProperty('android')) {
             jacoco {
                 toolVersion = Versions.jacoco
@@ -219,15 +225,18 @@ subprojects {
                     ignoreAssetsPattern "manifest.template.json"
                 }
 
+                compileSdkVersion config.compileSdkVersion
+
+                defaultConfig {
+                    minSdkVersion config.minSdkVersion
+                    targetSdkVersion config.targetSdkVersion
+                }
+
+                // This shouldn't be needed anymore with AGP 8.1.0+
+                // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
                 compileOptions {
                     sourceCompatibility JavaVersion.VERSION_17
                     targetCompatibility JavaVersion.VERSION_17
-                }
-
-                tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-                    kotlinOptions {
-                        jvmTarget = "17"
-                    }
                 }
             }
 

--- a/android-components/components/browser/domains/build.gradle
+++ b/android-components/components/browser/domains/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/browser/engine-gecko/build.gradle
+++ b/android-components/components/browser/engine-gecko/build.gradle
@@ -23,11 +23,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/browser/engine-system/build.gradle
+++ b/android-components/components/browser/engine-system/build.gradle
@@ -6,11 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/browser/errorpages/build.gradle
+++ b/android-components/components/browser/errorpages/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/browser/icons/build.gradle
+++ b/android-components/components/browser/icons/build.gradle
@@ -6,11 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/browser/menu/build.gradle
+++ b/android-components/components/browser/menu/build.gradle
@@ -7,13 +7,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/browser/menu2/build.gradle
+++ b/android-components/components/browser/menu2/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/browser/session-storage/build.gradle
+++ b/android-components/components/browser/session-storage/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArgument "clearPackageData", "true"
         testInstrumentationRunnerArgument "listener", "leakcanary.FailTestOnLeakRunListener"

--- a/android-components/components/browser/state/build.gradle
+++ b/android-components/components/browser/state/build.gradle
@@ -7,12 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/browser/storage-sync/build.gradle
+++ b/android-components/components/browser/storage-sync/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/browser/tabstray/build.gradle
+++ b/android-components/components/browser/tabstray/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     lint {
         warningsAsErrors true
         abortOnError true

--- a/android-components/components/browser/thumbnails/build.gradle
+++ b/android-components/components/browser/thumbnails/build.gradle
@@ -6,11 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/browser/toolbar/build.gradle
+++ b/android-components/components/browser/toolbar/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/compose/awesomebar/build.gradle
+++ b/android-components/components/compose/awesomebar/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/compose/browser-toolbar/build.gradle
+++ b/android-components/components/compose/browser-toolbar/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/compose/cfr/build.gradle
+++ b/android-components/components/compose/cfr/build.gradle
@@ -6,11 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/compose/engine/build.gradle
+++ b/android-components/components/compose/engine/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/compose/tabstray/build.gradle
+++ b/android-components/components/compose/tabstray/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/concept/awesomebar/build.gradle
+++ b/android-components/components/concept/awesomebar/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/concept/base/build.gradle
+++ b/android-components/components/concept/base/build.gradle
@@ -7,12 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         buildConfigField("String", "LIBRARY_VERSION", "\"" + config.componentsVersion + "\"")
     }
 

--- a/android-components/components/concept/engine/build.gradle
+++ b/android-components/components/concept/engine/build.gradle
@@ -7,13 +7,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/concept/fetch/build.gradle
+++ b/android-components/components/concept/fetch/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         buildConfigField("String", "LIBRARY_VERSION", "\"" + config.componentsVersion + "\"")
     }
 

--- a/android-components/components/concept/menu/build.gradle
+++ b/android-components/components/concept/menu/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/concept/push/build.gradle
+++ b/android-components/components/concept/push/build.gradle
@@ -10,13 +10,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/concept/storage/build.gradle
+++ b/android-components/components/concept/storage/build.gradle
@@ -7,13 +7,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/concept/sync/build.gradle
+++ b/android-components/components/concept/sync/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/concept/tabstray/build.gradle
+++ b/android-components/components/concept/tabstray/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/concept/toolbar/build.gradle
+++ b/android-components/components/concept/toolbar/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/accounts-push/build.gradle
+++ b/android-components/components/feature/accounts-push/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/feature/accounts/build.gradle
+++ b/android-components/components/feature/accounts/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/addons/build.gradle
+++ b/android-components/components/feature/addons/build.gradle
@@ -9,12 +9,7 @@ apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         kapt {
             arguments {
                 arg("room.schemaLocation", "$projectDir/schemas".toString())

--- a/android-components/components/feature/app-links/build.gradle
+++ b/android-components/components/feature/app-links/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/feature/autofill/build.gradle
+++ b/android-components/components/feature/autofill/build.gradle
@@ -7,13 +7,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/awesomebar/build.gradle
+++ b/android-components/components/feature/awesomebar/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/containers/build.gradle
+++ b/android-components/components/feature/containers/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/feature/contextmenu/build.gradle
+++ b/android-components/components/feature/contextmenu/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/customtabs/build.gradle
+++ b/android-components/components/feature/customtabs/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/downloads/build.gradle
+++ b/android-components/components/feature/downloads/build.gradle
@@ -9,11 +9,7 @@ apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/feature/findinpage/build.gradle
+++ b/android-components/components/feature/findinpage/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/intent/build.gradle
+++ b/android-components/components/feature/intent/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/logins/build.gradle
+++ b/android-components/components/feature/logins/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/feature/media/build.gradle
+++ b/android-components/components/feature/media/build.gradle
@@ -6,11 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/feature/privatemode/build.gradle
+++ b/android-components/components/feature/privatemode/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/prompts/build.gradle
+++ b/android-components/components/feature/prompts/build.gradle
@@ -6,11 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/feature/push/build.gradle
+++ b/android-components/components/feature/push/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/pwa/build.gradle
+++ b/android-components/components/feature/pwa/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/feature/qr/build.gradle
+++ b/android-components/components/feature/qr/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/feature/readerview/build.gradle
+++ b/android-components/components/feature/readerview/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/recentlyclosed/build.gradle
+++ b/android-components/components/feature/recentlyclosed/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/feature/search/build.gradle
+++ b/android-components/components/feature/search/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/serviceworker/build.gradle
+++ b/android-components/components/feature/serviceworker/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/session/build.gradle
+++ b/android-components/components/feature/session/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/share/build.gradle
+++ b/android-components/components/feature/share/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/feature/sitepermissions/build.gradle
+++ b/android-components/components/feature/sitepermissions/build.gradle
@@ -9,11 +9,7 @@ apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/feature/syncedtabs/build.gradle
+++ b/android-components/components/feature/syncedtabs/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/feature/tab-collections/build.gradle
+++ b/android-components/components/feature/tab-collections/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/feature/tabs/build.gradle
+++ b/android-components/components/feature/tabs/build.gradle
@@ -7,13 +7,6 @@ apply plugin: 'kotlin-android'
 
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/toolbar/build.gradle
+++ b/android-components/components/feature/toolbar/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/top-sites/build.gradle
+++ b/android-components/components/feature/top-sites/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/feature/webauthn/build.gradle
+++ b/android-components/components/feature/webauthn/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/webcompat-reporter/build.gradle
+++ b/android-components/components/feature/webcompat-reporter/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/webcompat/build.gradle
+++ b/android-components/components/feature/webcompat/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/feature/webnotifications/build.gradle
+++ b/android-components/components/feature/webnotifications/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/lib/auth/build.gradle
+++ b/android-components/components/lib/auth/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/lib/crash-sentry/build.gradle
+++ b/android-components/components/lib/crash-sentry/build.gradle
@@ -6,14 +6,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
     }
 
     buildTypes {

--- a/android-components/components/lib/crash/build.gradle
+++ b/android-components/components/lib/crash/build.gradle
@@ -28,12 +28,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlinx-serialization'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         javaCompileOptions {

--- a/android-components/components/lib/dataprotect/build.gradle
+++ b/android-components/components/lib/dataprotect/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/lib/fetch-httpurlconnection/build.gradle
+++ b/android-components/components/lib/fetch-httpurlconnection/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/lib/fetch-okhttp/build.gradle
+++ b/android-components/components/lib/fetch-okhttp/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/lib/jexl/build.gradle
+++ b/android-components/components/lib/jexl/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/lib/publicsuffixlist/build.gradle
+++ b/android-components/components/lib/publicsuffixlist/build.gradle
@@ -11,12 +11,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'mozac.PublicSuffixListPlugin'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/lib/push-firebase/build.gradle
+++ b/android-components/components/lib/push-firebase/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/lib/state/build.gradle
+++ b/android-components/components/lib/state/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/service/contile/build.gradle
+++ b/android-components/components/service/contile/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/service/digitalassetlinks/build.gradle
+++ b/android-components/components/service/digitalassetlinks/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/service/firefox-accounts/build.gradle
+++ b/android-components/components/service/firefox-accounts/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     lint {
         warningsAsErrors true
         abortOnError true

--- a/android-components/components/service/glean/build.gradle
+++ b/android-components/components/service/glean/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/service/location/build.gradle
+++ b/android-components/components/service/location/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/service/nimbus/build.gradle
+++ b/android-components/components/service/nimbus/build.gradle
@@ -30,13 +30,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         debug {
             // Export experiments proguard rules even in debug since consuming apps may still

--- a/android-components/components/service/pocket/build.gradle
+++ b/android-components/components/service/pocket/build.gradle
@@ -7,11 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kapt {

--- a/android-components/components/service/sync-autofill/build.gradle
+++ b/android-components/components/service/sync-autofill/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/service/sync-logins/build.gradle
+++ b/android-components/components/service/sync-logins/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     lint {
         warningsAsErrors true
         abortOnError true

--- a/android-components/components/support/android-test/build.gradle
+++ b/android-components/components/support/android-test/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/support/base/build.gradle
+++ b/android-components/components/support/base/build.gradle
@@ -18,12 +18,7 @@ def getGitHash = { ->
 }
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         def appServicesVersion = ApplicationServicesConfig.version

--- a/android-components/components/support/images/build.gradle
+++ b/android-components/components/support/images/build.gradle
@@ -6,11 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/support/ktx/build.gradle
+++ b/android-components/components/support/ktx/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/support/license/build.gradle
+++ b/android-components/components/support/license/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/support/locale/build.gradle
+++ b/android-components/components/support/locale/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/support/rusterrors/build.gradle
+++ b/android-components/components/support/rusterrors/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     lint {
         warningsAsErrors true
         abortOnError true

--- a/android-components/components/support/rusthttp/build.gradle
+++ b/android-components/components/support/rusthttp/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     lint {
         warningsAsErrors true
         abortOnError true

--- a/android-components/components/support/rustlog/build.gradle
+++ b/android-components/components/support/rustlog/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     lint {
         warningsAsErrors true
         abortOnError true

--- a/android-components/components/support/test-appservices/build.gradle
+++ b/android-components/components/support/test-appservices/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/support/test-fakes/build.gradle
+++ b/android-components/components/support/test-fakes/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/support/test-libstate/build.gradle
+++ b/android-components/components/support/test-libstate/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/support/test/build.gradle
+++ b/android-components/components/support/test/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/support/utils/build.gradle
+++ b/android-components/components/support/utils/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/support/webextensions/build.gradle
+++ b/android-components/components/support/webextensions/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/tooling/detekt/build.gradle
+++ b/android-components/components/tooling/detekt/build.gradle
@@ -5,9 +5,6 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
-targetCompatibility = JavaVersion.VERSION_17
-sourceCompatibility = JavaVersion.VERSION_17
-
 dependencies {
     implementation ComponentsDependencies.tools_detekt_api
 

--- a/android-components/components/tooling/fetch-tests/build.gradle
+++ b/android-components/components/tooling/fetch-tests/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/tooling/lint/build.gradle
+++ b/android-components/components/tooling/lint/build.gradle
@@ -5,9 +5,6 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
-targetCompatibility = JavaVersion.VERSION_17
-sourceCompatibility = JavaVersion.VERSION_17
-
 dependencies {
   compileOnly ComponentsDependencies.tools_lintapi
   compileOnly ComponentsDependencies.tools_lintchecks
@@ -39,11 +36,5 @@ tasks.register("assembleAndroidTest") {
   doLast {
     // Do nothing. Like the `lint` task above this is just a dummy task so that this module
     // behaves like our others and we do not need to special case it in automation.
-  }
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-  kotlinOptions {
-    jvmTarget = "17"
   }
 }

--- a/android-components/components/ui/autocomplete/build.gradle
+++ b/android-components/components/ui/autocomplete/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/components/ui/colors/build.gradle
+++ b/android-components/components/ui/colors/build.gradle
@@ -6,13 +6,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/ui/fonts/build.gradle
+++ b/android-components/components/ui/fonts/build.gradle
@@ -5,13 +5,6 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/ui/icons/build.gradle
+++ b/android-components/components/ui/icons/build.gradle
@@ -5,13 +5,6 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/ui/tabcounter/build.gradle
+++ b/android-components/components/ui/tabcounter/build.gradle
@@ -7,13 +7,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/components/ui/widgets/build.gradle
+++ b/android-components/components/ui/widgets/build.gradle
@@ -6,12 +6,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android-components/gradle.properties
+++ b/android-components/gradle.properties
@@ -54,3 +54,7 @@ android.enableJetifier=false
 
 # Non-Transitive R Classes
 android.nonTransitiveRClass=true
+
+# Make JVM target version mismatches fatal.
+# Default setting for Gradle 8.0+
+kotlin.jvm.target.validation.mode=error

--- a/android-components/samples/browser/build.gradle
+++ b/android-components/samples/browser/build.gradle
@@ -6,12 +6,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
         applicationId "org.mozilla.samples.browser"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/android-components/samples/compose-browser/build.gradle
+++ b/android-components/samples/compose-browser/build.gradle
@@ -7,12 +7,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
         applicationId "org.mozilla.samples.compose.browser"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/android-components/samples/crash/build.gradle
+++ b/android-components/samples/crash/build.gradle
@@ -6,12 +6,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
         applicationId "org.mozilla.samples.crash"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/android-components/samples/dataprotect/build.gradle
+++ b/android-components/samples/dataprotect/build.gradle
@@ -2,13 +2,9 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
         applicationId "org.mozilla.samples.dataprotect"
 
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/android-components/samples/firefox-accounts/build.gradle
+++ b/android-components/samples/firefox-accounts/build.gradle
@@ -6,12 +6,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
         applicationId "org.mozilla.samples.fxa"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/android-components/samples/glean/build.gradle
+++ b/android-components/samples/glean/build.gradle
@@ -22,12 +22,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
         applicationId "org.mozilla.samples.glean"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/android-components/samples/glean/samples-glean-library/build.gradle
+++ b/android-components/samples/glean/samples-glean-library/build.gradle
@@ -22,13 +22,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false

--- a/android-components/samples/sync-logins/build.gradle
+++ b/android-components/samples/sync-logins/build.gradle
@@ -6,12 +6,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
         applicationId "org.mozilla.samples.sync.logins"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/android-components/samples/sync/build.gradle
+++ b/android-components/samples/sync/build.gradle
@@ -6,12 +6,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
         applicationId "org.mozilla.samples.sync"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/android-components/samples/toolbar/build.gradle
+++ b/android-components/samples/toolbar/build.gradle
@@ -6,12 +6,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     defaultConfig {
         applicationId "org.mozilla.samples.toolbar"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -23,8 +23,6 @@ import static org.gradle.api.tasks.testing.TestResult.ResultType
 apply from: 'benchmark.gradle'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     project.maybeConfigForJetpackBenchmark(it)
     if (project.hasProperty("testBuildType")) {
         // Allowing to configure the test build type via command line flag (./gradlew -PtestBuildType=beta ..)
@@ -34,8 +32,6 @@ android {
 
     defaultConfig {
         applicationId "org.mozilla"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 1
         versionName Config.generateDebugVersionName()
         vectorDrawables.useSupportLibrary = true
@@ -212,11 +208,6 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-
     lint {
         lintConfig file("lint.xml")
         baseline file("lint-baseline.xml")
@@ -227,7 +218,6 @@ android {
                          'META-INF/LICENSE.md', 'META-INF/LICENSE-notice.md']
         }
     }
-
 
     testOptions {
         unitTests.returnDefaultValues = true

--- a/fenix/benchmark/build.gradle
+++ b/fenix/benchmark/build.gradle
@@ -9,20 +9,9 @@ plugins {
 
 android {
     namespace 'org.mozilla.fenix.benchmark'
-    compileSdk config.compileSdkVersion
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
-    }
 
     defaultConfig {
         minSdk 23
-        targetSdk config.targetSdkVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/fenix/build.gradle
+++ b/fenix/build.gradle
@@ -165,9 +165,7 @@ allprojects {
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions.jvmTarget = "17"
         kotlinOptions.allWarningsAsErrors = true
-        kotlinOptions.freeCompilerArgs += [
-            "-opt-in=kotlin.RequiresOptIn", "-Xjvm-default=all"
-        ]
+        kotlinOptions.freeCompilerArgs += "-Xjvm-default=all"
     }
 }
 

--- a/fenix/build.gradle
+++ b/fenix/build.gradle
@@ -163,9 +163,37 @@ allprojects {
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-        kotlinOptions.jvmTarget = "17"
         kotlinOptions.allWarningsAsErrors = true
         kotlinOptions.freeCompilerArgs += "-Xjvm-default=all"
+    }
+}
+
+subprojects {
+    afterEvaluate {
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlin {
+                jvmToolchain(17)
+            }
+        }
+
+        if (it.hasProperty('android')) {
+            android {
+                compileSdkVersion config.compileSdkVersion
+
+                defaultConfig {
+                    // Allow benchmark/build.gradle to set a higher minSdkVersion
+                    if (!minSdkVersion) { minSdkVersion config.minSdkVersion }
+                    targetSdkVersion config.targetSdkVersion
+                }
+
+                // This shouldn't be needed anymore with AGP 8.1.0+
+                // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+                compileOptions {
+                    sourceCompatibility JavaVersion.VERSION_17
+                    targetCompatibility JavaVersion.VERSION_17
+                }
+            }
+        }
     }
 }
 

--- a/fenix/gradle.properties
+++ b/fenix/gradle.properties
@@ -27,3 +27,7 @@ libUrl=https://github.com/mozilla-mobile/firefox-android/tree/main/fenix
 libVcsUrl=https://github.com/mozilla-mobile/firefox-android.git
 libLicense=MPL-2.0
 libLicenseUrl=https://www.mozilla.org/en-US/MPL/2.0/
+
+# Make JVM target version mismatches fatal.
+# Default setting for Gradle 8.0+
+kotlin.jvm.target.validation.mode=error

--- a/fenix/mozilla-lint-rules/build.gradle
+++ b/fenix/mozilla-lint-rules/build.gradle
@@ -5,9 +5,6 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 
-targetCompatibility = JavaVersion.VERSION_17
-sourceCompatibility = JavaVersion.VERSION_17
-
 repositories {
     if (project.hasProperty("centralRepo")) {
         maven {

--- a/fenix/mozilla-lint-rules/build.gradle
+++ b/fenix/mozilla-lint-rules/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     compileOnly "com.android.tools.lint:lint-api:${Versions.lint}"
     compileOnly "com.android.tools.lint:lint-checks:${Versions.lint}"
 
-    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${FenixVersions.junit}"
     testImplementation "com.android.tools.lint:lint:${Versions.lint}"
     testImplementation "com.android.tools.lint:lint-tests:${Versions.lint}"
 }

--- a/focus-android/app/build.gradle
+++ b/focus-android/app/build.gradle
@@ -13,8 +13,6 @@ import com.android.build.OutputFile
 import groovy.json.JsonOutput
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
     if (project.hasProperty("testBuildType")) {
         // Allowing to configure the test build type via command line flag (./gradlew -PtestBuildType=beta ..)
         // in order to run UI tests against other build variants than debug in automation.
@@ -23,8 +21,6 @@ android {
 
     defaultConfig {
         applicationId "org.mozilla"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
         versionCode 11 // This versionCode is "frozen" for local builds. For "release" builds we
                        // override this with a generated versionCode at build time.
         // The versionName is dynamically overridden for all the build variants at build time.
@@ -35,11 +31,6 @@ android {
         buildConfigField "String", "GIT_HASH", "\"\""
 
         vectorDrawables.useSupportLibrary = true
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
     }
 
     lint {
@@ -172,7 +163,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
             allWarningsAsErrors = true
             freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
             freeCompilerArgs += "-Xjvm-default=all"
-            jvmTarget = '11'
         }
 }
 

--- a/focus-android/app/build.gradle
+++ b/focus-android/app/build.gradle
@@ -171,7 +171,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
             allWarningsAsErrors = true
             freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
-            freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
             freeCompilerArgs += "-Xjvm-default=all"
             jvmTarget = '11'
         }

--- a/focus-android/build.gradle
+++ b/focus-android/build.gradle
@@ -103,6 +103,34 @@ allprojects {
     }
 }
 
+subprojects {
+    afterEvaluate {
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlin {
+                jvmToolchain(17)
+            }
+        }
+
+        if (it.hasProperty('android')) {
+            android {
+                compileSdkVersion config.compileSdkVersion
+
+                defaultConfig {
+                    minSdkVersion config.minSdkVersion
+                    targetSdkVersion config.targetSdkVersion
+                }
+
+                // This shouldn't be needed anymore with AGP 8.1.0+
+                // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+                compileOptions {
+                    sourceCompatibility JavaVersion.VERSION_17
+                    targetCompatibility JavaVersion.VERSION_17
+                }
+            }
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/focus-android/gradle.properties
+++ b/focus-android/gradle.properties
@@ -25,3 +25,7 @@ libUrl=https://github.com/mozilla-mobile/firefox-android/tree/main/focus-android
 libVcsUrl=https://github.com/mozilla-mobile/firefox-android.git
 libLicense=MPL-2.0
 libLicenseUrl=https://www.mozilla.org/en-US/MPL/2.0/
+
+# Make JVM target version mismatches fatal.
+# Default setting for Gradle 8.0+
+kotlin.jvm.target.validation.mode=error

--- a/focus-android/service-telemetry/build.gradle
+++ b/focus-android/service-telemetry/build.gradle
@@ -6,25 +6,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion config.compileSdkVersion
-
-    defaultConfig {
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-    }
-
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '11'
     }
 
     namespace 'org.mozilla.telemetry'


### PR DESCRIPTION
See the bug for some details on this. Overall, this should lead to more consistent setting of the various compiler options we use and reduce boilplate code in various build.gradle files. We could probably move more setting into the new top-level subprojects blocks if this approach looks good.
https://bugzilla.mozilla.org/show_bug.cgi?id=1838485
https://bugzilla.mozilla.org/show_bug.cgi?id=1838485
https://bugzilla.mozilla.org/show_bug.cgi?id=1838485
https://bugzilla.mozilla.org/show_bug.cgi?id=1838485
https://bugzilla.mozilla.org/show_bug.cgi?id=1838485