### PR TITLE
Bug 1849085 - Add localization for the "Search engines" setting preference header

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
@@ -70,7 +70,7 @@ class SettingsSubMenuSearchRobot {
     }
 
     fun verifySearchEnginesSectionHeader() {
-        onView(withText("Search Engines")).check(matches(isDisplayed()))
+        onView(withText("Search engines")).check(matches(isDisplayed()))
     }
 
     fun verifyDefaultSearchEngineHeader() {

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -360,6 +360,8 @@
     <string name="preferences_default_search_engine">Default search engine</string>
     <!-- Preference for settings related to Search -->
     <string name="preferences_search">Search</string>
+    <!-- Preference for settings related to Search engines -->
+    <string name="preferences_search_engines">Search engines</string>
     <!-- Preference for settings related to Search address bar -->
     <string name="preferences_search_address_bar">Address bar</string>
     <!-- Preference link to rating Fenix on the Play Store -->

--- a/fenix/app/src/main/res/xml/search_settings_preferences.xml
+++ b/fenix/app/src/main/res/xml/search_settings_preferences.xml
@@ -5,7 +5,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory
-        android:title="Search Engines"
+        android:title="@string/preferences_search_engines"
         android:selectable="false"
         app:iconSpaceReserved="false"
         android:layout="@layout/preference_category_no_icon_style">


### PR DESCRIPTION




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1849085