### PR TITLE
Bug 1837006 - Make the add to collection button follow existing disabled icon designs when disabled

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.tabstray.browser
 
 import android.content.Context
 import android.view.View
+import android.widget.ImageButton
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -53,7 +54,7 @@ class SelectionBannerBinding(
     class VisibilityModifier(vararg val views: View)
 
     private var isPreviousModeSelect = false
-
+    private var collectImageButton: ImageButton? = null
     override fun start() {
         super.start()
 
@@ -79,6 +80,8 @@ class SelectionBannerBinding(
                 updateSelectTitle(isSelectMode, mode.selectedTabs.size)
 
                 isPreviousModeSelect = isSelectMode
+
+                updateCollectionButtonColor(mode.selectedTabs.size)
             }
     }
 
@@ -89,6 +92,7 @@ class SelectionBannerBinding(
             interactor.onShareSelectedTabs()
         }
 
+        collectImageButton = tabsTrayMultiselectItemsBinding.collectMultiSelect
         tabsTrayMultiselectItemsBinding.collectMultiSelect.setOnClickListener {
             if (store.state.mode.selectedTabs.isNotEmpty()) {
                 interactor.onAddSelectedTabsToCollectionClicked()
@@ -122,6 +126,14 @@ class SelectionBannerBinding(
             val color = ContextCompat.getColor(backgroundView.context, colorResource)
 
             backgroundView.setBackgroundColor(color)
+        }
+    }
+
+    private fun updateCollectionButtonColor(tabCount: Int) {
+        if (tabCount == 0) {
+            collectImageButton?.setColorFilter(R.color.fx_mobile_icon_color_disabled)
+        } else {
+            collectImageButton?.colorFilter = null
         }
     }
 


### PR DESCRIPTION
### What
The PR makes the `add to collection button` follow existing 'disabled' icon designs when disabled.

### Steps to test

**Method 1**
1. Have at least one tab open
2. Open the tabs tray.
3. Tap the 3dot menu button.
4. Tap the "Select tabs" button.
5. Check the "Save tabs to collection" button


### Screenshots
| Issue | Fix |
| ----- | --- |
|https://www.loom.com/share/01b3a2ae047049dba8ce74cdfa511bb6 | https://www.loom.com/share/999c09227ecb4d97b6ebd44d92d87158 |

### Pull Request checklist
 - [x] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1837006