### PR TITLE
Bug 1837504 - Display undo snackbar when compose top site is removed

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -52,6 +52,7 @@ import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.feature.tab.collections.TabCollection
+import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.feature.top.sites.TopSitesConfig
 import mozilla.components.feature.top.sites.TopSitesFeature
 import mozilla.components.feature.top.sites.TopSitesFrecencyConfig
@@ -351,6 +352,7 @@ class HomeFragment : Fragment() {
                 viewLifecycleScope = viewLifecycleOwner.lifecycleScope,
                 registerCollectionStorageObserver = ::registerCollectionStorageObserver,
                 removeCollectionWithUndo = ::removeCollectionWithUndo,
+                showUndoSnackbarForTopSite = ::showUndoSnackbarForTopSite,
                 showTabTray = ::openTabsTray,
             ),
             recentTabController = DefaultRecentTabsController(
@@ -458,6 +460,24 @@ class HomeFragment : Fragment() {
                     }
                 },
             ),
+        )
+    }
+
+    @VisibleForTesting
+    internal fun showUndoSnackbarForTopSite(topSite: TopSite) {
+        lifecycleScope.allowUndo(
+            view = requireView(),
+            message = getString(R.string.snackbar_top_site_removed),
+            undoActionTitle = getString(R.string.snackbar_deleted_undo),
+            onCancel = {
+                requireComponents.useCases.topSitesUseCase.addPinnedSites(
+                    topSite.title.toString(),
+                    topSite.url,
+                )
+            },
+            operation = { },
+            elevation = TOAST_ELEVATION,
+            paddedForBottomToolbar = true,
         )
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -193,6 +193,7 @@ class DefaultSessionControlController(
     private val viewLifecycleScope: CoroutineScope,
     private val registerCollectionStorageObserver: () -> Unit,
     private val removeCollectionWithUndo: (tabCollection: TabCollection) -> Unit,
+    private val showUndoSnackbarForTopSite: (topSite: TopSite) -> Unit,
     private val showTabTray: () -> Unit,
 ) : SessionControlController {
 
@@ -332,6 +333,8 @@ class DefaultSessionControlController(
                 removeTopSites(topSite)
             }
         }
+
+        showUndoSnackbarForTopSite(topSite)
     }
 
     override fun handleRenameCollectionTapped(collection: TabCollection) {

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -868,6 +868,28 @@ class DefaultSessionControlControllerTest {
     }
 
     @Test
+    fun `WHEN top site is removed THEN the undo snackbar is called`() {
+        val mozillaTopSite = TopSite.Default(
+            id = 1L,
+            title = "Mozilla",
+            url = "https://mozilla.org",
+            null,
+        )
+        var undoSnackbarCalled = false
+        var undoSnackbarShownFor = "TopSiteName"
+
+        createController(
+            showUndoSnackbarForTopSite = { topSite ->
+                undoSnackbarCalled = true
+                undoSnackbarShownFor = topSite.title.toString()
+            },
+        ).handleRemoveTopSiteClicked(mozillaTopSite)
+
+        assertEquals(true, undoSnackbarCalled)
+        assertEquals("Mozilla", undoSnackbarShownFor)
+    }
+
+    @Test
     fun `GIVEN exactly the required amount of downloaded thumbnails with no errors WHEN handling wallpaper dialog THEN dialog is shown`() {
         val wallpaperState = WallpaperState.default.copy(
             availableWallpapers = makeFakeRemoteWallpapers(
@@ -1142,6 +1164,7 @@ class DefaultSessionControlControllerTest {
         registerCollectionStorageObserver: () -> Unit = { },
         showTabTray: () -> Unit = { },
         removeCollectionWithUndo: (tabCollection: TabCollection) -> Unit = { },
+        showUndoSnackbarForTopSite: (topSite: TopSite) -> Unit = { },
     ): DefaultSessionControlController {
         return DefaultSessionControlController(
             activity = activity,
@@ -1159,6 +1182,7 @@ class DefaultSessionControlControllerTest {
             viewLifecycleScope = scope,
             registerCollectionStorageObserver = registerCollectionStorageObserver,
             removeCollectionWithUndo = removeCollectionWithUndo,
+            showUndoSnackbarForTopSite = showUndoSnackbarForTopSite,
             showTabTray = showTabTray,
         )
     }


### PR DESCRIPTION
This patch aims to reimplement the previous behavior upon removing a pinned top site when a snackbar was shown giving the option to undo the removal.


https://github.com/mozilla-mobile/firefox-android/assets/32488956/fab2d4b5-15e2-4b68-acb3-012a32fef67c



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1837504