### PR TITLE
Bug 1847247 - Make the password shortcut should take directly to the saved logins page

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/home/intent/OpenPasswordManagerIntentProcessor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/intent/OpenPasswordManagerIntentProcessor.kt
@@ -19,7 +19,8 @@ class OpenPasswordManagerIntentProcessor : HomeIntentProcessor {
         return if (intent.extras?.getBoolean(HomeActivity.OPEN_PASSWORD_MANAGER) == true) {
             out.removeExtra(HomeActivity.OPEN_PASSWORD_MANAGER)
 
-            val directions = NavGraphDirections.actionGlobalSavedLoginsAuthFragment()
+            val directions =
+                NavGraphDirections.actionGlobalSavedLoginsAuthFragment(openedFromHomeShortcut = true)
             navController.nav(null, directions)
             true
         } else {

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
@@ -53,6 +54,14 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
 
         startForResult = registerForActivityResult {
             navigateToSavedLoginsFragment()
+        }
+
+        /**
+         * Handles authentication and then navigates to saved logins afterwards.
+         */
+        val args by navArgs<SavedLoginsAuthFragmentArgs>()
+        if (args.openedFromHomeShortcut) {
+            verifyCredentialsOrShowSetupWarning(requireContext())
         }
     }
 

--- a/fenix/app/src/main/res/navigation/nav_graph.xml
+++ b/fenix/app/src/main/res/navigation/nav_graph.xml
@@ -450,6 +450,10 @@
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
+        <argument
+            android:name="openedFromHomeShortcut"
+            android:defaultValue="false"
+            app:argType="boolean" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
### What
The PR makes the shortcut button on the Homepage to open the saved logins page.

### Steps to test

**Method 1**
1. Open the new shortcut "password shortcuts" by long pressing firefox icon,


### Screenshots
| Issue | Fix |
| ----- | --- |
|https://www.loom.com/share/e4cb450ff8634fc484312aac88eab51e | https://www.loom.com/share/d4bfbc6ef84f4fec8760892dc3521780?sid=5024e094-cc03-4776-80db-cf81c7c1f464 |

### Pull Request checklist
 - [x] Quality: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Changelog: This PR includes [a changelog entry](https://github.com/mozilla-mobile/android-components/blob/main/docs/changelog.md) or does not need one
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/main/android/accessibility_guide.md) or does not include any user facing features
### After merge
- Milestone: Make sure issues closed by this pull request are added to the [milestone](https://github.com/mozilla-mobile/android-components/milestones) of the version currently in development.
- Breaking Changes: If this is a breaking change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.

https://bugzilla.mozilla.org/show_bug.cgi?id=1847247
https://bugzilla.mozilla.org/show_bug.cgi?id=1847247