### PR TITLE
Bug 1839250 - Avoid crash caused by OOM while saving a just-closed tab into storage

### DIFF
--- a/android-components/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorage.kt
+++ b/android-components/components/feature/recentlyclosed/src/main/java/mozilla/components/feature/recentlyclosed/RecentlyClosedTabsStorage.kt
@@ -122,8 +122,13 @@ class RecentlyClosedTabsStorage(
         // itself in the db - that will allow user to restore it with a "fresh" engine state.
         // That's a form of data loss, but not much we can do here other than log.
         tab.engineSessionState?.let {
-            if (!engineStateStorage.write(entity.uuid, it)) {
-                logger.warn("Failed to write engine session state for tab UUID = ${entity.uuid}")
+            try {
+                if (!engineStateStorage.write(entity.uuid, it)) {
+                    logger.warn("Failed to write engine session state for tab UUID = ${entity.uuid}")
+                }
+            } catch (e: OutOfMemoryError) {
+                crashReporting.submitCaughtException(e)
+                logger.error("Failed to save state to disk due to OutOfMemoryError", e)
             }
         }
         database.value.recentlyClosedTabDao().insertTab(entity)


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1839250