### PR TITLE
Bug 1845944 - New custom tabs ETP settings UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
@@ -21,10 +21,12 @@ import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
+import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.openAppFromExternalLink
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.clickPageObject
 import org.mozilla.fenix.ui.robots.customTabScreen
+import org.mozilla.fenix.ui.robots.enhancedTrackingProtection
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.longClickPageObject
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -320,6 +322,46 @@ class CustomTabsTest {
         }
         homeScreen {
             verifyHomeScreenAppBarItems()
+        }
+    }
+
+    @Test
+    fun verifyETPSheetAndToggleTest() {
+        val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        intentReceiverActivityTestRule.launchActivity(
+            createCustomTabIntent(
+                pageUrl = customTabPage.url.toString(),
+                customActionButtonDescription = customTabActionButton,
+            ),
+        )
+
+        enhancedTrackingProtection {
+        }.openEnhancedTrackingProtectionSheet {
+            verifyEnhancedTrackingProtectionSheetStatus(status = "ON", state = true)
+        }.toggleEnhancedTrackingProtectionFromSheet {
+            verifyEnhancedTrackingProtectionSheetStatus(status = "OFF", state = false)
+        }
+
+        openAppFromExternalLink(customTabPage.url.toString())
+
+        browserScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openEnhancedTrackingProtectionSubMenu {
+            switchEnhancedTrackingProtectionToggle()
+            verifyEnhancedTrackingProtectionOptionsEnabled(enabled = false)
+        }
+
+        exitMenu()
+
+        browserScreen {
+        }.goBack {
+            // Actually exiting to the previously opened custom tab
+        }
+
+        enhancedTrackingProtection {
+            verifyETPSectionIsDisplayedInQuickSettingsSheet(isDisplayed = false)
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/EnhancedTrackingProtectionRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/EnhancedTrackingProtectionRobot.kt
@@ -22,6 +22,8 @@ import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.not
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
@@ -162,6 +164,12 @@ class EnhancedTrackingProtectionRobot {
                 ),
             )
     }
+
+    fun verifyETPSectionIsDisplayedInQuickSettingsSheet(isDisplayed: Boolean) =
+        assertItemWithResIdExists(
+            itemWithResId("$packageName:id/trackingProtectionLayout"),
+            exists = isDisplayed,
+        )
 
     fun navigateBackToDetails() {
         onView(withId(R.id.details_back)).click()


### PR DESCRIPTION
Bug 1845944 - New custom tabs ETP settings UI test

✅ Successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845944