### PR TITLE
Bug 1842164 - don't optimize away tasks whose configuration changes

### DIFF
--- a/taskcluster/android_taskgraph/transforms/gradle_optimization.py
+++ b/taskcluster/android_taskgraph/transforms/gradle_optimization.py
@@ -55,6 +55,7 @@ def extend_optimization_if_one_already_exists(config, tasks):
         optimization = task.get("optimization")
         if optimization:
             skip_unless_changed = optimization["skip-unless-changed"]
+            skip_unless_changed.append(f"{config.path}/**")
 
             gradle_project = get_gradle_project(task)
             # TODO Remove this special case when ui-test.sh is able to accept "browser-engine-gecko"


### PR DESCRIPTION
This matches what's done in
https://searchfox.org/mozilla-central/source/taskcluster/gecko_taskgraph/transforms/job/__init__.py#123



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1842164