### PR TITLE
Bug 1849278 - Ignore mainMenuOpenInAppTest failures

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
@@ -117,6 +117,7 @@ class ComposeSmokeTest {
 
     // Device or AVD requires a Google Services Android OS installation with Play Store installed
     // Verifies the Open in app button when an app is installed
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1849278")
     @Test
     fun mainMenuOpenInAppTest() {
         val youtubeURL = "https://m.youtube.com/user/mozilla?cbrd=1"

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -116,6 +116,7 @@ class SmokeTest {
 
     // Device or AVD requires a Google Services Android OS installation with Play Store installed
     // Verifies the Open in app button when an app is installed
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1849278")
     @Test
     fun mainMenuOpenInAppTest() {
         val youtubeURL = "https://m.youtube.com/user/mozilla?cbrd=1"


### PR DESCRIPTION
This started permafailing tonight due to what appears to be a change on the YouTube end. Ignore the test for now.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1849278