### PR TITLE
Bug 1847922 - Update ReviewQualityCheckState for analysis present and not

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
@@ -65,15 +65,19 @@ fun ProductAnalysis(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        ReviewGradeCard(
-            reviewGrade = productAnalysis.reviewGrade,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        if (productAnalysis.reviewGrade != null) {
+            ReviewGradeCard(
+                reviewGrade = productAnalysis.reviewGrade,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
 
-        AdjustedProductRatingCard(
-            rating = productAnalysis.adjustedRating,
-            modifier = Modifier.fillMaxWidth(),
-        )
+        if (productAnalysis.adjustedRating != null) {
+            AdjustedProductRatingCard(
+                rating = productAnalysis.adjustedRating,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
 
         if (productAnalysis.highlights != null) {
             HighlightsCard(
@@ -356,7 +360,7 @@ private fun ProductAnalysisPreview() {
                     needsAnalysis = false,
                     adjustedRating = 3.6f,
                     productUrl = "123",
-                    highlights = mapOf(
+                    highlights = sortedMapOf(
                         HighlightType.QUALITY to listOf(
                             "High quality",
                             "Excellent craftsmanship",

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStateTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStateTest.kt
@@ -5,7 +5,9 @@
 package org.mozilla.fenix.shopping.store
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent
 
 class ReviewQualityCheckStateTest {
 
@@ -64,5 +66,61 @@ class ReviewQualityCheckStateTest {
         )
 
         assertEquals(expected, highlights.forCompactMode())
+    }
+
+    @Test
+    fun `WHEN AnalysisPresent is created with grade, rating and highlights as null THEN exception is thrown`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            AnalysisPresent(
+                productId = "",
+                reviewGrade = null,
+                needsAnalysis = false,
+                adjustedRating = null,
+                productUrl = "",
+                highlights = null,
+            )
+        }
+    }
+
+    @Test
+    fun `WHEN AnalysisPresent is created with at least one of grade, rating and highlights as not null THEN no exception is thrown`() {
+        val ratingPresent = kotlin.runCatching {
+            AnalysisPresent(
+                productId = "1",
+                reviewGrade = null,
+                needsAnalysis = false,
+                adjustedRating = 1.2f,
+                productUrl = "",
+                highlights = null,
+            )
+        }
+
+        val gradePresent = kotlin.runCatching {
+            AnalysisPresent(
+                productId = "2",
+                reviewGrade = ReviewQualityCheckState.Grade.A,
+                needsAnalysis = false,
+                adjustedRating = null,
+                productUrl = "",
+                highlights = null,
+            )
+        }
+
+        val highlightsPresent = kotlin.runCatching {
+            AnalysisPresent(
+                productId = "2",
+                reviewGrade = null,
+                needsAnalysis = false,
+                adjustedRating = null,
+                productUrl = "",
+                highlights = sortedMapOf(
+                    ReviewQualityCheckState.HighlightType.QUALITY to listOf(""),
+                ),
+            )
+        }
+
+        assert(ratingPresent.isSuccess)
+        assert(gradePresent.isSuccess)
+        assert(highlightsPresent.isSuccess)
     }
 }


### PR DESCRIPTION
### What
This is a minor state update to more accurately reflect the nullability and present of some of the properties. More details in the bug.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847922