### PR TITLE
Bug 1838569 – added a nimbus flag for splash screen duration

### DIFF
--- a/fenix/app/.experimenter.yaml
+++ b/fenix/app/.experimenter.yaml
@@ -147,6 +147,14 @@ search-term-groups:
     enabled:
       type: boolean
       description: "If true, the feature shows up on the homescreen and on the new tab screen."
+splash-screen:
+  description: A feature that sets maximum duration for the splash screen during the first launch.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    maximum_duration:
+      type: int
+      description: The maximum amount of time the splashscreen will be visible while waiting for initialization calls to complete.
 toolbar:
   description: The searchbar/awesomebar that user uses to search.
   hasExposure: true

--- a/fenix/app/nimbus.fml.yaml
+++ b/fenix/app/nimbus.fml.yaml
@@ -318,6 +318,14 @@ features:
         type: Map<String, Boolean>
         default: {}
 
+  splash-screen:
+    description: "A feature that sets maximum duration for the splash screen during the first launch."
+    variables:
+      maximum_duration:
+        description: The maximum amount of time the splashscreen will be visible while waiting for initialization calls to complete.
+        type: Int
+        default: 0
+
 types:
   objects: {}
 

--- a/taskcluster/android_taskgraph/transforms/push_apk.py
+++ b/taskcluster/android_taskgraph/transforms/push_apk.py
@@ -34,3 +34,13 @@ def resolve_keys(config, tasks):
                 }
             )
         yield task
+
+
+@transforms.add
+def add_startup_test(config, tasks):
+    for task in tasks:
+        if "nightly" not in task["attributes"].get("build-type", ""):
+            yield task
+            continue
+        task["dependencies"]["startup-test"] = "startup-test-nightly-arm"
+        yield task

--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -13,6 +13,7 @@ transforms:
 
 kind-dependencies:
     - signing-apk
+    - startup-test
 
 primary-dependency: signing-apk
 

--- a/taskcluster/ci/startup-test/kind.yml
+++ b/taskcluster/ci/startup-test/kind.yml
@@ -13,7 +13,7 @@ task-defaults:
     treeherder:
         kind: test
         platform: 'nightly-start-test/opt'
-        tier: 2
+        tier: 1
     worker-type: b-android
     worker:
         docker-image: {in-tree: ui-tests}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1838231