### PR TITLE
Bug 1841073 - Add missing conditions when verifying link related context menu options in UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeContextMenusTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeContextMenusTest.kt
@@ -87,7 +87,7 @@ class ComposeContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 1"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Open link in new tab")
             verifySnackBarText("New tab opened")
             clickSnackbarButton("SWITCH")
@@ -111,7 +111,7 @@ class ComposeContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 2"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Open link in private tab")
             verifySnackBarText("New private tab opened")
             clickSnackbarButton("SWITCH")
@@ -133,7 +133,7 @@ class ComposeContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 3"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Copy link")
             verifySnackBarText("Link copied to clipboard")
         }.openNavigationToolbar {
@@ -150,7 +150,7 @@ class ComposeContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             longClickPageObject(itemWithText("Link 3"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Copy link")
             verifySnackBarText("Link copied to clipboard")
         }.openNavigationToolbar {
@@ -175,7 +175,7 @@ class ComposeContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 1"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Share link")
             shareOverlay {
                 verifyShareLinkIntent(genericURL.url)
@@ -258,7 +258,7 @@ class ComposeContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 1"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             dismissContentContextMenu()
             longClickPageObject(itemWithText("test_link_image"))
             verifyLinkImageContextMenuItems(imageResource.url)
@@ -278,12 +278,12 @@ class ComposeContextMenusTest {
             clickPageObject(itemWithText("PDF form file"))
             waitForPageToLoad()
             longClickPageObject(itemWithText("Wikipedia link"))
-            verifyLinkContextMenuItems("wikipedia.org".toUri(), false)
+            verifyContextMenuForLinksToOtherHosts("wikipedia.org".toUri())
             dismissContentContextMenu()
             // Some options are missing from the linked and non liked images context menus in PDF files
             // See https://bugzilla.mozilla.org/show_bug.cgi?id=1012805 for more details
             longClickPDFImage()
-            verifyLinkContextMenuItems("wikipedia.org".toUri())
+            verifyContextMenuForLinksToOtherHosts("wikipedia.org".toUri())
             dismissContentContextMenu()
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -81,7 +81,7 @@ class ContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 1"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Open link in new tab")
             verifySnackBarText("New tab opened")
             clickSnackbarButton("SWITCH")
@@ -105,7 +105,7 @@ class ContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 2"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Open link in private tab")
             verifySnackBarText("New private tab opened")
             clickSnackbarButton("SWITCH")
@@ -127,7 +127,7 @@ class ContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 3"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Copy link")
             verifySnackBarText("Link copied to clipboard")
         }.openNavigationToolbar {
@@ -144,7 +144,7 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             longClickPageObject(itemWithText("Link 3"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Copy link")
             verifySnackBarText("Link copied to clipboard")
         }.openNavigationToolbar {
@@ -169,7 +169,7 @@ class ContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 1"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             clickContextMenuItem("Share link")
             shareOverlay {
                 verifyShareLinkIntent(genericURL.url)
@@ -252,7 +252,7 @@ class ContextMenusTest {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
             longClickPageObject(itemWithText("Link 1"))
-            verifyLinkContextMenuItems(genericURL.url)
+            verifyContextMenuForLocalHostLinks(genericURL.url)
             dismissContentContextMenu()
             longClickPageObject(itemWithText("test_link_image"))
             verifyLinkImageContextMenuItems(imageResource.url)
@@ -272,12 +272,12 @@ class ContextMenusTest {
             clickPageObject(itemWithText("PDF form file"))
             waitForPageToLoad()
             longClickPageObject(itemWithText("Wikipedia link"))
-            verifyLinkContextMenuItems("wikipedia.org".toUri(), false)
+            verifyContextMenuForLinksToOtherHosts("wikipedia.org".toUri())
             dismissContentContextMenu()
             // Some options are missing from the linked and non liked images context menus in PDF files
             // See https://bugzilla.mozilla.org/show_bug.cgi?id=1012805 for more details
             longClickPDFImage()
-            verifyLinkContextMenuItems("wikipedia.org".toUri())
+            verifyContextMenuForLinksToOtherHosts("wikipedia.org".toUri())
             dismissContentContextMenu()
         }
     }
@@ -289,6 +289,7 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
             longClickPageObject(itemContainingText("Youtube link"))
+            verifyContextMenuForLinksToOtherApps("youtube.com".toUri())
             clickContextMenuItem("Open link in external app")
             assertYoutubeAppOpens()
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -178,55 +178,43 @@ class BrowserRobot {
         )
     }
 
-    fun verifyLinkContextMenuItems(containsURL: Uri, isTheLinkLocal: Boolean = true) {
+    fun verifyContextMenuForLocalHostLinks(containsURL: Uri) {
         // If the link is directing to another local asset the "Download link" option is not available
-        if (isTheLinkLocal) {
-            mDevice.waitNotNull(
-                Until.findObject(By.textContains(containsURL.toString())),
-                waitingTime,
-            )
-            mDevice.waitNotNull(
-                Until.findObject(text(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_new_tab))),
-                waitingTime,
-            )
-            mDevice.waitNotNull(
-                Until.findObject(text(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_private_tab))),
-                waitingTime,
-            )
-            mDevice.waitNotNull(
-                Until.findObject(text(getStringResource(R.string.mozac_feature_contextmenu_copy_link))),
-                waitingTime,
-            )
-            mDevice.waitNotNull(
-                Until.findObject(text(getStringResource(R.string.mozac_feature_contextmenu_share_link))),
-                waitingTime,
-            )
-        } else {
-            mDevice.waitNotNull(
-                Until.findObject(By.textContains(containsURL.toString())),
-                waitingTime,
-            )
-            mDevice.waitNotNull(
-                Until.findObject(text(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_new_tab))),
-                waitingTime,
-            )
-            mDevice.waitNotNull(
-                Until.findObject(text(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_private_tab))),
-                waitingTime,
-            )
-            mDevice.waitNotNull(
-                Until.findObject(text(getStringResource(R.string.mozac_feature_contextmenu_copy_link))),
-                waitingTime,
-            )
-            mDevice.waitNotNull(
-                Until.findObject(text(getStringResource(R.string.mozac_feature_contextmenu_download_link))),
-                waitingTime,
-            )
-            mDevice.waitNotNull(
-                Until.findObject(text(getStringResource(R.string.mozac_feature_contextmenu_share_link))),
-                waitingTime,
-            )
-        }
+        // If the link is not re-directing to an external app the "Open link in external app" option is not available
+        assertItemContainingTextExists(
+            contextMenuLinkUrl(containsURL.toString()),
+            contextMenuOpenLinkInNewTab,
+            contextMenuOpenLinkInPrivateTab,
+            contextMenuCopyLink,
+            contextMenuShareLink,
+        )
+    }
+
+    fun verifyContextMenuForLinksToOtherApps(containsURL: Uri) {
+        // If the link is re-directing to an external app the "Open link in external app" option is available
+        // If the link is not directing to another local asset the "Download link" option is not available
+        assertItemContainingTextExists(
+            contextMenuLinkUrl(containsURL.toString()),
+            contextMenuOpenLinkInNewTab,
+            contextMenuOpenLinkInPrivateTab,
+            contextMenuCopyLink,
+            contextMenuDownloadLink,
+            contextMenuShareLink,
+            contextMenuOpenInExternalApp,
+        )
+    }
+
+    fun verifyContextMenuForLinksToOtherHosts(containsURL: Uri) {
+        // If the link is re-directing to another host the "Download link" option is available
+        // If the link is not re-directing to an external app the "Open link in external app" option is not available
+        assertItemContainingTextExists(
+            contextMenuLinkUrl(containsURL.toString()),
+            contextMenuOpenLinkInNewTab,
+            contextMenuOpenLinkInPrivateTab,
+            contextMenuCopyLink,
+            contextMenuDownloadLink,
+            contextMenuShareLink,
+        )
     }
 
     fun verifyLinkImageContextMenuItems(containsURL: Uri) {
@@ -1308,3 +1296,32 @@ private val totalCookieProtectionHintLearnMoreLink =
     itemContainingText(getStringResource(R.string.tcp_cfr_learn_more))
 private val totalCookieProtectionHintCloseButton =
     itemWithDescription(getStringResource(R.string.mozac_cfr_dismiss_button_content_description))
+
+// Context menu items
+// Link URL
+private fun contextMenuLinkUrl(linkUrl: String) =
+    itemContainingText(linkUrl)
+
+// Open link in new tab option
+private val contextMenuOpenLinkInNewTab =
+    itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_new_tab))
+
+// Open link in private tab option
+private val contextMenuOpenLinkInPrivateTab =
+    itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_private_tab))
+
+// Copy link option
+private val contextMenuCopyLink =
+    itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_copy_link))
+
+// Download link option
+private val contextMenuDownloadLink =
+    itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_download_link))
+
+// Share link option
+private val contextMenuShareLink =
+    itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_share_link))
+
+// Open in external app option
+private val contextMenuOpenInExternalApp =
+    itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_external_app))


### PR DESCRIPTION
Added new conditions based on the link types and missing options when verifying link related context menu options.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1841073