### PR TITLE
Bug 1840896 - Remove `rememberSaveable` since bitmaps are not serializable

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ThumbnailImage.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ThumbnailImage.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.compose
 
 import android.graphics.Bitmap
-import android.os.Parcelable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -13,8 +12,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,7 +25,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-import kotlinx.parcelize.Parcelize
 import mozilla.components.concept.base.images.ImageLoadRequest
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -56,7 +54,7 @@ fun ThumbnailImage(
         val thumbnailSize = LocalDensity.current.run { size.toPx().toInt() }
         val request = ImageLoadRequest(key, thumbnailSize)
         val storage = components.core.thumbnailStorage
-        var state by rememberSaveable { mutableStateOf(ThumbnailImageState(null, false)) }
+        var state by remember { mutableStateOf(ThumbnailImageState(null, false)) }
         val scope = rememberCoroutineScope()
 
         DisposableEffect(Unit) {
@@ -102,11 +100,10 @@ fun ThumbnailImage(
 /**
  * State wrapper for [ThumbnailImage].
  */
-@Parcelize
 private data class ThumbnailImageState(
     val bitmap: Bitmap?,
     val hasLoaded: Boolean,
-) : Parcelable
+)
 
 /**
  * This preview does not demo anything. This is to ensure that [ThumbnailImage] does not break other previews.


### PR DESCRIPTION
Using `rememberSaveable` with a bitmap is causing crashes on certain combinations of Android devices and OS versions, since bitmaps are not serializable. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840896