### PR TITLE
Bug 1823492 - Add timespan metric for Adjust attribution

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -7256,6 +7256,28 @@ first_session:
       tags:
         - Performance
         - Attribution
+  adjust_attribution_timespan:
+    type: timespan
+    time_unit: millisecond
+    send_in_pings:
+      - first-session
+      - metrics
+    description: >
+      The time that it takes to derive the attribution parameters by
+      the Adjust SDK.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1823492
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/2974
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 124
+    metadata:
+      tags:
+        - Performance
+        - Attribution
 play_store_attribution:
   source:
     type: string

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt
@@ -51,8 +51,13 @@ class AdjustMetricsService(
 
         val installationPing = FirstSessionPing(application)
 
+        FirstSession.adjustAttributionTimespan.start()
         val timerId = FirstSession.adjustAttributionTime.start()
         config.setOnAttributionChangedListener {
+            if (!installationPing.wasAlreadyTriggered()) {
+                FirstSession.adjustAttributionTimespan.stop()
+            }
+
             FirstSession.adjustAttributionTime.stopAndAccumulate(timerId)
             if (!it.network.isNullOrEmpty()) {
                 application.applicationContext.settings().adjustNetwork =
@@ -81,6 +86,7 @@ class AdjustMetricsService(
     }
 
     override fun stop() {
+        FirstSession.adjustAttributionTimespan.cancel()
         Adjust.setEnabled(false)
         Adjust.gdprForgetMe(application.applicationContext)
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/FirstSessionPing.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/FirstSessionPing.kt
@@ -35,7 +35,6 @@ class FirstSessionPing(private val context: Context) {
      *
      * @return true if it was already triggered, false otherwise.
      */
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun wasAlreadyTriggered(): Boolean {
         return prefs.getBoolean("ping_sent", false)
     }


### PR DESCRIPTION
There was some questions related to Adjust attribution time.  This is to use a timespan telemetry to confirm the data that we have from the time distribution telemetry.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1823492