### PR TITLE
Bug 1837417 - Remember synced tabs collapsed/expanded state in composed tabs tray

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
@@ -167,6 +167,7 @@ fun TabsTray(
                 pageCount = Page.values().size,
                 modifier = Modifier.fillMaxSize(),
                 state = pagerState,
+                beyondBoundsPageCount = 2,
                 userScrollEnabled = false,
             ) { position ->
                 when (Page.positionToPage(position)) {


### PR DESCRIPTION
Performance seems to be similar with composed tabs tray disabled, tested on 2 devices with 40+ private, normal and synced tabs. This makes sense, considering we did the same in the XML version.

https://github.com/mozilla-mobile/firefox-android/assets/35462038/1881ce71-b597-403e-828f-a010b891fa82

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1837417