### PR TITLE
Bug 1844039 - New insecure website permission prompt UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSitePermissionsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSitePermissionsTest.kt
@@ -349,7 +349,7 @@ class SettingsSitePermissionsTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(permissionsTestPage.toUri()) {
         }.clickGetLocationButton {
-            verifyLocationPermissionPrompt(testPageSubstring)
+            verifyLocationPermissionPrompt(url = testPageSubstring, exists = true)
             pressBack()
         }
         browserScreen {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SitePermissionsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SitePermissionsTest.kt
@@ -30,6 +30,7 @@ import org.mozilla.fenix.helpers.TestHelper.grantSystemPermission
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.clickPageObject
 import org.mozilla.fenix.ui.robots.navigationToolbar
+import org.mozilla.fenix.ui.robots.sitePermissionsRobot
 
 /**
  *  Tests for verifying site permissions prompts & functionality
@@ -293,7 +294,7 @@ class SitePermissionsTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(testPage.toUri()) {
         }.clickGetLocationButton {
-            verifyLocationPermissionPrompt(testPageSubstring)
+            verifyLocationPermissionPrompt(url = testPageSubstring, exists = true)
         }.clickPagePermissionButton(true) {
             verifyPageContent("${mockLocationUpdatesRule.latitude}")
             verifyPageContent("${mockLocationUpdatesRule.longitude}")
@@ -305,7 +306,7 @@ class SitePermissionsTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(testPage.toUri()) {
         }.clickGetLocationButton {
-            verifyLocationPermissionPrompt(testPageSubstring)
+            verifyLocationPermissionPrompt(url = testPageSubstring, exists = true)
         }.clickPagePermissionButton(false) {
             verifyPageContent("User denied geolocation prompt")
         }
@@ -325,6 +326,28 @@ class SitePermissionsTest {
             } else {
                 assertExternalAppOpens("com.android.documentsui")
             }
+        }
+    }
+
+    @Test
+    fun verifyPermissionPromptForInsecureWebsiteTest() {
+        val insecureWebsite = "http://chrisdavidmills.github.io/location-finder-permissions-api"
+        val secureWebsite = "https://chrisdavidmills.github.io/location-finder-permissions-api"
+        val secureWebsiteSubstring = "https://chrisdavidmills.github.io:443"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(insecureWebsite.toUri()) {
+            waitForPageToLoad()
+        }
+        sitePermissionsRobot {
+            verifyLocationPermissionPrompt(url = secureWebsiteSubstring, exists = false)
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(secureWebsite.toUri()) {
+            waitForPageToLoad()
+        }
+        sitePermissionsRobot {
+            verifyLocationPermissionPrompt(url = secureWebsiteSubstring, exists = true)
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -180,6 +180,8 @@ class NavigationToolbarRobot {
                         UiSelector().resourceId("$packageName:id/download_button"),
                     ).waitForExists(waitingTime) || mDevice.findObject(
                         UiSelector().text(getStringResource(R.string.tcp_cfr_message)),
+                    ).waitForExists(waitingTime) || mDevice.findObject(
+                        UiSelector().resourceId("$packageName:id/title"),
                     ).waitForExists(waitingTime),
                 )
             }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SitePermissionsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SitePermissionsRobot.kt
@@ -74,14 +74,21 @@ class SitePermissionsRobot {
         assertTrue(allowPagePermissionButton.text.equals("Allow"))
     }
 
-    fun verifyLocationPermissionPrompt(url: String) {
+    fun verifyLocationPermissionPrompt(url: String, exists: Boolean) {
         try {
-            assertTrue(
-                mDevice.findObject(UiSelector().text("Allow $url to use your location?"))
-                    .waitForExists(waitingTime),
-            )
-            assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
-            assertTrue(allowPagePermissionButton.text.equals("Allow"))
+            if (exists) {
+                assertTrue(
+                    mDevice.findObject(UiSelector().text("Allow $url to use your location?"))
+                        .waitForExists(waitingTime),
+                )
+                assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
+                assertTrue(allowPagePermissionButton.text.equals("Allow"))
+            } else {
+                assertFalse(
+                    mDevice.findObject(UiSelector().text("Allow $url to use your location?"))
+                        .waitForExists(waitingTime),
+                )
+            }
         } catch (e: AssertionError) {
             browserScreen {
             }.openThreeDotMenu {
@@ -215,6 +222,11 @@ class SitePermissionsRobot {
             return BrowserRobot.Transition()
         }
     }
+}
+
+fun sitePermissionsRobot(interact: SitePermissionsRobot.() -> Unit): SitePermissionsRobot.Transition {
+    SitePermissionsRobot().interact()
+    return SitePermissionsRobot.Transition()
 }
 
 // Page permission prompts buttons


### PR DESCRIPTION
Bug 1844039 - New insecure website permission prompt UI test

Summary:
The prompt shouldn't normally be displayed on websites using `http` protocol
Even though localhost uses `http` protocol, the permission prompt is still displayed (not sure why)
Using the permission website from testapp wasn't feasible because github enforces `https` when publishing the pages
Found this website which supports both `http` and `https` protocol on the [Mozilla MDN page](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API/Using_the_Permissions_API) and seems to be working properly.

The UI test successfully passed 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1844039