### PR TITLE
Bug 1847956 - Show snackBars on top of the toolbar.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -79,7 +79,7 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
                 provideAddons = { addons },
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
-                view = view,
+                snackBarParentView = view,
                 onAddonChanged = {
                     runIfFragmentIsAttached {
                         adapter?.updateAddon(it)

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -920,7 +920,7 @@ abstract class BaseBrowserFragment :
                 provideAddons = ::provideAddons,
                 context = requireContext(),
                 fragmentManager = parentFragmentManager,
-                view = view,
+                snackBarParentView = binding.dynamicSnackbarContainer,
             ),
             owner = this,
             view = view,

--- a/fenix/app/src/main/java/org/mozilla/fenix/extension/WebExtensionPromptFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/extension/WebExtensionPromptFeature.kt
@@ -36,7 +36,7 @@ class WebExtensionPromptFeature(
     private val store: BrowserStore,
     private val provideAddons: suspend () -> List<Addon>,
     private val context: Context,
-    private val view: View,
+    private val snackBarParentView: View,
     private val fragmentManager: FragmentManager,
     private val onAddonChanged: (Addon) -> Unit = {},
 ) : LifecycleAwareFeature {
@@ -148,7 +148,7 @@ class WebExtensionPromptFeature(
     @VisibleForTesting
     internal fun showUnsupportedError() {
         showSnackBar(
-            view,
+            snackBarParentView,
             context.getString(R.string.addon_not_supported_error),
             FenixSnackbar.LENGTH_LONG,
         )

--- a/fenix/app/src/test/java/org/mozilla/fenix/extension/WebExtensionPromptFeatureTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/extension/WebExtensionPromptFeatureTest.kt
@@ -39,7 +39,7 @@ class WebExtensionPromptFeatureTest {
                 store = store,
                 provideAddons = { emptyList() },
                 context = testContext,
-                view = mockk(relaxed = true),
+                snackBarParentView = mockk(relaxed = true),
                 fragmentManager = mockk(relaxed = true),
             ),
         )


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847956