### PR TITLE
Bug 1846229 - Ignore flaky test in ReviewQualityCheckStoreTest

### DIFF
--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStoreTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStoreTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.runTest
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.shopping.middleware.ReviewQualityCheckPreferences
@@ -22,6 +23,7 @@ class ReviewQualityCheckStoreTest {
     private val scope = coroutinesTestRule.scope
 
     @Test
+    @Ignore("Flaky, see https://bugzilla.mozilla.org/show_bug.cgi?id=1846229")
     fun `GIVEN the user has not opted in the feature WHEN store is created THEN state should display not opted in UI`() =
         runTest {
             val tested = ReviewQualityCheckStore(


### PR DESCRIPTION
This test has failed a few times ([example tc task](https://firefox-ci-tc.services.mozilla.com/tasks/PyYeYU1GSLazqIcQyAFP1w#artifacts)) on the CI ([for an unrelated PR](https://github.com/mozilla-mobile/firefox-android/pull/3140)) and I've been unable to reporoduce the failure locally. Removing this so we don't block the CI. 

If anyone has some ideas on how to better test this, please let me know.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1846229