### PR TITLE
Bug 1840994 - Disable systemNotificationCantBeDismissedWhileDownloadingTest

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -8,6 +8,7 @@ import androidx.core.net.toUri
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -350,6 +351,7 @@ class DownloadTest {
         deleteDownloadedFileOnStorage(secondDownloadedFile)
     }
 
+    @Ignore("Failing: https://bugzilla.mozilla.org/show_bug.cgi?id=1840994")
     @Test
     fun systemNotificationCantBeDismissedWhileDownloadingTest() {
         // Clear the "Firefox Fenix default browser notification"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1840994
https://bugzilla.mozilla.org/show_bug.cgi?id=1840994