### PR TITLE
Bug 1848100 - Switch from a snackbar to a dialog for errors on the Addon manger.

### DIFF
--- a/android-components/components/feature/addons/src/main/res/values/strings.xml
+++ b/android-components/components/feature/addons/src/main/res/values/strings.xml
@@ -173,6 +173,8 @@
     <string name="mozac_feature_addons_successfully_installed">Successfully installed %1$s</string>
     <!-- Text shown after failed to install an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_failed_to_install">Failed to install %1$s</string>
+    <!-- Text shown after failed to install an add-on. -->
+    <string name="mozac_feature_addons_error_failed_to_install">Failed to install</string>
     <!-- Text shown when attempting to install a blocklisted add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_blocklisted">%1$s could not be installed because it has a high risk of causing stability or security problems</string>
     <!-- Text shown after successfully enabled an add-on. %1$s is the add-on name. -->

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonsManagementFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonsManagementFragmentTest.kt
@@ -8,7 +8,9 @@ import android.content.Context
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import io.mockk.CapturingSlot
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verify
 import mozilla.components.concept.engine.webextension.WebExtensionInstallException
@@ -71,7 +73,9 @@ class AddonsManagementFragmentTest {
             R.string.mozac_feature_addons_blocklisted,
             addon.translateName(context),
         )
+        val title = fragment.getString(R.string.mozac_feature_addons_error_failed_to_install)
 
+        every { fragment.showDialog(any(), any(), any()) } just runs
         every { fragment.provideAccessibilityServicesEnabled() } returns false
         every { fragment.provideAddonManger() } returns addonManger
         every { addonManger.installAddon(addon, any(), capture(onError)) } returns mockk()
@@ -79,6 +83,6 @@ class AddonsManagementFragmentTest {
         fragment.installAddon(addon)
         onError.captured("", WebExtensionInstallException.Blocklisted(mockk()))
 
-        verify { fragment.showErrorSnackBar(expectedErrorMessage) }
+        verify { fragment.showDialog(context, title, expectedErrorMessage) }
     }
 }


### PR DESCRIPTION

![image](https://github.com/mozilla-mobile/firefox-android/assets/773158/5ed6aa5b-f2d7-4aa6-a0e9-f552324099f6)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1848100