### PR TITLE
Revert "Bug 1807307 - Re-land disabling LeakCanary in CI fuzzy testing builds"

### DIFF
--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -339,13 +339,6 @@ tasks:
                   key: firebaseToken
                   path: .firebase_token.json
                   json: true
-            dummy-secrets:
-                - path: app/src/main/res/values/leakcanary.xml
-                  content: |
-                    <?xml version="1.0" encoding="utf-8"?>
-                    <resources>
-                        <string name="leak_canary_test_class_name">org.mozilla.fenix.DebugFenixApplication</string>
-                    </resources>
             pre-commands:
                 - ["cd", "fenix"]
             commands:


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-android#3046
https://bugzilla.mozilla.org/show_bug.cgi?id=1807307
https://bugzilla.mozilla.org/show_bug.cgi?id=1807307