### PR TITLE
Bug 1840315 – added telemetry to the splash screen data fetching

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -637,6 +637,27 @@ events:
       tags:
         - Search
 
+splash_screen:
+  first_launch_extended:
+    type: event
+    description: |
+      The splash screen was shown for an extended period of time, providing more time
+      to download marketing and experiment data.
+    extra_keys:
+      data_fetched:
+        type: boolean
+        description: |
+          If the splash screen was closed due to data being fetched or due to the time running out.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1840315
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/2616
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 126
+
 onboarding:
   syn_cfr_shown:
     type: event

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -84,6 +84,7 @@ import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.experiments.nimbus.initializeTooling
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.Metrics
+import org.mozilla.fenix.GleanMetrics.SplashScreen
 import org.mozilla.fenix.GleanMetrics.StartOnHome
 import org.mozilla.fenix.addons.AddonDetailsFragmentDirections
 import org.mozilla.fenix.addons.AddonPermissionsDetailsFragmentDirections
@@ -433,7 +434,13 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             splashScreen.setKeepOnScreenCondition {
                 val dataFetched = components.settings.utmParamsKnown &&
                     components.settings.nimbusExperimentsFetched
-                !maxDurationReached && !dataFetched
+                val keepOnScreen = !maxDurationReached && !dataFetched
+                if (!keepOnScreen) {
+                    SplashScreen.firstLaunchExtended.record(
+                        SplashScreen.FirstLaunchExtendedExtra(dataFetched = dataFetched),
+                    )
+                }
+                keepOnScreen
             }
             MainScope().launch {
                 delay(timeMillis = delay)


### PR DESCRIPTION
Follow up to [2615](https://github.com/mozilla-mobile/firefox-android/pull/2615).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.














### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840315