### PR TITLE
Bug 1847583 - Fenix: Add search by bookmarks tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -799,7 +799,7 @@ class BookmarksTest {
         }.clickSearchButton {
             // Search for a valid term
             typeSearch(firstWebPage.title)
-            verifySearchEngineSuggestionResults(activityTestRule, firstWebPage.url.toString())
+            verifySearchEngineSuggestionResults(activityTestRule, firstWebPage.url.toString(), searchTerm = firstWebPage.title)
             verifyNoSuggestionsAreDisplayed(activityTestRule, secondWebPage.url.toString())
         }.dismissSearchBar {}
         bookmarksMenu {
@@ -852,7 +852,7 @@ class BookmarksTest {
             typeSearch("generic")
             verifyNoSuggestionsAreDisplayed(activityTestRule, firstWebPage.url.toString())
             verifyNoSuggestionsAreDisplayed(activityTestRule, secondWebPage.url.toString())
-            verifySearchEngineSuggestionResults(activityTestRule, thirdWebPage.url.toString())
+            verifySearchEngineSuggestionResults(activityTestRule, thirdWebPage.url.toString(), searchTerm = "generic")
             pressBack()
         }
         bookmarksMenu {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeBookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeBookmarksTest.kt
@@ -809,7 +809,7 @@ class ComposeBookmarksTest {
         }.clickSearchButton {
             // Search for a valid term
             typeSearch(firstWebPage.title)
-            verifySearchEngineSuggestionResults(activityTestRule, firstWebPage.url.toString())
+            verifySearchEngineSuggestionResults(activityTestRule, firstWebPage.url.toString(), searchTerm = firstWebPage.title)
             verifyNoSuggestionsAreDisplayed(activityTestRule, secondWebPage.url.toString())
             // Search for invalid term
             typeSearch("Android")
@@ -856,7 +856,7 @@ class ComposeBookmarksTest {
             typeSearch("generic")
             verifyNoSuggestionsAreDisplayed(activityTestRule, firstWebPage.url.toString())
             verifyNoSuggestionsAreDisplayed(activityTestRule, secondWebPage.url.toString())
-            verifySearchEngineSuggestionResults(activityTestRule, thirdWebPage.url.toString())
+            verifySearchEngineSuggestionResults(activityTestRule, thirdWebPage.url.toString(), searchTerm = "generic")
             pressBack()
         }
         bookmarksMenu {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHistoryTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHistoryTest.kt
@@ -408,7 +408,7 @@ class ComposeHistoryTest {
         }.clickSearchButton {
             // Search for a valid term
             typeSearch(firstWebPage.title)
-            verifySearchEngineSuggestionResults(activityTestRule, firstWebPage.url.toString())
+            verifySearchEngineSuggestionResults(activityTestRule, firstWebPage.url.toString(), searchTerm = firstWebPage.title)
             verifyNoSuggestionsAreDisplayed(activityTestRule, secondWebPage.url.toString())
             clickClearButton()
             // Search for invalid term
@@ -447,7 +447,7 @@ class ComposeHistoryTest {
             typeSearch("generic")
             verifyNoSuggestionsAreDisplayed(activityTestRule, firstWebPage.url.toString())
             verifyNoSuggestionsAreDisplayed(activityTestRule, secondWebPage.url.toString())
-            verifySearchEngineSuggestionResults(activityTestRule, thirdWebPage.url.toString())
+            verifySearchEngineSuggestionResults(activityTestRule, thirdWebPage.url.toString(), searchTerm = "generic")
             pressBack()
         }
         historyMenu {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
@@ -326,6 +326,7 @@ class ComposeSmokeTest {
         }
     }
 
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1846941")
     @Test
     fun tabMediaControlButtonTest() {
         val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
@@ -3,6 +3,7 @@ package org.mozilla.fenix.ui
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -617,6 +618,7 @@ class CreditCardAutofillTest {
         }
     }
 
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1847774")
     @Test
     fun verifySavedCreditCardsRedirectionToAutofillAfterInterruptionTest() {
         homeScreen {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -406,7 +406,7 @@ class HistoryTest {
         }.clickSearchButton {
             // Search for a valid term
             typeSearch("generic")
-            verifySearchEngineSuggestionResults(activityTestRule, firstWebPage.url.toString())
+            verifySearchEngineSuggestionResults(activityTestRule, firstWebPage.url.toString(), searchTerm = "generic")
             verifyNoSuggestionsAreDisplayed(activityTestRule, secondWebPage.url.toString())
         }.dismissSearchBar {}
         historyMenu {
@@ -450,7 +450,11 @@ class HistoryTest {
             typeSearch("generic")
             verifyNoSuggestionsAreDisplayed(activityTestRule, firstWebPage.url.toString())
             verifyNoSuggestionsAreDisplayed(activityTestRule, secondWebPage.url.toString())
-            verifySearchEngineSuggestionResults(activityTestRule, thirdWebPage.url.toString())
+            verifySearchEngineSuggestionResults(
+                activityTestRule,
+                thirdWebPage.url.toString(),
+                searchTerm = "generic",
+            )
             pressBack()
         }
         historyMenu {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -152,11 +152,11 @@ class SettingsSearchTest {
         homeScreen {
         }.openSearch {
             typeSearch("test")
-            verifyFirefoxSuggestResults(
+            verifySearchEngineSuggestionResults(
                 activityTestRule,
-                "test",
                 "Firefox Suggest",
-                "Test_Page_1",
+                page1.title,
+                searchTerm = "test",
             )
         }.clickSearchSuggestion("Test_Page_1") {
             verifyUrl(page1.url.toString())
@@ -207,11 +207,11 @@ class SettingsSearchTest {
         homeScreen {
         }.openSearch {
             typeSearch("test")
-            verifyFirefoxSuggestResults(
+            verifySearchEngineSuggestionResults(
                 activityTestRule,
-                "test",
                 "Firefox Suggest",
-                "Test_Page_1",
+                website.title,
+                searchTerm = "test",
             )
         }.clickSearchSuggestion("Test_Page_1") {
             verifyUrl(website.url.toString())
@@ -236,7 +236,7 @@ class SettingsSearchTest {
             verifyNoSuggestionsAreDisplayed(
                 activityTestRule,
                 "Firefox Suggest",
-                "Test_Page_1",
+                website.title,
             )
         }
     }
@@ -455,8 +455,12 @@ class SettingsSearchTest {
     fun toggleSearchSuggestionsTest() {
         homeScreen {
         }.openSearch {
-            typeSearch("mozilla")
-            verifySearchEngineSuggestionResults(activityTestRule, "mozilla firefox")
+            typeSearch("mozilla ")
+            verifySearchEngineSuggestionResults(
+                activityTestRule,
+                "mozilla firefox",
+                searchTerm = "mozilla ",
+            )
         }.dismissSearchBar {
         }.openThreeDotMenu {
         }.openSettings {
@@ -492,7 +496,11 @@ class SettingsSearchTest {
             typeSearch("mozilla")
             verifyAllowSuggestionsInPrivateModeDialog()
             allowSuggestionsInPrivateMode()
-            verifySearchEngineSuggestionResults(activityTestRule, "mozilla firefox")
+            verifySearchEngineSuggestionResults(
+                activityTestRule,
+                "mozilla firefox",
+                searchTerm = "mozilla",
+            )
         }.dismissSearchBar {
         }.openThreeDotMenu {
         }.openSettings {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -133,11 +133,9 @@ class NavigationToolbarRobot {
     // New unified search UI selector
     fun verifyDefaultSearchEngine(engineName: String) =
         assertTrue(
-            mDevice.findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/search_selector")
-                    .childSelector(UiSelector().description(engineName)),
-            ).waitForExists(waitingTime),
+            searchSelectorButton
+                .getChild(UiSelector().description(engineName))
+                .waitForExists(waitingTime),
         )
 
     fun verifyTextSelectionOptions(vararg textSelectionOptions: String) {
@@ -355,6 +353,14 @@ class NavigationToolbarRobot {
             SearchRobot().interact()
             return SearchRobot.Transition()
         }
+
+        fun clickSearchSelectorButton(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
+            searchSelectorButton.waitForExists(waitingTime)
+            searchSelectorButton.click()
+
+            SearchRobot().interact()
+            return SearchRobot.Transition()
+        }
     }
 }
 
@@ -441,6 +447,9 @@ private fun assertCloseReaderViewDetected(visible: Boolean) {
         },
     )
 }
+
+private val searchSelectorButton =
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/search_selector"))
 
 inline fun runWithIdleRes(ir: IdlingResource?, pendingCheck: () -> Unit) {
     try {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -37,7 +37,6 @@ import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.grantSystemPermission
@@ -93,26 +92,7 @@ class SearchRobot {
         }
     }
 
-    fun verifySearchEngineSuggestionResults(rule: ComposeTestRule, searchSuggestion: String) {
-        rule.waitForIdle()
-        for (i in 1..RETRY_COUNT) {
-            try {
-                assertTrue(
-                    mDevice.findObject(UiSelector().textContains(searchSuggestion))
-                        .waitForExists(waitingTimeLong),
-                )
-                break
-            } catch (e: AssertionError) {
-                if (i == RETRY_COUNT) {
-                    throw e
-                } else {
-                    expandSearchSuggestionsList()
-                }
-            }
-        }
-    }
-
-    fun verifyFirefoxSuggestResults(rule: ComposeTestRule, searchTerm: String, vararg searchSuggestions: String) {
+    fun verifySearchEngineSuggestionResults(rule: ComposeTestRule, vararg searchSuggestions: String, searchTerm: String) {
         rule.waitForIdle()
         for (i in 1..RETRY_COUNT) {
             try {
@@ -122,7 +102,6 @@ class SearchRobot {
                         .performScrollToNode(hasText(searchSuggestion))
                         .assertExists()
                 }
-
                 break
             } catch (e: AssertionError) {
                 if (i == RETRY_COUNT) {


### PR DESCRIPTION
Made verifyFirefoxSuggestResults  and verifySearchEngineSuggestionResults only one method as they were practically the same.
Added new tests based on TestRail manual tests.
Fixed defaultSearchCodeGoogleUS failing on the PR, for un-related reasons.
Ran 100x on Firebase, and all passed.

Discussed with Aaron how to handle code duplication in old and new Composed test classes, we've made a decision to freeze the old UI classes (to be deprecated in the future) and only add to the new Compose test classes.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847583
https://bugzilla.mozilla.org/show_bug.cgi?id=1846941
https://bugzilla.mozilla.org/show_bug.cgi?id=1847774