### PR TITLE
Bug 1833960 - Use Browsers Cache utility in App Links

### DIFF
--- a/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
+++ b/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
@@ -16,6 +16,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import mozilla.components.support.utils.Browsers
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -237,7 +238,9 @@ class AppLinksUseCasesTest {
     @Test
     fun `WHEN A URL that matches a browser AND the scheme is not supported THEN is an app link`() {
         val context = createContext(Triple(browserSchemeUrl, browserPackage, ""))
-        val subject = AppLinksUseCases(context, { true })
+        val browsers: Browsers = mock()
+        whenever(browsers.isInstalled(browserPackage)).thenReturn(true)
+        val subject = AppLinksUseCases(context = context, launchInApp = { true }, installedBrowsers = browsers)
 
         val redirect = subject.interceptedAppLinkRedirect(browserSchemeUrl)
         assertTrue(redirect.isRedirect())
@@ -249,7 +252,9 @@ class AppLinksUseCasesTest {
     @Test
     fun `WHEN A URL that matches a browser AND the scheme is supported THEN is not an app link`() {
         val context = createContext(Triple(appUrl, browserPackage, ""))
-        val subject = AppLinksUseCases(context, { true })
+        val browsers: Browsers = mock()
+        whenever(browsers.isInstalled(browserPackage)).thenReturn(true)
+        val subject = AppLinksUseCases(context = context, launchInApp = { true }, installedBrowsers = browsers)
 
         val redirect = subject.interceptedAppLinkRedirect(appUrl)
         assertFalse(redirect.isRedirect())

--- a/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/Browsers.kt
+++ b/android-components/components/support/utils/src/main/java/mozilla/components/support/utils/Browsers.kt
@@ -195,6 +195,13 @@ class Browsers private constructor(
     }
 
     /**
+     * Does this device have browser with [packageName] installed?
+     */
+    fun isInstalled(packageName: String): Boolean {
+        return browsers.containsKey(packageName)
+    }
+
+    /**
      * Is **this** application the default browser?
      */
     val isDefaultBrowser: Boolean = defaultBrowser != null && packageName == defaultBrowser.packageName

--- a/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/BrowsersTest.kt
+++ b/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/BrowsersTest.kt
@@ -105,6 +105,18 @@ class BrowsersTest {
         assertFalse(browsers.isInstalled(Browsers.KnownBrowser.FIREFOX_BETA))
         assertFalse(browsers.isInstalled(Browsers.KnownBrowser.ANDROID_STOCK_BROWSER))
         assertFalse(browsers.isInstalled(Browsers.KnownBrowser.UC_BROWSER))
+
+        assertTrue(browsers.isInstalled(Browsers.KnownBrowser.REFERENCE_BROWSER.packageName))
+        assertTrue(browsers.isInstalled(Browsers.KnownBrowser.FIREFOX_NIGHTLY.packageName))
+        assertTrue(browsers.isInstalled(Browsers.KnownBrowser.FIREFOX.packageName))
+        assertTrue(browsers.isInstalled(Browsers.KnownBrowser.CHROME.packageName))
+        assertTrue(browsers.isInstalled(Browsers.KnownBrowser.REFERENCE_BROWSER.packageName))
+        assertTrue(browsers.isInstalled(Browsers.KnownBrowser.DUCKDUCKGO.packageName))
+
+        assertFalse(browsers.isInstalled(Browsers.KnownBrowser.CHROME_BETA.packageName))
+        assertFalse(browsers.isInstalled(Browsers.KnownBrowser.FIREFOX_BETA.packageName))
+        assertFalse(browsers.isInstalled(Browsers.KnownBrowser.ANDROID_STOCK_BROWSER.packageName))
+        assertFalse(browsers.isInstalled(Browsers.KnownBrowser.UC_BROWSER.packageName))
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1833960