### PR TITLE
Bug 1842039 - Add bread crumbs for IllegalArgumentException when navigating

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -142,6 +142,7 @@ import org.mozilla.fenix.ext.getFenixAddons
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.navigateWithBreadcrumb
 import org.mozilla.fenix.ext.registerForActivityResult
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
@@ -1439,12 +1440,14 @@ abstract class BaseBrowserFragment :
                                     MetricsUtils.BookmarkAction.EDIT,
                                     TOAST_METRIC_SOURCE,
                                 )
-                                nav(
-                                    R.id.browserFragment,
-                                    BrowserFragmentDirections.actionGlobalBookmarkEditFragment(
+                                findNavController().navigateWithBreadcrumb(
+                                    directions = BrowserFragmentDirections.actionGlobalBookmarkEditFragment(
                                         guid,
                                         true,
                                     ),
+                                    navigateFrom = "BrowserFragment",
+                                    navigateTo = "ActionGlobalBookmarkEditFragment",
+                                    crashReporter = it.context.components.analytics.crashReporter,
                                 )
                             }
                             .show()

--- a/fenix/app/src/main/java/org/mozilla/fenix/ext/NavController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ext/NavController.kt
@@ -9,7 +9,10 @@ import androidx.annotation.IdRes
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
+import mozilla.components.concept.base.crash.Breadcrumb
+import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.support.base.log.logger.Logger
+import java.lang.IllegalArgumentException
 
 /**
  * Navigate from the fragment with [id] using the given [directions].
@@ -33,6 +36,29 @@ fun NavController.navigateSafe(
 ) {
     if (currentDestination?.id == resId) {
         this.navigate(directions)
+    }
+}
+
+/**
+ * Navigates using the given [directions], and submit a Breadcrumb
+ * when an [IllegalArgumentException] happens.
+ */
+fun NavController.navigateWithBreadcrumb(
+    directions: NavDirections,
+    navigateFrom: String,
+    navigateTo: String,
+    crashReporter: CrashReporter,
+) {
+    try {
+        this.navigate(directions)
+    } catch (e: IllegalArgumentException) {
+        crashReporter.recordCrashBreadcrumb(
+            Breadcrumb(
+                "Navigation - " +
+                    "where we are: $currentDestination," + "where we are going: $navigateTo, " +
+                    "where we thought we were: $navigateFrom",
+            ),
+        )
     }
 }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
@@ -11,7 +11,9 @@ import mozilla.components.service.nimbus.ui.NimbusBranchesAdapterDelegate
 import org.mozilla.experiments.nimbus.Branch
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
+import org.mozilla.fenix.ext.navigateWithBreadcrumb
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.nimbus.NimbusBranchesAction
 import org.mozilla.fenix.nimbus.NimbusBranchesFragmentDirections
@@ -51,9 +53,12 @@ class NimbusBranchesController(
                 )
                     .setText(snackbarText)
                     .setAction(buttonText) {
-                        navController.navigate(
-                            NimbusBranchesFragmentDirections
+                        navController.navigateWithBreadcrumb(
+                            directions = NimbusBranchesFragmentDirections
                                 .actionNimbusBranchesFragmentToDataChoicesFragment(),
+                            navigateFrom = "NimbusBranchesController",
+                            navigateTo = "ActionNimbusBranchesFragmentToDataChoicesFragment",
+                            crashReporter = context.components.analytics.crashReporter,
                         )
                     }
                     .show()

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingFragment.kt
@@ -100,6 +100,7 @@ class OnboardingFragment : Fragment() {
                 activity = activity,
                 navController = findNavController(),
                 onboarding = requireComponents.fenixOnboarding,
+                crashReporter = requireComponents.analytics.crashReporter,
             ),
             privateBrowsingController = DefaultPrivateBrowsingController(
                 activity = activity,

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/controller/OnboardingController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/controller/OnboardingController.kt
@@ -5,8 +5,10 @@
 package org.mozilla.fenix.onboarding.controller
 
 import androidx.navigation.NavController
+import mozilla.components.lib.crash.CrashReporter
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.ext.navigateWithBreadcrumb
 import org.mozilla.fenix.onboarding.FenixOnboarding
 import org.mozilla.fenix.onboarding.OnboardingFragmentDirections
 import org.mozilla.fenix.onboarding.interactor.OnboardingInteractor
@@ -34,13 +36,17 @@ class DefaultOnboardingController(
     private val activity: HomeActivity,
     private val navController: NavController,
     private val onboarding: FenixOnboarding,
+    private val crashReporter: CrashReporter,
 ) : OnboardingController {
 
     override fun handleFinishOnboarding(focusOnAddressBar: Boolean) {
         onboarding.finish()
 
-        navController.navigate(
-            OnboardingFragmentDirections.actionHome(focusOnAddressBar = focusOnAddressBar),
+        navController.navigateWithBreadcrumb(
+            directions = OnboardingFragmentDirections.actionHome(focusOnAddressBar = focusOnAddressBar),
+            navigateFrom = "OnboardingFragment",
+            navigateTo = "ActionHome",
+            crashReporter = crashReporter,
         )
 
         if (focusOnAddressBar) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
@@ -15,6 +15,7 @@ import org.mozilla.fenix.GleanMetrics.CustomizeHome
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.navigateWithBreadcrumb
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.utils.view.addToRadioGroup
@@ -167,8 +168,11 @@ class HomeSettingsFragment : PreferenceFragmentCompat() {
 
         requirePreference<Preference>(R.string.pref_key_wallpapers).apply {
             setOnPreferenceClickListener {
-                view?.findNavController()?.navigate(
-                    HomeSettingsFragmentDirections.actionHomeSettingsFragmentToWallpaperSettingsFragment(),
+                view?.findNavController()?.navigateWithBreadcrumb(
+                    directions = HomeSettingsFragmentDirections.actionHomeSettingsFragmentToWallpaperSettingsFragment(),
+                    navigateFrom = "HomeSettingsFragment",
+                    navigateTo = "ActionHomeSettingsFragmentToWallpaperSettingsFragment",
+                    crashReporter = context.components.analytics.crashReporter,
                 )
                 true
             }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
@@ -27,7 +27,9 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.databinding.FragmentTurnOnSyncBinding
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.increaseTapArea
+import org.mozilla.fenix.ext.navigateWithBreadcrumb
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -66,7 +68,14 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
         val directions = TurnOnSyncFragmentDirections.actionTurnOnSyncFragmentToPairFragment(
             entrypoint = args.entrypoint,
         )
-        requireView().findNavController().navigate(directions)
+        context?.let {
+            requireView().findNavController().navigateWithBreadcrumb(
+                directions = directions,
+                navigateFrom = "TurnOnSyncFragment",
+                navigateTo = "ActionTurnOnSyncFragmentToPairFragment",
+                crashReporter = it.components.analytics.crashReporter,
+            )
+        }
         SyncAuth.scanPairing.record(NoExtras())
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
@@ -31,6 +31,7 @@ import org.mozilla.fenix.GleanMetrics.Logins
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.accounts.FenixFxAEntryPoint
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.navigateWithBreadcrumb
 import org.mozilla.fenix.ext.registerForActivityResult
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
@@ -246,7 +247,12 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
     private fun navigateToSaveLoginSettingFragment() {
         val directions =
             SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToSavedLoginsSettingFragment()
-        findNavController().navigate(directions)
+        findNavController().navigateWithBreadcrumb(
+            directions = directions,
+            navigateFrom = "SavedLoginsAuthFragment",
+            navigateTo = "ActionSavedLoginsAuthFragmentToSavedLoginsSettingFragment",
+            crashReporter = requireComponents.analytics.crashReporter,
+        )
     }
 
     private fun navigateToLoginExceptionFragment() {

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
@@ -16,6 +16,7 @@ import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.ext.navigateWithBreadcrumb
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SharedPreferenceUpdater
@@ -131,7 +132,14 @@ class SearchEngineFragment : PreferenceFragmentCompat() {
             getPreferenceKey(R.string.pref_key_add_search_engine) -> {
                 val directions = SearchEngineFragmentDirections
                     .actionSearchEngineFragmentToAddSearchEngineFragment()
-                findNavController().navigate(directions)
+                context?.let {
+                    findNavController().navigateWithBreadcrumb(
+                        directions = directions,
+                        navigateFrom = "SearchEngineFragment",
+                        navigateTo = "ActionSearchEngineFragmentToAddSearchEngineFragment",
+                        it.components.analytics.crashReporter,
+                    )
+                }
             }
             getPreferenceKey(R.string.pref_key_default_search_engine) -> {
                 val directions = SearchEngineFragmentDirections
@@ -141,7 +149,14 @@ class SearchEngineFragment : PreferenceFragmentCompat() {
             getPreferenceKey(R.string.pref_key_manage_search_shortcuts) -> {
                 val directions = SearchEngineFragmentDirections
                     .actionSearchEngineFragmentToSearchShortcutsFragment()
-                findNavController().navigate(directions)
+                context?.let {
+                    findNavController().navigateWithBreadcrumb(
+                        directions = directions,
+                        navigateFrom = "SearchEngineFragment",
+                        navigateTo = "ActionSearchEngineFragmentToSearchShortcutsFragment",
+                        it.components.analytics.crashReporter,
+                    )
+                }
             }
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsFragment.kt
@@ -13,7 +13,9 @@ import mozilla.components.service.glean.private.NoExtras
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.Autoplay
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.ext.navigateWithBreadcrumb
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.PhoneFeature
@@ -79,7 +81,13 @@ class SitePermissionsFragment : PreferenceFragmentCompat() {
         if (phoneFeature == PhoneFeature.AUTOPLAY_AUDIBLE) {
             Autoplay.visitedSetting.record(NoExtras())
         }
-
-        Navigation.findNavController(requireView()).navigate(directions)
+        context?.let {
+            Navigation.findNavController(requireView()).navigateWithBreadcrumb(
+                directions = directions,
+                navigateFrom = "SitePermissionsFragment",
+                navigateTo = "ActionSitePermissionsToManagePhoneFeatures",
+                crashReporter = it.components.analytics.crashReporter,
+            )
+        }
     }
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/onboarding/DefaultOnboardingControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/onboarding/DefaultOnboardingControllerTest.kt
@@ -54,6 +54,7 @@ class DefaultOnboardingControllerTest {
             activity = activity,
             navController = navController,
             onboarding = onboarding,
+            crashReporter = mockk(relaxed = true),
         )
     }
 


### PR DESCRIPTION
Tried to add as many scenarios from [crash-stats](https://crash-stats.mozilla.org/signature/?signature=java.lang.IllegalArgumentException%3A%20at%20androidx.navigation.NavController.navigate%28NavController.kt%3A23%29&date=%3E%3D2023-08-05T01%3A03%3A00.000Z&date=%3C2023-08-12T01%3A03%3A00.000Z&_columns=date&_columns=product&_columns=version&_columns=build_id&_columns=platform&_columns=reason&_columns=address&_columns=install_time&_columns=startup_crash&_sort=-date&page=1#reports) (Until page 2). 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1842039