### PR TITLE
Bug 1847756 - Adjust permissions dialog when there is no permission

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/PermissionsDialogFragment.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/PermissionsDialogFragment.kt
@@ -182,14 +182,17 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
 
     @VisibleForTesting
     internal fun buildPermissionsText(): String {
-        var permissionsText =
-            getString(R.string.mozac_feature_addons_permissions_dialog_subtitle) + "\n\n"
+        var permissionsText = ""
         val permissions = addon.translatePermissions(requireContext())
 
-        permissions.forEachIndexed { index, item ->
-            val brakeLine = if (index + 1 != permissions.size) "\n\n" else ""
-            permissionsText += "• $item $brakeLine"
+        if (permissions.isNotEmpty()) {
+            permissionsText += getString(R.string.mozac_feature_addons_permissions_dialog_subtitle) + "\n\n"
+            permissions.forEachIndexed { index, item ->
+                val brakeLine = if (index + 1 != permissions.size) "\n\n" else ""
+                permissionsText += "• $item $brakeLine"
+            }
         }
+
         return permissionsText
     }
 

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/PermissionsDialogFragmentTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/PermissionsDialogFragmentTest.kt
@@ -16,6 +16,7 @@ import mozilla.components.feature.addons.R
 import mozilla.components.feature.addons.ui.PermissionsDialogFragment.PromptsStyling
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -45,10 +46,12 @@ class PermissionsDialogFragmentTest {
         val permissionText = fragment.buildPermissionsText()
 
         assertTrue(titleTextView.text.contains(name))
+        assertTrue(permissionText.contains(testContext.getString(R.string.mozac_feature_addons_permissions_dialog_subtitle)))
         assertTrue(permissionText.contains(testContext.getString(R.string.mozac_feature_addons_permissions_privacy_description)))
         assertTrue(permissionText.contains(testContext.getString(R.string.mozac_feature_addons_permissions_all_urls_description)))
         assertTrue(permissionText.contains(testContext.getString(R.string.mozac_feature_addons_permissions_tabs_description)))
 
+        assertTrue(permissionTextView.text.contains(testContext.getString(R.string.mozac_feature_addons_permissions_dialog_subtitle)))
         assertTrue(permissionTextView.text.contains(testContext.getString(R.string.mozac_feature_addons_permissions_privacy_description)))
         assertTrue(permissionTextView.text.contains(testContext.getString(R.string.mozac_feature_addons_permissions_all_urls_description)))
         assertTrue(permissionTextView.text.contains(testContext.getString(R.string.mozac_feature_addons_permissions_tabs_description)))
@@ -122,6 +125,29 @@ class PermissionsDialogFragmentTest {
 
         assertTrue(dialogAttributes.gravity == TOP)
         assertTrue(dialogAttributes.width == ViewGroup.LayoutParams.MATCH_PARENT)
+    }
+
+    @Test
+    fun `handles add-ons without permissions`() {
+        val addon = Addon(
+            "id",
+            translatableName = mapOf(Addon.DEFAULT_LOCALE to "my_addon"),
+            permissions = emptyList(),
+        )
+        val fragment = createPermissionsDialogFragment(addon)
+
+        doReturn(testContext).`when`(fragment).requireContext()
+        val dialog = fragment.onCreateDialog(null)
+        dialog.show()
+
+        val name = addon.translateName(testContext)
+        val titleTextView = dialog.findViewById<TextView>(R.id.title)
+        val permissionTextView = dialog.findViewById<TextView>(R.id.permissions)
+        val permissionText = fragment.buildPermissionsText()
+
+        assertTrue(titleTextView.text.contains(name))
+        assertFalse(permissionText.contains(testContext.getString(R.string.mozac_feature_addons_permissions_dialog_subtitle)))
+        assertFalse(permissionTextView.text.contains(testContext.getString(R.string.mozac_feature_addons_permissions_dialog_subtitle)))
     }
 
     private fun createPermissionsDialogFragment(


### PR DESCRIPTION
In order to try this patch, I manually edited the `Addon` class as follows:

```diff
diff --git a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
index 3ead293ba2..ffa6793c93 100644
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -239,13 +239,13 @@ data class Addon(
         fun newFromWebExtension(extension: WebExtension, installedState: InstalledState? = null): Addon {
             val name = extension.getMetadata()?.name ?: extension.id
             val description = extension.getMetadata()?.description ?: extension.id
-            val permissions = extension.getMetadata()?.permissions.orEmpty() +
-                extension.getMetadata()?.hostPermissions.orEmpty()
+            //val permissions = extension.getMetadata()?.permissions.orEmpty() +
+            //    extension.getMetadata()?.hostPermissions.orEmpty()

             return Addon(
                 id = extension.id,
                 version = extension.getMetadata()?.version.orEmpty(),
-                permissions = permissions,
+                permissions = emptyList(),
                 downloadUrl = extension.url,
                 siteUrl = extension.url,
                 translatableName = mapOf(Addon.DEFAULT_LOCALE to name),
```

And then I installed an add-on from AMO.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- ~~[ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one~~
- ~~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features~~

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847756