### PR TITLE
Bug 1844386 - Only use splash screen animation for SDK 31+

### DIFF
--- a/fenix/app/src/main/res/drawable-v23/splash_screen.xml
+++ b/fenix/app/src/main/res/drawable-v23/splash_screen.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@mipmap/ic_launcher_round"
+        android:width="160dp"
+        android:height="160dp"
+        android:gravity="center" />
+</layer-list>

--- a/fenix/app/src/main/res/values-v24/styles.xml
+++ b/fenix/app/src/main/res/values-v24/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <style name="SplashScreen" parent="SplashScreenThemeBase">
+        <item name="windowSplashScreenAnimatedIcon">@drawable/animated_splash_screen</item>
+        <!-- Splash screen is animated to maximum 12 seconds -->
+        <item name="windowSplashScreenAnimationDuration">12000</item>
+    </style>
+</resources>

--- a/fenix/app/src/main/res/values/styles.xml
+++ b/fenix/app/src/main/res/values/styles.xml
@@ -4,12 +4,11 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="SplashScreen" parent="Theme.SplashScreen">
+    <style name="SplashScreen" parent="SplashScreenThemeBase"/>
+
+    <style name="SplashScreenThemeBase" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_screen</item>
         <item name="windowSplashScreenBackground">@color/fx_mobile_layer_color_1</item>
-        <item name="windowSplashScreenIconBackgroundColor">@color/fx_mobile_layer_color_1</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/animated_splash_screen</item>
-        <!-- Splash screen is animated to maximum 12 seconds -->
-        <item name="windowSplashScreenAnimationDuration">12000</item>
         <item name="postSplashScreenTheme">@style/NormalTheme</item>
     </style>
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1844386