### PR TITLE
Bug 1848377 - Add secret setting to control the visibility of the Shopping feature

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -50,6 +50,7 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.dialog.CookieBannerReEngagementDialogUtils
 import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.getCookieBannerUIMode
+import org.mozilla.fenix.shopping.DefaultShoppingExperienceFeature
 import org.mozilla.fenix.shopping.ReviewQualityCheckFeature
 import org.mozilla.fenix.shortcut.PwaOnboardingObserver
 import org.mozilla.fenix.theme.ThemeManager
@@ -226,6 +227,9 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         reviewQualityCheckFeature.set(
             feature = ReviewQualityCheckFeature(
                 browserStore = context.components.core.store,
+                shoppingExperienceFeature = DefaultShoppingExperienceFeature(
+                    settings = requireContext().settings(),
+                ),
                 onAvailabilityChange = { reviewQualityCheckAvailable = it },
             ),
             owner = this,

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -64,6 +64,12 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
 
+        requirePreference<SwitchPreference>(R.string.pref_key_enable_shopping_experience).apply {
+            isVisible = Config.channel.isNightlyOrDebug
+            isChecked = context.settings().enableShoppingExperience
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
         // for performance reasons, this is only available in Nightly or Debug builds
         requirePreference<EditTextPreference>(R.string.pref_key_custom_glean_server_url).apply {
             isVisible = Config.channel.isNightlyOrDebug && BuildConfig.GLEAN_CUSTOM_URL.isNullOrEmpty()

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeature.kt
@@ -25,7 +25,7 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
  */
 class ReviewQualityCheckFeature(
     private val browserStore: BrowserStore,
-    private val shoppingExperienceFeature: ShoppingExperienceFeature = ShoppingExperienceFeature(),
+    private val shoppingExperienceFeature: ShoppingExperienceFeature,
     private val onAvailabilityChange: (isAvailable: Boolean) -> Unit,
 ) : LifecycleAwareFeature {
     private var scope: CoroutineScope? = null

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ShoppingExperienceFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ShoppingExperienceFeature.kt
@@ -4,16 +4,28 @@
 
 package org.mozilla.fenix.shopping
 
-import org.mozilla.fenix.nimbus.FxNimbus
+import org.mozilla.fenix.utils.Settings
 
 /**
  * An abstraction for shopping experience feature flag.
  */
-class ShoppingExperienceFeature {
+interface ShoppingExperienceFeature {
 
     /**
      * Returns true if the shopping experience feature is enabled.
      */
-    val isEnabled
-        get() = FxNimbus.features.shoppingExperience.value().enabled
+    val isEnabled: Boolean
+}
+
+/**
+ * The default implementation of [ShoppingExperienceFeature].
+ *
+ * @property settings Used to check if the feature is enabled.
+ */
+class DefaultShoppingExperienceFeature(
+    private val settings: Settings,
+) : ShoppingExperienceFeature {
+
+    override val isEnabled
+        get() = settings.enableShoppingExperience
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1790,6 +1790,14 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
+     * Indicates if the shopping experience feature is enabled.
+     */
+    val enableShoppingExperience by booleanPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_enable_shopping_experience),
+        default = FxNimbus.features.shoppingExperience.value().enabled,
+    )
+
+    /**
      * Adjust Activated User sent
      */
     var growthUserActivatedSent by booleanPreference(

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -350,6 +350,7 @@
     <string name="pref_key_custom_sponsored_stories_country" translatable="false">pref_key_custom_sponsored_stories_country</string>
     <string name="pref_key_custom_sponsored_stories_city" translatable="false">pref_key_custom_sponsored_stories_city</string>
     <string name="pref_key_enable_compose_top_sites" translatable="false">pref_key_enable_compose_top_sites</string>
+    <string name="pref_key_enable_shopping_experience" translatable="false">pref_key_enable_shopping_experience</string>
 
     <!-- Growth Data -->
     <string name="pref_key_growth_set_as_default" translatable="false">pref_key_growth_set_as_default</string>

--- a/fenix/app/src/main/res/values/static_strings.xml
+++ b/fenix/app/src/main/res/values/static_strings.xml
@@ -66,6 +66,8 @@
     <string name="preferences_debug_settings_tabs_tray_to_compose" translatable="false">Enable Tabs Tray to Compose rewrite</string>
     <!-- Label for enabling the Compose Top Sites -->
     <string name="preferences_debug_settings_compose_top_sites" translatable="false">Enable Compose Top Sites</string>
+    <!-- Label for enabling the shopping experience -->
+    <string name="preferences_debug_settings_shopping_experience" translatable="false">Enable Shopping Experience</string>
 
     <!-- A secret menu option in the tabs tray for making a tab inactive for testing. -->
     <string name="inactive_tabs_menu_item">Make inactive</string>

--- a/fenix/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/fenix/app/src/main/res/xml/secret_settings_preferences.xml
@@ -30,6 +30,11 @@
         android:key="@string/pref_key_enable_compose_top_sites"
         android:title="@string/preferences_debug_settings_compose_top_sites"
         app:iconSpaceReserved="false" />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/pref_key_enable_shopping_experience"
+        android:title="@string/preferences_debug_settings_shopping_experience"
+        app:iconSpaceReserved="false" />
     <EditTextPreference
         android:key="@string/pref_key_custom_glean_server_url"
         android:title="@string/preferences_debug_settings_custom_glean_server_url"


### PR DESCRIPTION




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1848377