### PR TITLE
Bug 1845323 - Bring back the downloading add-on dialog.

### DIFF
--- a/fenix/app/src/main/res/drawable/mozac_ic_extensions_black.xml
+++ b/fenix/app/src/main/res/drawable/mozac_ic_extensions_black.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?android:attr/textColorPrimary"
+        android:pathData="M17.5,7H15.5V5.127C15.5,3.533 14.317,2.166 12.807,2.015C11.958,1.931 11.116,2.206 10.488,2.775C9.86,3.342 9.5,4.154 9.5,4.999V7H6.5C5.119,7 4,8.119 4,9.5V11.75C4,12.44 4.56,13 5.25,13H6.873C7.706,13 8.417,13.59 8.493,14.343C8.536,14.775 8.402,15.188 8.114,15.506C7.829,15.82 7.424,16 7.001,16H5.25C4.56,16 4,16.56 4,17.25V19.5C4,20.881 5.119,22 6.5,22H17.5C18.881,22 20,20.881 20,19.5V9.5C20,8.119 18.881,7 17.5,7ZM18.5,19.7L17.7,20.5H6.3L5.5,19.7V17.5H7.001C7.847,17.5 8.658,17.14 9.226,16.512C9.794,15.885 10.07,15.039 9.985,14.194C9.834,12.683 8.467,11.5 6.873,11.5H5.5V9.3L6.3,8.5H10C10.552,8.5 11,8.052 11,7.5V4.999C11,4.576 11.18,4.171 11.494,3.887C11.812,3.599 12.227,3.466 12.657,3.507C13.41,3.582 14,4.294 14,5.127V7.5C14,8.052 14.448,8.5 15,8.5H17.7L18.5,9.3V19.7Z" />
+</vector>

--- a/fenix/app/src/main/res/layout/fragment_add_ons_management.xml
+++ b/fenix/app/src/main/res/layout/fragment_add_ons_management.xml
@@ -15,6 +15,14 @@
         android:layout_marginTop="2dp"
         tools:context=".BrowserActivity" />
 
+    <include
+        android:id="@+id/addonProgressOverlay"
+        layout="@layout/overlay_add_on_progress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:visibility="gone" />
+
     <ProgressBar
         android:id="@+id/add_ons_progress_bar"
         android:layout_width="wrap_content"

--- a/fenix/app/src/main/res/layout/overlay_add_on_progress.xml
+++ b/fenix/app/src/main/res/layout/overlay_add_on_progress.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/overlay_card_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:elevation="1dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/add_ons_overlay_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:drawablePadding="8dp"
+            android:gravity="start|center_vertical"
+            android:padding="16dp"
+            android:text="@string/mozac_add_on_install_progress_caption"
+            app:drawableStartCompat="@drawable/mozac_ic_extensions_black" />
+
+        <Button
+            android:id="@+id/cancel_button"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/add_ons_overlay_text"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/mozac_feature_addons_install_addon_dialog_cancel"
+            android:textAlignment="center"
+            android:textAllCaps="false" />
+
+    </RelativeLayout>
+
+</androidx.cardview.widget.CardView>

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonsManagementFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonsManagementFragmentTest.kt
@@ -72,6 +72,7 @@ class AddonsManagementFragmentTest {
             addon.translateName(context),
         )
 
+        every { fragment.provideAccessibilityServicesEnabled() } returns false
         every { fragment.provideAddonManger() } returns addonManger
         every { addonManger.installAddon(addon, any(), capture(onError)) } returns mockk()
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845323