### PR TITLE
Bug 1807268 - Disable failing verifyContextCopyLinkNotDisplayedAfterApplied UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -10,6 +10,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -136,6 +137,7 @@ class ContextMenusTest {
         }
     }
 
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807268")
     @Test
     fun verifyContextCopyLinkNotDisplayedAfterApplied() {
         val pageLinks = TestAssetHelper.getGenericAsset(mockWebServer, 4)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -8,6 +8,7 @@ import androidx.core.net.toUri
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -350,6 +351,7 @@ class DownloadTest {
         deleteDownloadedFileOnStorage(secondDownloadedFile)
     }
 
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1840994")
     @Test
     fun systemNotificationCantBeDismissedWhileDownloadingTest() {
         // Clear the "Firefox Fenix default browser notification"


### PR DESCRIPTION
Bug 1807268 - Disable failing `verifyContextCopyLinkNotDisplayedAfterApplied` UI test
Bug 1840994 - Disable failing systemNotificationCantBeDismissedWhileDownloadingTest UI test

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807268
https://bugzilla.mozilla.org/show_bug.cgi?id=1840994