### PR TITLE
Bug 1813521 - Disable DownloadTest.pauseResumeCancelDownloadTest

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -126,6 +126,7 @@ class DownloadTest {
         deleteDownloadedFileOnStorage(downloadFile)
     }
 
+    @Ignore("Failing: Bug https://bugzilla.mozilla.org/show_bug.cgi?id=1813521")
     @SmokeTest
     @Test
     fun pauseResumeCancelDownloadTest() {


### PR DESCRIPTION
Recently started failing in https://github.com/mozilla-mobile/firefox-android/runs/16242371194 and in https://github.com/mozilla-mobile/firefox-android/runs/16249951484

https://bugzilla.mozilla.org/show_bug.cgi?id=1813521
https://bugzilla.mozilla.org/show_bug.cgi?id=1813521
https://bugzilla.mozilla.org/show_bug.cgi?id=1813521