### PR TITLE
Bug 1851676 - Adds ability to initialize Sentry on startup

### DIFF
--- a/android-components/components/lib/crash-sentry/src/main/java/mozilla/components/lib/crash/sentry/SentryService.kt
+++ b/android-components/components/lib/crash-sentry/src/main/java/mozilla/components/lib/crash/sentry/SentryService.kt
@@ -34,6 +34,7 @@ import mozilla.components.concept.base.crash.Breadcrumb as MozillaBreadcrumb
  * @param sendEventForNativeCrashes Allows configuring if native crashes should be submitted. Disabled by default.
  * @param sentryProjectUrl Base URL of the Sentry web interface pointing to the app/project.
  * @param sendCaughtExceptions Allows configuring if caught exceptions should be submitted. Enabled by default.
+ * @param autoInitializeSentry Initializes the Sentry SDK immediately on service creation.
  */
 class SentryService(
     private val applicationContext: Context,
@@ -108,9 +109,15 @@ class SentryService(
         }
     }
 
+    /**
+     * Initializes Sentry if needed.
+     *
+     * N.B: We've temporarily made this public so that Fenix can initialize Sentry on startup.
+     * As a result of https://bugzilla.mozilla.org/show_bug.cgi?id=1853059 we will have a better way
+     * to control how / when Sentry gets initialized and we will make this internal again.
+     */
     @Synchronized
-    @VisibleForTesting
-    internal fun initIfNeeded() {
+    fun initIfNeeded() {
         if (isInitialized) {
             return
         }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,9 @@ permalink: /changelog/
 
 * **feature-tabs**
   * Removed deprecated `TabsUseCases.AddNewPrivateTabUseCase`. [Bug 1853070](https://bugzilla.mozilla.org/show_bug.cgi?id=1853070)
+  
+* **lib-crash-sentry**
+  * `SentryService.initIfNeeded` is now public. [bug #1851676](https://bugzilla.mozilla.org/show_bug.cgi?id=1851676)
 
 * **feature-downloads**
   * Added a custom permission `${applicationId}.permission.RECEIVE_DOWNLOAD_BROADCAST` that needs to be used by apps in order to receive download related broadcasts

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -158,7 +158,7 @@ class Components(private val context: Context) {
         AddonManager(core.store, core.engine, addonsProvider, addonUpdater)
     }
 
-    val analytics by lazyMonitored { Analytics(context) }
+    val analytics by lazyMonitored { Analytics(context, performance.visualCompletenessQueue.queue) }
     val publicSuffixList by lazyMonitored { PublicSuffixList(context) }
     val clipboardHandler by lazyMonitored { ClipboardHandler(context) }
     val performance by lazyMonitored { PerformanceComponent() }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1851676