### PR TITLE
Bug 1849278 - Fix external links breaking tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSearchTest.kt
@@ -58,6 +58,7 @@ class ComposeSearchTest {
             isRecentTabsFeatureEnabled = false,
             isTCPCFREnabled = false,
             isWallpaperOnboardingEnabled = false,
+            isCookieBannerReductionDialogEnabled = false,
             tabsTrayRewriteEnabled = true,
         ),
     ) { it.activity }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
@@ -17,7 +17,6 @@ import mozilla.components.concept.engine.mediasession.MediaSession
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.IntentReceiverActivity
@@ -116,13 +115,12 @@ class ComposeSmokeTest {
 
     // Device or AVD requires a Google Services Android OS installation with Play Store installed
     // Verifies the Open in app button when an app is installed
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1849278")
     @Test
     fun mainMenuOpenInAppTest() {
-        val youtubeURL = "https://m.youtube.com/user/mozilla?cbrd=1"
+        val youtubeURL = "vnd.youtube://".toUri()
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(youtubeURL.toUri()) {
+        }.enterURLAndEnterToBrowser(youtubeURL) {
             verifyNotificationDotOnMainMenu()
         }.openThreeDotMenu {
         }.clickOpenInApp {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -54,7 +54,7 @@ import org.mozilla.fenix.ui.robots.searchScreen
  */
 
 class SearchTest {
-    lateinit var searchMockServer: MockWebServer
+    private lateinit var searchMockServer: MockWebServer
     private var queryString = "firefox"
     private val generalEnginesList = listOf("DuckDuckGo", "Google", "Bing")
     private val topicEnginesList = listOf("Amazon.com", "Wikipedia", "eBay")
@@ -68,6 +68,8 @@ class SearchTest {
             isRecentTabsFeatureEnabled = false,
             isTCPCFREnabled = false,
             isWallpaperOnboardingEnabled = false,
+            isCookieBannerReductionDialogEnabled = false,
+            tabsTrayRewriteEnabled = false,
         ),
     ) { it.activity }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -17,7 +17,6 @@ import mozilla.components.concept.engine.mediasession.MediaSession
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.IntentReceiverActivity
@@ -115,13 +114,12 @@ class SmokeTest {
 
     // Device or AVD requires a Google Services Android OS installation with Play Store installed
     // Verifies the Open in app button when an app is installed
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1849278")
     @Test
     fun mainMenuOpenInAppTest() {
-        val youtubeURL = "https://m.youtube.com/user/mozilla?cbrd=1"
+        val youtubeURL = "vnd.youtube://".toUri()
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(youtubeURL.toUri()) {
+        }.enterURLAndEnterToBrowser(youtubeURL) {
             verifyNotificationDotOnMainMenu()
         }.openThreeDotMenu {
         }.clickOpenInApp {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/WebControlsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/WebControlsTest.kt
@@ -164,17 +164,6 @@ class WebControlsTest {
     }
 
     @Test
-    fun externalLinkTest() {
-        val externalLinksPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(externalLinksPage.url) {
-            clickPageObject(itemContainingText("External link"))
-            verifyUrl("duckduckgo")
-        }
-    }
-
-    @Test
     fun emailLinkTest() {
         val externalLinksPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845098
https://bugzilla.mozilla.org/show_bug.cgi?id=1846773
https://bugzilla.mozilla.org/show_bug.cgi?id=1830348
https://bugzilla.mozilla.org/show_bug.cgi?id=1836971
https://bugzilla.mozilla.org/show_bug.cgi?id=1842736