### PR TITLE
Bug 1849146 - Add tab and history search smoke tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSearchTest.kt
@@ -21,7 +21,6 @@ import org.mozilla.fenix.helpers.Constants
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.MatcherHelper
 import org.mozilla.fenix.helpers.MockBrowserDataHelper.createBookmarkItem
-import org.mozilla.fenix.helpers.MockBrowserDataHelper.createHistoryItem
 import org.mozilla.fenix.helpers.MockBrowserDataHelper.createTabItem
 import org.mozilla.fenix.helpers.MockBrowserDataHelper.setCustomSearchEngine
 import org.mozilla.fenix.helpers.SearchDispatcher
@@ -672,6 +671,7 @@ class ComposeSearchTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun verifySearchTabsWithOpenTabsTest() {
         val firstPageUrl = TestAssetHelper.getGenericAsset(searchMockServer, 1)
@@ -778,36 +778,6 @@ class ComposeSearchTest {
             verifyNoSuggestionsAreDisplayed(rule = activityTestRule, "Mozilla")
             clickClearButton()
             verifySearchBarPlaceholder("Search history")
-        }
-    }
-
-    @Test
-    fun verifySearchHistoryWithBrowsingDataTest() {
-        val firstPageUrl = TestAssetHelper.getGenericAsset(searchMockServer, 1)
-        val secondPageUrl = TestAssetHelper.getGenericAsset(searchMockServer, 2)
-
-        createHistoryItem(firstPageUrl.url.toString())
-        createHistoryItem(secondPageUrl.url.toString())
-
-        navigationToolbar {
-        }.clickUrlbar {
-            clickSearchSelectorButton()
-            selectTemporarySearchMethod(searchEngineName = "History")
-            typeSearch(searchTerm = "Mozilla")
-            verifyNoSuggestionsAreDisplayed(rule = activityTestRule, "Mozilla")
-            clickClearButton()
-            typeSearch(searchTerm = "generic")
-            verifyTypedToolbarText("generic")
-            verifySearchEngineSuggestionResults(
-                rule = activityTestRule,
-                searchSuggestions = arrayOf(
-                    firstPageUrl.url.toString(),
-                    secondPageUrl.url.toString(),
-                ),
-                searchTerm = "generic",
-            )
-        }.clickSearchSuggestion(firstPageUrl.url.toString()) {
-            verifyUrl(firstPageUrl.url.toString())
         }
     }
 }


### PR DESCRIPTION
Bug 1849146 - Add tab and history search smoke tests

Summary:
Adding 2 UI test to our smoke test suite.
Because the composable tabs tray is only enabled on Nightly and Debug:
- I've moved the `verifySearchHistoryWithBrowsingDataTest` from `ComposeSearchTest` class to `SearchTest` class because it doesn't interact in any way with the tabs tray
- Added `verifySearchTabsWithOpenTabsTest` to the `SearchTest` class and will run only on Beta and RC builds. (We ignore the Compose* test classes when running the smoke test suite)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1849146