### PR TITLE
Bug 1848188 - Remove Nimbus flag for Juno Onboarding

### DIFF
--- a/fenix/app/.experimenter.yaml
+++ b/fenix/app/.experimenter.yaml
@@ -47,9 +47,6 @@ juno-onboarding:
     cards:
       type: json
       description: Collection of user facing onboarding cards.
-    enabled:
-      type: boolean
-      description: "if true, juno onboarding is shown to the user."
 messaging:
   description: "The in-app messaging system.\n"
   hasExposure: true

--- a/fenix/app/onboarding.fml.yaml
+++ b/fenix/app/onboarding.fml.yaml
@@ -5,10 +5,6 @@ features:
     description: A feature that shows juno onboarding flow.
 
     variables:
-      enabled:
-        description: if true, juno onboarding is shown to the user.
-        type: Boolean
-        default: false
       cards:
         description: Collection of user facing onboarding cards.
         type: Map<String, OnboardingCardData>
@@ -50,14 +46,6 @@ features:
               ordering: 30
               primary-button-label: juno_onboarding_enable_notifications_positive_button
               secondary-button-label: juno_onboarding_enable_notifications_negative_button
-
-    defaults:
-      - channel: developer
-        value:
-          enabled: false
-      - channel: nightly
-        value:
-          enabled: true
 
 objects:
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -308,6 +308,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             if (savedInstanceState == null) {
                 navigateToHome()
             }
+
             if (!shouldStartOnHome() && shouldNavigateToBrowserOnColdStart(savedInstanceState)) {
                 navigateToBrowserOnColdStart()
             } else {
@@ -317,6 +318,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             if (settings().showHomeOnboardingDialog && components.fenixOnboarding.userHasBeenOnboarded()) {
                 navHost.navController.navigate(NavGraphDirections.actionGlobalHomeOnboardingDialog())
             }
+
             showNotificationPermissionPromptIfRequired()
         }
 
@@ -413,10 +415,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
      * Show the pre permission dialog to the user once if the notification are not enabled.
      */
     private fun showNotificationPermissionPromptIfRequired() {
-        if (settings().junoOnboardingEnabled) {
-            return
-        }
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             !NotificationManagerCompat.from(applicationContext).areNotificationsEnabledSafe() &&
             settings().numberOfAppLaunches <= 1

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1658,20 +1658,16 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
-     * Indicates if juno onboarding feature is enabled.
-     */
-    val junoOnboardingEnabled: Boolean
-        get() = FxNimbus.features.junoOnboarding.value().enabled
-
-    /**
      * Returns whether juno onboarding should be shown to the user.
+     *
+     * @param hasUserBeenOnboarded Boolean to indicate whether the user has been onboarded.
      * @param isLauncherIntent Boolean to indicate whether the app was launched on tapping on the
      * app icon.
      */
     fun shouldShowJunoOnboarding(hasUserBeenOnboarded: Boolean, isLauncherIntent: Boolean): Boolean {
         return if (!hasUserBeenOnboarded && isLauncherIntent) {
             FxNimbus.features.junoOnboarding.recordExposure()
-            junoOnboardingEnabled
+            true
         } else {
             false
         }

--- a/fenix/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -827,22 +827,8 @@ class SettingsTest {
     }
 
     @Test
-    fun `GIVEN junoOnboarding is disabled THEN shouldShowJunoOnboarding returns false`() {
+    fun `GIVEN hasUserBeenOnboarded is false and isLauncherIntent is false THEN shouldShowJunoOnboarding returns false`() {
         val settings = spyk(settings)
-        every { settings.junoOnboardingEnabled } returns false
-
-        val actual = settings.shouldShowJunoOnboarding(
-            hasUserBeenOnboarded = false,
-            isLauncherIntent = true,
-        )
-
-        assertFalse(actual)
-    }
-
-    @Test
-    fun `GIVEN junoOnboarding is enabled, hasUserBeenOnboarded is false and isLauncherIntent is false THEN shouldShowJunoOnboarding returns false`() {
-        val settings = spyk(settings)
-        every { settings.junoOnboardingEnabled } returns true
 
         val actual = settings.shouldShowJunoOnboarding(
             hasUserBeenOnboarded = false,
@@ -853,9 +839,8 @@ class SettingsTest {
     }
 
     @Test
-    fun `GIVEN junoOnboarding is enabled and hasUserBeenOnboarded is true THEN shouldShowJunoOnboarding returns false`() {
+    fun `GIVEN hasUserBeenOnboarded is true THEN shouldShowJunoOnboarding returns false`() {
         val settings = spyk(settings)
-        every { settings.junoOnboardingEnabled } returns true
 
         val actual = settings.shouldShowJunoOnboarding(
             hasUserBeenOnboarded = true,
@@ -866,9 +851,8 @@ class SettingsTest {
     }
 
     @Test
-    fun `GIVEN junoOnboarding is enabled, hasUserBeenOnboarded is false and isLauncherIntent is true THEN shouldShowJunoOnboarding returns true`() {
+    fun `GIVEN hasUserBeenOnboarded is false and isLauncherIntent is true THEN shouldShowJunoOnboarding returns true`() {
         val settings = spyk(settings)
-        every { settings.junoOnboardingEnabled } returns true
 
         val actual = settings.shouldShowJunoOnboarding(
             hasUserBeenOnboarded = false,


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1848188