### PR TITLE
Revert "Bug 1842596 - Recover from UnrecoverableKeyException when retrieving sync key"

### DIFF
--- a/android-components/components/lib/dataprotect/src/main/java/mozilla/components/lib/dataprotect/Keystore.kt
+++ b/android-components/components/lib/dataprotect/src/main/java/mozilla/components/lib/dataprotect/Keystore.kt
@@ -8,12 +8,10 @@ import android.annotation.TargetApi
 import android.os.Build.VERSION_CODES.M
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
-import mozilla.components.support.base.log.logger.Logger
 import java.security.GeneralSecurityException
 import java.security.InvalidKeyException
 import java.security.Key
 import java.security.KeyStore
-import java.security.UnrecoverableKeyException
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
@@ -153,20 +151,14 @@ open class Keystore(
     manual: Boolean = false,
     internal val wrapper: KeyStoreWrapper = KeyStoreWrapper(),
 ) {
-    private val logger = Logger("Keystore")
-
     init {
         if (!manual and !available()) {
             generateKey()
         }
     }
 
-    private fun getKey(): SecretKey? = try {
+    private fun getKey(): SecretKey? =
         wrapper.getKeyFor(label) as? SecretKey?
-    } catch (e: UnrecoverableKeyException) {
-        logger.error("Failed to get key", e)
-        null
-    }
 
     /**
      * Determines if the managed key is available for use.  Consumers can use this to


### PR DESCRIPTION
This is not catching the failure at a low enough call.  The next call fails with the same error.  Reverting this fix for a better one.

Reverts mozilla-mobile/firefox-android#3294
https://bugzilla.mozilla.org/show_bug.cgi?id=1842596
https://bugzilla.mozilla.org/show_bug.cgi?id=1842596