### PR TITLE
Bug 1844305 - Add snackbar verification in UI tests when removing tabs from a collection

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
@@ -354,6 +354,31 @@ class CollectionTest {
     }
 
     @Test
+    fun undoTabRemovalFromCollectionTest() {
+        val webPage = getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openTabDrawer {
+            createCollection(webPage.title, collectionName = collectionName)
+            closeTab()
+        }
+
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            verifyTabSavedInCollection(webPage.title, true)
+            removeTabFromCollection(webPage.title)
+        }
+        homeScreen {
+            verifySnackBarText("Collection deleted")
+            clickSnackbarButton("UNDO")
+            verifyCollectionIsDisplayed(collectionName, true)
+            verifyCollectionIsDisplayed(collectionName, true)
+        }
+    }
+
+    @Test
     fun swipeLeftToRemoveTabFromCollectionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)
 
@@ -375,6 +400,8 @@ class CollectionTest {
             verifyTabSavedInCollection(testPage.title, false)
         }
         homeScreen {
+            verifySnackBarText("Collection deleted")
+            verifySnackBarText("UNDO")
             verifyCollectionIsDisplayed(collectionName, false)
         }
     }
@@ -401,6 +428,8 @@ class CollectionTest {
             verifyTabSavedInCollection(testPage.title, false)
         }
         homeScreen {
+            verifySnackBarText("Collection deleted")
+            verifySnackBarText("UNDO")
             verifyCollectionIsDisplayed(collectionName, false)
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeCollectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeCollectionTest.kt
@@ -358,6 +358,31 @@ class ComposeCollectionTest {
     }
 
     @Test
+    fun undoTabRemovalFromCollectionTest() {
+        val webPage = getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openComposeTabDrawer(composeTestRule) {
+            createCollection(webPage.title, collectionName = collectionName)
+            closeTab()
+        }
+
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            verifyTabSavedInCollection(webPage.title, true)
+            removeTabFromCollection(webPage.title)
+        }
+        homeScreen {
+            verifySnackBarText("Collection deleted")
+            clickSnackbarButton("UNDO")
+            verifyCollectionIsDisplayed(collectionName, true)
+            verifyCollectionIsDisplayed(collectionName, true)
+        }
+    }
+
+    @Test
     fun swipeLeftToRemoveTabFromCollectionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)
 
@@ -379,6 +404,8 @@ class ComposeCollectionTest {
             verifyTabSavedInCollection(testPage.title, false)
         }
         homeScreen {
+            verifySnackBarText("Collection deleted")
+            verifySnackBarText("UNDO")
             verifyCollectionIsDisplayed(collectionName, false)
         }
     }
@@ -405,6 +432,8 @@ class ComposeCollectionTest {
             verifyTabSavedInCollection(testPage.title, false)
         }
         homeScreen {
+            verifySnackBarText("Collection deleted")
+            verifySnackBarText("UNDO")
             verifyCollectionIsDisplayed(collectionName, false)
         }
     }


### PR DESCRIPTION
Bug 1844305 - Add snackbar verification in UI tests when removing tabs from a collection

Summary:
Based on the toDoAutomation notes from TestRail I've added tab removal snackbar verification steps where needed and also created a new one .
The tests successfully passed 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1844305