### PR TITLE
Bug 1840061 - Adds PDF viewer - Open in app button UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -14,7 +14,6 @@ import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_DOCS
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
-import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.assertExternalAppOpens
@@ -216,19 +215,6 @@ class DownloadTest {
         deleteDownloadedFileOnStorage(downloadFile)
     }
 
-    @SmokeTest
-    @Test
-    fun openPDFInBrowserTest() {
-        val genericURL =
-            TestAssetHelper.getGenericAsset(mockWebServer, 3)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-            clickPageObject(itemContainingText("PDF form file"))
-            verifyPageContent("Washington Crossing the Delaware")
-        }
-    }
-
     // Save PDF file from the share overlay
     @SmokeTest
     @Test
@@ -245,24 +231,6 @@ class DownloadTest {
         }.clickSaveAsPDF {
             verifyDownloadPrompt(downloadFile)
         }.clickDownload {
-        }.clickOpen("application/pdf") {
-            assertExternalAppOpens(GOOGLE_DOCS)
-        }
-        deleteDownloadedFileOnStorage(downloadFile)
-    }
-
-    // Download PDF file using the download toolbar button
-    @Test
-    fun pdfViewerDownloadButtonTest() {
-        val genericURL =
-            TestAssetHelper.getGenericAsset(mockWebServer, 3)
-        downloadFile = "pdfForm.pdf"
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-            clickPageObject(itemWithText("PDF form file"))
-        }.clickDownloadPDFButton {
-            verifyDownloadedFileName(downloadFile)
         }.clickOpen("application/pdf") {
             assertExternalAppOpens(GOOGLE_DOCS)
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PDFViewerTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PDFViewerTest.kt
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_DOCS
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
+import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
+import org.mozilla.fenix.helpers.TestHelper.assertExternalAppOpens
+import org.mozilla.fenix.helpers.TestHelper.deleteDownloadedFileOnStorage
+import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.ui.robots.clickPageObject
+import org.mozilla.fenix.ui.robots.navigationToolbar
+
+class PDFViewerTest {
+    private lateinit var mockWebServer: MockWebServer
+
+    @get:Rule
+    val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
+
+    @Before
+    fun setUp() {
+        mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @SmokeTest
+    @Test
+    fun openPDFInBrowserTest() {
+        val genericURL =
+            TestAssetHelper.getGenericAsset(mockWebServer, 3)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            clickPageObject(itemContainingText("PDF form file"))
+            verifyPageContent("Washington Crossing the Delaware")
+        }
+    }
+
+    @Test
+    fun pdfViewerOpenInAppTest() {
+        val genericURL = getGenericAsset(mockWebServer, 3)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            clickPageObject(itemWithText("PDF form file"))
+            verifyPDFReaderToolbarItems()
+            clickPageObject(itemWithResIdAndText("openInApp", "Open in app"))
+            assertExternalAppOpens(GOOGLE_DOCS)
+        }
+    }
+
+    // Download PDF file using the download toolbar button
+    @Test
+    fun pdfViewerDownloadButtonTest() {
+        val genericURL = getGenericAsset(mockWebServer, 3)
+        val downloadFile = "pdfForm.pdf"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            clickPageObject(itemWithText("PDF form file"))
+        }.clickDownloadPDFButton {
+            verifyDownloadedFileName(downloadFile)
+        }.clickOpen("application/pdf") {
+            assertExternalAppOpens(GOOGLE_DOCS)
+        }
+        deleteDownloadedFileOnStorage(downloadFile)
+    }
+}

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -318,6 +318,17 @@ class BrowserRobot {
 
     fun longClickPDFImage() = longClickPageObject(itemWithResId("pdfjs_internal_id_13R"))
 
+    fun verifyPDFReaderToolbarItems() {
+        assertTrue(
+            itemWithResIdAndText("download", "Download")
+                .waitForExists(waitingTime),
+        )
+        assertTrue(
+            itemWithResIdAndText("openInApp", "Open in app")
+                .waitForExists(waitingTime),
+        )
+    }
+
     fun clickSubmitLoginButton() {
         clickPageObject(itemWithResId("submit"))
         itemWithResId("submit").waitUntilGone(waitingTime)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840061