### PR TITLE
Bug 1843546 — Fixup malformed control messages

### DIFF
--- a/android-components/components/service/nimbus/messaging.fml.yaml
+++ b/android-components/components/service/nimbus/messaging.fml.yaml
@@ -57,6 +57,10 @@ features:
         description: Configuration of the notification worker for all notification messages.
         type: NotificationConfig
         default: {}
+      message-under-experiment:
+        description: Deprecated in favor of `MessageData#experiment`. This will be removed in future releases.
+        type: Option<String>
+        default: null
     defaults:
 
 objects:

--- a/fenix/app/.experimenter.yaml
+++ b/fenix/app/.experimenter.yaml
@@ -50,6 +50,9 @@ messaging:
     actions:
       type: json
       description: A growable map of action URLs.
+    message-under-experiment:
+      type: string
+      description: "Deprecated in favor of `MessageData#experiment`. This will be removed in future releases."
     messages:
       type: json
       description: A growable collection of messages


### PR DESCRIPTION
Fixes [Bug 1843546](https://bugzilla.mozilla.org/show_bug.cgi?id=1843546)
Fixes [EXP-3682](https://mozilla-hub.atlassian.net/browse/EXP-3682)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1843546