### PR TITLE
Bug 1840561 - Fix and refactor verifyLoginWithoutPasswordCanNotBeSavedTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
@@ -344,7 +344,7 @@ class LoginsTest {
     }
 
     @Test
-    fun verifyLoginWithNoUserNameCanBeSavedTest() {
+    fun verifyLoginWithNoUserNameCanNotBeSavedTest() {
         val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
         val originWebsite = "mozilla-mobile.github.io"
 
@@ -365,12 +365,13 @@ class LoginsTest {
             clickThreeDotButton(activityTestRule)
             clickEditLoginButton()
             clickClearUserNameButton()
-            saveEditedLogin()
-            verifyLoginItemUsername("")
+            verifyUserNameRequiredErrorMessage()
+            verifySaveLoginButtonIsEnabled(false)
+            clickGoBackButton()
+            verifyLoginItemUsername("mozilla")
         }
     }
 
-    @Ignore("https://bugzilla.mozilla.org/show_bug.cgi?id=1840561")
     @Test
     fun verifyLoginWithoutPasswordCanNotBeSavedTest() {
         val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
@@ -394,7 +395,8 @@ class LoginsTest {
             clickEditLoginButton()
             clickClearPasswordButton()
             verifyPasswordRequiredErrorMessage()
-            saveEditedLogin()
+            verifySaveLoginButtonIsEnabled(false)
+            clickGoBackButton()
             revealPassword()
             verifyPasswordSaved("firefox")
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.kt
@@ -23,6 +23,8 @@ import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
@@ -156,10 +158,21 @@ class SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot {
 
     fun saveEditedLogin() = itemWithResId("$packageName:id/save_login_button").click()
 
+    fun verifySaveLoginButtonIsEnabled(isEnabled: Boolean) {
+        if (isEnabled) {
+            assertTrue(itemWithResId("$packageName:id/save_login_button").isChecked)
+        } else {
+            assertFalse(itemWithResId("$packageName:id/save_login_button").isChecked)
+        }
+    }
+
     fun revealPassword() = onView(withId(R.id.revealPasswordButton)).click()
 
     fun verifyPasswordSaved(password: String) =
         onView(withId(R.id.passwordText)).check(matches(withText(password)))
+
+    fun verifyUserNameRequiredErrorMessage() =
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.saved_login_username_required)))
 
     fun verifyPasswordRequiredErrorMessage() =
         assertItemContainingTextExists(itemContainingText(getStringResource(R.string.saved_login_password_required)))


### PR DESCRIPTION
This PR re-enables `verifyLoginWithoutPasswordCanNotBeSavedTest` and refactors `verifyLoginWithNoUserNameCanNotBeSavedTest`

The changes recently introduces in #906 changed the save login button's behaviour, as it follows:
- The save button is inactive when no changes are made to the login credentials while in edit mode
- The save button is inactive when the user name field is empty in edit mode (we could previously save a login without a user name, and no error message was displayed)
- The save button is inactive when the password field is empty in edit mode

✅ Both tests successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840561