### PR TITLE
Bug 1839239 - Add crash bread crumbs for dialogs.

### DIFF
--- a/android-components/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
+++ b/android-components/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuFeature.kt
@@ -18,7 +18,9 @@ import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.HitResult
+import mozilla.components.feature.contextmenu.facts.emitCancelMenuFact
 import mozilla.components.feature.contextmenu.facts.emitClickFact
+import mozilla.components.feature.contextmenu.facts.emitDisplayFact
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 
@@ -108,10 +110,12 @@ class ContextMenuFeature(
 
         val fragment = ContextMenuFragment.create(tab, hitResult.getLink(), ids, labels, additionalNote(hitResult))
         fragment.feature = this
+        emitDisplayFact(labels.joinToString())
         fragment.show(fragmentManager, FRAGMENT_TAG)
     }
 
     private fun hideContextMenu() {
+        emitCancelMenuFact()
         fragmentManager.findFragmentByTag(FRAGMENT_TAG)?.let { fragment ->
             fragmentManager.beginTransaction()
                 .remove(fragment)

--- a/android-components/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/facts/ContextMenuFacts.kt
+++ b/android-components/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/facts/ContextMenuFacts.kt
@@ -18,6 +18,7 @@ class ContextMenuFacts {
      * Items that specify which portion of the [ContextMenuFeature] was interacted with
      */
     object Items {
+        const val MENU = "menu"
         const val ITEM = "item"
         const val TEXT_SELECTION_OPTION = "textSelectionOption"
     }
@@ -41,6 +42,14 @@ private fun emitContextMenuFact(
 internal fun emitClickFact(candidate: ContextMenuCandidate) {
     val metadata = mapOf("item" to candidate.id)
     emitContextMenuFact(Action.CLICK, ContextMenuFacts.Items.ITEM, metadata = metadata)
+}
+
+internal fun emitDisplayFact(labels: String) {
+    emitContextMenuFact(Action.DISPLAY, ContextMenuFacts.Items.MENU, labels)
+}
+
+internal fun emitCancelMenuFact() {
+    emitContextMenuFact(Action.CANCEL, ContextMenuFacts.Items.MENU)
 }
 
 internal fun emitTextSelectionClickFact(optionId: String) {

--- a/android-components/components/feature/downloads/README.md
+++ b/android-components/components/feature/downloads/README.md
@@ -158,13 +158,15 @@ Customizing SimpleDownloadDialogFragment.
 
 This component emits the following [Facts](../../support/base/README.md#Facts):
 
-| Action     | Item            |  Description                                      |
-|------------|-----------------|---------------------------------------------------|
-| RESUME     | notification    | The user resumes a download.                      |
-| PAUSE      | notification    | The user pauses a download.                       |
-| CANCEL     | notification    | The user cancels a download.                      |
-| TRY_AGAIN  | notification    | The user taps on try again when a download fails. |
-| OPEN       | notification    | The user opens a downloaded file.                 |
+| Action    | Item         | Description                                       |
+|-----------|--------------|---------------------------------------------------|
+| RESUME    | notification | The user resumes a download.                      |
+| PAUSE     | notification | The user pauses a download.                       |
+| CANCEL    | notification | The user cancels a download.                      |
+| TRY_AGAIN | notification | The user taps on try again when a download fails. |
+| OPEN      | notification | The user opens a downloaded file.                 |
+| DISPLAY   | prompt       | A download prompt was shown.                      |
+| CANCEL    | prompt       | A download prompt was canceled.                   |
 
 ## License
 

--- a/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
+++ b/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/DownloadsFeature.kt
@@ -26,6 +26,8 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.downloads.DownloadDialogFragment.Companion.FRAGMENT_TAG
 import mozilla.components.feature.downloads.dialog.DeniedPermissionDialogFragment
 import mozilla.components.feature.downloads.ext.realFilenameOrGuessed
+import mozilla.components.feature.downloads.facts.emitPromptDismissedFact
+import mozilla.components.feature.downloads.facts.emitPromptDisplayedFact
 import mozilla.components.feature.downloads.manager.AndroidDownloadManager
 import mozilla.components.feature.downloads.manager.DownloadManager
 import mozilla.components.feature.downloads.manager.noop
@@ -322,6 +324,7 @@ class DownloadsFeature(
         }
 
         if (!isAlreadyADownloadDialog() && fragmentManager != null && !fragmentManager.isDestroyed) {
+            emitPromptDisplayedFact()
             dialog.showNow(fragmentManager, FRAGMENT_TAG)
         }
     }
@@ -345,10 +348,12 @@ class DownloadsFeature(
         }
 
         appChooserDialog.onDismiss = {
+            emitPromptDismissedFact()
             useCases.cancelDownloadRequest.invoke(tab.id, download.id)
         }
 
         if (!isAlreadyAppDownloaderDialog() && fragmentManager != null && !fragmentManager.isDestroyed) {
+            emitPromptDisplayedFact()
             appChooserDialog.showNow(fragmentManager, DownloadAppChooserDialog.FRAGMENT_TAG)
         }
     }

--- a/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/facts/DownloadsFacts.kt
+++ b/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/facts/DownloadsFacts.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.downloads.facts
 
+import mozilla.components.feature.downloads.facts.DownloadsFacts.Items.PROMPT
 import mozilla.components.support.base.Component
 import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.Fact
@@ -18,21 +19,25 @@ class DownloadsFacts {
      */
     object Items {
         const val NOTIFICATION = "notification"
+        const val PROMPT = "prompt"
     }
 }
 
-internal fun emitNotificationResumeFact() = emitNotificationFact(Action.RESUME)
-internal fun emitNotificationPauseFact() = emitNotificationFact(Action.PAUSE)
-internal fun emitNotificationCancelFact() = emitNotificationFact(Action.CANCEL)
-internal fun emitNotificationTryAgainFact() = emitNotificationFact(Action.TRY_AGAIN)
-internal fun emitNotificationOpenFact() = emitNotificationFact(Action.OPEN)
+internal fun emitNotificationResumeFact() = emitFact(Action.RESUME)
+internal fun emitNotificationPauseFact() = emitFact(Action.PAUSE)
+internal fun emitNotificationCancelFact() = emitFact(Action.CANCEL)
+internal fun emitNotificationTryAgainFact() = emitFact(Action.TRY_AGAIN)
+internal fun emitNotificationOpenFact() = emitFact(Action.OPEN)
+internal fun emitPromptDisplayedFact() = emitFact(Action.DISPLAY, item = PROMPT)
+internal fun emitPromptDismissedFact() = emitFact(Action.CANCEL, item = PROMPT)
 
-private fun emitNotificationFact(
+private fun emitFact(
     action: Action,
+    item: String = DownloadsFacts.Items.NOTIFICATION,
 ) {
     Fact(
         Component.FEATURE_DOWNLOADS,
         action,
-        DownloadsFacts.Items.NOTIFICATION,
+        item,
     ).collect()
 }

--- a/android-components/components/feature/prompts/README.md
+++ b/android-components/components/feature/prompts/README.md
@@ -58,6 +58,17 @@ implementation "org.mozilla.components:feature-prompts:{latest-version}"
   }
   ```
 
+## Facts
+
+This component emits the following [Facts](../../support/base/README.md#Facts):
+
+| Action    | Item         | Description             |
+|-----------|--------------|-------------------------|
+| DISPLAY   | prompt       | A prompt was shown.     |
+| CANCEL    | prompt       | A prompt was canceled.  |
+| CONFIRM   | prompt       | A prompt was confirmed. |
+
+
 ## License
 
     This Source Code Form is subject to the terms of the Mozilla Public

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/PromptFeature.kt
@@ -70,6 +70,9 @@ import mozilla.components.feature.prompts.dialog.TextPromptDialogFragment
 import mozilla.components.feature.prompts.dialog.TimePickerDialogFragment
 import mozilla.components.feature.prompts.ext.executeIfWindowedPrompt
 import mozilla.components.feature.prompts.facts.emitCreditCardSaveShownFact
+import mozilla.components.feature.prompts.facts.emitPromptConfirmedFact
+import mozilla.components.feature.prompts.facts.emitPromptDismissedFact
+import mozilla.components.feature.prompts.facts.emitPromptDisplayedFact
 import mozilla.components.feature.prompts.facts.emitSuccessfulAddressAutofillFormDetectedFact
 import mozilla.components.feature.prompts.facts.emitSuccessfulCreditCardAutofillFormDetectedFact
 import mozilla.components.feature.prompts.file.FilePicker
@@ -91,6 +94,7 @@ import mozilla.components.support.base.feature.OnNeedToRequestPermissions
 import mozilla.components.support.base.feature.PermissionsFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.ktx.kotlin.ifNullOrEmpty
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import java.lang.ref.WeakReference
 import java.security.InvalidParameterException
@@ -485,7 +489,10 @@ class PromptFeature private constructor(
             }
 
             when (promptRequest) {
-                is File -> filePicker.handleFileRequest(promptRequest)
+                is File -> {
+                    emitPromptDisplayedFact(promptName = "FilePrompt")
+                    filePicker.handleFileRequest(promptRequest)
+                }
                 is Share -> handleShareRequest(promptRequest, session)
                 is SelectCreditCard -> {
                     emitSuccessfulCreditCardAutofillFormDetectedFact()
@@ -494,6 +501,7 @@ class PromptFeature private constructor(
                     }
                 }
                 is SelectLoginPrompt -> {
+                    emitPromptDisplayedFact(promptName = "SelectLoginPrompt")
                     if (promptRequest.logins.isNotEmpty()) {
                         loginPicker?.handleSelectLoginRequest(promptRequest)
                     }
@@ -519,6 +527,7 @@ class PromptFeature private constructor(
      */
     override fun onCancel(sessionId: String, promptRequestUID: String, value: Any?) {
         store.consumePromptFrom(sessionId, promptRequestUID, activePrompt) {
+            emitPromptDismissedFact(promptName = it::class.simpleName.ifNullOrEmpty { "" })
             when (it) {
                 is BeforeUnload -> it.onStay()
                 is Popup -> {
@@ -602,6 +611,7 @@ class PromptFeature private constructor(
                     // no-op
                 }
             }
+            emitPromptConfirmedFact(it::class.simpleName.ifNullOrEmpty { "" })
         }
     }
 
@@ -640,10 +650,14 @@ class PromptFeature private constructor(
     }
 
     private fun handleShareRequest(promptRequest: Share, session: SessionState) {
+        emitPromptDisplayedFact(promptName = "ShareSheet")
         shareDelegate.showShareSheet(
             context = container.context,
             shareData = promptRequest.data,
-            onDismiss = { onCancel(session.id, promptRequest.uid) },
+            onDismiss = {
+                emitPromptDismissedFact(promptName = "ShareSheet")
+                onCancel(session.id, promptRequest.uid)
+            },
             onSuccess = { onConfirm(session.id, promptRequest.uid, null) },
         )
     }
@@ -955,6 +969,7 @@ class PromptFeature private constructor(
                 }
             }
 
+            emitPromptDisplayedFact(promptName = dialog::class.simpleName.ifNullOrEmpty { "" })
             dialog.show(fragmentManager, FRAGMENT_TAG)
             activePrompt = WeakReference(dialog)
 
@@ -974,6 +989,7 @@ class PromptFeature private constructor(
     internal fun dismissDialogRequest(promptRequest: PromptRequest, session: SessionState) {
         (promptRequest as Dismissible).onDismiss()
         store.dispatch(ContentAction.ConsumePromptRequestAction(session.id, promptRequest))
+        emitPromptDismissedFact(promptName = promptRequest::class.simpleName.ifNullOrEmpty { "" })
     }
 
     private fun canShowThisPrompt(promptRequest: PromptRequest): Boolean {

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/facts/PromptFacts.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/facts/PromptFacts.kt
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.prompts.facts
+
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.collect
+
+/**
+ * Facts emitted for different events related to the prompt feature.
+ */
+class PromptFacts {
+    /**
+     * Different events emitted by prompts.
+     */
+    object Items {
+        const val PROMPT = "PROMPT"
+    }
+}
+
+private fun emitFact(
+    action: Action,
+    item: String,
+    value: String? = null,
+    metadata: Map<String, Any>? = null,
+) {
+    Fact(
+        Component.FEATURE_PROMPTS,
+        action,
+        item,
+        value,
+        metadata,
+    ).collect()
+}
+
+internal fun emitPromptDisplayedFact(promptName: String) {
+    emitFact(
+        Action.DISPLAY,
+        PromptFacts.Items.PROMPT,
+        value = promptName,
+    )
+}
+
+internal fun emitPromptDismissedFact(promptName: String) {
+    emitFact(
+        Action.CANCEL,
+        PromptFacts.Items.PROMPT,
+        value = promptName,
+    )
+}
+
+internal fun emitPromptConfirmedFact(promptName: String) {
+    emitFact(
+        Action.CONFIRM,
+        PromptFacts.Items.PROMPT,
+        value = promptName,
+    )
+}

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt
@@ -2638,8 +2638,7 @@ class PromptFeatureTest {
                 session = session,
             )
 
-            assertEquals(1, facts.size)
-            val fact = facts.single()
+            val fact = facts.find { it.item == CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SAVE_PROMPT_SHOWN }!!
             assertEquals(Component.FEATURE_PROMPTS, fact.component)
             assertEquals(Action.DISPLAY, fact.action)
             assertEquals(

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -442,6 +442,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
     private fun startMetricsIfEnabled() {
         if (settings().isTelemetryEnabled) {
             components.analytics.metrics.start(MetricServiceType.Data)
+            components.analytics.crashFactCollector.start()
         }
 
         if (settings().isMarketingTelemetryEnabled) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/android/FenixDialogFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/android/FenixDialogFragment.kt
@@ -19,7 +19,9 @@ import androidx.appcompat.view.ContextThemeWrapper
 import com.google.android.material.R
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import mozilla.components.concept.base.crash.Breadcrumb
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.ext.components
 
 /**
  * Base [AppCompatDialogFragment] that adds behaviour to create a top or bottom dialog.
@@ -36,6 +38,9 @@ abstract class FenixDialogFragment : AppCompatDialogFragment() {
     abstract val layoutId: Int
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("FenixDialogFragment onCreateDialog Gravity $gravity"),
+        )
         return if (gravity == Gravity.BOTTOM) {
             BottomSheetDialog(requireContext(), this.theme).apply {
                 setOnShowListener {

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -57,6 +57,7 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.thumbnails.BrowserThumbnails
+import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.feature.accounts.FxaCapability
@@ -550,6 +551,9 @@ abstract class BaseBrowserFragment :
             customFirstPartyDownloadDialog = { filename, contentSize, positiveAction, negativeAction ->
                 run {
                     if (currentStartDownloadDialog == null) {
+                        context.components.analytics.crashReporter.recordCrashBreadcrumb(
+                            Breadcrumb("FirstPartyDownloadDialog created"),
+                        )
                         FirstPartyDownloadDialog(
                             activity = requireActivity(),
                             filename = filename.value,
@@ -557,6 +561,9 @@ abstract class BaseBrowserFragment :
                             positiveButtonAction = positiveAction.value,
                             negativeButtonAction = negativeAction.value,
                         ).onDismiss {
+                            context.components.analytics.crashReporter.recordCrashBreadcrumb(
+                                Breadcrumb("FirstPartyDownloadDialog onDismiss"),
+                            )
                             currentStartDownloadDialog = null
                         }.show(binding.startDownloadDialogContainer)
                             .also {
@@ -568,12 +575,18 @@ abstract class BaseBrowserFragment :
             customThirdPartyDownloadDialog = { downloaderApps, onAppSelected, negativeActionCallback ->
                 run {
                     if (currentStartDownloadDialog == null) {
+                        context.components.analytics.crashReporter.recordCrashBreadcrumb(
+                            Breadcrumb("ThirdPartyDownloadDialog created"),
+                        )
                         ThirdPartyDownloadDialog(
                             activity = requireActivity(),
                             downloaderApps = downloaderApps.value,
                             onAppSelected = onAppSelected.value,
                             negativeButtonAction = negativeActionCallback.value,
                         ).onDismiss {
+                            context.components.analytics.crashReporter.recordCrashBreadcrumb(
+                                Breadcrumb("ThirdPartyDownloadDialog onDismiss"),
+                            )
                             currentStartDownloadDialog = null
                         }.show(binding.startDownloadDialogContainer).also {
                             currentStartDownloadDialog = it

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -30,6 +30,7 @@ import org.mozilla.fenix.components.metrics.GleanMetricsService
 import org.mozilla.fenix.components.metrics.InstallReferrerMetricsService
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.components.metrics.MetricsStorage
+import org.mozilla.fenix.crashes.CrashFactCollector
 import org.mozilla.fenix.experiments.createNimbus
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
@@ -118,6 +119,10 @@ class Analytics(
             nonFatalCrashIntent = pendingIntent,
             notificationsDelegate = context.components.notificationsDelegate,
         )
+    }
+
+    val crashFactCollector: CrashFactCollector by lazyMonitored {
+        CrashFactCollector(crashReporter)
     }
 
     val metricsStorage: MetricsStorage by lazyMonitored {

--- a/fenix/app/src/main/java/org/mozilla/fenix/crashes/CrashFactCollector.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/crashes/CrashFactCollector.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.crashes
+
+import mozilla.components.concept.base.crash.Breadcrumb
+import mozilla.components.concept.base.crash.CrashReporting
+import mozilla.components.feature.contextmenu.facts.ContextMenuFacts
+import mozilla.components.feature.downloads.facts.DownloadsFacts
+import mozilla.components.feature.prompts.facts.AddressAutofillDialogFacts
+import mozilla.components.feature.prompts.facts.CreditCardAutofillDialogFacts
+import mozilla.components.feature.prompts.facts.PromptFacts
+import mozilla.components.feature.sitepermissions.SitePermissionsFacts
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Fact
+import mozilla.components.support.base.facts.FactProcessor
+import mozilla.components.support.base.facts.Facts
+
+/**
+ * Collects facts and record bread crumbs for the events.
+ */
+class CrashFactCollector(
+    private val crashReporter: CrashReporting,
+) {
+
+    /**
+     * Starts collecting facts.
+     */
+    fun start() {
+        Facts.registerProcessor(
+            object : FactProcessor {
+                override fun process(fact: Fact) {
+                    fact.process()
+                }
+            },
+        )
+    }
+
+    internal fun Fact.process(): Unit = when (component to item) {
+        Component.FEATURE_CONTEXTMENU to ContextMenuFacts.Items.MENU,
+        Component.FEATURE_DOWNLOADS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_SHOWN,
+        Component.FEATURE_DOWNLOADS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SAVE_PROMPT_SHOWN,
+        Component.FEATURE_DOWNLOADS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_DISMISSED,
+        Component.FEATURE_DOWNLOADS to AddressAutofillDialogFacts.Items.AUTOFILL_ADDRESS_PROMPT_SHOWN,
+        Component.FEATURE_DOWNLOADS to AddressAutofillDialogFacts.Items.AUTOFILL_ADDRESS_PROMPT_DISMISSED,
+        Component.FEATURE_DOWNLOADS to DownloadsFacts.Items.PROMPT,
+        Component.FEATURE_SITEPERMISSIONS to SitePermissionsFacts.Items.PERMISSIONS,
+        Component.FEATURE_PROMPTS to PromptFacts.Items.PROMPT,
+        -> {
+            crashReporter.recordCrashBreadcrumb(Breadcrumb("$component $action $value"))
+        }
+        else -> {
+            // no-op
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/downloads/StartDownloadDialog.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/downloads/StartDownloadDialog.kt
@@ -20,6 +20,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.children
 import androidx.viewbinding.ViewBinding
+import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.feature.downloads.databinding.MozacDownloaderChooserPromptBinding
 import mozilla.components.feature.downloads.toMegabyteOrKilobyteString
 import mozilla.components.feature.downloads.ui.DownloaderApp
@@ -27,6 +28,7 @@ import mozilla.components.feature.downloads.ui.DownloaderAppAdapter
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.DialogScrimBinding
 import org.mozilla.fenix.databinding.StartDownloadDialogLayoutBinding
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 
 /**
@@ -54,6 +56,9 @@ abstract class StartDownloadDialog(
      * @param container The [ViewGroup] in which the download view will be inflated.
      */
     fun show(container: ViewGroup): StartDownloadDialog {
+        activity.components.analytics.crashReporter.recordCrashBreadcrumb(
+            Breadcrumb("StartDownloadDialog show"),
+        )
         this.container = container
 
         val dialogParent = container.parent as? ViewGroup
@@ -89,6 +94,9 @@ abstract class StartDownloadDialog(
      * @param callback The callback for when the view is dismissed.
      */
     fun onDismiss(callback: () -> Unit): StartDownloadDialog {
+        activity.components.analytics.crashReporter.recordCrashBreadcrumb(
+            Breadcrumb("StartDownloadDialog onDismiss"),
+        )
         this.onDismiss = callback
         return this
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -19,6 +19,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.selector.findTabOrCustomTab
+import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.feature.accounts.push.SendTabUseCases
 import mozilla.components.feature.share.RecentAppsStorage
@@ -26,6 +27,7 @@ import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.databinding.FragmentShareBinding
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -49,11 +51,17 @@ class ShareFragment : AppCompatDialogFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("ShareFragment onCreate"),
+        )
         setStyle(STYLE_NO_TITLE, R.style.ShareDialogStyle)
     }
 
     override fun onPause() {
         super.onPause()
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("ShareFragment dismiss"),
+        )
         consumePrompt { onDismiss() }
         dismiss()
     }
@@ -150,6 +158,9 @@ class ShareFragment : AppCompatDialogFragment() {
     }
 
     override fun onDestroy() {
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("ShareFragment onDestroy"),
+        )
         setFragmentResult(RESULT_KEY, Bundle())
         // Clear the stored result in case there is no listener with the same key set.
         clearFragmentResult(RESULT_KEY)

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -29,6 +29,7 @@ import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.feature.downloads.ui.DownloadCancelDialogFragment
 import mozilla.components.feature.tabs.tabstray.TabsFeature
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
@@ -125,6 +126,9 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("TabsTrayFragment dismissTabsTray"),
+        )
         setStyle(STYLE_NO_TITLE, R.style.TabTrayDialogStyle)
     }
 
@@ -190,13 +194,18 @@ class TabsTrayFragment : AppCompatDialogFragment() {
             controller = tabsTrayController,
         )
 
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("TabsTrayFragment onCreateDialog"),
+        )
         tabsTrayDialog = TabsTrayDialog(requireContext(), theme) { tabsTrayInteractor }
         return tabsTrayDialog
     }
 
     override fun onPause() {
         super.onPause()
-
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("TabsTrayFragment onPause"),
+        )
         dialog?.window?.setWindowAnimations(R.style.DialogFragmentRestoreAnimation)
     }
 
@@ -314,6 +323,9 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
     override fun onStart() {
         super.onStart()
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("TabsTrayFragment onStart"),
+        )
         findPreviousDialogFragment()?.let { dialog ->
             dialog.onAcceptClicked = ::onCancelDownloadWarningAccepted
         }
@@ -321,6 +333,9 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("TabsTrayFragment onDestroyView"),
+        )
         _tabsTrayBinding = null
         _tabsTrayDialogBinding = null
         _fabButtonBinding = null
@@ -551,6 +566,9 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
     @VisibleForTesting
     internal fun showCancelledDownloadWarning(downloadCount: Int, tabId: String?, source: String?) {
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("DownloadCancelDialogFragment show"),
+        )
         val dialog = DownloadCancelDialogFragment.newInstance(
             downloadCount = downloadCount,
             tabId = tabId,
@@ -687,6 +705,9 @@ class TabsTrayFragment : AppCompatDialogFragment() {
     internal fun dismissTabsTray() {
         // This should always be the last thing we do because nothing (e.g. telemetry)
         // is guaranteed after that.
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("TabsTrayFragment dismissTabsTray"),
+        )
         dismissAllowingStateLoss()
     }
 
@@ -750,6 +771,9 @@ class TabsTrayFragment : AppCompatDialogFragment() {
     }
 
     private fun onTabsTrayDismissed() {
+        context?.components?.analytics?.crashReporter?.recordCrashBreadcrumb(
+            Breadcrumb("TabsTrayFragment onTabsTrayDismissed"),
+        )
         TabsTray.closed.record(NoExtras())
         dismissAllowingStateLoss()
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/downloads/StartDownloadDialogTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/downloads/StartDownloadDialogTest.kt
@@ -25,6 +25,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.StartDownloadDialogLayoutBinding
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.utils.Settings
@@ -44,6 +45,7 @@ class StartDownloadDialogTest {
 
         mockkStatic("mozilla.components.support.ktx.android.view.WindowKt", "org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk(relaxed = true)
+            every { any<Context>().components } returns mockk(relaxed = true)
             val fluentDialog = dialog.show(dialogContainer)
 
             val scrim = dialogParent.children.first { it.id == R.id.scrim }
@@ -66,13 +68,16 @@ class StartDownloadDialogTest {
     @Test
     fun `GIVEN a dismiss callback WHEN the dialog is dismissed THEN the callback is informed`() {
         var wasDismissCalled = false
-        val dialog = TestDownloadDialog(mockk(relaxed = true))
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val dialog = TestDownloadDialog(activity)
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().components } returns mockk(relaxed = true)
+            val fluentDialog = dialog.onDismiss { wasDismissCalled = true }
+            dialog.onDismiss()
 
-        val fluentDialog = dialog.onDismiss { wasDismissCalled = true }
-        dialog.onDismiss()
-
-        assertTrue(wasDismissCalled)
-        assertEquals(dialog, fluentDialog)
+            assertTrue(wasDismissCalled)
+            assertEquals(dialog, fluentDialog)
+        }
     }
 
     @Test
@@ -86,6 +91,7 @@ class StartDownloadDialogTest {
         val dialog = TestDownloadDialog(activity)
         mockkStatic("mozilla.components.support.ktx.android.view.WindowKt", "org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk(relaxed = true)
+            every { any<Context>().components } returns mockk(relaxed = true)
             dialog.show(dialogContainer)
             dialog.binding = StartDownloadDialogLayoutBinding
                 .inflate(LayoutInflater.from(activity), dialogContainer, true)
@@ -161,6 +167,7 @@ class StartDownloadDialogTest {
                 every { accessibilityServicesEnabled } returns false
             }
             every { any<Context>().settings() } returns settings
+            every { any<Context>().components } returns mockk(relaxed = true)
             dialog.show(dialogContainer)
             assertEquals(2, dialogParent.children.count { it.isImportantForAccessibility })
 
@@ -189,6 +196,7 @@ class StartDownloadDialogTest {
                 every { accessibilityServicesEnabled } returns true
             }
             every { any<Context>().settings() } returns settings
+            every { any<Context>().components } returns mockk(relaxed = true)
             val dialog = TestDownloadDialog(activity)
             dialog.show(dialogContainer)
             dialog.binding = StartDownloadDialogLayoutBinding

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/recentvisits/view/RecentBookmarksViewHolderTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/recentvisits/view/RecentBookmarksViewHolderTest.kt
@@ -33,5 +33,5 @@ class RecentBookmarksViewHolderTest {
          verify { interactor.onRemoveGroups(setOf(group)) }
     }
 
-    */
+     */
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
@@ -363,10 +363,12 @@ class TabsTrayFragmentTest {
     @Test
     fun `WHEN dismissTabsTray is called THEN it dismisses the tray`() {
         every { fragment.dismissAllowingStateLoss() } just Runs
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().components } returns mockk(relaxed = true)
+            fragment.dismissTabsTray()
 
-        fragment.dismissTabsTray()
-
-        verify { fragment.dismissAllowingStateLoss() }
+            verify { fragment.dismissAllowingStateLoss() }
+        }
     }
 
     @Test


### PR DESCRIPTION
This patch will add [bread crumbs](https://docs.sentry.io/product/issues/issue-details/breadcrumbs/) that will help us detect the source of the [bug #1839239](https://bugzilla.mozilla.org/show_bug.cgi?id=1839239).




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.














### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1839239