### PR TITLE
Bug 1840491 – open sign in flow and account page in a regualar tab

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -59,6 +59,9 @@ import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.storage.HistoryMetadataKey
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.AuthType
+import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.feature.contextmenu.DefaultSelectionActionDelegate
 import mozilla.components.feature.media.ext.findActiveMediaTab
 import mozilla.components.feature.privatemode.notification.PrivateNotificationFeature
@@ -94,6 +97,7 @@ import org.mozilla.fenix.addons.AddonPermissionsDetailsFragmentDirections
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.browser.browsingmode.DefaultBrowsingModeManager
+import org.mozilla.fenix.components.accounts.FenixFxAEntryPoint
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.metrics.BreadcrumbsRecorder
 import org.mozilla.fenix.components.metrics.GrowthDataWorker
@@ -112,6 +116,7 @@ import org.mozilla.fenix.home.intent.AssistIntentProcessor
 import org.mozilla.fenix.home.intent.CrashReporterIntentProcessor
 import org.mozilla.fenix.home.intent.HomeDeepLinkIntentProcessor
 import org.mozilla.fenix.home.intent.OpenBrowserIntentProcessor
+import org.mozilla.fenix.home.intent.OpenNewTabIntentProcessor
 import org.mozilla.fenix.home.intent.OpenPasswordManagerIntentProcessor
 import org.mozilla.fenix.home.intent.OpenSpecificTabIntentProcessor
 import org.mozilla.fenix.home.intent.ReEngagementIntentProcessor
@@ -210,6 +215,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             StartSearchIntentProcessor(),
             OpenBrowserIntentProcessor(this, ::getIntentSessionId),
             OpenSpecificTabIntentProcessor(this),
+            OpenNewTabIntentProcessor(this),
             OpenPasswordManagerIntentProcessor(),
             ReEngagementIntentProcessor(this, settings()),
         )
@@ -933,6 +939,32 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     }
 
     protected open fun getIntentSessionId(intent: SafeIntent): String? = null
+
+    fun callItBetter() {
+        val accountStateObserver = object : AccountObserver {
+            /**
+             * Navigate away from this activity when we have successful authentication
+             */
+            override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
+                lifecycleScope.launch(Main) {
+                    // TODO do something upon logging it
+                    // we could load the user page, though it needs a sync first to support all cases
+//                    val acct = components.backgroundServices.accountManager.authenticatedAccount()
+//                    val url = acct?.getManageAccountURL(FenixFxAEntryPoint.SettingsMenu)
+//                    if (url != null) {
+//                        openToBrowserAndLoad(
+//                            searchTermOrURL = url,
+//                            newTab = true,
+//                            from = BrowserDirection.FromGlobal,
+//                        )
+//                    }
+                }
+            }
+        }
+
+        val accountManager = components.backgroundServices.accountManager
+        accountManager.register(accountStateObserver, this, true)
+    }
 
     /**
      * Navigates to the browser fragment and loads a URL or performs a search (depending on the

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Services.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Services.kt
@@ -5,12 +5,16 @@
 package org.mozilla.fenix.components
 
 import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.feature.accounts.FirefoxAccountsAuthFeature
 import mozilla.components.feature.app.links.AppLinksInterceptor
 import mozilla.components.service.fxa.manager.FxaAccountManager
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.settings.SupportUtils
@@ -25,8 +29,15 @@ class Services(
     val accountsAuthFeature by lazyMonitored {
         FirefoxAccountsAuthFeature(accountManager, FxaServer.REDIRECT_URL) { context, authUrl ->
             CoroutineScope(Dispatchers.Main).launch {
-                val intent = SupportUtils.createAuthCustomTabIntent(context, authUrl)
+                // new flow
+                val intent = Intent(context, HomeActivity::class.java)
+                intent.data = authUrl.toUri()
+                intent.putExtra(HomeActivity.OPEN_TO_BROWSER_AND_LOAD, true)
                 context.startActivity(intent)
+
+                // old flow
+//                val intent = SupportUtils.createAuthCustomTabIntent(context, authUrl)
+//                context.startActivity(intent)
             }
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/intent/OpenNewTabIntentProcessor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/intent/OpenNewTabIntentProcessor.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.intent
+
+import android.content.Intent
+import androidx.navigation.NavController
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
+
+class OpenNewTabIntentProcessor(
+    private val activity: HomeActivity,
+) : HomeIntentProcessor {
+
+    override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
+        return if (intent.extras?.getBoolean(HomeActivity.OPEN_TO_BROWSER_AND_LOAD) == true) {
+            out.putExtra(HomeActivity.OPEN_TO_BROWSER_AND_LOAD, false)
+            val url = intent.data.toString()
+            activity.openToBrowserAndLoad(
+                searchTermOrURL = url,
+                newTab = true,
+                from = BrowserDirection.FromGlobal,
+            )
+            activity.callItBetter()
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
@@ -37,9 +37,11 @@ import mozilla.components.service.fxa.sync.setLastSynced
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.ui.widgets.withCenterAlignedButtons
 import mozilla.telemetry.glean.private.NoExtras
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.SyncAccount
+import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
@@ -375,11 +377,19 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         return Preference.OnPreferenceClickListener {
             viewLifecycleOwner.lifecycleScope.launch(Main) {
                 context?.let {
-                    var acct = accountManager.authenticatedAccount()
-                    var url = acct?.getManageAccountURL(FenixFxAEntryPoint.SettingsMenu)
+                    val acct = accountManager.authenticatedAccount()
+                    val url = acct?.getManageAccountURL(FenixFxAEntryPoint.SettingsMenu)
                     if (url != null) {
-                        val intent = SupportUtils.createCustomTabIntent(it, url)
-                        startActivity(intent)
+                        // new flow
+                        (activity as HomeActivity).openToBrowserAndLoad(
+                            searchTermOrURL = url,
+                            newTab = true,
+                            from = BrowserDirection.FromGlobal,
+                        )
+
+                        // old flow
+//                        val intent = SupportUtils.createCustomTabIntent(it, url)
+//                        startActivity(intent)
                     }
                 }
             }


### PR DESCRIPTION
work in progress
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840491