### PR TITLE
Bug 1851012 – aligned Search Engine Suggestion Provider behaviour with Desktop

### DIFF
--- a/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchEngineSuggestionProvider.kt
+++ b/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SearchEngineSuggestionProvider.kt
@@ -44,7 +44,7 @@ class SearchEngineSuggestionProvider(
         }
 
         val suggestions = searchEnginesList
-            .filter { it.name.contains(text, true) }.take(maxSuggestions)
+            .filter { it.name.startsWith(text, true) }.take(maxSuggestions)
 
         return if (suggestions.isNotEmpty()) {
             suggestions.into()
@@ -73,6 +73,6 @@ class SearchEngineSuggestionProvider(
 
     companion object {
         internal const val DEFAULT_MAX_SUGGESTIONS = 1
-        internal const val DEFAULT_CHARACTERS_THRESHOLD = 1
+        internal const val DEFAULT_CHARACTERS_THRESHOLD = 2
     }
 }

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchEngineSuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchEngineSuggestionProviderTest.kt
@@ -22,6 +22,7 @@ class SearchEngineSuggestionProviderTest {
     private val engineList = listOf(
         createSearchEngine("amazon", "https://www.amazon.org/?q={searchTerms}", mock()),
         createSearchEngine("bing", "https://www.bing.com/?q={searchTerms}", mock()),
+        createSearchEngine("bingo", "https://www.bingo.com/?q={searchTerms}", mock()),
     )
     private val testContext: Context = mock()
 
@@ -40,6 +41,7 @@ class SearchEngineSuggestionProviderTest {
 
         whenever(testContext.getString(1, "amazon")).thenReturn("Search amazon")
         whenever(testContext.getString(1, "bing")).thenReturn("Search bing")
+        whenever(testContext.getString(1, "bingo")).thenReturn("Search bingo")
     }
 
     @Test
@@ -81,10 +83,17 @@ class SearchEngineSuggestionProviderTest {
     }
 
     @Test
-    fun `Provider returns a match when list contains the typed engine`() = runTest {
+    fun `WHEN input matches the beginning of the engine name THEN return the corresponding engine`() = runTest {
         val suggestions = defaultProvider.onInputChanged("am")
 
         assertEquals("Search amazon", suggestions[0].title)
+    }
+
+    @Test
+    fun `WHEN input matches not the beginning of the engine name THEN return nothing`() = runTest {
+        val suggestions = defaultProvider.onInputChanged("ma")
+
+        assertEquals(0, suggestions.size)
     }
 
     @Test
@@ -106,7 +115,7 @@ class SearchEngineSuggestionProviderTest {
     @Test
     fun `Provider limits number of returned suggestions to maxSuggestions`() = runTest {
         // this should match to both engines in list
-        val suggestions = defaultProvider.onInputChanged("n")
+        val suggestions = defaultProvider.onInputChanged("bi")
 
         assertEquals(defaultProvider.maxSuggestions, suggestions.size)
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,9 @@ permalink: /changelog/
 **feature-push**
   * We will no longer report `RecordNotFoundException` to the `CrashReporter` as it's largely a (web) application side reason why these messages are still trying to be delivered.
 
+* **feature-awesomebar**
+ * Search engine suggestions will only be displayed if the user inputs at least 2 characters and matches the starting characters of the search engine name. [bug #1851012](https://bugzilla.mozilla.org/show_bug.cgi?id=1851012) 
+
 # 118.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v117..releases_v118)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/releases_v118/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)


### PR DESCRIPTION
### Screenshots
 Old | New
 --- | --- 
<img src="https://github.com/mozilla-mobile/firefox-android/assets/92760693/0ef806ee-c2f2-46d3-8a5b-f5028d5e146e" width="300"> |  <img src="https://github.com/mozilla-mobile/firefox-android/assets/92760693/5e2aa2f3-2fc9-4367-bd86-b1140ba20afd" width="300">
<img src="https://github.com/mozilla-mobile/firefox-android/assets/92760693/b05bb940-fe30-4378-9f7d-c72c62df9fa4" width="300"> |  <img src="https://github.com/mozilla-mobile/firefox-android/assets/92760693/05994770-1d70-4c0e-9c05-8fcf8ed74266" width="300">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1851012