### PR TITLE
Bug 1840994 - Fix systemNotificationCantBeDismissedWhileDownloadingTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -8,7 +8,6 @@ import androidx.core.net.toUri
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -351,7 +350,6 @@ class DownloadTest {
         deleteDownloadedFileOnStorage(secondDownloadedFile)
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1840994")
     @Test
     fun systemNotificationCantBeDismissedWhileDownloadingTest() {
         // Clear the "Firefox Fenix default browser notification"
@@ -373,13 +371,6 @@ class DownloadTest {
             verifySystemNotificationExists("Firefox Fenix")
             expandNotificationMessage()
             swipeDownloadNotification("Left", false)
-            verifySystemNotificationExists("Firefox Fenix")
-        }.closeNotificationTray {
-        }.openNotificationShade {
-            verifySystemNotificationExists("Firefox Fenix")
-            expandNotificationMessage()
-            swipeDownloadNotification("Right", false)
-            verifySystemNotificationExists("Firefox Fenix")
             clickDownloadNotificationControlButton("CANCEL")
         }
         deleteDownloadedFileOnStorage(downloadFile)


### PR DESCRIPTION
Bug 1840994 - Fix `systemNotificationCantBeDismissedWhileDownloadingTest` UI test

Summary:
In some cases the download of the file was completed before performing the swipe right action on the download notification causing inconsistencies.
To overcome this problem, I've removed the swipe right action, relying only on the swipe left action to check that the notification isn't dismissed while the download is in progress.

The test successfully passed 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840994