### PR TITLE
Bug 1818183 - Fix verifyOpenTopSiteNormalTab UI test on legacy devices

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -948,8 +948,7 @@ private fun assertHomeComponent() =
 private fun threeDotButton() = onView(allOf(withId(R.id.menuButton)))
 
 private fun assertExistingTopSitesList() =
-    onView(allOf(withId(R.id.top_sites_list)))
-        .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
+    assertItemWithResIdExists(itemWithResId("$packageName:id/top_sites_list"))
 
 private fun assertExistingTopSitesTabs(title: String) {
     mDevice.findObject(


### PR DESCRIPTION
Bug 1818183 - Fix `verifyOpenTopSiteNormalTab` UI test on legacy devices

Summary:
The test was constantly flaky the last days on our legacy devices especially on the `SM-G981U1, API Level 29` AVD
After investigating, noticed that there's a delay displaying the top sites list on the home screen.
To overcome this problem, when verifying if the top sites list is displayed, I've switched from using Espresso to UIAutomator, to properly wait and assert for the list to be displayed.

Successfully passed 100x on Firebase using SM-G981U1, API Level 29 AVD ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1818183