### PR TITLE
Bug 1835816 - Do not try to redirect intent even if unsupported by engine

### DIFF
--- a/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -118,8 +118,7 @@ class AppLinksUseCases(
             }
 
             val appIntent = when {
-                redirectData.resolveInfo == null && isEngineSupportedScheme -> null
-                redirectData.resolveInfo == null && redirectData.marketplaceIntent != null -> null
+                redirectData.resolveInfo == null -> null
                 isBrowserRedirect && isEngineSupportedScheme -> null
                 includeHttpAppLinks && isAppIntentHttpOrHttps -> redirectData.appIntent
                 !launchInApp() && (isEngineSupportedScheme || fallbackUrl != null) -> null
@@ -175,7 +174,7 @@ class AppLinksUseCases(
                     context.packageName -> null
                     // no default app found but Android resolver shows there are multiple applications
                     // that can open this app link
-                    ANDROID_RESOLVER_PACKAGE_NAME -> {
+                    ANDROID_RESOLVER_PACKAGE_NAME, null -> {
                         findActivities(appIntent).filter {
                             it.filter != null &&
                                 !(it.filter.countDataPaths() == 0 && it.filter.countDataAuthorities() == 0)
@@ -295,6 +294,11 @@ class AppLinksUseCases(
     companion object {
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal var redirectCache: AppLinkRedirectCache? = null
+
+        @VisibleForTesting
+        internal fun clearRedirectCache() {
+            redirectCache = null
+        }
 
         // list of scheme from https://searchfox.org/mozilla-central/source/netwerk/build/components.conf
         internal val ENGINE_SUPPORTED_SCHEMES: Set<String> = setOf(


### PR DESCRIPTION
Originally we used to try to launch the intent if engine doesn't support the scheme even though no external app is found.  This is not a good behaviour since Android OS already told us nothing on the device support the intent.

Stop trying to redirect to an external app that doesn't exist on the device.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1835816