### PR TITLE
Bug 1840316 - New text selection and quick actions url bar UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
@@ -12,8 +12,8 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
-import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.clickContextMenuItem
 import org.mozilla.fenix.ui.robots.clickPageObject
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -21,6 +21,7 @@ import org.mozilla.fenix.ui.robots.longClickPageObject
 import org.mozilla.fenix.ui.robots.navigationToolbar
 import org.mozilla.fenix.ui.robots.openEditURLView
 import org.mozilla.fenix.ui.robots.searchScreen
+import org.mozilla.fenix.ui.robots.shareOverlay
 
 class TextSelectionTest {
     private lateinit var mDevice: UiDevice
@@ -28,10 +29,6 @@ class TextSelectionTest {
 
     @get:Rule
     val activityIntentTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
-
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
@@ -232,6 +229,93 @@ class TextSelectionTest {
             clickContextMenuItem("Private Search")
             verifyTabCounter("2")
             verifyUrl("google")
+        }
+    }
+
+    @Test
+    fun verifyUrlBarTextSelectionOptionsTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openNavigationToolbar {
+            longClickEditModeToolbar()
+            verifyTextSelectionOptions("Open", "Cut", "Copy", "Share")
+        }
+    }
+
+    @Test
+    fun copyUrlBarTextTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openNavigationToolbar {
+            longClickEditModeToolbar()
+            clickContextMenuItem("Copy")
+            clickClearToolbarButton()
+            verifyToolbarIsEmpty()
+            longClickEditModeToolbar()
+            clickContextMenuItem("Paste")
+            verifyUrl(genericURL.url.toString())
+        }
+    }
+
+    @Test
+    fun cutUrlBarTextTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openNavigationToolbar {
+            longClickEditModeToolbar()
+            clickContextMenuItem("Cut")
+            verifyToolbarIsEmpty()
+            longClickEditModeToolbar()
+            clickContextMenuItem("Paste")
+            verifyUrl(genericURL.url.toString())
+        }
+    }
+
+    @Test
+    fun shareUrlBarTextTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openNavigationToolbar {
+            longClickEditModeToolbar()
+            clickContextMenuItem("Share")
+        }
+        shareOverlay {
+            verifyAndroidShareLayout()
+        }
+    }
+
+    @Test
+    fun urlBarQuickActionsTest() {
+        val firstWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 2)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebsite.url) {
+            longClickToolbar()
+            clickContextMenuItem("Copy")
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(secondWebsite.url) {
+            longClickToolbar()
+            clickContextMenuItem("Paste")
+        }
+        searchScreen {
+            verifyTypedToolbarText(firstWebsite.url.toString())
+        }.dismissSearchBar {
+        }
+        browserScreen {
+            verifyUrl(secondWebsite.url.toString())
+            longClickToolbar()
+            clickContextMenuItem("Paste & Go")
+            verifyUrl(firstWebsite.url.toString())
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -869,6 +869,8 @@ class BrowserRobot {
             getStringResource(R.string.open_in_app_cfr_negative_button_text),
         ).click()
 
+    fun longClickToolbar() = mDevice.findObject(By.res("$packageName:id/mozac_browser_toolbar_url_view")).click(LONG_CLICK_DURATION)
+
     class Transition {
         fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
             mDevice.waitForIdle(waitingTime)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -24,6 +24,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.By.textContains
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers.allOf
@@ -31,6 +32,9 @@ import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
@@ -94,12 +98,37 @@ class NavigationToolbarRobot {
         }
     }
 
+    fun longClickEditModeToolbar() =
+        mDevice.findObject(By.res("$packageName:id/mozac_browser_toolbar_edit_url_view")).click(LONG_CLICK_DURATION)
+
+    fun clickContextMenuItem(item: String) {
+        mDevice.waitNotNull(
+            Until.findObject(By.text(item)),
+            waitingTime,
+        )
+        mDevice.findObject(By.text(item)).click()
+    }
+
+    fun clickClearToolbarButton() = clearAddressBarButton().click()
+
+    fun verifyToolbarIsEmpty() =
+        itemWithResIdContainingText(
+            "$packageName:id/mozac_browser_toolbar_edit_url_view",
+            getStringResource(R.string.search_hint),
+        )
+
+    fun verifyTextSelectionOptions(vararg textSelectionOptions: String) {
+        for (textSelectionOption in textSelectionOptions) {
+            mDevice.waitNotNull(Until.findObject(textContains(textSelectionOption)), waitingTime)
+        }
+    }
+
     class Transition {
         private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
 
         fun goBackToWebsite(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             openEditURLView()
-            clearAddressBar().click()
+            clearAddressBarButton().click()
             assertTrue(
                 mDevice.findObject(
                     UiSelector()
@@ -180,8 +209,8 @@ class NavigationToolbarRobot {
         }
 
         fun visitLinkFromClipboard(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            if (clearAddressBar().waitForExists(waitingTimeShort)) {
-                clearAddressBar().click()
+            if (clearAddressBarButton().waitForExists(waitingTimeShort)) {
+                clearAddressBarButton().click()
             }
 
             mDevice.waitNotNull(
@@ -312,10 +341,7 @@ private fun awesomeBar() =
 private fun threeDotButton() = onView(withId(R.id.mozac_browser_toolbar_menu))
 private fun tabTrayButton() = onView(withId(R.id.tab_button))
 private fun fillLinkButton() = onView(withId(R.id.fill_link_from_clipboard))
-private fun clearAddressBar() =
-    mDevice.findObject(
-        UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_clear_view"),
-    )
+private fun clearAddressBarButton() = itemWithResId("$packageName:id/mozac_browser_toolbar_clear_view")
 private fun goBackButton() = mDevice.pressBack()
 private fun readerViewToggle() =
     onView(withParent(withId(R.id.mozac_browser_toolbar_page_actions)))


### PR DESCRIPTION
Bug 1840316 - New text selection and quick actions url bar UI tests

The UI tests successfully passed 100x on Firebase. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840316