### PR TITLE
Bug 1840099 - Add bottom sheet container for shopping experience

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/BottomSheetHandle.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/BottomSheetHandle.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.compose
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.R
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * A handle present on top of a bottom sheet. This is selectable when talkback is enabled.
+ *
+ * @param onRequestDismiss Invoked on clicking the handle when talkback is enabled.
+ * @param contentDescription Content Description of the composable.
+ * @param modifier The modifier to be applied to the Composable.
+ * @param color Color of the handle.
+ */
+@Composable
+fun BottomSheetHandle(
+    onRequestDismiss: () -> Unit,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    color: Color = FirefoxTheme.colors.textSecondary,
+) {
+    Canvas(
+        modifier = modifier
+            .height(dimensionResource(id = R.dimen.bottom_sheet_handle_height))
+            .semantics(mergeDescendants = true) {
+                this.contentDescription = contentDescription
+                onClick {
+                    onRequestDismiss()
+                    true
+                }
+            },
+    ) {
+        drawRect(color = color)
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun BottomSheetHandlePreview() {
+    FirefoxTheme {
+        Column(
+            modifier = Modifier
+                .background(color = FirefoxTheme.colors.layer1)
+                .padding(16.dp),
+        ) {
+            BottomSheetHandle(
+                onRequestDismiss = {},
+                contentDescription = "",
+                modifier = Modifier
+                    .width(100.dp)
+                    .align(Alignment.CenterHorizontally),
+            )
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeature.kt
@@ -10,6 +10,9 @@ import org.mozilla.fenix.nimbus.FxNimbus
 /**
  * Feature implementation that provides review quality check information for supported product
  * pages.
+ *
+ * @param onAvailabilityChange Invoked when availability of this feature changes based on feature
+ * flag and when the loaded page is a supported product page.
  */
 class ReviewQualityCheckFeature(
     private val onAvailabilityChange: (isAvailable: Boolean) -> Unit,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFragment.kt
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.activityViewModels
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.mozilla.fenix.shopping.ui.ReviewQualityCheckContent
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * A bottom sheet fragment displaying Review Quality Check information.
+ */
+class ReviewQualityCheckFragment : BottomSheetDialogFragment() {
+
+    private val viewModel: ReviewQualityCheckViewModel by activityViewModels()
+    private var behavior: BottomSheetBehavior<View>? = null
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+        super.onCreateDialog(savedInstanceState).apply {
+            setOnShowListener {
+                val bottomSheet =
+                    findViewById<View?>(com.google.android.material.R.id.design_bottom_sheet)
+                bottomSheet?.setBackgroundResource(android.R.color.transparent)
+                behavior = BottomSheetBehavior.from(bottomSheet)
+            }
+        }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = ComposeView(requireContext()).apply {
+        setContent {
+            FirefoxTheme {
+                ReviewQualityCheckContent(
+                    onRequestDismiss = {
+                        behavior?.state = BottomSheetBehavior.STATE_HIDDEN
+                    },
+                )
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.onDialogCreated()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        viewModel.onDialogDismissed()
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckViewModel.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckViewModel.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * A ViewModel to communicate between ReviewQualityCheckFragment bottom sheet and the parent
+ * fragment.
+ */
+class ReviewQualityCheckViewModel : ViewModel() {
+
+    private val _isBottomSheetVisible = MutableStateFlow(false)
+    val isBottomSheetVisible: StateFlow<Boolean> = _isBottomSheetVisible
+
+    /**
+     * Invoked when bottom sheet dialog is created.
+     */
+    fun onDialogCreated() {
+        _isBottomSheetVisible.update { true }
+    }
+
+    /**
+     * Invoked when bottom sheet dialog is dismissed.
+     */
+    fun onDialogDismissed() {
+        _isBottomSheetVisible.update { false }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContent.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContent.kt
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.R
+import org.mozilla.fenix.compose.BottomSheetHandle
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.theme.FirefoxTheme
+
+private val bottomSheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+private const val BOTTOM_SHEET_HANDLE_WIDTH_PERCENT = 0.1f
+
+/**
+ * Top-level UI for the Review Quality Check feature.
+ *
+ * @param onRequestDismiss Invoked when a user actions requests dismissal of the bottom sheet.
+ * @param modifier The modifier to be applied to the Composable.
+ */
+@Composable
+fun ReviewQualityCheckContent(
+    onRequestDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .background(
+                color = FirefoxTheme.colors.layer1,
+                shape = bottomSheetShape,
+            )
+            .padding(16.dp),
+    ) {
+        BottomSheetHandle(
+            onRequestDismiss = onRequestDismiss,
+            contentDescription = stringResource(R.string.browser_menu_review_quality_check_close),
+            modifier = Modifier
+                .fillMaxWidth(BOTTOM_SHEET_HANDLE_WIDTH_PERCENT)
+                .align(Alignment.CenterHorizontally),
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Header()
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun Header() {
+    Row(
+        modifier = Modifier.semantics(mergeDescendants = true) {},
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_firefox),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+        )
+
+        Spacer(modifier = Modifier.width(10.dp))
+
+        Text(
+            text = stringResource(R.string.review_quality_check),
+            color = FirefoxTheme.colors.textPrimary,
+            style = FirefoxTheme.typography.headline6,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun ReviewQualityCheckContentPreview() {
+    FirefoxTheme {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+            ReviewQualityCheckContent(
+                onRequestDismiss = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/fenix/app/src/main/res/navigation/nav_graph.xml
+++ b/fenix/app/src/main/res/navigation/nav_graph.xml
@@ -325,6 +325,9 @@
         <action
             android:id="@+id/action_browserFragment_to_cookieBannerDialogFragment"
             app:destination="@id/cookieBannerDialogFragment" />
+        <action
+            android:id="@+id/action_browserFragment_to_reviewQualityCheckDialogFragment"
+            app:destination="@id/reviewQualityCheckFragment" />
     </fragment>
 
     <fragment
@@ -457,6 +460,10 @@
             android:id="@+id/action_bookmarkAddFolderFragment_to_bookmarkSelectFolderFragment"
             app:destination="@id/bookmarkSelectFolderFragment" />
     </fragment>
+
+    <dialog
+        android:id="@+id/reviewQualityCheckFragment"
+        android:name="org.mozilla.fenix.shopping.ReviewQualityCheckFragment"/>
 
     <fragment
         android:id="@+id/savedLoginsAuthFragment"

--- a/fenix/app/src/main/res/values/static_strings.xml
+++ b/fenix/app/src/main/res/values/static_strings.xml
@@ -114,4 +114,5 @@
     <string name="browser_menu_review_quality_check" translatable="false">Review quality check</string>
     <!-- Browser menu button content description to close review quality check-->
     <string name="browser_menu_review_quality_check_close" translatable="false">Close review quality check</string>
+    <string name="review_quality_check" translatable="false">Review quality check</string>
 </resources>


### PR DESCRIPTION
### How
– Add bottom sheet fragment 
– Add compose content with a basic header
– Create `BottomSheetHandle` common UI component
– Add `ViewModel` so parent fragment can observe the bottom sheet visibility state and update the `ToggleButton` selection.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840099