### PR TITLE
Bug 1837526 - Call StartupTimeline in the Compose Top Sites

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSites.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSites.kt
@@ -104,6 +104,7 @@ fun TopSites(
     onRemoveTopSiteClicked: (topSite: TopSite) -> Unit,
     onSettingsClicked: () -> Unit,
     onSponsorPrivacyClicked: () -> Unit,
+    onTopSitesItemBound: () -> Unit,
 ) {
     val pageCount = ceil((topSites.size.toDouble() / TOP_SITES_PER_PAGE)).toInt()
 
@@ -154,6 +155,7 @@ fun TopSites(
                                     topSiteColors = topSiteColors,
                                     onTopSiteClick = { item -> onTopSiteClick(item) },
                                     onTopSiteLongClick = onTopSiteLongClick,
+                                    onTopSitesItemBound = onTopSitesItemBound,
                                 )
                             }
                         }
@@ -251,6 +253,7 @@ private fun TopSiteItem(
     topSiteColors: TopSiteColors,
     onTopSiteClick: (TopSite) -> Unit,
     onTopSiteLongClick: (TopSite) -> Unit,
+    onTopSitesItemBound: () -> Unit,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
 
@@ -338,6 +341,10 @@ private fun TopSiteItem(
                 submitTopSitesImpressionPing(topSite = topSite, position = position)
             }
         }
+    }
+
+    LaunchedEffect(Unit) {
+        onTopSitesItemBound()
     }
 }
 
@@ -587,6 +594,7 @@ private fun TopSitesPreview() {
                 onRemoveTopSiteClicked = {},
                 onSettingsClicked = {},
                 onSponsorPrivacyClicked = {},
+                onTopSitesItemBound = {},
             )
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesViewHolder.kt
@@ -9,9 +9,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.LifecycleOwner
 import mozilla.components.lib.state.ext.observeAsComposableState
+import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
+import org.mozilla.fenix.perf.StartupTimeline
 import org.mozilla.fenix.wallpapers.WallpaperState
 
 /**
@@ -49,6 +51,9 @@ class TopSitesViewHolder(
                 onRemoveTopSiteClicked = interactor::onRemoveTopSiteClicked,
                 onSettingsClicked = interactor::onSettingsClicked,
                 onSponsorPrivacyClicked = interactor::onSponsorPrivacyClicked,
+                onTopSitesItemBound = {
+                    StartupTimeline.onTopSitesItemBound(activity = composeView.context as HomeActivity)
+                },
             )
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/perf/StartupReportFullyDrawn.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/perf/StartupReportFullyDrawn.kt
@@ -61,6 +61,24 @@ class StartupReportFullyDrawn {
         }
     }
 
+    /**
+     * Instruments "visually complete" cold startup time to homescreen for use with FNPRMS.
+     *
+     * For FNPRMS, we define "visually complete" to be when top sites is loaded with placeholders;
+     * the animation to display top sites will occur after this point, as will the asynchronous
+     * loading of the actual top sites icons. Our focus for visually complete is usability.
+     * There are no tabs available in our FNPRMS tests so they are ignored for this instrumentation.
+     */
+    fun onTopSitesItemBound(state: StartupState, activity: HomeActivity) {
+        if (!isInstrumented &&
+            state is StartupState.Cold && state.destination == HOMESCREEN
+        ) {
+            isInstrumented = true
+
+            attachReportFullyDrawn(activity)
+        }
+    }
+
     private fun attachReportFullyDrawn(activity: Activity, view: View) {
         // For greater accuracy, we could add an onDrawListener instead of a preDrawListener but:
         // - single use onDrawListeners are not built-in and it's non-trivial to write one
@@ -68,5 +86,9 @@ class StartupReportFullyDrawn {
         // - if we compare against another app using a preDrawListener, as we are with Fennec, it
         // should be comparable
         view.doOnPreDraw { activity.reportFullyDrawnSafe(Performance.logger) }
+    }
+
+    private fun attachReportFullyDrawn(activity: Activity) {
+        activity.reportFullyDrawnSafe(Performance.logger)
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/perf/StartupTimeline.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/perf/StartupTimeline.kt
@@ -54,6 +54,13 @@ object StartupTimeline {
         reportFullyDrawn.onTopSitesItemBound(state, holder)
     }
 
+    /**
+     * Instruments "visually complete" cold startup time to homescreen for use with FNPRMS.
+     */
+    fun onTopSitesItemBound(activity: HomeActivity) {
+        reportFullyDrawn.onTopSitesItemBound(state, activity)
+    }
+
     private fun advanceState(startingActivity: StartupActivity) {
         state = StartupTimelineStateMachine.getNextState(state, startingActivity)
     }


### PR DESCRIPTION
Because we are migrating Top Sites to Compose, we want to ensure we are still recording when top sites are loaded, therefore the call for StartupTimeline is now called after creating the top sites compose elements. Calling it here will ensure it will be called even after we replace the home page recycler with a Compose view.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1837526