### PR TITLE
Bug 1849599 - Reorganize the Smoke tests suite

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
@@ -22,6 +22,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
+import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
@@ -80,6 +81,7 @@ class SyncIntegrationTest {
         bookmarkAfterSyncIsShown()
     }
 
+    @SmokeTest
     @Test
     fun checkAccountSettings() {
         signInFxSync()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeContextMenusTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeContextMenusTest.kt
@@ -13,7 +13,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -75,7 +74,6 @@ class ComposeContextMenusTest {
         mockWebServer.shutdown()
     }
 
-    @SmokeTest
     @Test
     fun verifyContextOpenLinkNewTab() {
         val pageLinks =
@@ -99,7 +97,6 @@ class ComposeContextMenusTest {
         }
     }
 
-    @SmokeTest
     @Test
     fun verifyContextOpenLinkPrivateTab() {
         val pageLinks =

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHomeScreenTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
@@ -96,6 +97,7 @@ class ComposeHomeScreenTest {
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1364362
+    @SmokeTest
     @Test
     fun verifyJumpBackInSectionTest() {
         activityTestRule.activityRule.applySettingsExceptions {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeNavigationToolbarTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeNavigationToolbarTest.kt
@@ -224,6 +224,7 @@ class ComposeNavigationToolbarTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun verifySecurePageSecuritySubMenuTest() {
         val defaultWebPage = "https://mozilla-mobile.github.io/testapp/loginForm"
@@ -238,6 +239,7 @@ class ComposeNavigationToolbarTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun verifyInsecurePageSecuritySubMenuTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
@@ -87,34 +87,6 @@ class ComposeSmokeTest {
         mockWebServer.shutdown()
     }
 
-    /* Verifies the nav bar:
-     - opening a web page
-     - the existence of nav bar items
-     - editing the url bar
-     - the tab drawer button
-     - opening a new search and dismissing the nav bar
-     */
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807268")
-    @Test
-    fun verifyBasicNavigationToolbarFunctionality() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen {
-            navigationToolbar {
-            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-                mDevice.waitForIdle()
-                verifyNavURLBarItems()
-            }.openNavigationToolbar {
-            }.goBackToWebsite {
-            }.openComposeTabDrawer(activityTestRule) {
-                verifyNormalTabsList()
-            }.openNewTab {
-            }.dismissSearchBar {
-                verifyHomeScreen()
-            }
-        }
-    }
-
     // Device or AVD requires a Google Services Android OS installation with Play Store installed
     // Verifies the Open in app button when an app is installed
     @Test
@@ -205,23 +177,6 @@ class ComposeSmokeTest {
                 sharedUrlsString,
                 "$firstWebsiteTitle, $secondWebsiteTitle",
             )
-        }
-    }
-
-    @Test
-    fun emptyTabsTrayViewPrivateBrowsingTest() {
-        homeScreen {
-        }.openComposeTabDrawer(activityTestRule) {
-        }.toggleToPrivateTabs {
-            verifyNormalBrowsingButtonIsSelected(false)
-            verifyPrivateBrowsingButtonIsSelected(true)
-            verifySyncedTabsButtonIsSelected(false)
-            verifyNoOpenTabsInPrivateBrowsing()
-            verifyFab()
-            verifyThreeDotButton()
-        }.openThreeDotMenu {
-            verifyTabSettingsButton()
-            verifyRecentlyClosedTabsButton()
         }
     }
 
@@ -424,18 +379,6 @@ class ComposeSmokeTest {
             mDevice.waitForIdle()
         }.goToHomescreen {
             verifyHomeScreen()
-        }
-    }
-
-    @Test
-    fun tabsSettingsMenuItemsTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openTabsSubMenu {
-            verifyTabViewOptions()
-            verifyCloseTabsOptions()
-            verifyMoveOldTabsToInactiveOptions()
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
@@ -267,6 +267,7 @@ class ComposeTabbedBrowsingTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun closePrivateTabsNotificationTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -317,6 +318,23 @@ class ComposeTabbedBrowsingTest {
             verifyPrivateBrowsingButtonIsSelected(false)
             verifySyncedTabsButtonIsSelected(false)
             verifyNoOpenTabsInNormalBrowsing()
+            verifyFab()
+            verifyThreeDotButton()
+        }.openThreeDotMenu {
+            verifyTabSettingsButton()
+            verifyRecentlyClosedTabsButton()
+        }
+    }
+
+    @Test
+    fun emptyTabsTrayViewPrivateBrowsingTest() {
+        homeScreen {
+        }.openComposeTabDrawer(composeTestRule) {
+        }.toggleToPrivateTabs {
+            verifyNormalBrowsingButtonIsSelected(false)
+            verifyPrivateBrowsingButtonIsSelected(true)
+            verifySyncedTabsButtonIsSelected(false)
+            verifyNoOpenTabsInPrivateBrowsing()
             verifyFab()
             verifyThreeDotButton()
         }.openThreeDotMenu {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextualHintsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ContextualHintsTest.kt
@@ -10,7 +10,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
-import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
@@ -50,7 +49,6 @@ class ContextualHintsTest {
         mockWebServer.shutdown()
     }
 
-    @SmokeTest
     @Test
     fun openTotalCookieProtectionLearnMoreLinkTest() {
         val genericPage = getGenericAsset(mockWebServer, 1)
@@ -63,7 +61,6 @@ class ContextualHintsTest {
         }
     }
 
-    @SmokeTest
     @Test
     fun dismissTotalCookieProtectionHintTest() {
         val genericPage = getGenericAsset(mockWebServer, 1)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -12,6 +12,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
@@ -90,6 +91,7 @@ class HomeScreenTest {
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1364362
+    @SmokeTest
     @Test
     fun verifyJumpBackInSectionTest() {
         activityTestRule.activityRule.applySettingsExceptions {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
@@ -152,7 +152,6 @@ class LoginsTest {
         }
     }
 
-    @SmokeTest
     @Test
     fun openWebsiteForSavedLoginTest() {
         val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
@@ -462,6 +461,7 @@ class LoginsTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun verifyNeverSaveLoginOptionTest() {
         val loginPage = TestAssetHelper.getSaveLoginAsset(mockWebServer)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -218,6 +218,7 @@ class NavigationToolbarTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun verifySecurePageSecuritySubMenuTest() {
         val defaultWebPage = "https://mozilla-mobile.github.io/testapp/loginForm"
@@ -232,6 +233,7 @@ class NavigationToolbarTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun verifyInsecurePageSecuritySubMenuTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -8,7 +8,6 @@ import androidx.core.net.toUri
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.Constants.PackageName.GMAIL_APP
 import org.mozilla.fenix.helpers.Constants.PackageName.PHONE_APP
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -92,7 +91,6 @@ class PwaTest {
         }
     }
 
-    @SmokeTest
     @Test
     fun appLikeExperiencePWATest() {
         navigationToolbar {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -85,6 +85,7 @@ class SettingsAdvancedTest {
     }
 
     // Assumes Youtube is installed and enabled
+    @SmokeTest
     @Test
     fun neverOpenLinkInAppTest() {
         val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
@@ -198,7 +199,6 @@ class SettingsAdvancedTest {
     }
 
     // Assumes Youtube is installed and enabled
-    @SmokeTest
     @Test
     fun privateBrowsingAskBeforeOpeningLinkInAppCancelTest() {
         val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
@@ -232,7 +232,6 @@ class SettingsAdvancedTest {
     }
 
     // Assumes Youtube is installed and enabled
-    @SmokeTest
     @Test
     fun privateBrowsingAskBeforeOpeningLinkInAppOpenTest() {
         val defaultWebPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsGeneralTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsGeneralTest.kt
@@ -76,6 +76,7 @@ class SettingsGeneralTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun changeAccessibiltySettings() {
         // Goes through the settings and changes the default text on a webpage, then verifies if the text has changed.
@@ -189,6 +190,18 @@ class SettingsGeneralTest {
             verifySelectedOpeningScreenOption("Last tab")
         }.goBack {
             verifySettingsOptionSummary("Homepage", "Open on last tab")
+        }
+    }
+
+    @Test
+    fun tabsSettingsMenuItemsTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openTabsSubMenu {
+            verifyTabViewOptions()
+            verifyCloseTabsOptions()
+            verifyMoveOldTabsToInactiveOptions()
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
@@ -230,9 +230,8 @@ class SettingsHomepageTest {
         }
     }
 
-    @SmokeTest
-    @Test
     @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/26559")
+    @Test
     fun setWallpaperTest() {
         val wallpapers = listOf(
             "Wallpaper Item: amethyst",

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SitePermissionsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SitePermissionsTest.kt
@@ -286,6 +286,7 @@ class SitePermissionsTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun allowLocationPermissionsTest() {
         mockLocationUpdatesRule.setMockLocation()
@@ -300,6 +301,7 @@ class SitePermissionsTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun blockLocationPermissionsTest() {
         navigationToolbar {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -17,7 +17,6 @@ import mozilla.components.concept.engine.mediasession.MediaSession
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.IntentReceiverActivity
@@ -48,7 +47,6 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class SmokeTest {
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
-    private val customMenuItem = "TestMenuItem"
     private lateinit var browserStore: BrowserStore
 
     @get:Rule(order = 0)
@@ -84,34 +82,6 @@ class SmokeTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-    }
-
-    /* Verifies the nav bar:
-     - opening a web page
-     - the existence of nav bar items
-     - editing the url bar
-     - the tab drawer button
-     - opening a new search and dismissing the nav bar
-     */
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807268")
-    @Test
-    fun verifyBasicNavigationToolbarFunctionality() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen {
-            navigationToolbar {
-            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-                mDevice.waitForIdle()
-                verifyNavURLBarItems()
-            }.openNavigationToolbar {
-            }.goBackToWebsite {
-            }.openTabDrawer {
-                verifyExistingTabList()
-            }.openNewTab {
-            }.dismissSearchBar {
-                verifyHomeScreen()
-            }
-        }
     }
 
     // Device or AVD requires a Google Services Android OS installation with Play Store installed
@@ -204,21 +174,6 @@ class SmokeTest {
                 sharedUrlsString,
                 "$firstWebsiteTitle, $secondWebsiteTitle",
             )
-        }
-    }
-
-    @Test
-    fun emptyTabsTrayViewPrivateBrowsingTest() {
-        navigationToolbar {
-        }.openTabTray {
-        }.toggleToPrivateTabs() {
-            verifyNormalBrowsingButtonIsSelected(false)
-            verifyPrivateBrowsingButtonIsSelected(true)
-            verifySyncedTabsButtonIsSelected(false)
-            verifyNoOpenTabsInPrivateBrowsing()
-            verifyPrivateBrowsingNewTabButton()
-            verifyTabTrayOverflowMenu(true)
-            verifyEmptyTabsTrayMenuButtons()
         }
     }
 
@@ -420,18 +375,6 @@ class SmokeTest {
             mDevice.waitForIdle()
         }.goToHomescreen {
             verifyHomeScreen()
-        }
-    }
-
-    @Test
-    fun tabsSettingsMenuItemsTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openTabsSubMenu {
-            verifyTabViewOptions()
-            verifyCloseTabsOptions()
-            verifyMoveOldTabsToInactiveOptions()
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -256,6 +256,7 @@ class TabbedBrowsingTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun closePrivateTabsNotificationTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -307,6 +308,21 @@ class TabbedBrowsingTest {
             verifySyncedTabsButtonIsSelected(false)
             verifyNoOpenTabsInNormalBrowsing()
             verifyNormalBrowsingNewTabButton()
+            verifyTabTrayOverflowMenu(true)
+            verifyEmptyTabsTrayMenuButtons()
+        }
+    }
+
+    @Test
+    fun emptyTabsTrayViewPrivateBrowsingTest() {
+        navigationToolbar {
+        }.openTabTray {
+        }.toggleToPrivateTabs {
+            verifyNormalBrowsingButtonIsSelected(false)
+            verifyPrivateBrowsingButtonIsSelected(true)
+            verifySyncedTabsButtonIsSelected(false)
+            verifyNoOpenTabsInPrivateBrowsing()
+            verifyPrivateBrowsingNewTabButton()
             verifyTabTrayOverflowMenu(true)
             verifyEmptyTabsTrayMenuButtons()
         }


### PR DESCRIPTION
There are a few too many Smoke tests in TestRail to be done in one day by manual testing, in case a quick check is required. 

I reviewed them and kept what is still relevant, and also removed some that have dropped in severity or priority over time.

It can ride the train on 118, then it will need to be uplifted to the release branch too.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1849599