### PR TITLE
Bug 1847179 - Fix wrong error message displayed when trying to install an unsupported add-on

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/extension/WebExtensionPromptFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/extension/WebExtensionPromptFeature.kt
@@ -90,17 +90,10 @@ class WebExtensionPromptFeature(
     ) {
         if (hasExistingPermissionDialogFragment()) return
 
-        // If the add-on is not found, it is already installed because the install process can only
-        // be triggered for add-ons "known" by Fenix (the add-on is either part of the official list
-        // of supported extensions OR part of the user custom AMO collection).
         if (addon == null) {
             promptRequest.onConfirm(false)
             consumePromptRequest()
-            showSnackBar(
-                view,
-                context.getString(R.string.addon_already_installed),
-                FenixSnackbar.LENGTH_LONG,
-            )
+            showUnsupportedError()
         } else {
             showPermissionDialog(
                 addon,
@@ -150,6 +143,15 @@ class WebExtensionPromptFeature(
                 PERMISSIONS_DIALOG_FRAGMENT_TAG,
             )
         }
+    }
+
+    @VisibleForTesting
+    internal fun showUnsupportedError() {
+        showSnackBar(
+            view,
+            context.getString(R.string.addon_not_supported_error),
+            FenixSnackbar.LENGTH_LONG,
+        )
     }
 
     private fun tryToReAttachButtonHandlersToPreviousDialog() {
@@ -204,7 +206,8 @@ class WebExtensionPromptFeature(
         consumePromptRequest()
     }
 
-    private fun consumePromptRequest() {
+    @VisibleForTesting
+    internal fun consumePromptRequest() {
         store.dispatch(WebExtensionAction.ConsumePromptRequestWebExtensionAction)
     }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/extension/WebExtensionPromptFeatureTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/extension/WebExtensionPromptFeatureTest.kt
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.extension
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.spyk
+import io.mockk.verify
+import mozilla.components.browser.state.action.WebExtensionAction.UpdatePromptRequestWebExtensionAction
+import mozilla.components.browser.state.state.extension.WebExtensionPromptRequest.Permissions
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class WebExtensionPromptFeatureTest {
+
+    private lateinit var webExtensionPromptFeature: WebExtensionPromptFeature
+    private lateinit var store: BrowserStore
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    @Before
+    fun setup() {
+        store = BrowserStore()
+        webExtensionPromptFeature = spyk(
+            WebExtensionPromptFeature(
+                store = store,
+                provideAddons = { emptyList() },
+                context = testContext,
+                view = mockk(relaxed = true),
+                fragmentManager = mockk(relaxed = true),
+            ),
+        )
+    }
+
+    @Test
+    fun `WHEN add-on is not found THEN unsupported error message is shown`() {
+        val onConfirm = mockk<(Boolean) -> Unit>(relaxed = true)
+        every { webExtensionPromptFeature.consumePromptRequest() } just runs
+        every { webExtensionPromptFeature.showUnsupportedError() } returns mockk()
+
+        webExtensionPromptFeature.start()
+
+        // Passing a mocked WebExtension instance here will result in no add-on being found.
+        store.dispatch(UpdatePromptRequestWebExtensionAction(Permissions(mockk(), onConfirm))).joinBlocking()
+
+        verify { onConfirm(false) }
+        verify { webExtensionPromptFeature.consumePromptRequest() }
+        verify { webExtensionPromptFeature.showUnsupportedError() }
+    }
+}


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- ~~[ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one~~
- ~~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features~~

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847179