### PR TITLE
Bug 1849329 - Update local GV docs

### DIFF
--- a/fenix/docs/substituting-local-gv.md
+++ b/fenix/docs/substituting-local-gv.md
@@ -1,26 +1,8 @@
 # Substituting local GeckoView
 
 ### 1. Manually publish local GeckoView to local Maven
-First, to get the version that we are locally publishing (which will be used in later steps) please add the following:
 
-*geckoview/build.gradle*
-```diff
-diff --git a/mobile/android/geckoview/build.gradle b/mobile/android/geckoview/build.gradle
-index 731026796921b..81cc6782be291 100644
---- a/mobile/android/geckoview/build.gradle
-+++ b/mobile/android/geckoview/build.gradle
-@@ -398,6 +398,7 @@ android.libraryVariants.all { variant ->
- apply plugin: 'maven-publish'
- 
- version = getVersionNumber()
-+println("version = " + version)
- group = 'org.mozilla.geckoview'
- 
- def getArtifactId() {
-
-```
-
-We can now publish our local GeckoView to our local maven.
+Publish our local GeckoView to our local maven:
 ```sh
 ./mach build && ./mach gradle \
     geckoview:publishWithGeckoBinariesDebugPublicationToMavenLocal \
@@ -29,17 +11,17 @@ We can now publish our local GeckoView to our local maven.
 
 :warning: **This needs to be run every time you make changes.** :warning:
 
-You need to copy the version in the logs or run 
+You need to copy the version in the logs or run:
 ```sh
 ./mach build | grep version
-``` 
+```
 (ex. `115.0.20230511122045-SNAPSHOT`)
 
 ### 2. Modify Fenix to consume local GV
 Update the build.gradle and Gecko.kt file in Fenix (see the diffs below). Remember to update the GV version with the version you found in step 2!
 
 *fenix/build.gradle*
-```diff 
+```diff
 diff --git a/fenix/build.gradle b/fenix/build.gradle
 index 6a635a4818..4c8cc28995 100644
 --- a/fenix/build.gradle
@@ -73,7 +55,7 @@ index bed3fb0161..2d3a19a96e 100644
       */
 -    const val version = "115.0.20230511131014"
 +    const val version = "115.0.20230511122045-SNAPSHOT"
- 
+
      /**
       * GeckoView channel
 @@ -23,7 +23,7 @@ object Gecko {
@@ -89,6 +71,6 @@ index bed3fb0161..2d3a19a96e 100644
 ```
 
 ### 3. Build fenix with local GV
-Now sync your gradle changes and build! 
+Now sync your gradle changes and build!
 
 An easy way to confirm you are using a local GV is switching your Android Studio project tool window to "Project" and looking in the root directory called "External Libraries" for "GeckoView". You should see something like `Gradle: org.mozilla.geckoview-default-omni:115.0.20230511122045-SNAPSHOT@aar`


### PR DESCRIPTION
We do not need to patch the build system to read the GeckoView version anymore.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1849329