### PR TITLE
Bug 1845323 - Add download add-on dialog

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -374,6 +374,21 @@ class GeckoEngine(
             override fun onInstalled(extension: org.mozilla.geckoview.WebExtension) {
                 webExtensionDelegate.onInstalled(GeckoWebExtension(extension, runtime))
             }
+
+            override fun onDownloadStarted() {
+                webExtensionDelegate.onDownloadStarted()
+            }
+
+            override fun onDownloadEnded() {
+                webExtensionDelegate.onDownloadEnded()
+            }
+
+            override fun onDownloadFailed() {
+                webExtensionDelegate.onDownloadFailed()
+            }
+            override fun onDownloadCancelled() {
+                webExtensionDelegate.onDownloadCancelled()
+            }
         }
 
         runtime.webExtensionController.setPromptDelegate(promptDelegate)

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -2347,6 +2347,74 @@ class GeckoEngineTest {
         assertEquals(extension, capturedExtension.nativeExtension)
     }
 
+    @Test
+    fun `web extension delegate handles add-on onDownloadStarted event`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val geckoDelegateCaptor = argumentCaptor<WebExtensionController.AddonManagerDelegate>()
+        verify(webExtensionController).setAddonManagerDelegate(geckoDelegateCaptor.capture())
+
+        assertEquals(Unit, geckoDelegateCaptor.value.onDownloadStarted())
+        verify(webExtensionsDelegate).onDownloadStarted()
+    }
+
+    @Test
+    fun `web extension delegate handles add-on onDownloadEnded event`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val geckoDelegateCaptor = argumentCaptor<WebExtensionController.AddonManagerDelegate>()
+        verify(webExtensionController).setAddonManagerDelegate(geckoDelegateCaptor.capture())
+
+        assertEquals(Unit, geckoDelegateCaptor.value.onDownloadEnded())
+        verify(webExtensionsDelegate).onDownloadEnded()
+    }
+
+    @Test
+    fun `web extension delegate handles add-on onDownloadFailed event`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val geckoDelegateCaptor = argumentCaptor<WebExtensionController.AddonManagerDelegate>()
+        verify(webExtensionController).setAddonManagerDelegate(geckoDelegateCaptor.capture())
+
+        assertEquals(Unit, geckoDelegateCaptor.value.onDownloadFailed())
+        verify(webExtensionsDelegate).onDownloadFailed()
+    }
+
+    @Test
+    fun `web extension delegate handles add-on onDownloadCancelled event`() {
+        val runtime: GeckoRuntime = mock()
+        val webExtensionController: WebExtensionController = mock()
+        whenever(runtime.webExtensionController).thenReturn(webExtensionController)
+
+        val webExtensionsDelegate: WebExtensionDelegate = mock()
+        val engine = GeckoEngine(context, runtime = runtime)
+        engine.registerWebExtensionDelegate(webExtensionsDelegate)
+
+        val geckoDelegateCaptor = argumentCaptor<WebExtensionController.AddonManagerDelegate>()
+        verify(webExtensionController).setAddonManagerDelegate(geckoDelegateCaptor.capture())
+
+        assertEquals(Unit, geckoDelegateCaptor.value.onDownloadCancelled())
+        verify(webExtensionsDelegate).onDownloadCancelled()
+    }
+
     private fun createSocialTrackersLogEntryList(): List<ContentBlockingController.LogEntry> {
         val blockedLogEntry = object : ContentBlockingController.LogEntry() {}
 

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/extension/WebExtensionPromptRequest.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/extension/WebExtensionPromptRequest.kt
@@ -8,29 +8,59 @@ import mozilla.components.concept.engine.webextension.WebExtension
 
 /**
  * Value type that represents a request for showing a native dialog from a [WebExtension].
- *
- * @param extension The [WebExtension] that requested the dialog to be shown.
  */
 sealed class WebExtensionPromptRequest(
-    open val extension: WebExtension,
 ) {
 
     /**
-     * Value type that represents a request for a permission prompt.
-     * @property extension The [WebExtension] that requested the dialog to be shown.
-     * @property onConfirm A callback indicating whether the permissions were granted or not.
+     * Value type that represents a request for showing a native dialog from a [WebExtension] before
+     * the installation succeed.
      */
-    data class Permissions(
-        override val extension: WebExtension,
-        val onConfirm: (Boolean) -> Unit,
-    ) : WebExtensionPromptRequest(extension)
+    sealed class PreInstallation : WebExtensionPromptRequest() {
+        /**
+         * A request for indicating the download file of the extension has been started.
+         */
+        object DownloadStarted : PreInstallation()
+        /**
+         * A request for indicating the download file of the extension has been ended.
+         */
+        object DownloadEnded : PreInstallation()
+        /**
+         * A request for indicating the download file of the extension has been cancelled.
+         */
+        object DownloadCancelled : PreInstallation()
+        /**
+         * A request for indicating the download file of the extension has failed.
+         */
+        object DownloadFailed : PreInstallation()
+    }
 
     /**
-     * Value type that represents a request for showing post-installation prompt.
-     * Normally used to give users an opportunity to enable the [extension] in private browsing mode.
-     * @property extension The installed extension.
+     * Value type that represents a request for showing a native dialog from a [WebExtension] after
+     * installation succeed.
+     *
+     * @param extension The [WebExtension] that requested the dialog to be shown.
      */
-    data class PostInstallation(
-        override val extension: WebExtension,
-    ) : WebExtensionPromptRequest(extension)
+    sealed class PostInstallation(
+        open val extension: WebExtension,
+    ) : WebExtensionPromptRequest() {
+        /**
+         * Value type that represents a request for a permission prompt.
+         * @property extension The [WebExtension] that requested the dialog to be shown.
+         * @property onConfirm A callback indicating whether the permissions were granted or not.
+         */
+        data class Permissions(
+            override val extension: WebExtension,
+            val onConfirm: (Boolean) -> Unit,
+        ) : PostInstallation(extension)
+
+        /**
+         * Value type that represents a request for showing post-installation prompt.
+         * Normally used to give users an opportunity to enable the [extension] in private browsing mode.
+         * @property extension The installed extension.
+         */
+        data class Welcome(
+            override val extension: WebExtension,
+        ) : PostInstallation(extension)
+    }
 }

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
@@ -28,6 +28,23 @@ interface WebExtensionDelegate {
     fun onUninstalled(extension: WebExtension) = Unit
 
     /**
+     * Invoked when the download file for a web extension has started.
+     */
+    fun onDownloadStarted() = Unit
+
+    /**
+     * Invoked when the download file for a web extension has ended successfully.
+     */
+    fun onDownloadEnded() = Unit
+    /**
+     * Invoked when the download file for a web extension has failed.
+     */
+    fun onDownloadFailed() = Unit
+    /**
+     * Invoked when the download file for a web extension has been cancelled.
+     */
+    fun onDownloadCancelled() = Unit
+    /**
      * Invoked when a web extension was enabled successfully.
      *
      * @param extension The enabled extension.

--- a/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -233,12 +233,41 @@ object WebExtensionSupport {
                     if (!extension.isBuiltIn()) {
                         store.dispatch(
                             WebExtensionAction.UpdatePromptRequestWebExtensionAction(
-                                WebExtensionPromptRequest.PostInstallation(extension),
+                                WebExtensionPromptRequest.PostInstallation.Welcome(extension),
                             ),
                         )
                     }
                 }
 
+                override fun onDownloadStarted() {
+                    store.dispatch(
+                        WebExtensionAction.UpdatePromptRequestWebExtensionAction(
+                            WebExtensionPromptRequest.PreInstallation.DownloadStarted,
+                        ),
+                    )
+                }
+
+                override fun onDownloadEnded () {
+                    store.dispatch(
+                        WebExtensionAction.UpdatePromptRequestWebExtensionAction(
+                            WebExtensionPromptRequest.PreInstallation.DownloadEnded,
+                        ),
+                    )
+                }
+                override fun onDownloadFailed () {
+                    store.dispatch(
+                        WebExtensionAction.UpdatePromptRequestWebExtensionAction(
+                            WebExtensionPromptRequest.PreInstallation.DownloadFailed,
+                        ),
+                    )
+                }
+                override fun onDownloadCancelled () {
+                    store.dispatch(
+                        WebExtensionAction.UpdatePromptRequestWebExtensionAction(
+                            WebExtensionPromptRequest.PreInstallation.DownloadCancelled,
+                        ),
+                    )
+                }
                 override fun onUninstalled(extension: WebExtension) {
                     installedExtensions.remove(extension.id)
                     store.dispatch(WebExtensionAction.UninstallWebExtensionAction(extension.id))
@@ -270,7 +299,10 @@ object WebExtensionSupport {
                 ) {
                     store.dispatch(
                         WebExtensionAction.UpdatePromptRequestWebExtensionAction(
-                            WebExtensionPromptRequest.Permissions(extension, onPermissionsGranted),
+                            WebExtensionPromptRequest.PostInstallation.Permissions(
+                                extension,
+                                onPermissionsGranted,
+                            ),
                         ),
                     )
                 }

--- a/android-components/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/android-components/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -16,6 +16,8 @@ import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.browser.state.state.createCustomTab
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.state.extension.WebExtensionPromptRequest
+import mozilla.components.browser.state.state.extension.WebExtensionPromptRequest.PostInstallation
+import mozilla.components.browser.state.state.extension.WebExtensionPromptRequest.PreInstallation
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
@@ -400,7 +402,7 @@ class WebExtensionSupportTest {
         )
         verify(store).dispatch(
             WebExtensionAction.UpdatePromptRequestWebExtensionAction(
-                WebExtensionPromptRequest.PostInstallation(ext),
+                PostInstallation.Welcome(ext),
             ),
         )
         assertEquals(ext, WebExtensionSupport.installedExtensions[ext.id])
@@ -452,7 +454,7 @@ class WebExtensionSupportTest {
 
         verify(store).dispatch(
             WebExtensionAction.UpdatePromptRequestWebExtensionAction(
-                WebExtensionPromptRequest.Permissions(ext, onPermissionsGranted),
+                PostInstallation.Permissions(ext, onPermissionsGranted),
             ),
         )
     }
@@ -503,7 +505,79 @@ class WebExtensionSupportTest {
         delegateCaptor.value.onInstalled(ext)
         verify(store, times(0)).dispatch(
             WebExtensionAction.UpdatePromptRequestWebExtensionAction(
-                WebExtensionPromptRequest.PostInstallation(ext),
+                PostInstallation.Welcome(ext),
+            ),
+        )
+    }
+
+    @Test
+    fun `reacts to extension being onDownloadStarted`() {
+        val store = spy(BrowserStore())
+        val engine: Engine = mock()
+
+        val delegateCaptor = argumentCaptor<WebExtensionDelegate>()
+        WebExtensionSupport.initialize(engine, store)
+        verify(engine).registerWebExtensionDelegate(delegateCaptor.capture())
+
+        delegateCaptor.value.onDownloadStarted()
+
+        verify(store).dispatch(
+            WebExtensionAction.UpdatePromptRequestWebExtensionAction(
+                PreInstallation.DownloadStarted,
+            ),
+        )
+    }
+
+    @Test
+    fun `reacts to extension being onDownloadEnded`() {
+        val store = spy(BrowserStore())
+        val engine: Engine = mock()
+
+        val delegateCaptor = argumentCaptor<WebExtensionDelegate>()
+        WebExtensionSupport.initialize(engine, store)
+        verify(engine).registerWebExtensionDelegate(delegateCaptor.capture())
+
+        delegateCaptor.value.onDownloadEnded()
+
+        verify(store).dispatch(
+            WebExtensionAction.UpdatePromptRequestWebExtensionAction(
+                PreInstallation.DownloadEnded,
+            ),
+        )
+    }
+
+    @Test
+    fun `reacts to extension being onDownloadFailed`() {
+        val store = spy(BrowserStore())
+        val engine: Engine = mock()
+
+        val delegateCaptor = argumentCaptor<WebExtensionDelegate>()
+        WebExtensionSupport.initialize(engine, store)
+        verify(engine).registerWebExtensionDelegate(delegateCaptor.capture())
+
+        delegateCaptor.value.onDownloadFailed()
+
+        verify(store).dispatch(
+            WebExtensionAction.UpdatePromptRequestWebExtensionAction(
+                PreInstallation.DownloadFailed,
+            ),
+        )
+    }
+
+    @Test
+    fun `reacts to extension being onDownloadCancelled`() {
+        val store = spy(BrowserStore())
+        val engine: Engine = mock()
+
+        val delegateCaptor = argumentCaptor<WebExtensionDelegate>()
+        WebExtensionSupport.initialize(engine, store)
+        verify(engine).registerWebExtensionDelegate(delegateCaptor.capture())
+
+        delegateCaptor.value.onDownloadCancelled()
+
+        verify(store).dispatch(
+            WebExtensionAction.UpdatePromptRequestWebExtensionAction(
+                PreInstallation.DownloadCancelled,
             ),
         )
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/extension/AddonDownloadingDialogFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/extension/AddonDownloadingDialogFragment.kt
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.extension
+
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.mozilla.fenix.R
+import org.mozilla.fenix.android.FenixDialogFragment
+import org.mozilla.fenix.databinding.OverlayAddOnProgressBinding
+
+/**
+ * A [FenixDialogFragment] that shows an overlay while an extension file is been downloaded.
+ */
+class AddonDownloadingDialogFragment : FenixDialogFragment() {
+    override val gravity: Int = Gravity.BOTTOM
+    override val layoutId: Int = R.layout.overlay_add_on_progress
+    private var _binding: OverlayAddOnProgressBinding? = null
+
+    /**
+     * A lambda called when the dialog is dismissed.
+     */
+    var onDismissed: (() -> Unit)? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val rootView = inflateRootView(container)
+
+        _binding = OverlayAddOnProgressBinding.bind(rootView)
+
+        _binding?.cancelButton?.setOnClickListener { dismiss() }
+        return rootView
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        onDismissed?.invoke()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/fenix/app/src/main/res/drawable/mozac_ic_extensions_black.xml
+++ b/fenix/app/src/main/res/drawable/mozac_ic_extensions_black.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?android:attr/textColorPrimary"
+        android:pathData="M17.5,7H15.5V5.127C15.5,3.533 14.317,2.166 12.807,2.015C11.958,1.931 11.116,2.206 10.488,2.775C9.86,3.342 9.5,4.154 9.5,4.999V7H6.5C5.119,7 4,8.119 4,9.5V11.75C4,12.44 4.56,13 5.25,13H6.873C7.706,13 8.417,13.59 8.493,14.343C8.536,14.775 8.402,15.188 8.114,15.506C7.829,15.82 7.424,16 7.001,16H5.25C4.56,16 4,16.56 4,17.25V19.5C4,20.881 5.119,22 6.5,22H17.5C18.881,22 20,20.881 20,19.5V9.5C20,8.119 18.881,7 17.5,7ZM18.5,19.7L17.7,20.5H6.3L5.5,19.7V17.5H7.001C7.847,17.5 8.658,17.14 9.226,16.512C9.794,15.885 10.07,15.039 9.985,14.194C9.834,12.683 8.467,11.5 6.873,11.5H5.5V9.3L6.3,8.5H10C10.552,8.5 11,8.052 11,7.5V4.999C11,4.576 11.18,4.171 11.494,3.887C11.812,3.599 12.227,3.466 12.657,3.507C13.41,3.582 14,4.294 14,5.127V7.5C14,8.052 14.448,8.5 15,8.5H17.7L18.5,9.3V19.7Z" />
+</vector>

--- a/fenix/app/src/main/res/layout/overlay_add_on_progress.xml
+++ b/fenix/app/src/main/res/layout/overlay_add_on_progress.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/overlay_card_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:elevation="1dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/add_ons_overlay_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:drawablePadding="8dp"
+            android:gravity="start|center_vertical"
+            android:padding="16dp"
+            android:text="@string/mozac_add_on_install_progress_caption"
+            app:drawableStartCompat="@drawable/mozac_ic_extensions_black" />
+
+        <Button
+            android:id="@+id/cancel_button"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/add_ons_overlay_text"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/mozac_feature_addons_install_addon_dialog_cancel"
+            android:textAlignment="center"
+            android:textAllCaps="false" />
+
+    </RelativeLayout>
+
+</androidx.cardview.widget.CardView>

--- a/fenix/app/src/test/java/org/mozilla/fenix/extension/WebExtensionPromptFeatureTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/extension/WebExtensionPromptFeatureTest.kt
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.extension
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.spyk
+import io.mockk.verify
+import mozilla.components.browser.state.action.WebExtensionAction.UpdatePromptRequestWebExtensionAction
+import mozilla.components.browser.state.state.extension.WebExtensionPromptRequest.PreInstallation
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import java.lang.ref.WeakReference
+
+@RunWith(FenixRobolectricTestRunner::class)
+class WebExtensionPromptFeatureTest {
+
+    private lateinit var webExtensionPromptFeature: WebExtensionPromptFeature
+    private lateinit var store: BrowserStore
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    @Before
+    fun setup() {
+        store = BrowserStore()
+        webExtensionPromptFeature = spyk(
+            WebExtensionPromptFeature(
+                store = store,
+                provideAddons = { emptyList() },
+                context = testContext,
+                view = mockk(relaxed = true),
+                fragmentManager = mockk(relaxed = true),
+            ),
+        )
+    }
+
+    @Test
+    fun `WHEN DownloadStarted is dispatched THEN showDownloadDialog`() {
+        assertNull(webExtensionPromptFeature.activeDownloadingDialog)
+
+        webExtensionPromptFeature.start()
+
+        every { webExtensionPromptFeature.showDownloadDialog() } returns mockk()
+
+        store.dispatch(UpdatePromptRequestWebExtensionAction(PreInstallation.DownloadStarted))
+            .joinBlocking()
+
+        verify { webExtensionPromptFeature.showDownloadDialog() }
+        assertNotNull(webExtensionPromptFeature.activeDownloadingDialog)
+    }
+
+    @Test
+    fun `WHEN DownloadEnded is dispatched THEN clear download dialog reference`() {
+        val activeDialog: WeakReference<AddonDownloadingDialogFragment> = mockk(relaxed = true)
+
+        webExtensionPromptFeature.start()
+
+        webExtensionPromptFeature.activeDownloadingDialog = activeDialog
+
+        assertNotNull(webExtensionPromptFeature.activeDownloadingDialog)
+
+        store.dispatch(UpdatePromptRequestWebExtensionAction(PreInstallation.DownloadEnded))
+            .joinBlocking()
+
+        verify { activeDialog.clear() }
+    }
+
+    @Test
+    fun `WHEN DownloadCancelled is dispatched THEN clear download dialog reference`() {
+        val activeDialog: WeakReference<AddonDownloadingDialogFragment> = mockk(relaxed = true)
+
+        webExtensionPromptFeature.start()
+
+        webExtensionPromptFeature.activeDownloadingDialog = activeDialog
+
+        assertNotNull(webExtensionPromptFeature.activeDownloadingDialog)
+
+        store.dispatch(UpdatePromptRequestWebExtensionAction(PreInstallation.DownloadCancelled))
+            .joinBlocking()
+
+        verify { activeDialog.clear() }
+    }
+
+    @Test
+    fun `WHEN DownloadFailed is dispatched THEN clear download dialog reference`() {
+        val activeDialog: WeakReference<AddonDownloadingDialogFragment> = mockk(relaxed = true)
+
+        webExtensionPromptFeature.start()
+
+        webExtensionPromptFeature.activeDownloadingDialog = activeDialog
+
+        assertNotNull(webExtensionPromptFeature.activeDownloadingDialog)
+
+        store.dispatch(UpdatePromptRequestWebExtensionAction(PreInstallation.DownloadFailed))
+            .joinBlocking()
+
+        verify { activeDialog.clear() }
+    }
+
+    @Test
+    fun `WHEN dismissing the download dialog THEN clear download dialog reference and consumePromptRequest`() {
+        val activeDialog: WeakReference<AddonDownloadingDialogFragment> = mockk(relaxed = true)
+
+        every { webExtensionPromptFeature.consumePromptRequest() } just runs
+
+        webExtensionPromptFeature.activeDownloadingDialog = activeDialog
+
+        val dialog = webExtensionPromptFeature.showDownloadDialog()
+
+        dialog.onDismissed!!.invoke()
+
+        verify { activeDialog.clear() }
+        verify { webExtensionPromptFeature.consumePromptRequest() }
+    }
+}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
