### PR TITLE
Bug 1848502 - Remove unused media storage permissions in Android 13+ 

### DIFF
--- a/android-components/components/feature/prompts/src/main/AndroidManifest.xml
+++ b/android-components/components/feature/prompts/src/main/AndroidManifest.xml
@@ -2,12 +2,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <!-- Needed for uploading media files on devices with Android 13 and later. -->
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-
     <application android:supportsRtl="true">
         <provider
             android:name="mozilla.components.feature.prompts.provider.FileProvider"

--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/MimeType.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/MimeType.kt
@@ -6,9 +6,6 @@ package mozilla.components.feature.prompts.file
 
 import android.Manifest.permission.CAMERA
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
-import android.Manifest.permission.READ_MEDIA_AUDIO
-import android.Manifest.permission.READ_MEDIA_IMAGES
-import android.Manifest.permission.READ_MEDIA_VIDEO
 import android.Manifest.permission.RECORD_AUDIO
 import android.annotation.SuppressLint
 import android.content.Context
@@ -43,11 +40,7 @@ internal sealed class MimeType(
         },
     ) : MimeType(
         "image/",
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            listOf(CAMERA, READ_MEDIA_IMAGES)
-        } else {
-            listOf(CAMERA)
-        },
+        listOf(CAMERA),
     ) {
         /**
          * Build an image capture intent using the application FileProvider.
@@ -72,11 +65,7 @@ internal sealed class MimeType(
 
     object Video : MimeType(
         "video/",
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            listOf(CAMERA, READ_MEDIA_VIDEO)
-        } else {
-            listOf(CAMERA)
-        },
+        listOf(CAMERA),
     ) {
         override fun buildIntent(context: Context, request: File) =
             Intent(ACTION_VIDEO_CAPTURE).withDeviceSupport(context)?.addCaptureHint(request.captureMode)
@@ -84,11 +73,7 @@ internal sealed class MimeType(
 
     object Audio : MimeType(
         "audio/",
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            listOf(RECORD_AUDIO, READ_MEDIA_AUDIO)
-        } else {
-            listOf(RECORD_AUDIO)
-        },
+        listOf(RECORD_AUDIO),
     ) {
         override fun buildIntent(context: Context, request: File) =
             Intent(RECORD_SOUND_ACTION).withDeviceSupport(context)
@@ -97,7 +82,7 @@ internal sealed class MimeType(
     object Wildcard : MimeType(
         "*/",
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            listOf(READ_MEDIA_IMAGES, READ_MEDIA_AUDIO, READ_MEDIA_VIDEO)
+            emptyList()
         } else {
             listOf(READ_EXTERNAL_STORAGE)
         },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,9 @@ permalink: /changelog/
  * Implemented new `NimbusExperimentDelegate` to allow GeckoView to send and recieve Nimbus experiment information. [Bug 1843592](https://bugzilla.mozilla.org/show_bug.cgi?id=1843592)
   * Removed deprecated `ContentDelegate.onGetNimbusFeature`. Please use `ExperimentDelegate.onGetExperimentFeature`. [Bug 1843592](https://bugzilla.mozilla.org/show_bug.cgi?id=1843592)
 
+* **feature-prompts**:
+ * Removed media storage permissions (`READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` and `READ_MEDIA_AUDIO`) as they weren't needed to open the system file picker 
+
 # 117.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v116..main)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/releases_v117/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,7 +26,7 @@ permalink: /changelog/
   * Removed deprecated `ContentDelegate.onGetNimbusFeature`. Please use `ExperimentDelegate.onGetExperimentFeature`. [Bug 1843592](https://bugzilla.mozilla.org/show_bug.cgi?id=1843592)
 
 * **feature-prompts**:
- * Removed media storage permissions (`READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` and `READ_MEDIA_AUDIO`) as they weren't needed to open the system file picker 
+ * Removed media storage permissions (`READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` and `READ_MEDIA_AUDIO`) as they weren't needed to open the system file picker. [Bug 1848502](https://bugzilla.mozilla.org/show_bug.cgi?id=1848502)
 
 # 117.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v116..main)

--- a/fenix/app/src/main/AndroidManifest.xml
+++ b/fenix/app/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28"
@@ -34,11 +35,6 @@
 
     <!-- Needed to post notifications on devices with Android 13 and later-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-
-    <!-- Needed for uploading media files on devices with Android 13 and later. -->
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <application
         android:name=".FenixApplication"

--- a/focus-android/app/src/main/AndroidManifest.xml
+++ b/focus-android/app/src/main/AndroidManifest.xml
@@ -37,11 +37,6 @@
     <!-- Needed to post notifications on devices with Android 13 and later-->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
-    <!-- Needed for uploading media files on devices with Android 13 and later. -->
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
-
     <application
         android:allowBackup="false"
         android:extractNativeLibs="true"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.














### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1848502