### PR TITLE
Bug 1845820 - Add the `WebExtensionInstallException.Blocklisted` class

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionException.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionException.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.engine.gecko.webextension
 import mozilla.components.concept.engine.webextension.WebExtensionException
 import mozilla.components.concept.engine.webextension.WebExtensionInstallException
 import org.mozilla.geckoview.WebExtension.InstallException
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_BLOCKLISTED
 import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_USER_CANCELED
 
 /**
@@ -19,11 +20,15 @@ class GeckoWebExtensionException(throwable: Throwable) : WebExtensionException(t
 
     companion object {
         internal fun createWebExtensionException(throwable: Throwable): WebExtensionException {
-            return if (throwable is InstallException && throwable.code == ERROR_USER_CANCELED) {
-                WebExtensionInstallException.UserCancelled(throwable)
-            } else {
-                GeckoWebExtensionException(throwable)
+            if (throwable is InstallException) {
+                return when (throwable.code) {
+                    ERROR_USER_CANCELED -> WebExtensionInstallException.UserCancelled(throwable)
+                    ERROR_BLOCKLISTED -> WebExtensionInstallException.Blocklisted(throwable)
+                    else -> GeckoWebExtensionException(throwable)
+                }
             }
+
+            return GeckoWebExtensionException(throwable)
         }
     }
 }

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoWebExtensionExceptionTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoWebExtensionExceptionTest.kt
@@ -13,6 +13,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.geckoview.WebExtension
+import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_BLOCKLISTED
 import org.mozilla.geckoview.WebExtension.InstallException.ErrorCodes.ERROR_USER_CANCELED
 
 @RunWith(AndroidJUnit4::class)
@@ -35,5 +36,15 @@ class GeckoWebExtensionExceptionTest {
             GeckoWebExtensionException.createWebExtensionException(geckoException)
 
         assertTrue(webExtensionException is GeckoWebExtensionException)
+    }
+
+    @Test
+    fun `Handles a blocklisted exception`() {
+        val geckoException = mock<WebExtension.InstallException>()
+        ReflectionUtils.setField(geckoException, "code", ERROR_BLOCKLISTED)
+        val webExtensionException =
+            GeckoWebExtensionException.createWebExtensionException(geckoException)
+
+        assertTrue(webExtensionException is WebExtensionInstallException.Blocklisted)
     }
 }

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -491,4 +491,9 @@ sealed class WebExtensionInstallException(
      * The extension install was canceled by the user.
      */
     class UserCancelled(throwable: Throwable) : WebExtensionInstallException(throwable)
+
+    /**
+     * The extension install was cancelled because the extension is blocklisted.
+     */
+    class Blocklisted(throwable: Throwable) : WebExtensionInstallException(throwable)
 }


### PR DESCRIPTION
This is going to fail a bit until the patch for https://bugzilla.mozilla.org/show_bug.cgi?id=1845745 lands...

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- ~~[ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one~~
- ~~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features~~

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845820