### PR TITLE
Bug 1810630 - add 'manage account' to the sync menu.

### DIFF
--- a/android-components/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/android-components/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -157,6 +157,14 @@ interface OAuthAccount : AutoCloseable {
     suspend fun getTokenServerEndpointURL(): String?
 
     /**
+     * Fetches the URL for the user to manage their account
+     *
+     * @param entryPoint A string which will be included as a query param in the URL for metrics.
+     * @return The URL which should be opened in a browser tab.
+     */
+    suspend fun getManageAccountURL(entryPoint: FxAEntryPoint): String
+
+    /**
      * Get the pairing URL to navigate to on the Authority side (typically a computer).
      *
      * @return The URL to show the pairing user

--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -156,6 +156,10 @@ class FirefoxAccount internal constructor(
         }
     }
 
+    override suspend fun getManageAccountURL(entryPoint: FxAEntryPoint): String {
+        return inner.getManageAccountURL(entryPoint.entryName)
+    }
+
     override fun getPairingAuthorityURL(): String {
         return inner.getPairingAuthorityURL()
     }

--- a/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -490,6 +490,10 @@ class FxaAccountManagerTest {
             return ""
         }
 
+        override suspend fun getManageAccountURL(entryPoint: FxAEntryPoint): String {
+            return "https://firefox.com/settings"
+        }
+
         override fun getPairingAuthorityURL(): String {
             return "https://firefox.com/pair"
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
@@ -41,12 +41,14 @@ import org.mozilla.fenix.GleanMetrics.SyncAccount
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
+import org.mozilla.fenix.components.accounts.FenixFxAEntryPoint
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.secure
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
+import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.settings.requirePreference
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
@@ -123,6 +125,10 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
         accountManager = requireComponents.backgroundServices.accountManager
         accountManager.register(accountStateObserver, this, true)
+
+        // Manage account
+        val preferenceManageAccount = requirePreference<Preference>(R.string.pref_key_sync_manage_account)
+        preferenceManageAccount.onPreferenceClickListener = getClickListenerForManageAccount()
 
         // Sign out
         val preferenceSignOut = requirePreference<Preference>(R.string.pref_key_sign_out)
@@ -360,6 +366,22 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
             }
         }
         return true
+    }
+
+    private fun getClickListenerForManageAccount(): Preference.OnPreferenceClickListener {
+        return Preference.OnPreferenceClickListener {
+            viewLifecycleOwner.lifecycleScope.launch(Main) {
+                context?.let {
+                    var acct = accountManager.authenticatedAccount()
+                    var url = acct?.getManageAccountURL(FenixFxAEntryPoint.SettingsMenu)
+                    if (url != null) {
+                        val intent = SupportUtils.createCustomTabIntent(it, url)
+                        startActivity(intent)
+                    }
+                }
+            }
+            true
+        }
     }
 
     private fun getClickListenerForSignOut(): Preference.OnPreferenceClickListener {

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -81,6 +81,7 @@
 
     <!-- Account Settings -->
     <string name="pref_key_account_category" translatable="false">pref_key_account_category</string>
+    <string name="pref_key_sync_manage_account" translatable="false">pref_key_sync_manage_account</string>
     <string name="pref_key_sync_device_name" translatable="false">pref_key_sync_device_name</string>
     <string name="pref_key_sync_now" translatable="false">pref_key_sync_now</string>
     <string name="pref_key_sync_history" translatable="false">pref_key_sync_history</string>

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -608,6 +608,8 @@
     <string name="addon_already_installed">Add-on is already installed</string>
 
     <!-- Account Preferences -->
+    <!-- Preference for managing your account via accounts.firefox.com -->
+    <string name="preferences_manage_account">Manage account</string>
     <!-- Preference for triggering sync -->
     <string name="preferences_sync_now">Sync now</string>
     <!-- Preference category for sync -->

--- a/fenix/app/src/main/res/xml/account_settings_preferences.xml
+++ b/fenix/app/src/main/res/xml/account_settings_preferences.xml
@@ -6,6 +6,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <Preference
+        android:key="@string/pref_key_sync_manage_account"
+        android:title="@string/preferences_manage_account" />
+
+    <Preference
         android:key="@string/pref_key_sync_now"
         android:title="@string/preferences_sync_now"
         app:icon="@drawable/mozac_ic_sync" />


### PR DESCRIPTION
This seems to work well - for reasons I don't fully understand, the `FxaWebChannelFeature` automagically kicks in when opening the view, so we get the correct exchange of the FxA account information between the server and the browser "for free".

I put the menu item at the top of the menu and made the English version of the string "Manage account" to match desktop.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1810630