### PR TITLE
Bug 1848142 - Homescreen TestRail matching

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHomeScreenTest.kt
@@ -60,6 +60,7 @@ class ComposeHomeScreenTest {
         mockWebServer.shutdown()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/235396
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1844580")
     @Test
     fun homeScreenItemsTest() {
@@ -83,8 +84,9 @@ class ComposeHomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/244199
     @Test
-    fun privateModeScreenItemsTest() {
+    fun privateBrowsingHomeScreenItemsTest() {
         homeScreen { }.dismissOnboarding()
         homeScreen { }.togglePrivateBrowsingMode()
 
@@ -95,6 +97,7 @@ class ComposeHomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1364362
     @Test
     fun verifyJumpBackInSectionTest() {
         activityTestRule.activityRule.applySettingsExceptions {
@@ -145,9 +148,26 @@ class ComposeHomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1569867
+    @Test
+    fun verifyJumpBackInContextualHintTest() {
+        activityTestRule.activityRule.applySettingsExceptions {
+            it.isJumpBackInCFREnabled = true
+        }
+
+        val genericPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericPage.url) {
+        }.goToHomescreen {
+            verifyJumpBackInMessage(activityTestRule)
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252509
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1844580")
     @Test
-    fun verifyPocketHomepageStoriesTest() {
+    fun verifyPocketSectionTest() {
         activityTestRule.activityRule.applySettingsExceptions {
             it.isRecentTabsFeatureEnabled = false
             it.isRecentlyVisitedFeatureEnabled = false
@@ -175,6 +195,7 @@ class ComposeHomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252513
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1844580")
     @Test
     fun openPocketStoryItemTest() {
@@ -195,8 +216,9 @@ class ComposeHomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252514
     @Test
-    fun openPocketDiscoverMoreTest() {
+    fun pocketDiscoverMoreButtonTest() {
         activityTestRule.activityRule.applySettingsExceptions {
             it.isRecentTabsFeatureEnabled = false
             it.isRecentlyVisitedFeatureEnabled = false
@@ -213,9 +235,10 @@ class ComposeHomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252515
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1844580")
     @Test
-    fun selectStoriesByTopicItemTest() {
+    fun selectPocketStoriesByTopicTest() {
         activityTestRule.activityRule.applySettingsExceptions {
             it.isRecentTabsFeatureEnabled = false
             it.isRecentlyVisitedFeatureEnabled = false
@@ -231,8 +254,9 @@ class ComposeHomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252516
     @Test
-    fun verifyPocketLearnMoreLinkTest() {
+    fun pocketLearnMoreButtonTest() {
         activityTestRule.activityRule.applySettingsExceptions {
             it.isRecentTabsFeatureEnabled = false
             it.isRecentlyVisitedFeatureEnabled = false
@@ -248,8 +272,9 @@ class ComposeHomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1569839
     @Test
-    fun verifyCustomizeHomepageTest() {
+    fun verifyCustomizeHomepageButtonTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextualHintsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextualHintsTest.kt
@@ -17,7 +17,6 @@ import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
-import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.ui.robots.clickPageObject
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -49,20 +48,6 @@ class ContextualHintsTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-    }
-
-    @Test
-    fun jumpBackInCFRTest() {
-        val genericPage = getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(genericPage.url) {
-            verifyCookiesProtectionHintIsDisplayed(true)
-            // One back press to dismiss the TCP hint
-            mDevice.pressBack()
-        }.goToHomescreen {
-            verifyJumpBackInMessage()
-        }
     }
 
     @SmokeTest

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -55,6 +55,7 @@ class HomeScreenTest {
         mockWebServer.shutdown()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/235396
     @Test
     fun homeScreenItemsTest() {
         homeScreen {}.dismissOnboarding()
@@ -77,8 +78,9 @@ class HomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/244199
     @Test
-    fun privateModeScreenItemsTest() {
+    fun privateBrowsingHomeScreenItemsTest() {
         homeScreen { }.dismissOnboarding()
         homeScreen { }.togglePrivateBrowsingMode()
 
@@ -89,6 +91,7 @@ class HomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1364362
     @Test
     fun verifyJumpBackInSectionTest() {
         activityTestRule.activityRule.applySettingsExceptions {
@@ -139,8 +142,9 @@ class HomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252509
     @Test
-    fun verifyPocketHomepageStoriesTest() {
+    fun verifyPocketSectionTest() {
         activityTestRule.activityRule.applySettingsExceptions {
             it.isRecentTabsFeatureEnabled = false
             it.isRecentlyVisitedFeatureEnabled = false
@@ -168,6 +172,7 @@ class HomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252513
     @Test
     fun openPocketStoryItemTest() {
         activityTestRule.activityRule.applySettingsExceptions {
@@ -187,8 +192,9 @@ class HomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252514
     @Test
-    fun openPocketDiscoverMoreTest() {
+    fun pocketDiscoverMoreButtonTest() {
         activityTestRule.activityRule.applySettingsExceptions {
             it.isRecentTabsFeatureEnabled = false
             it.isRecentlyVisitedFeatureEnabled = false
@@ -205,8 +211,9 @@ class HomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252515
     @Test
-    fun selectStoriesByTopicItemTest() {
+    fun selectPocketStoriesByTopicTest() {
         activityTestRule.activityRule.applySettingsExceptions {
             it.isRecentTabsFeatureEnabled = false
             it.isRecentlyVisitedFeatureEnabled = false
@@ -222,8 +229,9 @@ class HomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252516
     @Test
-    fun verifyPocketLearnMoreLinkTest() {
+    fun pocketLearnMoreButtonTest() {
         activityTestRule.activityRule.applySettingsExceptions {
             it.isRecentTabsFeatureEnabled = false
             it.isRecentlyVisitedFeatureEnabled = false
@@ -239,8 +247,9 @@ class HomeScreenTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1569839
     @Test
-    fun verifyCustomizeHomepageTest() {
+    fun verifyCustomizeHomepageButtonTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -501,15 +501,11 @@ class HomeScreenRobot {
         }
     }
 
-    fun verifyJumpBackInMessage() {
-        assertTrue(
-            mDevice.findObject(
-                UiSelector().text(
-                    getStringResource(R.string.onboarding_home_screen_jump_back_contextual_hint_2),
-                ),
-            ).waitForExists(waitingTime),
-        )
-    }
+    fun verifyJumpBackInMessage(composeTestRule: ComposeTestRule) =
+        composeTestRule
+            .onNodeWithText(
+                getStringResource(R.string.onboarding_home_screen_jump_back_contextual_hint_2),
+            ).assertExists()
 
     fun getProvokingStoryPublisher(position: Int): String {
         val publisher = mDevice.findObject(


### PR DESCRIPTION
These changes are part of our data alignment between testRail and our automated UI tests.

For more information please see this [document](https://docs.google.com/document/d/1k4xjEtbWThvBNflIq6_0MtLIWaMK9Rjy7s-R2g2xMcM/edit)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1848142