### PR TITLE
Bug 1840151 - Remove telemetry probes expiring in v118

### DIFF
--- a/focus-android/app/metrics.yaml
+++ b/focus-android/app/metrics.yaml
@@ -2105,23 +2105,6 @@ privacy_settings:
           A string containing the new block cookies option the user has chosen:
           yes, third_party_only, third_party_tracker, cross_site, no
         type: string
-nimbus_experiments:
-  nimbus_initial_fetch:
-    type: timespan
-    description: >
-      Measures the time spent to download the nimbus experiments
-    time_unit: millisecond
-    lifetime: application
-    bugs:
-      - https://github.com/mozilla-mobile/focus-android/issues/6847
-    data_reviews:
-      - https://github.com/mozilla-mobile/focus-android/pull/6972
-      - https://github.com/mozilla-mobile/firefox-android/pull/632
-    notification_emails:
-      - android-probes@mozilla.com
-    expires: 118
-    data_sensitivity:
-      - technical
 
 metrics:
   start_reason_process_error:

--- a/focus-android/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
@@ -13,7 +13,6 @@ import org.json.JSONObject
 import org.mozilla.experiments.nimbus.NimbusInterface
 import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.mozilla.focus.BuildConfig
-import org.mozilla.focus.GleanMetrics.NimbusExperiments
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.components
 import org.mozilla.focus.ext.settings
@@ -89,14 +88,12 @@ internal fun finishNimbusInitialization(experiments: NimbusApi) =
             register(
                 object : NimbusInterface.Observer {
                     override fun onExperimentsFetched() {
-                        NimbusExperiments.nimbusInitialFetch.stop()
                         applyPendingExperiments()
                         // Remove lingering observer when we're done fetching experiments on startup.
                         unregister(this)
                     }
                 },
             )
-            NimbusExperiments.nimbusInitialFetch.start()
         }
         fetchExperiments()
     }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840151