### PR TITLE
Bug 1845644 - Update Sentry to version 6.27.0

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -37,7 +37,7 @@ object Versions {
     const val detekt = "1.23.0"
     const val ktlint = "0.49.1"
 
-    const val sentry_latest = "6.24.0"
+    const val sentry_latest = "6.27.0"
 
     // zxing 3.4+ requires a minimum API of 24 or higher
     const val zxing = "3.3.3"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1845644
https://bugzilla.mozilla.org/show_bug.cgi?id=1845644