### PR TITLE
Bug 1840634 - Refactor test to remove usage of mockkStatic.

### DIFF
--- a/fenix/app/src/test/java/org/mozilla/fenix/home/HomeFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/HomeFragmentTest.kt
@@ -7,11 +7,12 @@ package org.mozilla.fenix.home
 import android.content.Context
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
+import mozilla.components.browser.state.search.SearchEngine
+import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.SearchState
-import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.top.sites.TopSite
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -72,15 +73,18 @@ class HomeFragmentTest {
 
     @Test
     fun `GIVEN the selected search engine is set to eBay WHEN getTopSitesConfig is called THEN providerFilter filters the eBay provided top sites`() {
-        mockkStatic("mozilla.components.browser.state.state.SearchStateKt")
-        every { core.store } returns mockk() {
-            every { state } returns mockk() {
-                every { search } returns mockk()
-            }
-        }
-        every { any<SearchState>().selectedOrDefaultSearchEngine } returns mockk {
-            every { name } returns EBAY_SPONSORED_TITLE
-        }
+        val searchEngine: SearchEngine = mockk()
+        val browserStore = BrowserStore(
+            initialState = BrowserState(
+                search = SearchState(
+                    regionSearchEngines = listOf(searchEngine),
+                ),
+            ),
+        )
+
+        every { core.store } returns browserStore
+        every { searchEngine.name } returns EBAY_SPONSORED_TITLE
+
         val eBayTopSite = TopSite.Provided(1L, EBAY_SPONSORED_TITLE, "eBay.com", "", "", "", 0L)
         val amazonTopSite = TopSite.Provided(2L, AMAZON_SPONSORED_TITLE, "Amazon.com", "", "", "", 0L)
         val firefoxTopSite = TopSite.Provided(3L, "Firefox", "mozilla.org", "", "", "", 0L)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840634