### PR TITLE
Bug 1833666 - Update references to archived repos

### DIFF
--- a/fenix/README.md
+++ b/fenix/README.md
@@ -1,7 +1,6 @@
 # Firefox for Android
 
-[![Task Status](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/fenix/main/badge.svg)](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/fenix/main/latest)
-[![codecov](https://codecov.io/gh/mozilla-mobile/fenix/branch/main/graph/badge.svg)](https://codecov.io/gh/mozilla-mobile/fenix)
+[![Task Status](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/firefox-android/main/badge.svg)](https://firefox-ci-tc.services.mozilla.com/api/github/v1/repository/mozilla-mobile/firefox-android/main/latest)
 
 Fenix (internal codename) is the all-new Firefox for Android browser, based on [GeckoView](https://mozilla.github.io/geckoview/) and [Mozilla Android Components](https://mozac.org/).
 
@@ -11,28 +10,28 @@ Fenix (internal codename) is the all-new Firefox for Android browser, based on [
 
 Please read the [Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/) and the [Bugzilla Etiquette guidelines](https://bugzilla.mozilla.org/page.cgi?id=etiquette.html) before filing an issue. This is our professional working environment as much as it is our bug tracker, and we want to keep our workspace clean and healthy.
 
-* [Guide to Contributing](https://github.com/mozilla-mobile/shared-docs/blob/master/android/CONTRIBUTING.md) (**New contributors start here!**)
+* [Guide to Contributing](../docs/shared/android/CONTRIBUTING.md) (**New contributors start here!**)
 
-* Browse our [current Issues](https://github.com/mozilla-mobile/fenix/issues), or [file a security issue][sec issue].
+* Browse our [current Issues](https://bugzilla.mozilla.org/buglist.cgi?product=Fenix&resolution=---), or [file a security issue][sec issue].
 
 * Matrix: [#fenix:mozilla.org channel](https://chat.mozilla.org/#/room/#fenix:mozilla.org) (**We're available Monday-Friday, GMT and PST working hours**). Related channels:
   * [#mobile-test-eng:mozilla.org channel](https://chat.mozilla.org/#/room/#mobile-test-eng:mozilla.org): for UI test automation
   * [#perf-android-frontend:mozilla.org channel](https://chat.mozilla.org/#/room/#perf-android-frontend:mozilla.org): for front-end (JVM) performance of Android apps
   * [#android-tips:mozilla.org channel](https://chat.mozilla.org/#/room/#android-tips:mozilla.org): for tips on Android development
 
-* Check out the [project wiki](https://github.com/mozilla-mobile/fenix/wiki) for more information.
-  * See [our guide on Writing Custom Lint Rules](https://github.com/mozilla-mobile/shared-docs/blob/master/android/writing_lint_rules.md).
+* Check out the [project documentation](docs/Home.md) for more information.
+  * See [our guide on Writing Custom Lint Rules](../docs/shared/android/writing_lint_rules.md).
 
 * Localization happens on [Pontoon](https://pontoon.mozilla.org/projects/firefox-for-android/). Please get in touch with delphine (at) mozilla (dot) com directly for more information.
 
-**Beginners!** - Watch out for [Issues with the "Good First Issue" label](https://github.com/mozilla-mobile/fenix/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). These are easy bugs that have been left for first timers to have a go, get involved and make a positive contribution to the project!
+**Beginners!** - Watch out for [Issues with the "good-first-bug" keyword](https://bugzilla.mozilla.org/buglist.cgi?product=Fenix&keywords=good-first-bug&resolution=---). These are easy bugs that have been left for first timers to have a go, get involved and make a positive contribution to the project!
 
 
 ## I want to open a Pull Request!
 
 We encourage you to participate in this open source project. We love Pull Requests, Bug Reports, ideas, (security) code reviews or any other kind of positive contribution.
 
-Since we are a small team, however, **we do not have the bandwidth to review unsolicited PRs**. Please follow our [Pull Request guidelines](https://github.com/mozilla-mobile/shared-docs/blob/master/android/CONTRIBUTING_code.md#creating-a-pull-request), or **we may close the PR**.
+Since we are a small team, however, **we do not have the bandwidth to review unsolicited PRs**. Please follow our [Pull Request guidelines](../docs/shared/android/CONTRIBUTING_code.md#creating-a-pull-request), or **we may close the PR**.
 
 To make it easier to review, we have these PR requirements:
 
@@ -71,15 +70,15 @@ Please keep in mind that even though a feature you have in mind may seem like a 
 
 Pre-requisites:
 * Android SDK
-* To run command line tools, you'll need to configure Java: see [our how-to guide](https://github.com/mozilla-mobile/shared-docs/blob/master/android/configure_java.md).
+* To run command line tools, you'll need to configure Java: see [our how-to guide](../docs/shared/android/configure_java.md).
 
 1. Clone or Download the repository:
 
   ```shell
-  git clone https://github.com/mozilla-mobile/fenix
+  git clone https://github.com/mozilla-mobile/firefox-android
   ```
 
-2. **Import** the project into Android Studio **or** build on the command line:
+2. **Import** the project from the `fenix` directory into Android Studio **or** build on the command line:
 
   ```shell
   ./gradlew clean app:assembleDebug
@@ -133,7 +132,7 @@ Using this hook will guarantee your hook gets updated as the repository changes.
 This hook tries to run as much as possible without taking too much time.
 
 Before you can run the hook, you'll need to configure Java properly because it relies on command line tools: see
-[our how-to guide](https://github.com/mozilla-mobile/shared-docs/blob/master/android/configure_java.md).
+[our how-to guide](../docs/shared/android/configure_java.md).
 
 To add it on Mac/Linux, run this command from the project root:
 ```sh
@@ -211,8 +210,6 @@ In order to build successfully, you need to check out a commit in the dependency
 - Run the `<android-components>/tools/list_compatible_dependency_versions.py` script to output a compatible commit
 - Check out the latest commit from main in this repository and the dependency repository. However, this may fail if there were breaking changes added recently to the dependency.
 
-If you're trying to build fenix with a local ac AND a local GV, you'll have to use another method: see [this doc](https://github.com/mozilla-mobile/fenix/blob/main/docs/substituting-local-ac-and-gv.md).
-
 ### Using Nimbus servers during local development
 If you're working with the Nimbus experiments platform, by default for local development Fenix configures Nimbus to not use a server.
 
@@ -228,7 +225,7 @@ If you wish to use a custom Glean server during local development, you can add a
 - `glean.custom.server.url`
 
 ### GeckoView
-For building with a local checkout of `mozilla-central` see [Substituting Local GeckoView](https://github.com/mozilla-mobile/firefox-android/blob/main/fenix/docs/substituting-local-gv.md)
+For building with a local checkout of `mozilla-central` see [Substituting Local GeckoView](docs/substituting-local-gv.md)
 
 ## License
 

--- a/fenix/SECURITY.md
+++ b/fenix/SECURITY.md
@@ -2,4 +2,4 @@
 
 ## Reporting a Vulnerability
 
-Report all security vunerablites to [Bugzilla Fenix::Security](https://bugzilla.mozilla.org/enter_bug.cgi?product=Fenix&component=Security). If they are not a security bug you will be asked to move your report to [Fenix GitHub](https://github.com/mozilla-mobile/fenix/issues). See the [Mozilla Security Bug Bounty Program](https://www.mozilla.org/en-US/security/bug-bounty/) and the [client security reporting](https://www.mozilla.org/en-US/security/client-bug-bounty/) pages for details. In any case where this document and the Mozilla.org pages differ the Mozilla.org pages are the official documentation.
+Report all security vunerablites to [Bugzilla Fenix::Security](https://bugzilla.mozilla.org/enter_bug.cgi?product=Fenix&component=Security). See the [Mozilla Security Bug Bounty Program](https://www.mozilla.org/en-US/security/bug-bounty/) and the [client security reporting](https://www.mozilla.org/en-US/security/client-bug-bounty/) pages for details. In any case where this document and the Mozilla.org pages differ the Mozilla.org pages are the official documentation.

--- a/fenix/automation/taskcluster/androidTest/parse-ui-test.py
+++ b/fenix/automation/taskcluster/androidTest/parse-ui-test.py
@@ -63,7 +63,7 @@ def main():
     print("---\n")
     print("# References & Documentation\n")
     print(
-        "* [Automated UI Testing Documentation](https://github.com/mozilla-mobile/shared-docs/blob/main/android/ui-testing.md)\n"
+        "* [Automated UI Testing Documentation](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/ui-testing.md)\n"
     )
     print(
         "* Mobile Test Engineering on [Confluence](https://mozilla-hub.atlassian.net/wiki/spaces/MTE/overview) | [Slack](https://mozilla.slack.com/archives/C02KDDS9QM9) | [Alerts](https://mozilla.slack.com/archives/C0134KJ4JHL)\n"

--- a/fenix/docs/Addressing-a-performance-regression.md
+++ b/fenix/docs/Addressing-a-performance-regression.md
@@ -68,7 +68,7 @@ Where:
 *  **--repository_to_test_path** is the path where your local Fenix repository is.
 
 
-**Note**: Make sure your repository includes all the tokens (Sentry, Nimbus, … etc) that we include in our release builds, as not adding them could affect the test results, as we want the APKs to be the same [experience as normal users will have](https://wiki.mozilla.org/Performance/Fenix#How_to_measure_what_users_experience). Part of this is making sure you have [autosignReleaseWithDebugKey in your local.properties](https://github.com/mozilla-mobile/fenix#automatically-sign-release-builds).
+**Note**: Make sure your repository includes all the tokens (Sentry, Nimbus, … etc) that we include in our release builds, as not adding them could affect the test results, as we want the APKs to be the same [experience as normal users will have](https://wiki.mozilla.org/Performance/Fenix#How_to_measure_what_users_experience). Part of this is making sure you have [autosignReleaseWithDebugKey in your local.properties](../README.md#automatically-sign-release-builds).
 
 
 🕐 Be patient, as we will have to build an APK for each possible commit in the range and for this range there [are 19 commits](https://github.com/mozilla-mobile/fenix/compare/98455c01eeba7c63775f18817cd079f5d08b4513...2f7f5988fccad2cf2043eed4b6849b32a4c76048) then we will build 19 APKs, and run the performance test for each one.

--- a/fenix/docs/Architecture-Decisions.md
+++ b/fenix/docs/Architecture-Decisions.md
@@ -1,4 +1,4 @@
-For an overview of our current architecture, please see [this document](https://github.com/mozilla-mobile/fenix/blob/master/docs/architecture-overview.md)
+For an overview of our current architecture, please see [this document](architecture-overview.md)
 
 ---
 

--- a/fenix/docs/Data-Practices.md
+++ b/fenix/docs/Data-Practices.md
@@ -4,7 +4,7 @@
 
 When a user has "Telemetry" enabled under Data Choices in the browser settings, Firefox Preview sends a "core" ping and an "event" ping to Mozilla's telemetry service. "core" ping using the same format documented on firefox-source-docs.mozilla.org.
 
-[Here](https://github.com/mozilla-mobile/fenix/blob/master/docs/metrics.md) is a list of Event Pings, Metrics Pings, and Activation Pings.
+[Here](metrics.md) is a list of Event Pings, Metrics Pings, and Activation Pings.
 
 **User can disable telemetry by turning the Telemetry toggle off under Data Choices.**
 
@@ -12,7 +12,7 @@ When a user has "Telemetry" enabled under Data Choices in the browser settings, 
 ***
 ### Adjust
 
-See [here](https://github.com/mozilla-mobile/fenix/wiki/Adjust-Usage) for details on Adjust usage in Firefox Preview.
+See [here](adjust.md) for details on Adjust usage in Firefox Preview.
 
 ***
 

--- a/fenix/docs/Fennec-Migration.md
+++ b/fenix/docs/Fennec-Migration.md
@@ -87,13 +87,13 @@ android {
 }
 ```
 
-Follow the build instructions in the [README](https://github.com/mozilla-mobile/fenix/blob/main/README.md) to get a Fenix build setup.
+Follow the build instructions in the [README](../README.md) to get a Fenix build setup.
 
 Now select the `geckoNightlyFennecNightly` build variant in Android Studio and deploy it. This build should have replaced your Fennec build now.
 
 ## Sample browser
 
-When working on migration code that lives in the [Android Components repository](https://github.com/mozilla-mobile/android-components) it can be helpful to replace a local Fennec build with the sample browser (instead of Fenix). The following setup is needed for that.
+When working on migration code that lives in the [Android Components repository](../../android-components) it can be helpful to replace a local Fennec build with the sample browser (instead of Fenix). The following setup is needed for that.
 
 Add the sharedUserId to the AndroidManifest.xml of sample browser:
 

--- a/fenix/docs/Home.md
+++ b/fenix/docs/Home.md
@@ -4,7 +4,7 @@ Firefox for Android is Mozilla's new browser for Android devices. Powered by Gec
 
 Firefox for Android is the first step in building a better mobile browser: one that’s faster, more secure and more independent than any mobile Firefox browser before it. It will combine the speed, privacy, control, and easy-to-use features you have come to expect from Firefox.
 
-*Don't see what you're looking for? Check out our shared docs: https://github.com/mozilla-mobile/shared-docs.*
+*Don't see what you're looking for? Check out [our shared docs](../../docs/shared).*
 
 ## User support
 
@@ -16,13 +16,13 @@ Firefox for Android is the first step in building a better mobile browser: one t
 * Google Play: [Release](https://play.google.com/store/apps/details?id=org.mozilla.firefox)
 * Google Play: [Beta](https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta)
 * Google Play: [Nightly](https://play.google.com/store/apps/details?id=org.mozilla.fenix)
-* Release APKs: https://github.com/mozilla-mobile/fenix/releases
+* Release APKs: https://github.com/mozilla-mobile/firefox-android/releases?q=Firefox
 * Nightly APKs: https://firefox-ci-tc.services.mozilla.com/tasks/index/mobile.v2.fenix.nightly.latest
 
 ## Contribute
 
-* [Contributing (Writing code, translating the app, testing the app)](https://github.com/mozilla-mobile/shared-docs/blob/master/android/CONTRIBUTING.md)
-* [List of good first issues for new contributors](https://github.com/mozilla-mobile/fenix/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+)
+* [Contributing (Writing code, translating the app, testing the app)](../../docs/shared/android/CONTRIBUTING.md)
+* [List of good first issues for new contributors](https://bugzilla.mozilla.org/buglist.cgi?product=Fenix&keywords=good-first-bug&resolution=---)
 * [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
 
 ## Communication

--- a/fenix/docs/Implementing-Telemetry.md
+++ b/fenix/docs/Implementing-Telemetry.md
@@ -20,13 +20,13 @@
 
 ## Procedure to follow when implementing a Glean telemetry event
 * A full example of adding an event with keys can be found [here](https://github.com/mozilla-mobile/android-components/pull/10837) (Android Components), [here](https://github.com/mozilla-mobile/fenix/pull/20909) (Fenix) and [here](https://github.com/mozilla/glean-annotations/pull/77) (Glean Annotation)
-1. Create an event in [metrics.yaml](https://github.com/mozilla-mobile/fenix/blob/master/app/metrics.yaml) and do a project rebuild to generate the event
-2. To add feature tags see steps [here](https://github.com/mozilla-mobile/fenix/wiki/Metric-Feature-Tags).
+1. Create an event in [metrics.yaml](../app/metrics.yaml) and do a project rebuild to generate the event
+2. To add feature tags see steps [here](Metric-Feature-Tags.md).
 5. Send the event from the proper place in the code with the appropriate generated method (e.g. `GeneratedClassMetrics.generatedEvent.record()`)
 6. Create pull requests
 7. Submit a data review ([example here](https://github.com/mozilla-mobile/fenix/pull/20909#issuecomment-902119039)).  There's also a [command-line tool for generating Data Review Requests](https://chuttenblog.wordpress.com/2021/09/07/this-week-in-glean-data-reviews-are-important-glean-parser-makes-them-easy/)
-8. Update the [metrics.yaml](https://github.com/mozilla-mobile/fenix/blob/master/app/metrics.yaml) with the data review
-9. For startup metrics, make sure to [manually test it](https://github.com/mozilla-mobile/fenix/wiki/Test-telemetry-pings)
+8. Update the [metrics.yaml](../app/metrics.yaml) with the data review
+9. For startup metrics, make sure to [manually test it](Test-telemetry-pings.md)
 
 ## Review
 See example [here](https://github.com/mozilla-mobile/fenix/pull/20909)

--- a/fenix/docs/adjust.md
+++ b/fenix/docs/adjust.md
@@ -4,7 +4,7 @@ The framework consists of a software development kit (SDK) linked into Firefox f
 
 ## Adjust Integration
 
-The Adjust framework is abstracted via the [AdjustMetricService](https://github.com/mozilla-mobile/fenix/blob/main/app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt) class. All interaction with Adjust happens via this class.
+The Adjust framework is abstracted via the [AdjustMetricService](../app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt) class. All interaction with Adjust happens via this class.
 
 ## Adjust Messages
 

--- a/fenix/docs/crash-reporting.md
+++ b/fenix/docs/crash-reporting.md
@@ -4,23 +4,23 @@ Firefox for Android uses a few libraries for crash and exception reporting. This
 
 This page documents the types of crash reporting, how the various parts interact, and what kind of data is sent back to Mozilla.
 
-Documentation for the specific libraries is included in the [Android Components Crash Reporting README](https://github.com/mozilla-mobile/android-components/blob/main/components/lib/crash/README.md).
+Documentation for the specific libraries is included in the [Android Components Crash Reporting README](../../android-components/components/lib/crash/README.md).
 
 ## Glean crash ping
 
 [Glean SDK](https://mozilla.github.io/glean/book/index.html) is a Mozilla open source telemetry library, which Firefox for Android uses to collect app telemetry. It can also collect crash counts as a labeled counter with each label corresponding to a specific type of crash (such as `native_code_crash`, `unhandled_exception`).
 
-The Glean crash ping format is documented [here](https://github.com/mozilla-mobile/android-components/blob/main/components/lib/crash/docs/metrics.md).
+The Glean crash ping format is documented [here](../../android-components/components/lib/crash/docs/metrics.md).
 
 To opt in or out of Glean telemetry reporting, visit the Data collection menu under Settings.
 
 ## Breadcrumbs
 
-[Breadcrumbs](https://github.com/mozilla-mobile/android-components/blob/main/components/support/base/src/main/java/mozilla/components/support/base/crash/Breadcrumb.kt) are trail of events that are sent with each crash report to both Socorro and Sentry.
+[Breadcrumbs](../../android-components/components/concept/base/src/main/java/mozilla/components/concept/base/crash/Breadcrumb.kt) are trail of events that are sent with each crash report to both Socorro and Sentry.
 
 ### Events
 
-In [HomeActivity](https://github.com/mozilla-mobile/fenix/blob/main/app/src/main/java/org/mozilla/fenix/HomeActivity.kt) when `onDestinationChanged` occurs, the destination fragment's name and and whether it is a custom tab is added to the breadcrumbs.
+In [HomeActivity](../app/src/main/java/org/mozilla/fenix/HomeActivity.kt) when `onDestinationChanged` occurs, the destination fragment's name and and whether it is a custom tab is added to the breadcrumbs.
 
 ## Socorro
 

--- a/fenix/docs/l10nScreenshotsTests.md
+++ b/fenix/docs/l10nScreenshotsTests.md
@@ -14,7 +14,7 @@ By running them manually you can check whether the test works or not but screens
 2. From command line run:
 `fastlane screengrab --test_instrumentation_runner "androidx.test.runner.AndroidJUnitRunner"`
 
-The package configuration, apk paths as well as the locales are set in [Screengrab file](https://github.com/mozilla-mobile/fenix/blob/073fd8939067bc7a367d8db497bcf53fbd24cdd2/fastlane/Screengrabfile#L5).
+The package configuration, apk paths as well as the locales are set in [Screengrab file](../fastlane/Screengrabfile#L5).
 In case there is a change there the file has to be modified accordingly.
 Before launching that command, there has to be an emulator running.
 

--- a/fenix/docs/release-checklist.md
+++ b/fenix/docs/release-checklist.md
@@ -15,8 +15,8 @@ There are two releases this covers: the current changes in the Fenix Nightly cha
 
 ## Cutting a Beta
 
-- [ ] Review [FeatureFlags](https://github.com/mozilla-mobile/fenix/blob/main/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt) to determine if there are features that need to be enabled (or disabled) for Beta and Production release of Fenix. This will be a discussion with PO, PMs, EMs.
-- [ ] Make a new Beta: Follow instructions [here](https://github.com/mozilla-mobile/fenix/wiki/Creating-a-release-branch) and notify the Release Management team (slack: #releaseduty-mobile). QA team is notified that a Beta release has been captured and they will run tests for Beta release sign-off
+- [ ] Review [FeatureFlags](../app/src/main/java/org/mozilla/fenix/FeatureFlags.kt) to determine if there are features that need to be enabled (or disabled) for Beta and Production release of Fenix. This will be a discussion with PO, PMs, EMs.
+- [ ] Make a new Beta: Follow instructions [here](Creating-a-release-branch.md) and notify the Release Management team (slack: #releaseduty-mobile). QA team is notified that a Beta release has been captured and they will run tests for Beta release sign-off
 - [ ] Once there is GREEN QA signoff, the Release Management team (slack: #releaseduty-mobile) pushes the Beta version in the [Google Play Console](https://play.google.com/console/)
 - [ ] Check Sentry each day for issues on [Firefox Beta](https://sentry.prod.mozaws.net/operations/firefox-beta/) and if nothing concerning, Release Management team bumps releases to 25%. Subsequent Beta builds are bumped to 100% assuming no blocking issues arise.
 ### Bugfix uplifts / Beta Product Integrity
@@ -32,6 +32,6 @@ There are two releases this covers: the current changes in the Fenix Nightly cha
 ## Production Release
 - [ ] Once there is GREEN QA signoff, the Production Release Candidate is pushed to the Alpha testing track in [Google Play Console](https://play.google.com/console/u/0/developers/7083182635971239206/app/4972519468758466290/releases/overview) by the Release Management team (slack: #releaseduty-mobile)
 - [ ] If nothing is concerning, release management officially tags the Release Candidate as Production release, (usually 1 week after 1st Release Candidate)
-- [ ] Check Sentry for new crashes. Follow instructions for [Crash Monitoring](https://github.com/mozilla-mobile/fenix/wiki/Crash-Monitoring). File issues and triage.
+- [ ] Check Sentry for new crashes. Follow instructions for [Crash Monitoring](Crash-Monitoring.md). File issues and triage.
 - [ ] If nothing concerning, release management bumps releases(5%, 25%, 100%)
 

--- a/fenix/docs/telemetry.md
+++ b/fenix/docs/telemetry.md
@@ -10,4 +10,4 @@ Additional metrics or pings defined by Fenix are documented in the [Glean Dictio
 
 ## Crash reporting
 
-See [here](https://github.com/mozilla-mobile/fenix/blob/main/docs/crash-reporting.md) for details on crash reporting in Firefox for Android.
+See [here](crash-reporting.md) for details on crash reporting in Firefox for Android.

--- a/fenix/settings.gradle
+++ b/fenix/settings.gradle
@@ -87,7 +87,7 @@ if (file('local.properties').canRead()) {
     localProperties.load(file('local.properties').newDataInputStream())
     log('Loaded local.properties')
 } else {
-    log('Missing local.properties; see https://github.com/mozilla-mobile/fenix/blob/main/README.md#local-properties-helpers for instructions.')
+    log('Missing local.properties; see https://github.com/mozilla-mobile/firefox-android/blob/main/fenix/README.md#localproperties-helpers for instructions.')
 }
 
 if (localProperties != null) {


### PR DESCRIPTION
As a follow-up to #2964, updating more references to archived repos that were migrated to this monorepo in the documentation and other files. Also using relative paths wherever possible to help avoid bitrot in the future (and to navigate when using local files).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1833666