### PR TITLE
Bug 1838547 - Disable verifyPocketHomepageStoriesTest for investigation

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -142,6 +143,7 @@ class HomeScreenTest {
         }
     }
 
+    @Ignore("Failing: https://bugzilla.mozilla.org/show_bug.cgi?id=1838547")
     @Test
     fun verifyPocketHomepageStoriesTest() {
         activityTestRule.activityRule.applySettingsExceptions {


### PR DESCRIPTION
Started failing in [matrix](https://console.firebase.google.com/u/0/project/moz-fenix/testlab/histories/bh.66b7091e15d53d45/matrices/7391707890175752810/details?stepId=bs.d2d35d93aed94e62&testCaseId=5)  

https://treeherder.mozilla.org/jobs?repo=firefox-android&revision=bf5d9578c342fd7cf0c9c60ea820e28793aa971d

Possible erroneous data from Pocket? Needs investigation 

```
java.lang.AssertionError: Pocket story item at position 8 not found.
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.mozilla.fenix.ui.robots.HomeScreenRobot.verifyPocketSponsoredStoriesItems(HomeScreenRobot.kt:419)
	at org.mozilla.fenix.ui.HomeScreenTest$verifyPocketHomepageStoriesTest$3.invoke(HomeScreenTest.kt:159)
	at org.mozilla.fenix.ui.HomeScreenTest$verifyPocketHomepageStoriesTest$3.invoke(HomeScreenTest.kt:155)
	at org.mozilla.fenix.ui.robots.HomeScreenRobotKt.homeScreen(HomeScreenRobot.kt:886)
	at org.mozilla.fenix.ui.HomeScreenTest.verifyPocketHomepageStoriesTest(HomeScreenTest.kt:155)
```