### PR TITLE
Bug 1833666 - Remove extra bracket from uplift video link

### DIFF
--- a/docs/shared/uplift_guide.md
+++ b/docs/shared/uplift_guide.md
@@ -30,7 +30,7 @@ For Beta and Release, the following steps outline the process:
 - NOTE: The developer should choose beta or release depending on which channel the targeted version is currently on.
 - NOTE: There can be a window of time around RC week where approval-mozilla-beta is requested, but no further beta builds are planned. In this scenario, the release manager will take care of changing the pending beta approval request to a release request instead.
 7. The developer provides details for the approval request and clicks Submit.
-- [Video Example of adding a uplift request](https://video.chevrel.org/demos/upliftRequestForm.mp4]) 📺
+- [Video Example of adding a uplift request](https://video.chevrel.org/demos/upliftRequestForm.mp4) 📺
 8. The approval flag is added to the attachment and the information from the form is added as a comment in the bug.
 9. The release manager regularly checks Bugzilla for uplift requests.
 10. The release manager reviews the uplift approval request on the bug. If approved, they will change the approval status flag from ‘?’ to ‘+’ and add a comment indicating the next build that will include that change.


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1833666