### PR TITLE
Bug 1845098 - give java more heap space for external-gradle-dependencies job

### DIFF
--- a/taskcluster/scripts/toolchain/external-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/external-gradle-dependencies.sh
@@ -18,9 +18,16 @@ WORKING_DIR="$REPO_ROOT_DIR/$1"
 shift
 GRADLE_COMMANDS="$@"
 
+: WORKSPACE ${WORKSPACE:=/builds/worker/workspace}
 NEXUS_PREFIX='http://localhost:8081/nexus/content/repositories'
 REPOS="-PgoogleRepo=$NEXUS_PREFIX/google/ -PcentralRepo=$NEXUS_PREFIX/central/"
 GRADLE_ARGS="--parallel $REPOS -Pcoverage"
+
+# override the default org.gradle.jvmargs to add more heap space
+GRADLE_USER_HOME="${WORKSPACE}/gradle-home"
+mkdir -p "${GRADLE_USER_HOME}"
+export GRADLE_USER_HOME
+echo "org.gradle.jvmargs=-Xmx16g -Xms2g -XX:MaxMetaspaceSize=6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC" > "${GRADLE_USER_HOME}/gradle.properties"
 
 pushd "$WORKING_DIR"
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845098