### PR TITLE
Bug 1809828 - Display Tab Thumbnail when failing to download image

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/Image.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/Image.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.support.images.compose.loader.ImageLoader
 import mozilla.components.support.images.compose.loader.WithImage
 import org.mozilla.fenix.components.components
@@ -24,6 +25,8 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * while that image is downloaded or a default fallback image when downloading failed.
  *
  * @param url URL from where the to download the image to be shown.
+ * @param tabState The given [TabSessionState] to render a thumbnail in case downloading image fails.
+ * Defaults to [null] when the image loaded does not have a tab state provided (e.g. pocket stories).
  * @param modifier [Modifier] to be applied to the layout.
  * @param private Whether or not this is a private request. Like in private browsing mode,
  * private requests will not cache anything on disk and not send any cookies shared with the browser.
@@ -41,6 +44,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
 fun Image(
     url: String,
     modifier: Modifier = Modifier,
+    tabState: TabSessionState? = null,
     private: Boolean = false,
     targetSize: Dp = 100.dp,
     contentDescription: String? = null,
@@ -66,9 +70,9 @@ fun Image(
                 )
             }
 
-            WithDefaultPlaceholder(modifier, contentDescription)
+            WithDefaultPlaceholder(modifier, tabState, contentDescription)
 
-            WithDefaultFallback(modifier, contentDescription)
+            WithDefaultFallback(modifier, tabState, contentDescription)
         }
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ImagesPlaceholder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ImagesPlaceholder.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.support.images.compose.loader.Fallback
 import mozilla.components.support.images.compose.loader.ImageLoaderScope
 import mozilla.components.support.images.compose.loader.Placeholder
@@ -22,6 +23,8 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * Renders the app default image placeholder while the image is still getting loaded.
  *
  * @param modifier [Modifier] allowing to control among others the dimensions and shape of the image.
+ * @param tabState The given [TabSessionState] to render a thumbnail in case downloading image fails.
+ * Defaults to [null] when the image loaded does not have a tab state provided (e.g. pocket stories).
  * @param contentDescription Text provided to accessibility services to describe what this image represents.
  * Defaults to [null] suited for an image used only for decorative purposes and not to be read by
  * accessibility services.
@@ -29,10 +32,11 @@ import org.mozilla.fenix.theme.FirefoxTheme
 @Composable
 internal fun ImageLoaderScope.WithDefaultPlaceholder(
     modifier: Modifier,
+    tabState: TabSessionState? = null,
     contentDescription: String? = null,
 ) {
     Placeholder {
-        DefaultImagePlaceholder(modifier, contentDescription)
+        DefaultImagePlaceholder(modifier, tabState, contentDescription)
     }
 }
 
@@ -40,6 +44,8 @@ internal fun ImageLoaderScope.WithDefaultPlaceholder(
  * Renders the app default image placeholder if loading the image failed.
  *
  * @param modifier [Modifier] allowing to control among others the dimensions and shape of the image.
+ * @param tabState The given [TabSessionState] to render a thumbnail in case downloading image fails.
+ * Defaults to [null] when the image loaded does not have a tab state provided (e.g. pocket stories).
  * @param contentDescription Text provided to accessibility services to describe what this image represents.
  * Defaults to [null] suited for an image used only for decorative purposes and not to be read by
  * accessibility services.
@@ -47,10 +53,11 @@ internal fun ImageLoaderScope.WithDefaultPlaceholder(
 @Composable
 internal fun ImageLoaderScope.WithDefaultFallback(
     modifier: Modifier,
+    tabState: TabSessionState? = null,
     contentDescription: String? = null,
 ) {
     Fallback {
-        DefaultImagePlaceholder(modifier, contentDescription)
+        DefaultImagePlaceholder(modifier, tabState,contentDescription)
     }
 }
 
@@ -58,6 +65,8 @@ internal fun ImageLoaderScope.WithDefaultFallback(
  * Application default image placeholder.
  *
  * @param modifier [Modifier] allowing to control among others the dimensions and shape of the image.
+ * @param tabState The given [TabSessionState] to render a thumbnail in case downloading image fails.
+ * Defaults to [null] when the image loaded does not have a tab state provided (e.g. pocket stories)
  * @param contentDescription Text provided to accessibility services to describe what this image represents.
  * Defaults to [null] suited for an image used only for decorative purposes and not to be read by
  * accessibility services.
@@ -65,9 +74,17 @@ internal fun ImageLoaderScope.WithDefaultFallback(
 @Composable
 internal fun DefaultImagePlaceholder(
     modifier: Modifier,
+    tabState: TabSessionState? = null,
     contentDescription: String? = null,
 ) {
-    Image(ColorPainter(FirefoxTheme.colors.layer2), contentDescription, modifier)
+    if(tabState == null) {
+        Image(ColorPainter(FirefoxTheme.colors.layer2), contentDescription, modifier)
+    } else {
+        TabThumbnail(
+            tab = tabState,
+            modifier = modifier
+        )
+    }
 }
 
 @Composable

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLarge.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLarge.kt
@@ -159,7 +159,12 @@ fun ListItemTabSurface(
                 .size(imageWidth, imageHeight)
                 .clip(RoundedCornerShape(8.dp))
 
-            Image(imageUrl, imageModifier, false, imageWidth)
+            Image(
+                url = imageUrl,
+                modifier = imageModifier,
+                private = false,
+                targetSize = imageWidth
+            )
 
             Spacer(Modifier.width(16.dp))
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -224,6 +224,7 @@ fun RecentTabImage(
             Image(
                 url = previewImageUrl,
                 modifier = modifier,
+                tabState = tab.state,
                 targetSize = 108.dp,
                 contentScale = ContentScale.Crop,
             )


### PR DESCRIPTION
When trying to download an image provided by a website to set as thumbnail for Jump Back In section of the home page, the download might fail due to image being to large. In order to fix this, as a fallback when the download fails, a snapshot of the website will be provided as Tab Thumbnail. Previously, the fallback was a blank white rectangle.

| Before | After |
|--------------|-------------|
|<img src=https://github.com/mozilla-mobile/firefox-android/assets/32488956/c43befa0-efa7-4cb4-9c55-ff7674f57fda> | <img src=https://github.com/mozilla-mobile/firefox-android/assets/32488956/268439c9-56c5-46f2-8e42-10e30ed4ce88> |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
