### PR TITLE
Bug 1845307 - New verifySyncedTabsWhenUserIsNotSignedInTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
@@ -375,4 +375,17 @@ class ComposeTabbedBrowsingTest {
             verifyNavigationToolbar()
         }
     }
+
+    @Test
+    fun verifySyncedTabsWhenUserIsNotSignedInTest() {
+        navigationToolbar {
+        }.openComposeTabDrawer(composeTestRule) {
+            verifySyncedTabsButtonIsSelected(isSelected = false)
+        }.toggleToSyncedTabs {
+            verifySyncedTabsButtonIsSelected(isSelected = true)
+            verifySyncedTabsListWhenUserIsNotSignedIn()
+        }.clickSignInToSyncButton {
+            verifyTurnOnSyncMenu()
+        }
+    }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -363,4 +363,18 @@ class TabbedBrowsingTest {
             verifyNavigationToolbar()
         }
     }
+
+    @Test
+    fun verifySyncedTabsWhenUserIsNotSignedInTest() {
+        navigationToolbar {
+        }.openTabTray {
+            verifySyncedTabsButtonIsSelected(isSelected = false)
+            clickSyncedTabsButton()
+        }.toggleToSyncedTabs {
+            verifySyncedTabsButtonIsSelected(isSelected = true)
+            verifySyncedTabsListWhenUserIsNotSignedIn()
+        }.clickSignInToSyncButton {
+            verifyTurnOnSyncMenu()
+        }
+    }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
@@ -40,9 +40,11 @@ import org.hamcrest.Matcher
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants
 import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.clickAtLocationInView
 import org.mozilla.fenix.helpers.idlingresource.BottomSheetBehaviorStateIdlingResource
@@ -77,6 +79,15 @@ class ComposeTabDrawerRobot(private val composeTestRule: HomeActivityComposeTest
         } else {
             composeTestRule.syncedTabsButton().assertIsNotSelected()
         }
+    }
+
+    fun verifySyncedTabsListWhenUserIsNotSignedIn() {
+        verifySyncedTabsList()
+        assertItemContainingTextExists(
+            itemContainingText(getStringResource(R.string.synced_tabs_sign_in_message)),
+            itemContainingText(getStringResource(R.string.sync_sign_in)),
+            itemContainingText(getStringResource(R.string.tab_drawer_fab_sync)),
+        )
     }
 
     fun verifyExistingOpenTabs(vararg titles: String) {
@@ -285,6 +296,19 @@ class ComposeTabDrawerRobot(private val composeTestRule: HomeActivityComposeTest
             composeTestRule.privateBrowsingButton().performClick()
             ComposeTabDrawerRobot(composeTestRule).interact()
             return Transition(composeTestRule)
+        }
+
+        fun toggleToSyncedTabs(interact: ComposeTabDrawerRobot.() -> Unit): Transition {
+            composeTestRule.syncedTabsButton().performClick()
+            ComposeTabDrawerRobot(composeTestRule).interact()
+            return Transition(composeTestRule)
+        }
+
+        fun clickSignInToSyncButton(interact: SyncSignInRobot.() -> Unit): SyncSignInRobot.Transition {
+            itemContainingText(getStringResource(R.string.sync_sign_in))
+                .clickAndWaitForNewWindow(TestAssetHelper.waitingTimeShort)
+            SyncSignInRobot().interact()
+            return SyncSignInRobot.Transition()
         }
 
         fun openThreeDotMenu(interact: ComposeTabDrawerRobot.() -> Unit): Transition {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -8,6 +8,7 @@ package org.mozilla.fenix.ui.robots
 
 import android.net.Uri
 import android.os.Build
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
@@ -32,7 +33,9 @@ import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
+import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
@@ -41,8 +44,10 @@ import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
+import org.mozilla.fenix.helpers.TestHelper.waitForObjects
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
+import org.mozilla.fenix.tabstray.TabsTrayTestTag
 
 /**
  * Implementation of Robot Pattern for the URL toolbar.
@@ -224,6 +229,37 @@ class NavigationToolbarRobot {
 
             TabDrawerRobot().interact()
             return TabDrawerRobot.Transition()
+        }
+
+        fun openComposeTabDrawer(composeTestRule: HomeActivityComposeTestRule, interact: ComposeTabDrawerRobot.() -> Unit): ComposeTabDrawerRobot.Transition {
+            for (i in 1..Constants.RETRY_COUNT) {
+                try {
+                    mDevice.waitForObjects(
+                        mDevice.findObject(
+                            UiSelector()
+                                .resourceId("$packageName:id/mozac_browser_toolbar_browser_actions"),
+                        ),
+                        waitingTime,
+                    )
+
+                    tabTrayButton().click()
+
+                    composeTestRule.onNodeWithTag(TabsTrayTestTag.tabsTray).assertExists()
+
+                    break
+                } catch (e: AssertionError) {
+                    if (i == Constants.RETRY_COUNT) {
+                        throw e
+                    } else {
+                        mDevice.waitForIdle()
+                    }
+                }
+            }
+
+            composeTestRule.onNodeWithTag(TabsTrayTestTag.fab).assertExists()
+
+            ComposeTabDrawerRobot(composeTestRule).interact()
+            return ComposeTabDrawerRobot.Transition(composeTestRule)
         }
 
         fun visitLinkFromClipboard(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
@@ -25,7 +25,16 @@ import org.mozilla.fenix.helpers.click
 class SyncSignInRobot {
 
     fun verifyAccountSettingsMenuHeader() = assertAccountSettingsMenuHeader()
-    fun verifyTurnOnSyncMenu() = assertTurnOnSyncMenu()
+    fun verifyTurnOnSyncMenu() {
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/container")).waitForExists(waitingTime)
+        assertTrue(
+            mDevice.findObject(
+                UiSelector()
+                    .resourceId("$packageName:id/signInScanButton")
+                    .resourceId("$packageName:id/signInEmailButton"),
+            ).waitForExists(waitingTime),
+        )
+    }
 
     class Transition {
         fun goBack(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
@@ -45,15 +54,4 @@ private fun assertAccountSettingsMenuHeader() {
     // Sync tests in SettingsSyncTest are still TO-DO, so I'm not sure that we have a test for signing into Sync
     onView(withText(R.string.preferences_account_settings))
         .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
-}
-
-private fun assertTurnOnSyncMenu() {
-    mDevice.findObject(UiSelector().resourceId("$packageName:id/container")).waitForExists(waitingTime)
-    assertTrue(
-        mDevice.findObject(
-            UiSelector()
-                .resourceId("$packageName:id/signInScanButton")
-                .resourceId("$packageName:id/signInEmailButton"),
-        ).waitForExists(waitingTime),
-    )
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -39,6 +40,7 @@ import org.mozilla.fenix.compose.button.PrimaryButton
 import org.mozilla.fenix.compose.ext.dashedBorder
 import org.mozilla.fenix.compose.list.ExpandableListHeader
 import org.mozilla.fenix.compose.list.FaviconListItem
+import org.mozilla.fenix.tabstray.TabsTrayTestTag
 import org.mozilla.fenix.theme.FirefoxTheme
 import mozilla.components.browser.storage.sync.Tab as SyncTab
 
@@ -64,7 +66,9 @@ fun SyncedTabsList(
         remember(syncedTabs) { syncedTabs.map { EXPANDED_BY_DEFAULT }.toMutableStateList() }
 
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(TabsTrayTestTag.syncedTabsList),
         state = listState,
     ) {
         if (taskContinuityEnabled) {


### PR DESCRIPTION
Bug 1845307 - New `verifySyncedTabsWhenUserIsNotSignedInTest` UI test

1. Created 2 new UI test ✅ successfully passed 100x on Firebase
2. While trying to create the UI test that uses the refactored tabs tray, noticed that the [verifySyncedTabsList](https://github.com/mozilla-mobile/firefox-android/pull/2984/files#diff-d35ffbcbe6efc7f36d175346b6dc94963663e0c3b3c36764a12795e273658b95R85) function didn't work
    After taking a closer look how the tests tags are actually used, noticed that the synced tabs list composable didn't have 
    any testTag (compared it against the other tab lists)
    Asked @Alexandru2909 if that could cause the problems, added the missing `testTag` and afterwards the 
    synced tabs list verification worked properly.
    @MozillaNoah I would kindly ask you to review that change ☺️ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
4. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
5. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
6. Click on `View task in Taskcluster` in the new `DETAILS` section.
7. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845307