### PR TITLE
Bug 1845354 - Refactor ApkSizeTask into a plugin using composite build

### DIFF
--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -1,5 +1,4 @@
 import org.apache.tools.ant.util.StringUtils
-import org.mozilla.fenix.gradle.tasks.ApkSizeTask
 
 plugins {
     id "com.jetbrains.python.envs" version "$python_envs_plugin"

--- a/fenix/plugins/apksize/build.gradle
+++ b/fenix/plugins/apksize/build.gradle
@@ -17,3 +17,14 @@ repositories {
         mavenCentral()
     }
 }
+
+dependencies {
+    implementation "org.json:json:20210307"
+}
+
+gradlePlugin {
+    plugins.register("ApkSizePlugin") {
+        id = "ApkSizePlugin"
+        implementationClass = "ApkSizePlugin"
+    }
+}

--- a/fenix/plugins/apksize/settings.gradle
+++ b/fenix/plugins/apksize/settings.gradle
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Prevents gradle builds from looking for a root settings.gradle

--- a/fenix/plugins/apksize/src/main/java/ApkSizePlugin.kt
+++ b/fenix/plugins/apksize/src/main/java/ApkSizePlugin.kt
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.gradle.tasks
-
 import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.json.JSONArray
@@ -13,6 +13,10 @@ import org.json.JSONObject
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
+
+class ApkSizePlugin : Plugin<Settings> {
+    override fun apply(settings: Settings) = Unit
+}
 
 /**
  * Gradle task for determining the size of APKs and logging them in a perfherder compatible format.

--- a/fenix/settings.gradle
+++ b/fenix/settings.gradle
@@ -6,10 +6,12 @@ pluginManagement {
     includeBuild("../android-components/plugins/publicsuffixlist")
     includeBuild("../android-components/plugins/dependencies")
     includeBuild("../android-components/plugins/config")
+    includeBuild("./plugins/apksize")
     includeBuild("./plugins/fenixdependencies")
 }
 
 plugins {
+    id 'ApkSizePlugin'
     id 'FenixDependenciesPlugin'
     id "mozac.ConfigPlugin"
     id 'mozac.DependenciesPlugin'


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845354