### PR TITLE
Bug 1849112 - Remove duplicate pocket related UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHomeScreenTest.kt
@@ -14,7 +14,6 @@ import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.Constants.POCKET_RECOMMENDED_STORIES_UTM_PARAM
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
@@ -31,7 +30,6 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class ComposeHomeScreenTest {
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
-    private lateinit var firstPocketStoryPublisher: String
 
     @get:Rule(order = 0)
     val activityTestRule =
@@ -161,114 +159,6 @@ class ComposeHomeScreenTest {
         }.enterURLAndEnterToBrowser(genericPage.url) {
         }.goToHomescreen {
             verifyJumpBackInMessage(activityTestRule)
-        }
-    }
-
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252509
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1844580")
-    @Test
-    fun verifyPocketSectionTest() {
-        activityTestRule.activityRule.applySettingsExceptions {
-            it.isRecentTabsFeatureEnabled = false
-            it.isRecentlyVisitedFeatureEnabled = false
-        }
-
-        homeScreen {
-        }.dismissOnboarding()
-
-        homeScreen {
-            verifyThoughtProvokingStories(true)
-            scrollToPocketProvokingStories()
-            verifyPocketRecommendedStoriesItems()
-            // Sponsored Pocket stories are only advertised for a limited time.
-            // See also known issue https://bugzilla.mozilla.org/show_bug.cgi?id=1828629
-            // verifyPocketSponsoredStoriesItems(2, 8)
-            verifyDiscoverMoreStoriesButton()
-            verifyStoriesByTopic(true)
-            verifyPoweredByPocket()
-        }.openThreeDotMenu {
-        }.openCustomizeHome {
-            clickPocketButton()
-        }.goBackToHomeScreen {
-            verifyThoughtProvokingStories(false)
-            verifyStoriesByTopic(false)
-        }
-    }
-
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252513
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1844580")
-    @Test
-    fun openPocketStoryItemTest() {
-        activityTestRule.activityRule.applySettingsExceptions {
-            it.isRecentTabsFeatureEnabled = false
-            it.isRecentlyVisitedFeatureEnabled = false
-        }
-
-        homeScreen {
-        }.dismissOnboarding()
-
-        homeScreen {
-            verifyThoughtProvokingStories(true)
-            scrollToPocketProvokingStories()
-            firstPocketStoryPublisher = getProvokingStoryPublisher(1)
-        }.clickPocketStoryItem(firstPocketStoryPublisher, 1) {
-            verifyUrl(POCKET_RECOMMENDED_STORIES_UTM_PARAM)
-        }
-    }
-
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252514
-    @Test
-    fun pocketDiscoverMoreButtonTest() {
-        activityTestRule.activityRule.applySettingsExceptions {
-            it.isRecentTabsFeatureEnabled = false
-            it.isRecentlyVisitedFeatureEnabled = false
-        }
-
-        homeScreen {
-        }.dismissOnboarding()
-
-        homeScreen {
-            scrollToPocketProvokingStories()
-            verifyDiscoverMoreStoriesButton()
-        }.clickPocketDiscoverMoreButton {
-            verifyUrl("getpocket.com/explore")
-        }
-    }
-
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252515
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1844580")
-    @Test
-    fun selectPocketStoriesByTopicTest() {
-        activityTestRule.activityRule.applySettingsExceptions {
-            it.isRecentTabsFeatureEnabled = false
-            it.isRecentlyVisitedFeatureEnabled = false
-        }
-
-        homeScreen {
-        }.dismissOnboarding()
-
-        homeScreen {
-            verifyStoriesByTopicItemState(activityTestRule, false, 1)
-            clickStoriesByTopicItem(activityTestRule, 1)
-            verifyStoriesByTopicItemState(activityTestRule, true, 1)
-        }
-    }
-
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2252516
-    @Test
-    fun pocketLearnMoreButtonTest() {
-        activityTestRule.activityRule.applySettingsExceptions {
-            it.isRecentTabsFeatureEnabled = false
-            it.isRecentlyVisitedFeatureEnabled = false
-        }
-
-        homeScreen {
-        }.dismissOnboarding()
-
-        homeScreen {
-            verifyPoweredByPocket()
-        }.clickPocketLearnMoreLink(activityTestRule) {
-            verifyUrl("mozilla.org/en-US/firefox/pocket")
         }
     }
 


### PR DESCRIPTION
These pocket related UI tests don't interact with the composable tabs tray so there's no need to have them also in the `ComposeHomeScreenTest` class


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
