### PR TITLE
Bug 1840332 - Add ReviewGradeCard

### DIFF
--- a/android-components/components/ui/icons/src/main/res/drawable/mozac_ic_chevron_down_20.xml
+++ b/android-components/components/ui/icons/src/main/res/drawable/mozac_ic_chevron_down_20.xml
@@ -1,0 +1,12 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="@color/mozac_ui_icons_fill"
+        android:pathData="M10,12.19 L5.06,7.25 4,8.31l5.47,5.47a0.75,0.75 0,0 0,1.06 0L16,8.31l-1.061,-1.06L10,12.19z" />
+</vector>

--- a/android-components/components/ui/icons/src/main/res/drawable/mozac_ic_chevron_up_20.xml
+++ b/android-components/components/ui/icons/src/main/res/drawable/mozac_ic_chevron_up_20.xml
@@ -1,0 +1,12 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="@color/mozac_ui_icons_fill"
+        android:pathData="M10,7a0.75,0.75 0,0 1,0.53 0.22L16,12.69l-1.061,1.06L10,8.81l-4.94,4.94L4,12.69l5.47,-5.47A0.75,0.75 0,0 1,10 7z" />
+</vector>

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckCards.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckCards.kt
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.R
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.theme.FirefoxTheme
+
+private val cardShape = RoundedCornerShape(8.dp)
+private val defaultCardElevation = 5.dp
+private val defaultCardContentPadding = 16.dp
+
+/**
+ * A card container for review quality check UI that can be expanded and collapsed.
+ *
+ * @param title The title of the card.
+ * @param modifier Modifier to be applied to the card.
+ * @param content The content of the card.
+ */
+@Composable
+fun ReviewQualityCheckExpandableCard(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    ReviewQualityCheckCard(
+        modifier = modifier,
+        contentPadding = 0.dp,
+    ) {
+        var isExpanded by remember { mutableStateOf(false) }
+
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    isExpanded = isExpanded.not()
+                }
+                .padding(defaultCardContentPadding),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = title,
+                color = FirefoxTheme.colors.textPrimary,
+                style = FirefoxTheme.typography.headline8,
+            )
+
+            val chevronDrawable = if (isExpanded) {
+                R.drawable.mozac_ic_chevron_up_20
+            } else {
+                R.drawable.mozac_ic_chevron_down_20
+            }
+
+            Icon(
+                painter = painterResource(id = chevronDrawable),
+                contentDescription = null,
+                tint = FirefoxTheme.colors.iconPrimary,
+            )
+        }
+
+        AnimatedVisibility(visible = isExpanded) {
+            Box(
+                modifier = Modifier.padding(
+                    start = defaultCardContentPadding,
+                    end = defaultCardContentPadding,
+                    bottom = defaultCardContentPadding,
+                ),
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+/**
+ * A card container for review quality check UI.
+ *
+ * @param modifier Modifier to be applied to the card.
+ * @param backgroundColor The background color of the card.
+ * @param elevation The elevation of the card.
+ * @param content The content of the card.
+ */
+@Composable
+fun ReviewQualityCheckCard(
+    modifier: Modifier,
+    backgroundColor: Color = FirefoxTheme.colors.layer2,
+    elevation: Dp = defaultCardElevation,
+    contentPadding: Dp = defaultCardContentPadding,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        shape = cardShape,
+        backgroundColor = backgroundColor,
+        elevation = elevation,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.padding(contentPadding),
+        ) {
+            content()
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun ReviewQualityCheckCardPreview() {
+    FirefoxTheme {
+        Column(modifier = Modifier.padding(16.dp)) {
+            ReviewQualityCheckCard(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = "Review Quality Check Card Content",
+                    color = FirefoxTheme.colors.textPrimary,
+                    style = FirefoxTheme.typography.headline8,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            ReviewQualityCheckExpandableCard(
+                title = "Review Quality Check Expandable Card",
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = "content",
+                    color = FirefoxTheme.colors.textPrimary,
+                    style = FirefoxTheme.typography.body2,
+                )
+            }
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContent.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContent.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.BottomSheetHandle
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.shopping.state.ReviewQualityCheckState
 import org.mozilla.fenix.theme.FirefoxTheme
 
 private val bottomSheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
@@ -65,6 +66,13 @@ fun ReviewQualityCheckContent(
         Header()
 
         Spacer(modifier = Modifier.height(16.dp))
+
+        ReviewGradeCard(
+            modifier = Modifier.fillMaxWidth(),
+            reviewGrade = ReviewQualityCheckState.Grade.B,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
     }
 }
 
@@ -87,6 +95,24 @@ private fun Header() {
             color = FirefoxTheme.colors.textPrimary,
             style = FirefoxTheme.typography.headline6,
         )
+    }
+}
+
+@Composable
+private fun ReviewGradeCard(
+    reviewGrade: ReviewQualityCheckState.Grade,
+    modifier: Modifier = Modifier,
+) {
+    ReviewQualityCheckCard(modifier = modifier.semantics(mergeDescendants = true) {}) {
+        Text(
+            text = stringResource(R.string.review_quality_check_grade_title),
+            color = FirefoxTheme.colors.textPrimary,
+            style = FirefoxTheme.typography.headline8,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        ReviewGradeExpanded(grade = reviewGrade)
     }
 }
 

--- a/fenix/app/src/main/res/values/static_strings.xml
+++ b/fenix/app/src/main/res/values/static_strings.xml
@@ -119,4 +119,5 @@
     <string name="review_quality_check_grade_c_description" translatable="false">Only some reliable reviews</string>
     <string name="review_quality_check_grade_d_f_description" translatable="false">Unreliable reviews</string>
     <string name="review_quality_check_star_rating_content_description">%1$s out of 5 stars</string>
+    <string name="review_quality_check_grade_title">How reliable are the reviews?</string>
 </resources>


### PR DESCRIPTION
### How
– Create common `ReviewQualityCheckCard` and `ReviewQualityCheckExpandableCard` components that will be used to display various cards.
– Create `ReviewGradeCard` and display in the content with static data.

### Preview
<img width="434" alt="Screenshot 2023-07-19 at 15 41 45" src="https://github.com/mozilla-mobile/firefox-android/assets/38040960/a86b0710-b066-4605-a516-ae93e8f27e3b">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840332