### PR TITLE
Bug 1795140 - Enable AbsentOrWrongFileLicense detekt rule

### DIFF
--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package mozilla.components.browser.engine.gecko.ext
 

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/mediasession/GeckoMediaSessionDelegateTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/mediasession/GeckoMediaSessionDelegateTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.browser.engine.gecko.mediasession
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/ext/BrowserMenuItemTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/ext/BrowserMenuItemTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.browser.menu.ext
 
 import android.graphics.Color

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCategoryTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCategoryTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.browser.menu.item
 
 import android.content.Context

--- a/android-components/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
+++ b/android-components/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ConstellationObserverTest.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package mozilla.components.feature.accounts.push
 

--- a/android-components/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/FxaPushSupportFeatureTest.kt
+++ b/android-components/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/FxaPushSupportFeatureTest.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package mozilla.components.feature.accounts.push
 

--- a/android-components/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ext/StringKtTest.kt
+++ b/android-components/components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/ext/StringKtTest.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package mozilla.components.feature.accounts.push.ext
 

--- a/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinkRedirectTest.kt
+++ b/android-components/components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinkRedirectTest.kt
@@ -1,8 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package mozilla.components.feature.app.links
 

--- a/android-components/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/DefaultSelectionActionDelegateTest.kt
+++ b/android-components/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/DefaultSelectionActionDelegateTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.feature.contextmenu
 
 import android.content.res.Resources

--- a/android-components/components/feature/media/src/test/java/mozilla/components/feature/media/ext/SessionStateKtTest.kt
+++ b/android-components/components/feature/media/src/test/java/mozilla/components/feature/media/ext/SessionStateKtTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.feature.media.ext
 
 import android.graphics.Bitmap

--- a/android-components/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/notification/PrivateNotificationFeatureTest.kt
+++ b/android-components/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/notification/PrivateNotificationFeatureTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.feature.privatemode.notification
 
 import android.content.Context

--- a/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardsAdapterTest.kt
+++ b/android-components/components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardsAdapterTest.kt
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package mozilla.components.feature.prompts.creditcard
 

--- a/android-components/components/feature/pwa/src/androidTest/java/mozilla/components/feature/pwa/db/ManifestDatabaseMigrationTest.kt
+++ b/android-components/components/feature/pwa/src/androidTest/java/mozilla/components/feature/pwa/db/ManifestDatabaseMigrationTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.feature.pwa.db
 
 import androidx.core.database.getStringOrNull

--- a/android-components/components/feature/search/src/test/java/mozilla/components/feature/search/SearchFeatureTest.kt
+++ b/android-components/components/feature/search/src/test/java/mozilla/components/feature/search/SearchFeatureTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.feature.search
 
 import mozilla.components.browser.state.action.ContentAction

--- a/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
+++ b/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
@@ -1,9 +1,3 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/android-components/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/fact/TopSitesFactsTest.kt
+++ b/android-components/components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/fact/TopSitesFactsTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.feature.top.sites.fact
 
 import mozilla.components.feature.top.sites.facts.TopSitesFacts

--- a/android-components/components/lib/crash-sentry/src/test/java/mozilla/components/lib/crash/sentry/SentryServiceTest.kt
+++ b/android-components/components/lib/crash-sentry/src/test/java/mozilla/components/lib/crash/sentry/SentryServiceTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.lib.crash.sentry
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/android-components/components/lib/crash-sentry/src/test/java/mozilla/components/lib/crash/sentry/eventprocessors/AddMechanismEventProcessorTest.kt
+++ b/android-components/components/lib/crash-sentry/src/test/java/mozilla/components/lib/crash/sentry/eventprocessors/AddMechanismEventProcessorTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.lib.crash.sentry.eventprocessors
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/android-components/components/lib/crash-sentry/src/test/java/mozilla/components/lib/crash/sentry/eventprocessors/RustCrashEventProcessorTest.kt
+++ b/android-components/components/lib/crash-sentry/src/test/java/mozilla/components/lib/crash/sentry/eventprocessors/RustCrashEventProcessorTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.lib.crash.sentry.eventprocessors
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/android-components/components/lib/dataprotect/src/test/java/mozilla/components/lib/dataprotect/SecurePrefsReliabilityExperimentTest.kt
+++ b/android-components/components/lib/dataprotect/src/test/java/mozilla/components/lib/dataprotect/SecurePrefsReliabilityExperimentTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.lib.dataprotect
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/store/SyncStoreSupportTest.kt
+++ b/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/store/SyncStoreSupportTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.service.fxa.store
 
 import androidx.lifecycle.LifecycleOwner

--- a/android-components/components/support/test/src/main/java/mozilla/components/support/test/ThrowProperty.kt
+++ b/android-components/components/support/test/src/main/java/mozilla/components/support/test/ThrowProperty.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.support.test
 
 import kotlin.properties.ReadWriteProperty

--- a/android-components/components/support/test/src/test/java/mozilla/components/support/test/ThrowPropertyTest.kt
+++ b/android-components/components/support/test/src/test/java/mozilla/components/support/test/ThrowPropertyTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.support.test.robolectric.mozilla.components.support.test
 
 import mozilla.components.support.test.ThrowProperty

--- a/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/BootUtilsTest.kt
+++ b/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/BootUtilsTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.support.utils
 
 import android.os.Build

--- a/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/WebURLFinderTest.kt
+++ b/android-components/components/support/utils/src/test/java/mozilla/components/support/utils/WebURLFinderTest.kt
@@ -1,5 +1,7 @@
-/* Any copyright is dedicated to the Public Domain.
-   http://creativecommons.org/publicdomain/zero/1.0/ */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package mozilla.components.support.utils
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/android-components/config/detekt.yml
+++ b/android-components/config/detekt.yml
@@ -53,7 +53,7 @@ output-reports:
 comments:
   active: true
   AbsentOrWrongFileLicense:
-    active: false
+    active: true # Enabled in https://bugzilla.mozilla.org/show_bug.cgi?id=1795140
     licenseTemplateFile: 'license.template'
     licenseTemplateIsRegex: false
   CommentOverPrivateFunction:
@@ -784,9 +784,3 @@ style:
     active: true
     excludeImports:
       - 'java.util.*'
-
-# Custom Rules
-
-mozilla-rules:
-  AbsentOrWrongFileLicense:
-    active: true

--- a/android-components/config/license.template
+++ b/android-components/config/license.template
@@ -1,0 +1,3 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/onboarding/view/JunoOnboardingMapperTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.onboarding.view
 
 import androidx.compose.ui.layout.ContentScale

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/AddToHomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/AddToHomeScreenTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import okhttp3.mockwebserver.MockWebServer

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeMediaNotificationTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeMediaNotificationTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CookieBannerReductionTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import okhttp3.mockwebserver.MockWebServer

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 @file:Suppress("DEPRECATION")
 
 package org.mozilla.fenix.ui

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/MainMenuTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/MainMenuTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import androidx.test.platform.app.InstrumentationRegistry

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import android.content.res.Configuration

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsCustomizeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsCustomizeTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import android.content.res.Configuration

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import androidx.test.platform.app.InstrumentationRegistry

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuExperimentsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuExperimentsRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/GrowthDataWorker.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/GrowthDataWorker.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components.metrics
 
 import android.content.Context

--- a/fenix/app/src/main/java/org/mozilla/fenix/ext/Bitmap.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ext/Bitmap.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
 import android.graphics.Bitmap

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapper.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.shopping.middleware
 
 import mozilla.components.browser.engine.gecko.shopping.GeckoProductAnalysis

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/blocklist/BlocklistHandlerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/blocklist/BlocklistHandlerTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.home.blocklist
 
 import io.mockk.every

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/intent/HomeDeepLinkIntentProcessorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/intent/HomeDeepLinkIntentProcessorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.home.intent
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/intent/ExternalDeepLinkIntentProcessorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/intent/ExternalDeepLinkIntentProcessorTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.intent
 
 import android.content.Intent

--- a/fenix/app/src/test/java/org/mozilla/fenix/library/history/state/HistoryNavigationMiddlewareTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/library/history/state/HistoryNavigationMiddlewareTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.library.history.state
 
 import androidx.navigation.NavController

--- a/fenix/app/src/test/java/org/mozilla/fenix/library/history/state/HistoryStorageMiddlewareTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/library/history/state/HistoryStorageMiddlewareTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.library.history.state
 
 import kotlinx.coroutines.runBlocking

--- a/fenix/app/src/test/java/org/mozilla/fenix/library/history/state/HistoryTelemetryMiddlewareTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/library/history/state/HistoryTelemetryMiddlewareTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.library.history.state
 
 import mozilla.components.service.glean.testing.GleanTestRule

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/SearchSelectorMenuTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/SearchSelectorMenuTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.search.toolbar
 
 import io.mockk.Runs

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/ProductAnalysisTestData.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/ProductAnalysisTestData.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.shopping
 
 import mozilla.components.browser.engine.gecko.shopping.GeckoProductAnalysis

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapperTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapperTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.shopping.middleware
 
 import mozilla.components.browser.engine.gecko.shopping.Highlight

--- a/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/LegacyWallpaperMigrationTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/LegacyWallpaperMigrationTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.wallpapers
 
 import io.mockk.mockk

--- a/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperDownloaderTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperDownloaderTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.wallpapers
 
 import io.mockk.every

--- a/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperFileManagerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperFileManagerTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.wallpapers
 
 import io.mockk.every

--- a/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcherTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcherTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.wallpapers
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.wallpapers
 
 import org.junit.Assert.assertFalse

--- a/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpapersUseCasesTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/wallpapers/WallpapersUseCasesTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.wallpapers
 
 import io.mockk.Runs

--- a/fenix/config/detekt.yml
+++ b/fenix/config/detekt.yml
@@ -56,7 +56,7 @@ output-reports:
 comments:
   active: true
   AbsentOrWrongFileLicense:
-    active: false
+    active: true
     licenseTemplateFile: 'license.template'
     licenseTemplateIsRegex: false
   CommentOverPrivateFunction:

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/SettingsTest.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/SettingsTest.kt
@@ -1,7 +1,7 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.activity
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/testAnnotations/SmokeTest.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/testAnnotations/SmokeTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.testAnnotations
 
 /**

--- a/focus-android/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/activity/InstallFirefoxActivity.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/activity/InstallFirefoxActivity.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/animation/TransitionDrawableGroup.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.focus.animation
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/firstrun/FirstrunPagerAdapter.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/firstrun/FirstrunPagerAdapter.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/AddToHomescreenDialogFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/AddToHomescreenDialogFragment.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/fragment/FirstrunFragment.kt
@@ -1,7 +1,7 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.fragment
 
 import android.content.Context

--- a/focus-android/app/src/main/java/org/mozilla/focus/search/SearchEnginePreference.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/search/SearchEnginePreference.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/settings/LearnMoreSwitchPreference.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.settings
 
 import android.content.Context

--- a/focus-android/app/src/main/java/org/mozilla/focus/settings/privacy/PreferenceSwitch.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/settings/privacy/PreferenceSwitch.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.settings.privacy
 
 import android.content.Context

--- a/focus-android/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/theme/Theme.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/theme/Theme.kt
@@ -1,7 +1,7 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.theme
 
 import android.content.res.Resources

--- a/focus-android/app/src/main/java/org/mozilla/focus/utils/AppConstants.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/utils/AppConstants.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/utils/Features.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/utils/Features.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.focus.utils
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/utils/SupportUtils.kt
@@ -1,5 +1,4 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/focus-android/app/src/test/java/org/mozilla/focus/locale/LocalesTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/locale/LocalesTest.kt
@@ -1,7 +1,7 @@
-/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.locale
 
 import org.junit.Assert.assertEquals

--- a/focus-android/app/src/test/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModelTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/searchsuggestions/SearchSuggestionsViewModelTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.searchsuggestions
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule

--- a/focus-android/app/src/test/java/org/mozilla/focus/utils/MobileMetricsPingStorageTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/utils/MobileMetricsPingStorageTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.utils
 
 import androidx.test.core.app.ApplicationProvider

--- a/focus-android/app/src/test/java/org/mozilla/focus/utils/SupportUtilsTest.kt
+++ b/focus-android/app/src/test/java/org/mozilla/focus/utils/SupportUtilsTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.utils
 
 import org.junit.Assert.assertEquals

--- a/focus-android/quality/detekt.yml
+++ b/focus-android/quality/detekt.yml
@@ -56,7 +56,7 @@ output-reports:
 comments:
   active: true
   AbsentOrWrongFileLicense:
-    active: false
+    active: true # Enabled in https://bugzilla.mozilla.org/show_bug.cgi?id=1795140
     licenseTemplateFile: 'license.template'
     licenseTemplateIsRegex: false
   CommentOverPrivateFunction:


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1795140