### PR TITLE
Bug 1843895 - Update AppLinksUseCases launchInApp when updating the interceptor

### DIFF
--- a/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
+++ b/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksInterceptor.kt
@@ -58,8 +58,7 @@ class AppLinksInterceptor(
     private var launchInApp: () -> Boolean = { false },
     private val useCases: AppLinksUseCases = AppLinksUseCases(
         context,
-        // passing launchInApp() in the lambda to make sure it will always get the updated value
-        { launchInApp() },
+        launchInApp,
         alwaysDeniedSchemes = alwaysDeniedSchemes,
     ),
     private val launchFromInterceptor: Boolean = false,
@@ -71,6 +70,7 @@ class AppLinksInterceptor(
      */
     fun updateLaunchInApp(launchInApp: () -> Boolean) {
         this.launchInApp = launchInApp
+        useCases.updateLaunchInApp(launchInApp)
     }
 
     @Suppress("ComplexMethod", "ReturnCount")

--- a/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -55,7 +55,7 @@ private const val ANDROID_RESOLVER_PACKAGE_NAME = "android"
  */
 class AppLinksUseCases(
     private val context: Context,
-    private val launchInApp: () -> Boolean = { false },
+    private var launchInApp: () -> Boolean = { false },
     private val alwaysDeniedSchemes: Set<String> = ALWAYS_DENY_SCHEMES,
     private val installedBrowsers: Browsers = BrowsersCache.all(context),
 ) {
@@ -72,6 +72,14 @@ class AppLinksUseCases(
             Logger("AppLinksUseCases").error("failed to query activities", e)
             emptyList()
         }
+    }
+
+    /**
+     * Update launchInApp for this instance of AppLinksUseCases
+     * @param launchInApp the new value of launchInApp
+     */
+    fun updateLaunchInApp(launchInApp: () -> Boolean) {
+        this.launchInApp = launchInApp
     }
 
     private fun findDefaultActivity(intent: Intent): ResolveInfo? {

--- a/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
+++ b/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt
@@ -137,6 +137,7 @@ class AppLinksInterceptorTest {
         assertEquals(null, response)
 
         appLinksInterceptor.updateLaunchInApp { true }
+        verify(mockUseCases).updateLaunchInApp(any())
         val response2 = appLinksInterceptor.onLoadRequest(mockEngineSession, webUrlWithAppLink, null, true, false, false, false, false)
         assert(response2 is RequestInterceptor.InterceptionResponse.AppIntent)
     }

--- a/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
+++ b/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt
@@ -630,4 +630,18 @@ class AppLinksUseCasesTest {
         assertNotNull(result)
         assertEquals(result?.`package`, "org.mozilla.test")
     }
+
+    @Test
+    fun `WHEN launch in app is updated to true THEN should redirect`() {
+        val context = createContext(Triple(appUrl, appPackage, ""))
+        val subject = AppLinksUseCases(context, { false })
+
+        var redirect = subject.interceptedAppLinkRedirect(appUrl)
+        assertFalse(redirect.isRedirect())
+
+        AppLinksUseCases.clearRedirectCache()
+        subject.updateLaunchInApp { true }
+        redirect = subject.interceptedAppLinkRedirect(appUrl)
+        assertTrue(redirect.isRedirect())
+    }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
@@ -18,6 +18,7 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.FeatureSettingsHelperDelegate
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
@@ -310,6 +311,7 @@ class CustomTabsTest {
 
         customTabScreen {
             clickPageObject(itemWithText("PDF form file"))
+            clickPageObject(itemWithResIdAndText("android:id/button2", "CANCEL"))
             waitForPageToLoad()
             verifyPDFReaderToolbarItems()
             verifyCustomTabCloseButton()


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1843895