### PR TITLE
Bug 1839443 - Adds Recently closed tabs UI tests coverage

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -335,30 +335,6 @@ class HistoryTest {
         }
     }
 
-    // This test verifies the Recently Closed Tabs List and items
-    @Test
-    fun verifyRecentlyClosedTabsListTest() {
-        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen {
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(website.url) {
-            mDevice.waitForIdle()
-        }.openTabDrawer {
-            closeTab()
-        }.openTabDrawer {
-        }.openRecentlyClosedTabs {
-            waitForListToExist()
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1),
-            ) {
-                verifyRecentlyClosedTabsMenuView()
-            }
-            verifyRecentlyClosedTabsPageTitle("Test_Page_1")
-            verifyRecentlyClosedTabsUrl(website.url)
-        }
-    }
-
     @Test
     fun verifySearchHistoryViewTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -56,6 +56,7 @@ class PwaTest {
         }
     }
 
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1807275")
     @SmokeTest
     @Test
     fun emailLinkPWATest() {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/RecentlyClosedTabsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/RecentlyClosedTabsTest.kt
@@ -1,0 +1,291 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
+
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
+import androidx.test.espresso.intent.Intents
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.R
+import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
+import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
+import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
+import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
+import org.mozilla.fenix.ui.robots.browserScreen
+import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.navigationToolbar
+
+/**
+ *  Tests for verifying basic functionality of recently closed tabs history
+ *
+ */
+class RecentlyClosedTabsTest {
+    private lateinit var mockWebServer: MockWebServer
+
+    @get:Rule
+    val activityTestRule = AndroidComposeTestRule(
+        HomeActivityTestRule.withDefaultSettingsOverrides(
+            tabsTrayRewriteEnabled = true,
+        ),
+    ) { it.activity }
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+
+        Intents.init()
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    // This test verifies the Recently Closed Tabs List and items
+    @Test
+    fun verifyRecentlyClosedTabsListTest() {
+        val website = getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openComposeTabDrawer(activityTestRule) {
+            closeTab()
+        }
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openHistory {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(
+                    activityTestRule.activity.findViewById(R.id.recently_closed_list),
+                    1,
+                ),
+            ) {
+                verifyRecentlyClosedTabsMenuView()
+            }
+            verifyRecentlyClosedTabsPageTitle("Test_Page_1")
+            verifyRecentlyClosedTabsUrl(website.url)
+        }
+    }
+
+    // Verifies that a recently closed item is properly opened
+    @SmokeTest
+    @Test
+    fun openRecentlyClosedItemTest() {
+        val website = getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openComposeTabDrawer(activityTestRule) {
+            closeTab()
+        }
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openHistory {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1),
+            ) {
+                verifyRecentlyClosedTabsMenuView()
+            }
+        }.clickRecentlyClosedItem("Test_Page_1") {
+            verifyUrl(website.url.toString())
+        }
+    }
+
+    // Verifies that tapping the "x" button removes a recently closed item from the list
+    @SmokeTest
+    @Test
+    fun deleteRecentlyClosedTabsItemTest() {
+        val website = getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openComposeTabDrawer(activityTestRule) {
+            closeTab()
+        }
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openHistory {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1),
+            ) {
+                verifyRecentlyClosedTabsMenuView()
+            }
+            clickDeleteRecentlyClosedTabs()
+            verifyEmptyRecentlyClosedTabsList()
+        }
+    }
+
+    @Test
+    fun openInNewTabRecentlyClosedTabsTest() {
+        val firstPage = getGenericAsset(mockWebServer, 1)
+        val secondPage = getGenericAsset(mockWebServer, 2)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstPage.url) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openNewTab {
+        }.submitQuery(secondPage.url.toString()) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openThreeDotMenu {
+        }.closeAllTabs {
+        }.openThreeDotMenu {
+        }.openHistory {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            longTapSelectItem(firstPage.url)
+            longTapSelectItem(secondPage.url)
+            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+        }.clickOpenInNewTab(activityTestRule) {
+            // URL verification to be removed once https://bugzilla.mozilla.org/show_bug.cgi?id=1839179 is fixed.
+            browserScreen {
+                verifyPageContent(secondPage.content)
+                verifyUrl(secondPage.url.toString())
+            }.openComposeTabDrawer(activityTestRule) {
+                verifyNormalBrowsingButtonIsSelected(true)
+                verifyExistingOpenTabs(firstPage.title, secondPage.title)
+            }
+        }
+    }
+
+    @Test
+    fun openInPrivateTabRecentlyClosedTabsTest() {
+        val firstPage = getGenericAsset(mockWebServer, 1)
+        val secondPage = getGenericAsset(mockWebServer, 2)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstPage.url) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openNewTab {
+        }.submitQuery(secondPage.url.toString()) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openThreeDotMenu {
+        }.closeAllTabs {
+        }.openThreeDotMenu {
+        }.openHistory {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            longTapSelectItem(firstPage.url)
+            longTapSelectItem(secondPage.url)
+            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+        }.clickOpenInPrivateTab(activityTestRule) {
+            // URL verification to be removed once https://bugzilla.mozilla.org/show_bug.cgi?id=1839179 is fixed.
+            browserScreen {
+                verifyPageContent(secondPage.content)
+                verifyUrl(secondPage.url.toString())
+            }.openComposeTabDrawer(activityTestRule) {
+                verifyPrivateBrowsingButtonIsSelected(true)
+                verifyExistingOpenTabs(firstPage.title, secondPage.title)
+            }
+        }
+    }
+
+    @Test
+    fun shareMultipleRecentlyClosedTabsTest() {
+        val firstPage = getGenericAsset(mockWebServer, 1)
+        val secondPage = getGenericAsset(mockWebServer, 2)
+        val sharingApp = "Gmail"
+        val urlString = "${firstPage.url}\n\n${secondPage.url}"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstPage.url) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openNewTab {
+        }.submitQuery(secondPage.url.toString()) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openThreeDotMenu {
+        }.closeAllTabs {
+        }.openThreeDotMenu {
+        }.openHistory {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            longTapSelectItem(firstPage.url)
+            longTapSelectItem(secondPage.url)
+        }.clickShare {
+            verifyShareTabsOverlay(firstPage.title, secondPage.title)
+            verifySharingWithSelectedApp(sharingApp, urlString, "${firstPage.title}, ${secondPage.title}")
+        }
+    }
+
+    @Test
+    fun privateBrowsingNotSavedInRecentlyClosedTabsTest() {
+        val firstPage = getGenericAsset(mockWebServer, 1)
+        val secondPage = getGenericAsset(mockWebServer, 2)
+
+        homeScreen {}.togglePrivateBrowsingMode()
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstPage.url) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openNewTab {
+        }.submitQuery(secondPage.url.toString()) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openThreeDotMenu {
+        }.closeAllTabs {
+        }.openThreeDotMenu {
+        }.openHistory {
+        }.openRecentlyClosedTabs {
+            verifyEmptyRecentlyClosedTabsList()
+        }
+    }
+
+    @Test
+    fun deleteHistoryClearsRecentlyClosedTabsListTest() {
+        val firstPage = getGenericAsset(mockWebServer, 1)
+        val secondPage = getGenericAsset(mockWebServer, 2)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstPage.url) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openNewTab {
+        }.submitQuery(secondPage.url.toString()) {
+            waitForPageToLoad()
+        }.openComposeTabDrawer(activityTestRule) {
+        }.openThreeDotMenu {
+        }.closeAllTabs {
+        }.openThreeDotMenu {
+        }.openHistory {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+        }.goBackToHistoryMenu {
+            clickDeleteAllHistoryButton()
+            selectEverythingOption()
+            confirmDeleteAllHistory()
+            verifyEmptyHistoryView()
+        }.openRecentlyClosedTabs {
+            verifyEmptyRecentlyClosedTabsList()
+        }
+    }
+}

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -26,7 +26,6 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
-import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.assertYoutubeAppOpens
@@ -146,54 +145,6 @@ class SmokeTest {
             }.submitQuery("mozilla ") {
                 verifyUrl(searchEngine)
             }.goToHomescreen { }
-        }
-    }
-
-    // Verifies that a recently closed item is properly opened
-    @Test
-    fun openRecentlyClosedItemTest() {
-        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen {
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(website.url) {
-            mDevice.waitForIdle()
-        }.openTabDrawer {
-            closeTab()
-        }.openTabDrawer {
-        }.openRecentlyClosedTabs {
-            waitForListToExist()
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1),
-            ) {
-                verifyRecentlyClosedTabsMenuView()
-            }
-        }.clickRecentlyClosedItem("Test_Page_1") {
-            verifyUrl(website.url.toString())
-        }
-    }
-
-    // Verifies that tapping the "x" button removes a recently closed item from the list
-    @Test
-    fun deleteRecentlyClosedTabsItemTest() {
-        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen {
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(website.url) {
-            mDevice.waitForIdle()
-        }.openTabDrawer {
-            closeTab()
-        }.openTabDrawer {
-        }.openRecentlyClosedTabs {
-            waitForListToExist()
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1),
-            ) {
-                verifyRecentlyClosedTabsMenuView()
-            }
-            clickDeleteRecentlyClosedTabs()
-            verifyEmptyRecentlyClosedTabsList()
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
@@ -190,10 +190,10 @@ class ComposeTabDrawerRobot(private val composeTestRule: HomeActivityComposeTest
             return Transition(composeTestRule)
         }
 
-        fun closeAllTabs(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+        fun closeAllTabs(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
             composeTestRule.dropdownMenuItemCloseAllTabs().performClick()
-            BrowserRobot().interact()
-            return BrowserRobot.Transition()
+            HomeScreenRobot().interact()
+            return HomeScreenRobot.Transition()
         }
 
         fun openTab(title: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -208,6 +208,14 @@ class HistoryRobot {
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
+
+        fun openRecentlyClosedTabs(interact: RecentlyClosedTabsRobot.() -> Unit): RecentlyClosedTabsRobot.Transition {
+            recentlyClosedTabsListButton.waitForExists(waitingTime)
+            recentlyClosedTabsListButton.click()
+
+            RecentlyClosedTabsRobot().interact()
+            return RecentlyClosedTabsRobot.Transition()
+        }
     }
 }
 
@@ -299,3 +307,6 @@ private fun deleteHistoryEverythingOption() =
                 .textContains(getStringResource(R.string.delete_history_prompt_button_everything))
                 .resourceId("$packageName:id/everything_button"),
         )
+
+private val recentlyClosedTabsListButton =
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/recently_closed_tabs_header"))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -6,10 +6,7 @@
 
 package org.mozilla.fenix.ui.robots
 
-import android.content.Context
 import android.view.View
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
@@ -276,15 +273,7 @@ class TabDrawerRobot {
         )
 
     class Transition {
-        fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
-            mDevice.waitForIdle()
-
-            Espresso.openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext<Context>())
-            ThreeDotMenuMainRobot().interact()
-            return ThreeDotMenuMainRobot.Transition()
-        }
-
-        fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
+        fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): Transition {
             mDevice.waitForIdle(waitingTime)
             tabsCounter().click()
             mDevice.waitNotNull(
@@ -293,7 +282,7 @@ class TabDrawerRobot {
             )
 
             TabDrawerRobot().interact()
-            return TabDrawerRobot.Transition()
+            return Transition()
         }
 
         fun closeTabDrawer(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1839443
https://bugzilla.mozilla.org/show_bug.cgi?id=1807275