### PR TITLE
Bug 1826245 - Convert ReaderView (readerview@mozac.org) built-in extension to event pages.

### DIFF
--- a/android-components/components/feature/readerview/src/main/assets/extensions/readerview/manifest.template.json
+++ b/android-components/components/feature/readerview/src/main/assets/extensions/readerview/manifest.template.json
@@ -15,13 +15,15 @@
     }
   ],
   "background": {
-    "scripts": ["readerview-background.js"]
+    "scripts": ["readerview-background.js"],
+    "persistent": false
   },
   "permissions": [
     "mozillaAddons",
     "geckoViewAddons",
     "nativeMessaging",
     "nativeMessagingFromContent",
+    "storage",
     "tabs",
     "<all_urls>"
   ]

--- a/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
+++ b/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
@@ -5,9 +5,7 @@
 // This background script is needed to update the current tab
 // and activate reader view.
 
-let serializedDocs = new Map();
-
-browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
   switch (message.action) {
      case 'show':
        let readerViewUrl = new URL(browser.runtime.getURL("/readerview.html"));
@@ -19,13 +17,11 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
        });
        break;
      case 'addSerializedDoc':
-        serializedDocs.set(sender.contextId.toString(), message.doc);
+        storage.session.set(sender.contextId.toString(), message.doc);
         break;
      case 'getSerializedDoc':
-       let doc = serializedDocs.get(message.id);
-       if (doc) {
-         serializedDocs.delete(message.id);
-       }
+       let doc = await storage.session.get(message.id);
+       storage.session.delete(message.id);
        sendResponse(doc);
        break;
      default:


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
  - This PR only applies changes to the builtin extension part (in particular the manifest.json template and the background script js file), and so detekt and ktlint checks wouldn't apply
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - This android-component doesn't seem to include any tests, and so the readerview@mozac.org builtin as changed in this PR has been tested locally by manually testing out its behavior (described in [Bug 1826245 comment 1](https://bugzilla.mozilla.org/show_bug.cgi?id=1826245#c1)
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
  - The API exposed by the android components stays unchanged and so the change may not be relevant enough for a changelog entry (but I'm happy to add it if we think it still should be included in the changelogs)  
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features
  - This PR doesn't introduce any additional user facing feature, the accessibility of the android component stays unchanged

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1826245