### PR TITLE
Bug 1845520 - Remove smoke test annotation from pwa related UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -35,7 +35,6 @@ class PwaTest {
     @get:Rule
     val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
 
-    @SmokeTest
     @Test
     fun externalLinkPWATest() {
         val externalLinkURL = "https://mozilla-mobile.github.io/testapp/downloads"
@@ -57,7 +56,6 @@ class PwaTest {
     }
 
     @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1807275")
-    @SmokeTest
     @Test
     fun emailLinkPWATest() {
         navigationToolbar {
@@ -74,7 +72,6 @@ class PwaTest {
         }
     }
 
-    @SmokeTest
     @Test
     fun telephoneLinkPWATest() {
         navigationToolbar {
@@ -111,7 +108,6 @@ class PwaTest {
     }
 
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807273")
-    @SmokeTest
     @Test
     fun saveLoginsInPWATest() {
         val pwaPage = "https://mozilla-mobile.github.io/testapp/loginForm"


### PR DESCRIPTION
Based on the recent changes made in TestRail, some PWA related tests were removed from our smoke and sanity tests suite (as there will be no more development done on this feature).
We'll need to remove the `@ SmokeTest` annotation from the corresponding automated UI tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845520