### PR TITLE
Bug 1844386 - Only use splash screen animation for SDK 31+

### DIFF
--- a/fenix/app/src/main/res/values-v24/styles.xml
+++ b/fenix/app/src/main/res/values-v24/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <style name="SplashScreen" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/fx_mobile_layer_color_1</item>
+        <item name="windowSplashScreenIconBackgroundColor">@color/fx_mobile_layer_color_1</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/animated_splash_screen</item>
+        <item name="postSplashScreenTheme">@style/NormalTheme</item>
+    </style>
+</resources>

--- a/fenix/app/src/main/res/values-v31/styles.xml
+++ b/fenix/app/src/main/res/values-v31/styles.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <style name="SplashScreen" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/fx_mobile_layer_color_1</item>
+        <item name="windowSplashScreenIconBackgroundColor">@color/fx_mobile_layer_color_1</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/animated_splash_screen</item>
+        <!-- Splash screen is animated to maximum 12 seconds -->
+        <item name="windowSplashScreenAnimationDuration">12000</item>
+        <item name="postSplashScreenTheme">@style/NormalTheme</item>
+    </style>
+</resources>

--- a/fenix/app/src/main/res/values/styles.xml
+++ b/fenix/app/src/main/res/values/styles.xml
@@ -3,16 +3,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources xmlns:tools="http://schemas.android.com/tools">
-
-    <style name="SplashScreen" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/fx_mobile_layer_color_1</item>
-        <item name="windowSplashScreenIconBackgroundColor">@color/fx_mobile_layer_color_1</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/animated_splash_screen</item>
-        <!-- Splash screen is animated to maximum 12 seconds -->
-        <item name="windowSplashScreenAnimationDuration">12000</item>
-        <item name="postSplashScreenTheme">@style/NormalTheme</item>
-    </style>
-
     <style name="NormalThemeBase" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
         <!-- Android system styling -->
         <item name="searchViewStyle">@style/SearchViewStyle</item>


### PR DESCRIPTION
We want splash screen to work safely between SDK 23 to SDK 30.  Since animated splash screen is only supported for SDK 31+, add SVG for SDK 24+ and PNG for SDK 23.

With this change, SDK 21 and 22 will not have a splash screen.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1844386