### PR TITLE
Bug 1826467 - Searching for words with spaces matches bookmarks and history entries in Unified Search, but not open tabs

### DIFF
--- a/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
+++ b/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
@@ -46,7 +46,8 @@ class SessionSuggestionProvider(
 
     @Suppress("ComplexCondition")
     override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
-        if (text.isEmpty()) {
+        val safeText = text.trim()
+        if (safeText.isEmpty()) {
             return emptyList()
         }
 
@@ -61,7 +62,7 @@ class SessionSuggestionProvider(
         tabs.zip(iconRequests) { result, icon ->
             if (
                 resultsUriFilter?.sameHostWithoutMobileSubdomainAs(result.content.url.toUri()) != false &&
-                result.contains(text) &&
+                result.contains(safeText) &&
                 !result.content.private &&
                 shouldIncludeSelectedTab(state, result)
             ) {
@@ -69,7 +70,7 @@ class SessionSuggestionProvider(
                     AwesomeBar.Suggestion(
                         provider = this,
                         id = result.id,
-                        title = if (result.content.title.isNotBlank()) result.content.title else result.content.url,
+                        title = result.content.title.ifBlank { result.content.url },
                         description = resources.getString(R.string.switch_to_tab_description),
                         flags = setOf(AwesomeBar.Suggestion.Flag.OPEN_TAB),
                         icon = icon?.await()?.bitmap,

--- a/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
+++ b/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
@@ -46,8 +46,8 @@ class SessionSuggestionProvider(
 
     @Suppress("ComplexCondition")
     override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
-        val safeText = text.trim()
-        if (safeText.isEmpty()) {
+        val searchText = text.trim()
+        if (searchText.isEmpty()) {
             return emptyList()
         }
 
@@ -59,10 +59,11 @@ class SessionSuggestionProvider(
             icons?.loadIcon(IconRequest(url = it.content.url, waitOnNetworkLoad = false))
         }
 
+        val searchWords = searchText.split(" ")
         tabs.zip(iconRequests) { result, icon ->
             if (
                 resultsUriFilter?.sameHostWithoutMobileSubdomainAs(result.content.url.toUri()) != false &&
-                result.contains(safeText) &&
+                searchWords.all { result.contains(it) } &&
                 !result.content.private &&
                 shouldIncludeSelectedTab(state, result)
             ) {

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
@@ -138,6 +138,47 @@ class SessionSuggestionProviderTest {
         }
 
     @Test
+    fun `GIVEN input text has multiple matching words WHEN all match THEN Provider returns Sessions with matching URLs`() =
+        runTest {
+            val store = BrowserStore()
+
+            val tab1 = createTab("https://www.mozilla.org/example/of/content")
+
+            val resources: Resources = mock()
+            `when`(resources.getString(anyInt())).thenReturn("Switch to tab")
+
+            val provider = SessionSuggestionProvider(resources, store, mock())
+            store.dispatch(TabListAction.AddTabAction(tab1)).join()
+
+            run {
+                val suggestions = provider.onInputChanged("mozilla example content")
+                assertEquals(1, suggestions.size)
+
+                assertEquals(tab1.id, suggestions[0].id)
+                assertEquals("Switch to tab", suggestions[0].description)
+            }
+        }
+
+    @Test
+    fun `GIVEN input text has multiple matching words WHEN some match THEN Provider returns an empty list`() =
+        runTest {
+            val store = BrowserStore()
+
+            val tab1 = createTab("https://www.mozilla.org/example/of/content")
+
+            val resources: Resources = mock()
+            `when`(resources.getString(anyInt())).thenReturn("Switch to tab")
+
+            val provider = SessionSuggestionProvider(resources, store, mock())
+            store.dispatch(TabListAction.AddTabAction(tab1)).join()
+
+            run {
+                val suggestions = provider.onInputChanged("mozilla example test")
+                assertTrue(suggestions.isEmpty())
+            }
+        }
+
+    @Test
     fun `Provider returns Sessions with matching titles`() = runTest {
         val tab1 = createTab("https://allizom.org", title = "Internet for people, not profit — Mozilla")
         val tab2 = createTab("https://getpocket.com", title = "Pocket: My List")

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
@@ -84,6 +84,60 @@ class SessionSuggestionProviderTest {
     }
 
     @Test
+    fun `WHEN input text has trailing space THEN Provider returns Sessions with matching URLs`() =
+        runTest {
+            val store = BrowserStore()
+
+            val tab1 = createTab("https://www.mozilla.org")
+            val tab2 = createTab("https://www.mozilla.org/example/of/content")
+
+            val resources: Resources = mock()
+            `when`(resources.getString(anyInt())).thenReturn("Switch to tab")
+
+            val provider = SessionSuggestionProvider(resources, store, mock())
+            store.dispatch(TabListAction.AddTabAction(tab1)).join()
+            store.dispatch(TabListAction.AddTabAction(tab2)).join()
+
+            run {
+                val suggestions = provider.onInputChanged("mozilla ")
+                assertEquals(2, suggestions.size)
+
+                assertEquals(tab1.id, suggestions[0].id)
+                assertEquals("Switch to tab", suggestions[0].description)
+
+                assertEquals(tab2.id, suggestions[1].id)
+                assertEquals("Switch to tab", suggestions[1].description)
+            }
+        }
+
+    @Test
+    fun `WHEN input text has leading space THEN Provider returns Sessions with matching URLs`() =
+        runTest {
+            val store = BrowserStore()
+
+            val tab1 = createTab("https://www.mozilla.org")
+            val tab2 = createTab("https://www.mozilla.org/example/of/content")
+
+            val resources: Resources = mock()
+            `when`(resources.getString(anyInt())).thenReturn("Switch to tab")
+
+            val provider = SessionSuggestionProvider(resources, store, mock())
+            store.dispatch(TabListAction.AddTabAction(tab1)).join()
+            store.dispatch(TabListAction.AddTabAction(tab2)).join()
+
+            run {
+                val suggestions = provider.onInputChanged(" mozilla")
+                assertEquals(2, suggestions.size)
+
+                assertEquals(tab1.id, suggestions[0].id)
+                assertEquals("Switch to tab", suggestions[0].description)
+
+                assertEquals(tab2.id, suggestions[1].id)
+                assertEquals("Switch to tab", suggestions[1].description)
+            }
+        }
+
+    @Test
     fun `Provider returns Sessions with matching titles`() = runTest {
         val tab1 = createTab("https://allizom.org", title = "Internet for people, not profit — Mozilla")
         val tab2 = createTab("https://getpocket.com", title = "Pocket: My List")


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1826467