### PR TITLE
Bug 1845098 - detect external-gradle-dependencies hangs and automatically retry the task

### DIFF
--- a/taskcluster/ci/external-gradle-dependencies/kind.yml
+++ b/taskcluster/ci/external-gradle-dependencies/kind.yml
@@ -49,6 +49,7 @@ task-defaults:
         retry-exit-status:
             - 1     # Test failures (which actually catch any gradle failure)
             - 17    # Download errors
+            - 42    # Hangs
     worker-type: b-android-xlarge
 
 tasks:

--- a/taskcluster/scripts/toolchain/external-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/external-gradle-dependencies.sh
@@ -48,7 +48,19 @@ if [[ $WORKING_DIR == ${ANDROID_COMPONENTS_DIR}* ]]; then
   done
 fi
 
-./gradlew $GRADLE_ARGS $GRADLE_COMMANDS
+# gradle occasionally hangs, so run a watchdog that'll exit after 30min
+(
+sleep 30m &
+trap "kill $!" EXIT
+wait
+exit 42
+) &
+
+./gradlew $GRADLE_ARGS $GRADLE_COMMANDS &
+# wait for either the watchdog or gradle process to exit
+wait -n %1 %2
+# if gradle finished in time, kill the watchdog, no longer necessary
+kill %1 || :
 
 . "$REPO_ROOT_DIR/taskcluster/scripts/toolchain/external-gradle-dependencies/after.sh"
 


### PR DESCRIPTION
Add a watchdog to external-gradle-dependencies.sh so that if gradle isn't done after 30 minutes we give up and return an exit code that signals to TC that the task should be rerun.

Second attempt after #3334.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1845098