### PR TITLE
Bug 1838662 - cleanup push-apk.py in firefox-android

### DIFF
--- a/taskcluster/android_taskgraph/transforms/push_apk.py
+++ b/taskcluster/android_taskgraph/transforms/push_apk.py
@@ -42,7 +42,6 @@ def add_startup_test(config, tasks):
         if "nightly" not in task["attributes"].get("build-type", ""):
             yield task
             continue
-        task["dependencies"]["startup-test"] = "startup-test-nightly-arm"
         for dep_label, dep_task in config.kind_dependencies_tasks.items():
             if dep_task.kind == "startup-test" and dep_task.attributes['shipping-product'] == task['attributes']['shipping-product']:
                 task["dependencies"]["startup-test"] = dep_label


### PR DESCRIPTION
https://github.com/mozilla-mobile/firefox-android/blob/348dc4badab80135f016076eb7c071d478afc96d/taskcluster/android_taskgraph/transforms/push_apk.py#L45 is not needed as it is replaced in https://github.com/mozilla-mobile/firefox-android/blob/348dc4badab80135f016076eb7c071d478afc96d/taskcluster/android_taskgraph/transforms/push_apk.py#L48 as the `startup-test` config has a Fenix and Focus task in it now and those tasks are new/renamed.
https://bugzilla.mozilla.org/show_bug.cgi?id=1838662