### PR TITLE
Bug 1842179 - Enable Unified Search in all UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
@@ -82,16 +82,6 @@ interface FeatureSettingsHelper {
      */
     var tabsTrayRewriteEnabled: Boolean
 
-    /**
-     * Enable or disable the Unified search feature.
-     */
-    var isUnifiedSearchEnabled: Boolean
-
-    /**
-     * Enable or disable the Unified search settings feature.
-     */
-    var newSearchSettingsEnabled: Boolean
-
     fun applyFlagUpdates()
 
     fun resetAllFeatureFlags()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelperDelegate.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelperDelegate.kt
@@ -31,14 +31,12 @@ class FeatureSettingsHelperDelegate() : FeatureSettingsHelper {
         isRecentlyVisitedFeatureEnabled = settings.historyMetadataUIFeature,
         isPWAsPromptEnabled = !settings.userKnowsAboutPwas,
         isTCPCFREnabled = settings.shouldShowTotalCookieProtectionCFR,
-        isUnifiedSearchEnabled = false,
         isWallpaperOnboardingEnabled = settings.showWallpaperOnboarding,
         isDeleteSitePermissionsEnabled = settings.deleteSitePermissions,
         isCookieBannerReductionDialogEnabled = !settings.userOptOutOfReEngageCookieBannerDialog,
         isOpenInAppBannerEnabled = settings.shouldShowOpenInAppBanner,
         etpPolicy = getETPPolicy(settings),
         tabsTrayRewriteEnabled = settings.enableTabsTrayToCompose,
-        newSearchSettingsEnabled = false,
     )
 
     /**
@@ -57,8 +55,6 @@ class FeatureSettingsHelperDelegate() : FeatureSettingsHelper {
             }
         }
 
-    override var isUnifiedSearchEnabled: Boolean by updatedFeatureFlags::isUnifiedSearchEnabled
-    override var newSearchSettingsEnabled: Boolean by updatedFeatureFlags::newSearchSettingsEnabled
     override var isPocketEnabled: Boolean by updatedFeatureFlags::isPocketEnabled
     override var isJumpBackInCFREnabled: Boolean by updatedFeatureFlags::isJumpBackInCFREnabled
     override var isWallpaperOnboardingEnabled: Boolean by updatedFeatureFlags::isWallpaperOnboardingEnabled
@@ -90,13 +86,11 @@ class FeatureSettingsHelperDelegate() : FeatureSettingsHelper {
         settings.historyMetadataUIFeature = featureFlags.isRecentlyVisitedFeatureEnabled
         settings.userKnowsAboutPwas = !featureFlags.isPWAsPromptEnabled
         settings.shouldShowTotalCookieProtectionCFR = featureFlags.isTCPCFREnabled
-        settings.showUnifiedSearchFeature = featureFlags.isUnifiedSearchEnabled
         settings.showWallpaperOnboarding = featureFlags.isWallpaperOnboardingEnabled
         settings.deleteSitePermissions = featureFlags.isDeleteSitePermissionsEnabled
         settings.userOptOutOfReEngageCookieBannerDialog = !featureFlags.isCookieBannerReductionDialogEnabled
         settings.shouldShowOpenInAppBanner = featureFlags.isOpenInAppBannerEnabled
         settings.enableTabsTrayToCompose = featureFlags.tabsTrayRewriteEnabled
-        settings.enableUnifiedSearchSettingsUI = featureFlags.newSearchSettingsEnabled
         setETPPolicy(featureFlags.etpPolicy)
     }
 }
@@ -110,14 +104,12 @@ private data class FeatureFlags(
     var isRecentlyVisitedFeatureEnabled: Boolean,
     var isPWAsPromptEnabled: Boolean,
     var isTCPCFREnabled: Boolean,
-    var isUnifiedSearchEnabled: Boolean,
     var isWallpaperOnboardingEnabled: Boolean,
     var isDeleteSitePermissionsEnabled: Boolean,
     var isCookieBannerReductionDialogEnabled: Boolean,
     var isOpenInAppBannerEnabled: Boolean,
     var etpPolicy: ETPPolicy,
     var tabsTrayRewriteEnabled: Boolean,
-    var newSearchSettingsEnabled: Boolean,
 )
 
 internal fun getETPPolicy(settings: Settings): ETPPolicy {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
@@ -56,8 +56,6 @@ class HomeActivityTestRule(
         isOpenInAppBannerEnabled: Boolean = settings.shouldShowOpenInAppBanner,
         etpPolicy: ETPPolicy = getETPPolicy(settings),
         tabsTrayRewriteEnabled: Boolean = false,
-        isUnifiedSearchEnabled: Boolean = false,
-        newSearchSettingsEnabled: Boolean = false,
     ) : this(initialTouchMode, launchActivity, skipOnboarding) {
         this.isHomeOnboardingDialogEnabled = isHomeOnboardingDialogEnabled
         this.isPocketEnabled = isPocketEnabled
@@ -72,8 +70,6 @@ class HomeActivityTestRule(
         this.isOpenInAppBannerEnabled = isOpenInAppBannerEnabled
         this.etpPolicy = etpPolicy
         this.tabsTrayRewriteEnabled = tabsTrayRewriteEnabled
-        this.isUnifiedSearchEnabled = isUnifiedSearchEnabled
-        this.newSearchSettingsEnabled = newSearchSettingsEnabled
     }
 
     /**
@@ -129,8 +125,6 @@ class HomeActivityTestRule(
             isWallpaperOnboardingEnabled = false,
             isCookieBannerReductionDialogEnabled = false,
             isOpenInAppBannerEnabled = false,
-            isUnifiedSearchEnabled = false,
-            newSearchSettingsEnabled = false,
         )
     }
 }
@@ -164,8 +158,6 @@ class HomeActivityIntentTestRule internal constructor(
         isRecentlyVisitedFeatureEnabled: Boolean = settings.historyMetadataUIFeature,
         isPWAsPromptEnabled: Boolean = !settings.userKnowsAboutPwas,
         isTCPCFREnabled: Boolean = settings.shouldShowTotalCookieProtectionCFR,
-        isUnifiedSearchEnabled: Boolean = false,
-        newSearchSettingsEnabled: Boolean = false,
         isWallpaperOnboardingEnabled: Boolean = settings.showWallpaperOnboarding,
         isDeleteSitePermissionsEnabled: Boolean = settings.deleteSitePermissions,
         isCookieBannerReductionDialogEnabled: Boolean = !settings.userOptOutOfReEngageCookieBannerDialog,
@@ -180,8 +172,6 @@ class HomeActivityIntentTestRule internal constructor(
         this.isRecentlyVisitedFeatureEnabled = isRecentlyVisitedFeatureEnabled
         this.isPWAsPromptEnabled = isPWAsPromptEnabled
         this.isTCPCFREnabled = isTCPCFREnabled
-        this.isUnifiedSearchEnabled = isUnifiedSearchEnabled
-        this.newSearchSettingsEnabled = newSearchSettingsEnabled
         this.isWallpaperOnboardingEnabled = isWallpaperOnboardingEnabled
         this.isDeleteSitePermissionsEnabled = isDeleteSitePermissionsEnabled
         this.isCookieBannerReductionDialogEnabled = isCookieBannerReductionDialogEnabled
@@ -269,8 +259,6 @@ class HomeActivityIntentTestRule internal constructor(
             launchActivity: Boolean = true,
             skipOnboarding: Boolean = false,
             tabsTrayRewriteEnabled: Boolean = false,
-            isUnifiedSearchEnabled: Boolean = false,
-            newSearchSettingsEnabled: Boolean = false,
         ) = HomeActivityIntentTestRule(
             initialTouchMode = initialTouchMode,
             launchActivity = launchActivity,
@@ -279,8 +267,6 @@ class HomeActivityIntentTestRule internal constructor(
             isJumpBackInCFREnabled = false,
             isPWAsPromptEnabled = false,
             isTCPCFREnabled = false,
-            isUnifiedSearchEnabled = isUnifiedSearchEnabled,
-            newSearchSettingsEnabled = newSearchSettingsEnabled,
             isWallpaperOnboardingEnabled = false,
             isCookieBannerReductionDialogEnabled = false,
             isOpenInAppBannerEnabled = false,

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -50,7 +50,7 @@ class BookmarksTest {
     @get:Rule(order = 0)
     val activityTestRule =
         AndroidComposeTestRule(
-            HomeActivityIntentTestRule.withDefaultSettingsOverrides(isUnifiedSearchEnabled = true),
+            HomeActivityIntentTestRule.withDefaultSettingsOverrides(),
         ) { it.activity }
 
     @Rule(order = 1)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -45,7 +45,7 @@ class HistoryTest {
     @get:Rule
     val activityTestRule =
         AndroidComposeTestRule(
-            HomeActivityIntentTestRule.withDefaultSettingsOverrides(isUnifiedSearchEnabled = true),
+            HomeActivityIntentTestRule.withDefaultSettingsOverrides(),
         ) { it.activity }
 
     @Before

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -71,7 +71,6 @@ class HomeScreenTest {
             verifyStoriesByTopicItems()
             verifyCustomizeHomepageButton(true)
             verifyNavigationToolbar()
-            verifyDefaultSearchEngine("Google")
             verifyHomeMenuButton()
             verifyTabButton()
             verifyTabCounter("0")

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
@@ -132,7 +132,7 @@ class OnboardingTest {
         homeScreen {
             verifyStartBrowsingButton()
         }.openSearch {
-            verifySearchEngineButton()
+            verifySearchView()
             verifyKeyboardVisibility()
         }.dismissSearchBar {
             verifyStartBrowsingButton()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -69,8 +69,6 @@ class SearchTest {
             isRecentTabsFeatureEnabled = false,
             isTCPCFREnabled = false,
             isWallpaperOnboardingEnabled = false,
-            isUnifiedSearchEnabled = true,
-            newSearchSettingsEnabled = true,
         ),
     ) { it.activity }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -37,7 +37,7 @@ class SettingsSearchTest {
 
     @get:Rule
     val activityTestRule = AndroidComposeTestRule(
-        HomeActivityIntentTestRule.withDefaultSettingsOverrides(isUnifiedSearchEnabled = true, newSearchSettingsEnabled = true),
+        HomeActivityIntentTestRule.withDefaultSettingsOverrides(),
     ) { it.activity }
 
     @Before

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SponsoredShortcutsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SponsoredShortcutsTest.kt
@@ -17,7 +17,6 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.Constants.defaultTopSitesList
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.getSponsoredShortcutTitle
 import org.mozilla.fenix.ui.robots.homeScreen
 
@@ -117,26 +116,6 @@ class SponsoredShortcutsTest {
 
             verifySponsoredShortcutDetails(sponsoredShortcutTitle, 2)
             verifySponsoredShortcutDetails(sponsoredShortcutTitle2, 3)
-        }
-    }
-
-    // The default search engine should not be displayed as a sponsored shortcut
-    @Test
-    fun defaultSearchEngineIsNotDisplayedAsSponsoredShortcutTest() {
-        val sponsoredShortcutTitle = "Amazon"
-
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openSearchSubMenu {
-            changeDefaultSearchEngine(defaultSearchEngine)
-        }
-
-        exitMenu()
-
-        homeScreen {
-            verifySponsoredShortcutDoesNotExist(sponsoredShortcutTitle, 2)
-            verifySponsoredShortcutDoesNotExist(sponsoredShortcutTitle, 3)
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
@@ -118,7 +118,7 @@ class TextSelectionTest {
             clickContextMenuItem("Search")
             mDevice.waitForIdle()
             verifyTabCounter("2")
-            verifyUrl("google")
+            verifyUrl("content")
         }
     }
 
@@ -136,7 +136,7 @@ class TextSelectionTest {
             clickContextMenuItem("Private Search")
             mDevice.waitForIdle()
             verifyTabCounter("2")
-            verifyUrl("google")
+            verifyUrl("content")
         }
     }
 
@@ -214,7 +214,7 @@ class TextSelectionTest {
             longClickPageObject(itemContainingText("Crossing"))
             clickContextMenuItem("Search")
             verifyTabCounter("2")
-            verifyUrl("google")
+            verifyUrl("Crossing")
         }
     }
 
@@ -233,7 +233,7 @@ class TextSelectionTest {
             longClickPageObject(itemContainingText("Crossing"))
             clickContextMenuItem("Private Search")
             verifyTabCounter("2")
-            verifyUrl("google")
+            verifyUrl("Crossing")
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -6,7 +6,6 @@
 
 package org.mozilla.fenix.ui.robots
 
-import android.graphics.Bitmap
 import android.view.View
 import android.widget.EditText
 import android.widget.TextView
@@ -78,7 +77,6 @@ import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
-import org.mozilla.fenix.helpers.withBitmapDrawable
 import org.mozilla.fenix.tabstray.TabsTrayTestTag
 import org.mozilla.fenix.utils.Settings
 
@@ -207,10 +205,9 @@ class HomeScreenRobot {
         assertItemWithResIdExists(homepageWordmark)
     }
     fun verifyHomeComponent() = assertHomeComponent()
-    fun verifyDefaultSearchEngine(searchEngine: String) = verifySearchEngineIcon(searchEngine)
+
     fun verifyTabCounter(numberOfOpenTabs: String) =
         assertItemWithResIdAndTextExists(tabCounter(numberOfOpenTabs))
-    fun verifyKeyboardVisible() = assertKeyboardVisibility(isExpectedToBeVisible = true)
 
     fun verifyWallpaperImageApplied(isEnabled: Boolean) {
         if (isEnabled) {
@@ -942,19 +939,8 @@ private fun assertHomeComponent() =
 
 private fun threeDotButton() = onView(allOf(withId(R.id.menuButton)))
 
-private fun verifySearchEngineIcon(searchEngineIcon: Bitmap, searchEngineName: String) {
-    onView(withId(R.id.search_engine_icon))
-        .check(matches(withBitmapDrawable(searchEngineIcon, searchEngineName)))
-}
-
 private fun getSearchEngine(searchEngineName: String) =
     appContext.components.core.store.state.search.searchEngines.find { it.name == searchEngineName }
-
-private fun verifySearchEngineIcon(searchEngineName: String) {
-    val defaultSearchEngine = getSearchEngine(searchEngineName)
-        ?: throw AssertionError("No search engine with name $searchEngineName")
-    verifySearchEngineIcon(defaultSearchEngine.icon, defaultSearchEngine.name)
-}
 
 private fun collectionTitle(title: String, rule: ComposeTestRule) =
     rule.onNode(hasText(title))


### PR DESCRIPTION
https://github.com/mozilla-mobile/firefox-android/pull/2755 needs to land first so the UI test run here can be green.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1842179