### PR TITLE
Bug 1836360 - Add a dialog for handling FedCM showPolicyPrompt.

### DIFF
--- a/android-components/.buildconfig.yml
+++ b/android-components/.buildconfig.yml
@@ -819,24 +819,33 @@ projects:
     publish: true
     upstream_dependencies:
     - browser-errorpages
+    - browser-menu2
+    - browser-session-storage
     - browser-state
+    - browser-tabstray
+    - browser-thumbnails
     - concept-base
     - concept-engine
     - concept-fetch
+    - concept-menu
     - concept-storage
+    - concept-tabstray
     - concept-toolbar
     - feature-prompts
     - feature-session
+    - feature-tabs
     - lib-publicsuffixlist
     - lib-state
     - support-android-test
     - support-base
+    - support-images
     - support-ktx
     - support-test
     - support-utils
     - tooling-lint
     - ui-colors
     - ui-icons
+    - ui-tabcounter
     - ui-widgets
   feature-media:
     description: Feature component for website media related features.
@@ -885,17 +894,25 @@ projects:
     publish: true
     upstream_dependencies:
     - browser-errorpages
+    - browser-menu2
+    - browser-session-storage
     - browser-state
+    - browser-tabstray
+    - browser-thumbnails
     - concept-base
     - concept-engine
     - concept-fetch
+    - concept-menu
     - concept-storage
+    - concept-tabstray
     - concept-toolbar
     - feature-session
+    - feature-tabs
     - lib-publicsuffixlist
     - lib-state
     - support-android-test
     - support-base
+    - support-images
     - support-ktx
     - support-test
     - support-test-libstate
@@ -903,6 +920,7 @@ projects:
     - tooling-lint
     - ui-colors
     - ui-icons
+    - ui-tabcounter
     - ui-widgets
   feature-push:
     description: Feature that implements push notifications with a supported push

--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegate.kt
@@ -44,6 +44,7 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.DateTimePrompt.Type.MON
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DateTimePrompt.Type.TIME
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.DateTimePrompt.Type.WEEK
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.IdentityCredential.AccountSelectorPrompt
+import org.mozilla.geckoview.GeckoSession.PromptDelegate.IdentityCredential.PrivacyPolicyPrompt
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.IdentityCredential.ProviderSelectorPrompt
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.PromptResponse
 import java.io.File
@@ -131,6 +132,40 @@ internal class GeckoPromptDelegate(private val geckoEngineSession: GeckoEngineSe
             onPromptRequest(
                 PromptRequest.IdentityCredential.SelectAccount(
                     accounts = prompt.accounts.map { it.toAccount() },
+                    onConfirm = onConfirm,
+                    onDismiss = onDismiss,
+                ),
+            )
+        }
+        return geckoResult
+    }
+
+    override fun onShowPrivacyPolicyIdentityCredential(
+        session: GeckoSession,
+        prompt: PrivacyPolicyPrompt,
+    ): GeckoResult<PromptResponse> {
+        val geckoResult = GeckoResult<PromptResponse>()
+
+        val onConfirm: (Boolean) -> Unit = { confirmed ->
+            if (!prompt.isComplete) {
+                geckoResult.complete(
+                    prompt.confirm(confirmed),
+                )
+            }
+        }
+
+        val onDismiss: () -> Unit = {
+            prompt.dismissSafely(geckoResult)
+        }
+
+        geckoEngineSession.notifyObservers {
+            onPromptRequest(
+                PromptRequest.IdentityCredential.PrivacyPolicy(
+                    privacyPolicyUrl = prompt.privacyPolicyUrl,
+                    termsOfServiceUrl = prompt.termsOfServiceUrl,
+                    providerDomain = prompt.providerDomain,
+                    host = prompt.host,
+                    icon = prompt.icon,
                     onConfirm = onConfirm,
                     onDismiss = onDismiss,
                 ),

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/prompt/PromptRequest.kt
@@ -137,6 +137,26 @@ sealed class PromptRequest(
             val onConfirm: (Account) -> Unit,
             override val onDismiss: () -> Unit,
         ) : IdentityCredential(onDismiss), Dismissible
+
+        /**
+         * Value type that represents Identity Credential request for a privacy policy prompt.
+         * @property privacyPolicyUrl A The URL where the policy for using this provider is hosted.
+         * @property termsOfServiceUrl The URL where the terms of service for using this provider are.
+         * @property providerDomain The domain of the provider.
+         * @property host The host of the provider.
+         * @property icon A base64 string for given icon for the provider; may be null.
+         * @property onConfirm callback to let the page know the user have confirmed or not the privacy policy.
+         * @property onDismiss callback to let the page know the user dismissed the dialog.
+         */
+        data class PrivacyPolicy(
+            val privacyPolicyUrl: String,
+            val termsOfServiceUrl: String,
+            val providerDomain: String,
+            val host: String,
+            val icon: String?,
+            val onConfirm: (Boolean) -> Unit,
+            override val onDismiss: () -> Unit,
+        ) : IdentityCredential(onDismiss), Dismissible
     }
 
     /**

--- a/android-components/components/feature/prompts/build.gradle
+++ b/android-components/components/feature/prompts/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':browser-state')
     implementation project(':concept-engine')
     implementation project(':feature-session')
+    implementation project(':feature-tabs')
     implementation project(':lib-state')
     implementation project(':support-ktx')
     implementation project(':support-utils')

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptContainer.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptContainer.kt
@@ -27,7 +27,7 @@ internal sealed class PromptContainer {
     /**
      * Returns a localized string.
      */
-    abstract fun getString(@StringRes res: Int): String
+    abstract fun getString(@StringRes res: Int, vararg objects: Any): String
 
     internal class Activity(
         private val activity: android.app.Activity,
@@ -38,7 +38,7 @@ internal sealed class PromptContainer {
         override fun startActivityForResult(intent: Intent, code: Int) =
             activity.startActivityForResult(intent, code)
 
-        override fun getString(res: Int) = activity.getString(res)
+        override fun getString(res: Int, vararg objects: Any) = activity.getString(res, *objects)
     }
 
     internal class Fragment(
@@ -52,12 +52,12 @@ internal sealed class PromptContainer {
         override fun startActivityForResult(intent: Intent, code: Int) =
             fragment.startActivityForResult(intent, code)
 
-        override fun getString(res: Int) = fragment.getString(res)
+        override fun getString(res: Int, vararg objects: Any) = fragment.getString(res, *objects)
     }
 
     @VisibleForTesting
     internal class TestPromptContainer(override val context: Context) : PromptContainer() {
         override fun startActivityForResult(intent: Intent, code: Int) = Unit
-        override fun getString(res: Int) = context.getString(res)
+        override fun getString(res: Int, vararg objects: Any) = context.getString(res, *objects)
     }
 }

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/PromptDialogFragment.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/dialog/PromptDialogFragment.kt
@@ -88,4 +88,11 @@ internal interface Prompter {
      * @param promptRequestUID id of the [PromptRequest] for which this dialog was shown.
      */
     fun onClear(sessionId: String, promptRequestUID: String)
+
+    /**
+     * Invoked when the user is requesting to open a website from the dialog.
+     *
+     * @param url The url to be opened.
+     */
+    fun onOpenLink(url: String)
 }

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/PrivacyPolicyDialogFragment.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/PrivacyPolicyDialogFragment.kt
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.identitycredential
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.text.SpannableStringBuilder
+import android.text.method.LinkMovementMethod
+import android.text.method.ScrollingMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.URLSpan
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.core.text.HtmlCompat
+import androidx.core.text.getSpans
+import mozilla.components.feature.prompts.R
+import mozilla.components.feature.prompts.dialog.AbstractPromptTextDialogFragment
+import mozilla.components.feature.prompts.dialog.KEY_MESSAGE
+import mozilla.components.feature.prompts.dialog.KEY_PROMPT_UID
+import mozilla.components.feature.prompts.dialog.KEY_SESSION_ID
+import mozilla.components.feature.prompts.dialog.KEY_SHOULD_DISMISS_ON_LOAD
+import mozilla.components.feature.prompts.dialog.KEY_TITLE
+import mozilla.components.ui.widgets.withCenterAlignedButtons
+
+internal const val KEY_ICON = "KEY_ICON"
+
+/**
+ * [ A Federated Credential Management dialog for showing a privacy policy.
+ */
+internal class PrivacyPolicyDialogFragment : AbstractPromptTextDialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = AlertDialog.Builder(requireContext())
+            .setTitle(title)
+            .setCancelable(true)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                onConfirmAction(true)
+            }
+            .setNegativeButton(android.R.string.cancel) { _, _ ->
+                onConfirmAction(false)
+            }
+
+        return setMessage(builder)
+            .create()
+            .withCenterAlignedButtons()
+    }
+
+    internal fun setMessage(builder: AlertDialog.Builder): AlertDialog.Builder {
+        val inflater = LayoutInflater.from(requireContext())
+        val view = inflater.inflate(R.layout.mozac_feature_prompt_with_check_box, null)
+        val textView = view.findViewById<TextView>(R.id.message)
+        val text = HtmlCompat.fromHtml(message, HtmlCompat.FROM_HTML_MODE_COMPACT)
+        textView.movementMethod = ScrollingMovementMethod()
+
+        val spannableStringBuilder = SpannableStringBuilder(text)
+        val links = spannableStringBuilder.getSpans<URLSpan>()
+        for (link in links) {
+            addActionToLinks(spannableStringBuilder, link)
+        }
+        textView.text = spannableStringBuilder
+        textView.movementMethod = LinkMovementMethod.getInstance()
+
+        builder.setView(view)
+
+        return builder
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        feature?.onCancel(sessionId, promptRequestUID)
+    }
+
+    private fun addActionToLinks(
+        spannableStringBuilder: SpannableStringBuilder,
+        link: URLSpan,
+    ) {
+        val start = spannableStringBuilder.getSpanStart(link)
+        val end = spannableStringBuilder.getSpanEnd(link)
+        val flags = spannableStringBuilder.getSpanFlags(link)
+        val clickable: ClickableSpan = object : ClickableSpan() {
+            override fun onClick(view: View) {
+                view.setOnClickListener {
+                    dismiss()
+                    feature?.onOpenLink(link.url)
+                }
+            }
+        }
+        spannableStringBuilder.setSpan(clickable, start, end, flags)
+        spannableStringBuilder.removeSpan(link)
+    }
+
+    private fun onConfirmAction(confirmed: Boolean) {
+        feature?.onConfirm(sessionId, promptRequestUID, confirmed)
+    }
+
+    companion object {
+        /**
+         * A builder method for creating a [PrivacyPolicyDialogFragment]
+         * @param sessionId to create the dialog.
+         * @param promptRequestUID identifier of the [PromptRequest] for which this dialog is shown.
+         * @param shouldDismissOnLoad whether or not the dialog should automatically be dismissed
+         * when a new page is loaded.
+         * @param title the title of the dialog.
+         * @param message the message of the dialog.
+         * @param icon an icon of the provider.
+         */
+        @Suppress("LongParameterList")
+        fun newInstance(
+            sessionId: String,
+            promptRequestUID: String,
+            shouldDismissOnLoad: Boolean,
+            title: String,
+            message: String,
+            icon: String?,
+        ): PrivacyPolicyDialogFragment {
+            val fragment = PrivacyPolicyDialogFragment()
+            val arguments = fragment.arguments ?: Bundle()
+
+            with(arguments) {
+                putString(KEY_SESSION_ID, sessionId)
+                putString(KEY_PROMPT_UID, promptRequestUID)
+                putString(KEY_TITLE, title)
+                putString(KEY_MESSAGE, message)
+                putBoolean(KEY_SHOULD_DISMISS_ON_LOAD, shouldDismissOnLoad)
+                putString(KEY_ICON, icon)
+            }
+            fragment.arguments = arguments
+            return fragment
+        }
+    }
+}

--- a/android-components/components/feature/prompts/src/main/res/values/strings.xml
+++ b/android-components/components/feature/prompts/src/main/res/values/strings.xml
@@ -46,10 +46,6 @@
     <string name="mozac_feature_prompts_content_description_input_label">Label for entering a text input field</string>
     <!-- Title of a color picker dialog, this text is shown above a color picker. -->
     <string name="mozac_feature_prompts_choose_a_color">Choose a color</string>
-    <!-- Title of the Identity Credential provider dialog choose. -->
-    <string name="mozac_feature_prompts_identity_credentials_choose_provider">Choose a login provider</string>
-    <!-- Title of an account picker dialog for identity credentials. -->
-    <string name="mozac_feature_prompts_identity_credentials_choose_account">Choose an account</string>
     <!-- Text of a confirm button in dialog requesting to open a new window. -->
     <string name="mozac_feature_prompts_allow">Allow</string>
     <!-- Text of a negative button in dialog requesting to open a new window. -->
@@ -136,4 +132,12 @@
     <!-- Federated Credential Management prompts -->
     <!--Content description for the Account picture in the Select Account FedCM prompt -->
     <string name="mozac_feature_prompts_account_picture">Account picture</string>
+    <!-- Title of the Identity Credential provider dialog choose. -->
+    <string name="mozac_feature_prompts_identity_credentials_choose_provider">Choose a login provider</string>
+    <!-- Title of an account picker dialog for identity credentials. -->
+    <string name="mozac_feature_prompts_identity_credentials_choose_account">Choose an account</string>
+    <!-- Title of the Identity Credential privacy policy dialog title. The %1$s will be replaced with the name of the provider. -->
+    <string name="mozac_feature_prompts_identity_credentials_privacy_policy_title">Use %1$s as a login provider</string>
+    <!-- Title of the Identity Credential privacy policy dialog description. The %1$s will be replaced with the name of the provider, %2$s will be replaced with the account, %3$s will be replaced with the privacy policy url and  %4$s will be replaced with the terms of service. -->
+    <string name="mozac_feature_prompts_identity_credentials_privacy_policy_description"><![CDATA[ Logging in to %1$s with a %2$s account is subject to their <a href="%3$s">Privacy Policy</a> and <a href="%4$s">Terms of Service</a>]]></string>
 </resources>

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptContainerTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptContainerTest.kt
@@ -62,15 +62,15 @@ class PromptContainerTest {
 
     @Test
     fun `getString must delegate its calls either to an activity or a fragment`() {
-        doReturn("").`when`(activity).getString(anyInt())
-        doReturn("").`when`(fragment).getString(anyInt())
+        doReturn("").`when`(activity).getString(anyInt(), *emptyArray())
+        doReturn("").`when`(fragment).getString(anyInt(), *emptyArray())
 
         var container: PromptContainer = PromptContainer.Activity(activity)
         container.getString(R.string.mozac_feature_prompts_ok)
-        verify(activity).getString(R.string.mozac_feature_prompts_ok)
+        verify(activity).getString(R.string.mozac_feature_prompts_ok, *emptyArray())
 
         container = PromptContainer.Fragment(fragment)
         container.getString(R.string.mozac_feature_prompts_ok)
-        verify(fragment).getString(R.string.mozac_feature_prompts_ok)
+        verify(fragment).getString(R.string.mozac_feature_prompts_ok, *emptyArray())
     }
 }

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -132,6 +132,7 @@ class PromptFeatureTest {
             PromptFeature(
                 fragment = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
             ) { },
         )
@@ -148,6 +149,7 @@ class PromptFeatureTest {
             PromptFeature(
                 fragment = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 customTabId = "custom-tab",
                 fragmentManager = fragmentManager,
             ) { },
@@ -166,6 +168,7 @@ class PromptFeatureTest {
             PromptFeature(
                 fragment = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 customTabId = tabId,
                 fragmentManager = fragmentManager,
             ) { },
@@ -180,7 +183,12 @@ class PromptFeatureTest {
     @Test
     fun `New promptRequests for selected session will cause fragment transaction`() {
         val feature =
-            PromptFeature(fragment = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                fragment = mock(),
+                store = store,
+                tabsUseCases = mock(),
+                fragmentManager = fragmentManager,
+            ) { }
         feature.start()
 
         val singleChoiceRequest = SingleChoice(arrayOf(), {}, {})
@@ -192,7 +200,12 @@ class PromptFeatureTest {
     @Test
     fun `New promptRequests for selected session will not cause fragment transaction if feature is stopped`() {
         val feature =
-            PromptFeature(fragment = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                fragment = mock(),
+                tabsUseCases = mock(),
+                store = store,
+                fragmentManager = fragmentManager,
+            ) { }
         feature.start()
         feature.stop()
 
@@ -213,7 +226,12 @@ class PromptFeatureTest {
             .joinBlocking()
 
         val feature =
-            PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                activity = mock(),
+                tabsUseCases = mock(),
+                store = store,
+                fragmentManager = fragmentManager,
+            ) { }
         feature.start()
         verify(fragment).feature = feature
     }
@@ -229,7 +247,12 @@ class PromptFeatureTest {
         doReturn(transaction).`when`(transaction).remove(any())
 
         val feature =
-            PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                activity = mock(),
+                store = store,
+                tabsUseCases = mock(),
+                fragmentManager = fragmentManager,
+            ) { }
         feature.start()
 
         verify(fragment, never()).feature = feature
@@ -252,7 +275,12 @@ class PromptFeatureTest {
         doReturn(transaction).`when`(transaction).remove(any())
 
         val feature =
-            PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                activity = mock(),
+                store = store,
+                tabsUseCases = mock(),
+                fragmentManager = fragmentManager,
+            ) { }
         feature.start()
 
         verify(fragment, never()).feature = feature
@@ -266,6 +294,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
             ) { },
         )
@@ -283,6 +312,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 loginDelegate = object : LoginDelegate {
                     override val loginPickerView = loginPickerView
@@ -323,6 +353,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
                 isSaveLoginEnabled = { true },
@@ -356,6 +387,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 isSaveLoginEnabled = { false },
             ) {},
@@ -383,6 +415,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 isSaveLoginEnabled = { true },
             ) {},
@@ -413,6 +446,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
         ) {}
 
@@ -440,6 +474,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 loginDelegate = object : LoginDelegate {
                     override val loginPickerView = loginPickerView
@@ -468,6 +503,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 loginDelegate = object : LoginDelegate {
                     override val loginPickerView = loginPickerView
@@ -496,6 +532,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 loginDelegate = object : LoginDelegate {
                     override val loginPickerView = loginPickerView
@@ -525,6 +562,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 creditCardDelegate = object : CreditCardDelegate {
                     override val creditCardPickerView = creditCardPickerView
@@ -553,6 +591,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 creditCardDelegate = object : CreditCardDelegate {
                     override val creditCardPickerView = creditCardPickerView
@@ -580,6 +619,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 creditCardDelegate = object : CreditCardDelegate {
                     override val creditCardPickerView = creditCardPickerView
@@ -608,6 +648,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 creditCardDelegate = object : CreditCardDelegate {
                     override val creditCardPickerView = creditCardPickerView
@@ -641,6 +682,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 addressDelegate = addressDelegate,
             ) { },
@@ -674,6 +716,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 addressDelegate = addressDelegate,
             ) { },
@@ -694,7 +737,12 @@ class PromptFeatureTest {
     @Test
     fun `Calling onCancel will consume promptRequest`() {
         val feature =
-            PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                activity = mock(),
+                store = store,
+                tabsUseCases = mock(),
+                fragmentManager = fragmentManager,
+            ) { }
 
         val singleChoiceRequest = SingleChoice(arrayOf(), {}, {})
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, singleChoiceRequest))
@@ -714,6 +762,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -737,6 +786,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -760,6 +810,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -783,6 +834,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -818,6 +870,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -839,6 +892,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -875,6 +929,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -912,6 +967,7 @@ class PromptFeatureTest {
             val feature = PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -951,7 +1007,12 @@ class PromptFeatureTest {
     @Test(expected = InvalidParameterException::class)
     fun `calling handleDialogsRequest with invalid type will throw an exception`() {
         val feature =
-            PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                activity = mock(),
+                tabsUseCases = mock(),
+                store = store,
+                fragmentManager = fragmentManager,
+            ) { }
         feature.handleDialogsRequest(mock<PromptRequest.File>(), mock())
     }
 
@@ -967,7 +1028,12 @@ class PromptFeatureTest {
             PromptRequest.File(emptyArray(), false, onSingleFileSelection, { _, _ -> }) { }
 
         val feature =
-            PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                activity = mock(),
+                store = store,
+                tabsUseCases = mock(),
+                fragmentManager = fragmentManager,
+            ) { }
         val intent = Intent()
 
         intent.data = mock()
@@ -992,7 +1058,12 @@ class PromptFeatureTest {
             PromptRequest.File(emptyArray(), true, { _, _ -> }, onMultipleFileSelection) {}
 
         val feature =
-            PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                activity = mock(),
+                tabsUseCases = mock(),
+                store = store,
+                fragmentManager = fragmentManager,
+            ) { }
         val intent = Intent()
 
         intent.clipData = mock()
@@ -1024,7 +1095,12 @@ class PromptFeatureTest {
             }
 
         val feature =
-            PromptFeature(activity = mock(), store = store, fragmentManager = fragmentManager) { }
+            PromptFeature(
+                activity = mock(),
+                store = store,
+                tabsUseCases = mock(),
+                fragmentManager = fragmentManager,
+            ) { }
         val intent = Intent()
 
         store.dispatch(ContentAction.UpdatePromptRequestAction(tabId, filePickerRequest))
@@ -1043,6 +1119,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 creditCardDelegate = object : CreditCardDelegate {
                     override val creditCardPickerView = creditCardPickerView
@@ -1066,6 +1143,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 creditCardDelegate = object : CreditCardDelegate {
                     override val creditCardPickerView = creditCardPickerView
@@ -1089,6 +1167,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 creditCardDelegate = object : CreditCardDelegate {
                     override val creditCardPickerView = creditCardPickerView
@@ -1111,6 +1190,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 creditCardDelegate = object : CreditCardDelegate {
                     override val creditCardPickerView = creditCardPickerView
@@ -1210,6 +1290,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1266,6 +1347,7 @@ class PromptFeatureTest {
             PromptFeature(
                 fragment = fragment,
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1294,6 +1376,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1330,6 +1413,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1374,6 +1458,7 @@ class PromptFeatureTest {
             PromptFeature(
                 fragment = fragment,
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1406,6 +1491,7 @@ class PromptFeatureTest {
             PromptFeature(
                 fragment = fragment,
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1447,6 +1533,7 @@ class PromptFeatureTest {
             PromptFeature(
                 fragment = fragment,
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1472,6 +1559,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1532,6 +1620,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1572,6 +1661,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1601,6 +1691,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
             ) { }
@@ -1630,6 +1721,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = Robolectric.buildActivity(Activity::class.java).setup().get(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = mock(),
         ) { }
@@ -1661,6 +1753,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
                 loginDelegate = object : LoginDelegate {
@@ -1698,6 +1791,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
                 creditCardDelegate = object : CreditCardDelegate {
@@ -1744,6 +1838,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity,
                 store,
+                tabsUseCases = mock(),
                 customTabId = "custom-tab",
                 shareDelegate = delegate,
                 fragmentManager = fragmentManager,
@@ -1770,6 +1865,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 customTabId = "custom-tab",
                 fragmentManager = fragmentManager,
                 isCreditCardAutofillEnabled = { true },
@@ -1792,6 +1888,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 customTabId = "custom-tab",
                 fragmentManager = fragmentManager,
                 isCreditCardAutofillEnabled = { true },
@@ -1814,6 +1911,7 @@ class PromptFeatureTest {
             PromptFeature(
                 mock<Activity>(),
                 store,
+                tabsUseCases = mock(),
                 customTabId = "custom-tab",
                 fragmentManager = fragmentManager,
                 isCreditCardAutofillEnabled = { false },
@@ -1836,6 +1934,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             fragment = mock(),
             store = store,
+            tabsUseCases = mock(),
             customTabId = "custom-tab",
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = exitFullScreenUseCase,
@@ -1854,6 +1953,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             fragment = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = exitFullScreenUseCase,
         ) { }
@@ -1881,6 +1981,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             fragment = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = exitFullScreenUseCase,
         ) { }
@@ -1913,6 +2014,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 isCreditCardAutofillEnabled = { false },
             ) {},
@@ -1947,6 +2049,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 isCreditCardAutofillEnabled = { true },
             ) {},
@@ -1966,6 +2069,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = mock(),
             shareDelegate = delegate,
@@ -1997,6 +2101,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = mock(),
             shareDelegate = delegate,
@@ -2028,6 +2133,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
                 shareDelegate = mock(),
@@ -2068,6 +2174,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
                 shareDelegate = mock(),
@@ -2101,6 +2208,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
                 shareDelegate = mock(),
@@ -2129,6 +2237,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             shareDelegate = mock(),
             isSaveLoginEnabled = { true },
@@ -2168,6 +2277,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 shareDelegate = mock(),
             ) { },
@@ -2210,6 +2320,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 shareDelegate = mock(),
             ) { },
@@ -2241,6 +2352,7 @@ class PromptFeatureTest {
             // Proper activity here to allow for the feature to properly execute "container.context.getString"
             activity = Robolectric.buildActivity(Activity::class.java).setup().get(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             shareDelegate = mock(),
             isSaveLoginEnabled = { true },
@@ -2269,6 +2381,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = Robolectric.buildActivity(Activity::class.java).setup().get(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = mock(),
         ) { }
@@ -2297,6 +2410,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = Robolectric.buildActivity(Activity::class.java).setup().get(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = mock(),
         ) { }
@@ -2325,6 +2439,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = mock(),
             isCreditCardAutofillEnabled = { true },
@@ -2410,6 +2525,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             isCreditCardAutofillEnabled = { true },
             creditCardValidationDelegate = mock(),
@@ -2472,6 +2588,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             exitFullscreenUsecase = mock(),
             isCreditCardAutofillEnabled = { true },
@@ -2493,6 +2610,7 @@ class PromptFeatureTest {
         val feature = PromptFeature(
             activity = mock(),
             store = store,
+            tabsUseCases = mock(),
             fragmentManager = fragmentManager,
             isCreditCardAutofillEnabled = { true },
             creditCardValidationDelegate = mock(),
@@ -2537,6 +2655,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
                 shareDelegate = mock(),
@@ -2566,6 +2685,7 @@ class PromptFeatureTest {
             PromptFeature(
                 activity = mock(),
                 store = store,
+                tabsUseCases = mock(),
                 fragmentManager = fragmentManager,
                 exitFullscreenUsecase = mock(),
                 shareDelegate = mock(),

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/BaseBrowserFragment.kt
@@ -184,6 +184,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 fragment = this,
                 store = components.store,
                 customTabId = sessionId,
+                tabsUseCases = components.tabsUseCases,
                 fragmentManager = parentFragmentManager,
                 onNeedToRequestPermissions = { permissions ->
                     requestInPlacePermissions(REQUEST_KEY_PROMPT_PERMISSIONS, permissions) { result ->

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonPopupBaseFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonPopupBaseFragment.kt
@@ -46,6 +46,7 @@ abstract class AddonPopupBaseFragment : Fragment(), EngineSession.Observer, User
                     onNeedToRequestPermissions = { permissions ->
                         requestPermissions(permissions, REQUEST_CODE_PROMPT_PERMISSIONS)
                     },
+                    tabsUseCases = requireComponents.useCases.tabsUseCases,
                 ),
                 owner = this,
                 view = view,

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -663,6 +663,7 @@ abstract class BaseBrowserFragment :
                 store = store,
                 customTabId = customTabSessionId,
                 fragmentManager = parentFragmentManager,
+                tabsUseCases = requireComponents.useCases.tabsUseCases,
                 creditCardValidationDelegate = DefaultCreditCardValidationDelegate(
                     context.components.core.lazyAutofillStorage,
                 ),

--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/BrowserFragment.kt
@@ -321,6 +321,7 @@ class BrowserFragment :
             PromptFeature(
                 fragment = this,
                 store = components.store,
+                tabsUseCases = components.tabsUseCases,
                 customTabId = tryGetCustomTabId(),
                 fragmentManager = parentFragmentManager,
                 onNeedToRequestPermissions = { permissions ->


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.























### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1836360