### PR TITLE
Bug 1847031: add image mime types so that pngs can also be uploaded

### DIFF
--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/MimeType.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/MimeType.kt
@@ -108,22 +108,35 @@ internal sealed class MimeType(
 
         override fun shouldCapture(mimeTypes: Array<out String>, capture: File.FacingMode) = false
 
+        @Suppress("NestedBlockDepth")
         override fun buildIntent(context: Context, request: File) =
             Intent(ACTION_GET_CONTENT).apply {
                 type = "*/*"
                 addCategory(CATEGORY_OPENABLE)
                 putExtra(EXTRA_LOCAL_ONLY, true)
                 if (request.mimeTypes.isNotEmpty()) {
+                    var shouldAddImageTypes = false
                     val types = request.mimeTypes
                         .map {
+                            shouldAddImageTypes = shouldAddImageTypes || it.startsWith("image")
+
                             if (it.contains("/")) {
                                 it
                             } else {
                                 mimeTypeMap.getMimeTypeFromExtension(it) ?: "*/*"
                             }
+                        }.toMutableList()
+
+                    if (shouldAddImageTypes) {
+                        val imageTypes =
+                            arrayOf("image/jpeg", "image/png", "image/gif", "image/bmp")
+                        for (imageType in imageTypes) {
+                            if (!types.contains(imageType)) {
+                                types += imageType
+                            }
                         }
-                        .toTypedArray()
-                    putExtra(EXTRA_MIME_TYPES, types)
+                    }
+                    putExtra(EXTRA_MIME_TYPES, types.toTypedArray())
                 }
                 putExtra(EXTRA_ALLOW_MULTIPLE, request.isMultipleFilesSelection)
             }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847031