### PR TITLE
Bug 1851006 - SearchEngineSuggestionProvider should always be added to the provider list.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -318,9 +318,7 @@ class AwesomeBarView(
             providersToAdd.add(getLocalTabsProvider(state.searchEngineSource, true))
         }
 
-        if (!activity.settings().showUnifiedSearchFeature) {
-            providersToAdd.add(searchEngineSuggestionProvider)
-        }
+        providersToAdd.add(searchEngineSuggestionProvider)
 
         return providersToAdd
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/awesomebar/AwesomeBarViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/awesomebar/AwesomeBarViewTest.kt
@@ -765,24 +765,9 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN unified search feature is enabled WHEN configuring providers THEN don't add the engine suggestions provider`() {
+    fun `GIVEN a search is made by the user WHEN configuring providers THEN search engine suggestion provider should always be added`() {
         val settings: Settings = mockk(relaxed = true) {
             every { showUnifiedSearchFeature } returns true
-        }
-        every { activity.settings() } returns settings
-        val state = getSearchProviderState(
-            searchEngineSource = SearchEngineSource.Default(mockk(relaxed = true)),
-        )
-
-        val result = awesomeBarView.getProvidersToAdd(state)
-
-        assertEquals(0, result.filterIsInstance<SearchEngineSuggestionProvider>().size)
-    }
-
-    @Test
-    fun `GIVEN unified search feature is disabled WHEN configuring providers THEN add the engine suggestions provider`() {
-        val settings: Settings = mockk(relaxed = true) {
-            every { showUnifiedSearchFeature } returns false
         }
         every { activity.settings() } returns settings
         val state = getSearchProviderState(
@@ -834,7 +819,7 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN a search from the default engine with no suggestions asked WHEN configuring providers THEN don't add any provider`() {
+    fun `GIVEN a search from the default engine with no suggestions asked WHEN configuring providers THEN add only search engine suggestion provider`() {
         val settings: Settings = mockk(relaxed = true) {
             every { showUnifiedSearchFeature } returns true
         }
@@ -862,7 +847,7 @@ class AwesomeBarViewTest {
         assertEquals(0, result.filterIsInstance<SearchSuggestionProvider>().size)
         assertEquals(0, result.filterIsInstance<SyncedTabsStorageSuggestionProvider>().size)
         assertEquals(0, result.filterIsInstance<SessionSuggestionProvider>().size)
-        assertEquals(0, result.filterIsInstance<SearchEngineSuggestionProvider>().size)
+        assertEquals(1, result.filterIsInstance<SearchEngineSuggestionProvider>().size)
     }
 
     @Test


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1851006