### PR TITLE
Bug 1842886 - bump the version of the webcompat-reporter addon up

### DIFF
--- a/android-components/components/feature/webcompat-reporter/src/main/assets/extensions/webcompat-reporter/manifest.json
+++ b/android-components/components/feature/webcompat-reporter/src/main/assets/extensions/webcompat-reporter/manifest.json
@@ -3,7 +3,7 @@
   "name": "Mozilla Android Components - WebCompat Reporter",
   "description": "Report site compatibility issues on webcompat.com",
   "author": "Thomas Wisniewski <twisniewski@mozilla.com>",
-  "version": "1.5.1",
+  "version": "2.0.2",
   "homepage_url": "https://github.com/mozilla/webcompat-reporter",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
We accidentally updated the addon but gave it a lower version number. Since we're not sure if that's going to cause any issues, let's bump the version higher.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1842886