### PR TITLE
Bug 1845255 - Add loading UI for review quality check

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -120,6 +120,7 @@ object ComponentsDependencies {
     const val androidx_biometric = "androidx.biometric:biometric:${Versions.AndroidX.biometric}"
     const val androidx_browser = "androidx.browser:browser:${Versions.AndroidX.browser}"
     const val androidx_cardview = "androidx.cardview:cardview:${Versions.AndroidX.cardview}"
+    const val androidx_compose_animation = "androidx.compose.animation:animation:${Versions.AndroidX.compose}"
     const val androidx_compose_ui = "androidx.compose.ui:ui:${Versions.AndroidX.compose}"
     const val androidx_compose_ui_graphics = "androidx.compose.ui:ui-graphics:${Versions.AndroidX.compose}"
     const val androidx_compose_ui_test = "androidx.compose.ui:ui-test-junit4:${Versions.AndroidX.compose}"

--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -588,6 +588,7 @@ dependencies {
     implementation ComponentsDependencies.androidx_annotation
     implementation ComponentsDependencies.androidx_compose_ui
     implementation ComponentsDependencies.androidx_compose_ui_tooling_preview
+    implementation ComponentsDependencies.androidx_compose_animation
     implementation ComponentsDependencies.androidx_compose_foundation
     implementation ComponentsDependencies.androidx_compose_material
     implementation FenixDependencies.androidx_legacy

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductReviewLoading.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductReviewLoading.kt
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.ui
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.StartOffset
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.theme.FirefoxTheme
+
+private const val ANIMATION_DURATION_MS = 1000
+private const val INITIAL_ALPHA = 0.25f
+private const val TARGET_ALPHA = 1f
+private val boxes = listOf(
+    BoxInfo(height = 80.dp, offsetMillis = 500),
+    BoxInfo(height = 80.dp, offsetMillis = 1000),
+    BoxInfo(height = 192.dp, offsetMillis = 0),
+    BoxInfo(height = 40.dp, offsetMillis = 500),
+    BoxInfo(height = 192.dp, offsetMillis = 1000),
+)
+
+/**
+ * Loading UI for review quality check content.
+ */
+@Composable
+fun ProductReviewLoading(
+    modifier: Modifier = Modifier,
+) {
+    val infiniteTransition = rememberInfiniteTransition("ProductReviewLoading")
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        boxes.forEach { boxInfo ->
+            val alpha by infiniteTransition.animateFloat(
+                initialValue = INITIAL_ALPHA,
+                targetValue = TARGET_ALPHA,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(ANIMATION_DURATION_MS, easing = LinearEasing),
+                    repeatMode = RepeatMode.Reverse,
+                    initialStartOffset = StartOffset(offsetMillis = boxInfo.offsetMillis),
+                ),
+                label = "ProductReviewLoading-Alpha",
+            )
+
+            Box(
+                modifier = Modifier
+                    .height(boxInfo.height)
+                    .fillMaxWidth()
+                    .alpha(alpha)
+                    .background(
+                        color = FirefoxTheme.colors.layer3,
+                        shape = RoundedCornerShape(8.dp),
+                    ),
+            )
+        }
+    }
+}
+
+private data class BoxInfo(
+    val height: Dp,
+    val offsetMillis: Int,
+)
+
+@LightDarkPreview
+@Composable
+private fun ProductReviewLoadingPreview() {
+    FirefoxTheme {
+        ReviewQualityCheckScaffold(
+            onRequestDismiss = {},
+        ) {
+            ProductReviewLoading()
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckBottomSheet.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckBottomSheet.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.shopping.ui
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -67,26 +68,31 @@ private fun ProductReview(
     onOptOutClick: () -> Unit,
     onProductRecommendationsEnabledStateChange: (Boolean) -> Unit,
 ) {
-    when (val productReviewState = state.productReviewState) {
-        is AnalysisPresent -> {
-            ProductAnalysis(
-                productRecommendationsEnabled = state.productRecommendationsPreference,
-                productAnalysis = productReviewState,
-                onOptOutClick = onOptOutClick,
-                onProductRecommendationsEnabledStateChange = onProductRecommendationsEnabledStateChange,
-            )
-        }
+    Crossfade(
+        targetState = state.productReviewState,
+        label = "ProductReview-Crossfade",
+    ) { productReviewState ->
+        when (productReviewState) {
+            is AnalysisPresent -> {
+                ProductAnalysis(
+                    productRecommendationsEnabled = state.productRecommendationsPreference,
+                    productAnalysis = productReviewState,
+                    onOptOutClick = onOptOutClick,
+                    onProductRecommendationsEnabledStateChange = onProductRecommendationsEnabledStateChange,
+                )
+            }
 
-        is ReviewQualityCheckState.OptedIn.ProductReviewState.Error -> {
-            // Bug 1840113
-        }
+            is ReviewQualityCheckState.OptedIn.ProductReviewState.Error -> {
+                // Bug 1840113
+            }
 
-        is ReviewQualityCheckState.OptedIn.ProductReviewState.Loading -> {
-            // Bug 1845255
-        }
+            is ReviewQualityCheckState.OptedIn.ProductReviewState.Loading -> {
+                ProductReviewLoading()
+            }
 
-        is ReviewQualityCheckState.OptedIn.ProductReviewState.NoAnalysisPresent -> {
-            // Bug 1840333
+            is ReviewQualityCheckState.OptedIn.ProductReviewState.NoAnalysisPresent -> {
+                // Bug 1840333
+            }
         }
     }
 }


### PR DESCRIPTION
Same as #3068 along with the compose animation dependency


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845255