### PR TITLE
Bug 1840339 - Add review highlights card for shopping experience

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
@@ -5,6 +5,9 @@
 package org.mozilla.fenix.shopping.store
 
 import mozilla.components.lib.state.State
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.HighlightType
+
+private const val NUMBER_OF_HIGHLIGHTS_FOR_COMPACT_MODE = 2
 
 /**
  * UI state of the review quality check feature.
@@ -138,6 +141,15 @@ sealed interface ReviewQualityCheckState : State {
 }
 
 /**
+ * Highlights to display in compact mode that contains first 2 highlights of the first
+ * highlight type.
+ */
+fun Map<HighlightType, List<String>>.forCompactMode(): Map<HighlightType, List<String>> =
+    entries.first().let { entry ->
+        mapOf(entry.key to entry.value.take(NUMBER_OF_HIGHLIGHTS_FOR_COMPACT_MODE))
+    }
+
+/**
  * Fake analysis for showing the UI. To be deleted once the API is integrated.
  */
 private val fakeAnalysis = ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent(
@@ -146,5 +158,31 @@ private val fakeAnalysis = ReviewQualityCheckState.OptedIn.ProductReviewState.An
     needsAnalysis = false,
     adjustedRating = 3.6f,
     productUrl = "123",
-    highlights = null,
+    highlights = mapOf(
+        HighlightType.QUALITY to listOf(
+            "High quality",
+            "Excellent craftsmanship",
+            "Superior materials",
+        ),
+        HighlightType.PRICE to listOf(
+            "Affordable prices",
+            "Great value for money",
+            "Discounted offers",
+        ),
+        HighlightType.SHIPPING to listOf(
+            "Fast and reliable shipping",
+            "Free shipping options",
+            "Express delivery",
+        ),
+        HighlightType.PACKAGING_AND_APPEARANCE to listOf(
+            "Elegant packaging",
+            "Attractive appearance",
+            "Beautiful design",
+        ),
+        HighlightType.COMPETITIVENESS to listOf(
+            "Competitive pricing",
+            "Strong market presence",
+            "Unbeatable deals",
+        ),
+    ),
 )

--- a/fenix/app/src/main/res/values/static_strings.xml
+++ b/fenix/app/src/main/res/values/static_strings.xml
@@ -130,4 +130,13 @@
     <string name="review_quality_check_settings_turn_off" translatable="false">Turn off review quality check</string>
     <string name="review_quality_check_adjusted_rating_title" translatable="false">Adjusted rating</string>
     <string name="review_quality_check_adjusted_rating_description" translatable="false">Unreliable reviews removed</string>
+    <string name="review_quality_check_highlights_caption" translatable="false">Summarized using information provided by Fakespot.com. View full analysis</string>
+    <string name="review_quality_check_highlights_title" translatable="false">Highlights from recent reviews</string>
+    <string name="review_quality_check_highlights_show_less" translatable="false">Show less</string>
+    <string name="review_quality_check_highlights_show_more" translatable="false">Show more</string>
+    <string name="review_quality_check_highlights_type_quality" translatable="false">Quality</string>
+    <string name="review_quality_check_highlights_type_price" translatable="false">Price</string>
+    <string name="review_quality_check_highlights_type_shipping" translatable="false">Shipping</string>
+    <string name="review_quality_check_highlights_type_packaging_appearance" translatable="false">Packaging and appearance</string>
+    <string name="review_quality_check_highlights_type_competitiveness" translatable="false">Competitiveness</string>
 </resources>

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStateTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStateTest.kt
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.store
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReviewQualityCheckStateTest {
+
+    @Test
+    fun `WHEN highlights are present THEN highlights to display in compact mode should contain first 2 highlights of the first highlight type`() {
+        val highlights = mapOf(
+            ReviewQualityCheckState.HighlightType.QUALITY to listOf(
+                "High quality",
+                "Excellent craftsmanship",
+                "Superior materials",
+            ),
+            ReviewQualityCheckState.HighlightType.PRICE to listOf(
+                "Affordable prices",
+                "Great value for money",
+                "Discounted offers",
+            ),
+            ReviewQualityCheckState.HighlightType.SHIPPING to listOf(
+                "Fast and reliable shipping",
+                "Free shipping options",
+                "Express delivery",
+            ),
+            ReviewQualityCheckState.HighlightType.PACKAGING_AND_APPEARANCE to listOf(
+                "Elegant packaging",
+                "Attractive appearance",
+                "Beautiful design",
+            ),
+            ReviewQualityCheckState.HighlightType.COMPETITIVENESS to listOf(
+                "Competitive pricing",
+                "Strong market presence",
+                "Unbeatable deals",
+            ),
+        )
+
+        val expected = mapOf(
+            ReviewQualityCheckState.HighlightType.QUALITY to listOf(
+                "High quality",
+                "Excellent craftsmanship",
+            ),
+        )
+
+        assertEquals(expected, highlights.forCompactMode())
+    }
+
+    @Test
+    fun `WHEN only 1 highlight is present THEN highlights to display in compact mode should contain that one`() {
+        val highlights = mapOf(
+            ReviewQualityCheckState.HighlightType.PRICE to listOf(
+                "Affordable prices",
+            ),
+        )
+
+        val expected = mapOf(
+            ReviewQualityCheckState.HighlightType.PRICE to listOf(
+                "Affordable prices",
+            ),
+        )
+
+        assertEquals(expected, highlights.forCompactMode())
+    }
+}


### PR DESCRIPTION
### How
– Add composable UI
~– Add `highlightsForCompactMode` property that contains the first two highlights of the first highlight type to display in the highlights card in compact state.~
– Add `highlights.forCompactMode()` extension function that returns the first two highlights of the first highlight type to display in the highlights card in compact state.

### Previews
<img width="402" alt="Screenshot 2023-08-03 at 13 58 27" src="https://github.com/mozilla-mobile/firefox-android/assets/38040960/8b7728f0-b301-4f30-abc7-ed745b987fa4">
<img width="398" alt="Screenshot 2023-08-03 at 13 58 10" src="https://github.com/mozilla-mobile/firefox-android/assets/38040960/3bf730e9-f83e-4f0a-a553-6347444b53bd">



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840339