### PR TITLE
Bug 1841749 - Prevent interaction with toolbar when elements on top

### DIFF
--- a/fenix/app/src/main/res/layout/fragment_browser.xml
+++ b/fenix/app/src/main/res/layout/fragment_browser.xml
@@ -78,6 +78,8 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom"
                 android:visibility="gone"
+                android:clickable="true"
+                android:focusable="true"
                 android:elevation="@dimen/browser_fragment_toolbar_elevation"/>
 
             <FrameLayout


### PR DESCRIPTION
When the toolbar is positioned at the bottom and the download prompt appears, the user is still able to interact with the toolbar. This issue is also reproducible when displaying the find in page bar or the reader view controls, the user being able to swipe on these to navigate to another tab. 

| Download Prompt Before | After |
| ------------- | ------------- |
| <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/5019a600-bf25-48a9-8ce9-3570f070e95d"> | <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/10342a69-4e19-4a29-bb8f-dd803d139460"> |

| FIP Before | After |
| ------------- | ------------- |
| <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/e17013a4-064a-4cb2-8c03-e51975f8d7f0"> | <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/2aa61a2b-9983-48f9-afe6-cfc031442bf2"> |

| Reader View Controls Actual | Expected |
| ------------- | ------------- |
| <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/ce3f6efe-2522-48be-a364-5c9232455f68"> | <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/54578704-63a9-435d-9426-820693231108"> |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1841749