### PR TITLE
Bug 1847746 - Content Description on Print and Save to PDF

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/share/PrintItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/PrintItem.kt
@@ -43,9 +43,7 @@ fun PrintItem(
 
         Icon(
             painter = painterResource(R.drawable.ic_print),
-            contentDescription = stringResource(
-                R.string.content_description_close_button,
-            ),
+            contentDescription = null,
             tint = FirefoxTheme.colors.iconPrimary,
         )
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/share/SaveToPDFItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/SaveToPDFItem.kt
@@ -43,9 +43,7 @@ fun SaveToPDFItem(
 
         Icon(
             painter = painterResource(R.drawable.ic_download),
-            contentDescription = stringResource(
-                R.string.content_description_close_button,
-            ),
+            contentDescription = null,
             tint = FirefoxTheme.colors.iconPrimary,
         )
 


### PR DESCRIPTION
The content description was incorrectly set on the print and save to PDF icon as "close". The content description should be null because the elements are decorative and are a part of a compose button.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847746