### PR TITLE
Bug 1847906 - Add `getAddonIconBitmap()` to the `AddonsProvider` interface

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonsProvider.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonsProvider.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.feature.addons
 
+import android.graphics.Bitmap
+
 /**
  * A contract that indicate how an add-on provider must behave.
  */
@@ -25,4 +27,11 @@ interface AddonsProvider {
         readTimeoutInSeconds: Long? = null,
         language: String? = null,
     ): List<Addon>
+
+    /**
+     * Provides the decoded bitmap of an add-on's icon.
+     *
+     * @param addon the add-on for which we want to retrieve its icon as a decoded bitmap
+     */
+    suspend fun getAddonIconBitmap(addon: Addon): Bitmap?
 }

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AMOAddonsProvider.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AMOAddonsProvider.kt
@@ -178,7 +178,7 @@ class AMOAddonsProvider(
      * a connectivity problem or a timeout.
      */
     @Throws(IOException::class)
-    suspend fun getAddonIconBitmap(addon: Addon): Bitmap? {
+    override suspend fun getAddonIconBitmap(addon: Addon): Bitmap? {
         var bitmap: Bitmap? = null
         if (addon.iconUrl != "") {
             client.fetch(

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragment.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragment.kt
@@ -33,8 +33,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.AddonsProvider
 import mozilla.components.feature.addons.R
-import mozilla.components.feature.addons.amo.AMOAddonsProvider
 import mozilla.components.feature.addons.databinding.MozacFeatureAddonsFragmentDialogAddonInstalledBinding
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.appName
@@ -74,9 +74,9 @@ class AddonInstallationDialogFragment : AppCompatDialogFragment() {
     var onDismissed: (() -> Unit)? = null
 
     /**
-     * Reference to the application's [AMOAddonsProvider] to fetch add-on icons.
+     * Reference to the application's [AddonsProvider] to fetch add-on icons.
      */
-    var addonsProvider: AMOAddonsProvider? = null
+    var addonsProvider: AddonsProvider? = null
 
     private val safeArguments get() = requireNotNull(arguments)
 
@@ -267,13 +267,14 @@ class AddonInstallationDialogFragment : AppCompatDialogFragment() {
         /**
          * Returns a new instance of [AddonInstallationDialogFragment].
          * @param addon The addon to show in the dialog.
+         * @param addonsProvider An add-ons provider.
          * @param promptsStyling Styling properties for the dialog.
          * @param onDismissed A lambda called when the dialog is dismissed.
          * @param onConfirmButtonClicked A lambda called when the confirm button is clicked.
          */
         fun newInstance(
             addon: Addon,
-            addonsProvider: AMOAddonsProvider,
+            addonsProvider: AddonsProvider,
             promptsStyling: PromptsStyling? = PromptsStyling(
                 gravity = Gravity.BOTTOM,
                 shouldWidthMatchParent = true,

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -30,8 +30,8 @@ import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.AddonsProvider
 import mozilla.components.feature.addons.R
-import mozilla.components.feature.addons.amo.AMOAddonsProvider
 import mozilla.components.feature.addons.ui.CustomViewHolder.AddonViewHolder
 import mozilla.components.feature.addons.ui.CustomViewHolder.SectionViewHolder
 import mozilla.components.feature.addons.ui.CustomViewHolder.UnsupportedSectionViewHolder
@@ -49,15 +49,15 @@ private const val VIEW_HOLDER_TYPE_ADDON = 2
  * an add-on such as recommended, unsupported or installed. In addition, it will perform actions
  * such as installing an add-on.
  *
- * @property addonsProvider Provider of AMO collection API.
+ * @property addonsProvider An add-ons provider.
  * @property addonsManagerDelegate Delegate that will provides method for handling the add-on items.
- * @param addons The list of add-on based on the AMO store.
+ * @param addons The list of add-ons to display.
  * @property style Indicates how items should look like.
  * @property excludedAddonIDs The list of add-on IDs to be excluded from the recommended section.
  */
 @Suppress("LargeClass")
 class AddonsManagerAdapter(
-    private val addonsProvider: AMOAddonsProvider,
+    private val addonsProvider: AddonsProvider,
     private val addonsManagerDelegate: AddonsManagerAdapterDelegate,
     addons: List<Addon>,
     private val style: Style? = null,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ permalink: /changelog/
 * **feature-addons**
   * ⚠️ **This is a breaking change**: the method `getAvailableAddons()` in `AddonsProvider` has been renamed to `getFeaturedAddons()`.
   * ⚠️ **This is a breaking change**: the `AddonCollectionProvider` has been renamed to `AMOAddonsProvider`.
+  * ⚠️ **This is a breaking change**: add new method `getAddonIconBitmap()` to `AddonsProvider`.
 
 # 117.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v116..main)


### PR DESCRIPTION
~~:warning: Depends on https://github.com/mozilla-mobile/firefox-android/pull/3154~~


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- ~~[ ] **Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- ~~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features~~

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847906