### PR TITLE
Bug 1838389 - Catch NullPointerException while printStackTrace

### DIFF
--- a/android-components/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
+++ b/android-components/components/lib/crash/src/main/java/mozilla/components/lib/crash/service/MozillaSocorroService.kt
@@ -552,10 +552,16 @@ class MozillaSocorroService(
         return resultMap
     }
 
-    private fun getExceptionStackTrace(throwable: Throwable, isCaughtException: Boolean): String {
-        return when (isCaughtException) {
-            true -> "$LIB_CRASH_INFO_PREFIX ${throwable.getStacktraceAsString()}"
-            false -> throwable.getStacktraceAsString()
+    @Suppress("TooGenericExceptionCaught")
+    // printStackTrace() can throw a NullPointerException exception even if throwable is not null
+    private fun getExceptionStackTrace(throwable: Throwable, isCaughtException: Boolean): String? {
+        return try {
+            when (isCaughtException) {
+                true -> "$LIB_CRASH_INFO_PREFIX ${throwable.getStacktraceAsString()}"
+                false -> throwable.getStacktraceAsString()
+            }
+        } catch (e: NullPointerException) {
+            null
         }
     }
 }


### PR DESCRIPTION
In some cases `printStackTrace` fails with `NullPointerException`.
The value is direction retrieved through the throwable and there's nothing we can do about it.

Couple reasons why we should catch this exception:

-   In general crash reporter should avoid crashing.
-   We also attempts to report stack trace through `extractThrowableList`, we should catch the `NullPointerException` so the crash report can still be sent without the stack trace in string.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1838389