### PR TITLE
Bug 1838657 - PlacesApiException.UnexpectedPlacesException should no …

### DIFF
--- a/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesStorageTest.kt
+++ b/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesStorageTest.kt
@@ -44,6 +44,17 @@ class PlacesStorageTest {
     }
 
     @Test
+    fun `WHEN an unexpected places exception is thrown it is consumed`() {
+        doAnswer {
+            throw PlacesApiException.UnexpectedPlacesException("This should be caught")
+        }.`when`(storage.writer).interrupt()
+
+        storage.interruptCurrentWrites()
+
+        verify(storage.writer).interrupt()
+    }
+
+    @Test
     fun `WHEN a call is made to clean all reads THEN they are cancelled`() {
         storage.readScope = mock {
             doReturn(mock<CoroutineContext>()).`when`(this).coroutineContext


### PR DESCRIPTION
…longer cause the browser to crash

Anything else we need to do here? Existing tests seem to pass.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1838657