### PR TITLE
Bug 1838512 - Fix detekt issue from moving Browsers Cache utility into Android Components

### DIFF
--- a/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/BrowsersCache.kt
+++ b/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/BrowsersCache.kt
@@ -25,6 +25,10 @@ object BrowsersCache {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal var cachedBrowsers: Browsers? = null
 
+    /**
+     * Return installed browsers if cache exist.  If not, Collect information about all installed
+     * browsers and return a [Browsers] object containing that data.
+     */
     @Synchronized
     fun all(context: Context): Browsers {
         run {
@@ -38,6 +42,9 @@ object BrowsersCache {
         }
     }
 
+    /**
+     * Remove installed browsers cache
+     */
     @Synchronized
     fun resetAll() {
         cachedBrowsers = null

--- a/fenix/detekt-baseline.xml
+++ b/fenix/detekt-baseline.xml
@@ -557,8 +557,6 @@
     <ID>UndocumentedPublicFunction:BrowserToolbarView.kt$BrowserToolbarView$fun collapse()</ID>
     <ID>UndocumentedPublicFunction:BrowserToolbarView.kt$BrowserToolbarView$fun dismissMenu()</ID>
     <ID>UndocumentedPublicFunction:BrowserToolbarView.kt$BrowserToolbarView$fun expand()</ID>
-    <ID>UndocumentedPublicFunction:BrowsersCache.kt$BrowsersCache$@Synchronized fun all(context: Context): Browsers</ID>
-    <ID>UndocumentedPublicFunction:BrowsersCache.kt$BrowsersCache$@Synchronized fun resetAll()</ID>
     <ID>UndocumentedPublicFunction:ClearSiteDataView.kt$ClearSiteDataView$fun update(webInfoState: WebsiteInfoState)</ID>
     <ID>UndocumentedPublicFunction:ClearableEditText.kt$ClearableEditText$fun onTextChanged(text: CharSequence?)</ID>
     <ID>UndocumentedPublicFunction:ColdStartupDurationTelemetry.kt$ColdStartupDurationTelemetry$fun onHomeActivityOnCreate( visualCompletenessQueue: VisualCompletenessQueue, startupStateProvider: StartupStateProvider, safeIntent: SafeIntent, rootContainer: View, )</ID>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1838512