### PR TITLE
Bug 1847141 - Remove hardcoding of RECEIVE_DOWNLOAD_BROADCAST_PERMISSION

### DIFF
--- a/android-components/components/feature/downloads/src/main/AndroidManifest.xml
+++ b/android-components/components/feature/downloads/src/main/AndroidManifest.xml
@@ -16,8 +16,11 @@
     <!-- Needed to prompt the user to give permission to install a downloaded apk -->
     <uses-permission-sdk-23 android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
+    <!-- Needed to receive broadcasts from AC code-->
+    <uses-permission android:name="${applicationId}.permission.RECEIVE_DOWNLOAD_BROADCAST" />
+
     <permission
-        android:name="org.mozilla.permission.RECEIVE_DOWNLOAD_BROADCAST"
+        android:name="${applicationId}.permission.RECEIVE_DOWNLOAD_BROADCAST"
         android:protectionLevel="signature" />
 
     <application android:supportsRtl="true">

--- a/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -840,7 +840,7 @@ abstract class AbstractFetchDownloadService : Service() {
         intent.putExtra(EXTRA_DOWNLOAD_STATUS, getDownloadJobStatus(downloadState))
         intent.putExtra(EXTRA_DOWNLOAD_ID, downloadState.state.id)
 
-        context.sendBroadcast(intent, RECEIVE_DOWNLOAD_BROADCAST_PERMISSION)
+        context.sendBroadcast(intent, "${context.packageName}.permission.RECEIVE_DOWNLOAD_BROADCAST")
     }
 
     /**
@@ -955,13 +955,6 @@ abstract class AbstractFetchDownloadService : Service() {
     }
 
     companion object {
-
-        /**
-         * Custom permission that needs to be requested by app using feature-downloads in order to receive
-         * download releated broadcasts.
-         */
-        const val RECEIVE_DOWNLOAD_BROADCAST_PERMISSION = "org.mozilla.permission.RECEIVE_DOWNLOAD_BROADCAST"
-
         /**
          * Launches an intent to open the given file, returns whether or not the file could be opened
          */

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ permalink: /changelog/
 
 
 * **feature-downloads**
-  * Added a custom permission `org.mozilla.permission.RECEIVE_DOWNLOAD_BROADCAST` that needs to be used by apps in order to receive download related broadcasts
+  * Added a custom permission `${applicationId}.permission.RECEIVE_DOWNLOAD_BROADCAST` that needs to be used by apps in order to receive download related broadcasts
   
 * **ui-tabcounter**
   * Adds a mask overlay to the tabcounter that can be shown with `toggleCounterMask`.

--- a/fenix/app/src/main/AndroidManifest.xml
+++ b/fenix/app/src/main/AndroidManifest.xml
@@ -40,9 +40,6 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
-    <!-- Needed to receive broadcasts from AC code-->
-    <uses-permission android:name="org.mozilla.permission.RECEIVE_DOWNLOAD_BROADCAST" />
-
     <application
         android:name=".FenixApplication"
         android:allowBackup="false"

--- a/focus-android/app/src/main/AndroidManifest.xml
+++ b/focus-android/app/src/main/AndroidManifest.xml
@@ -42,9 +42,6 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
-    <!-- Needed to receive broadcasts from AC code-->
-    <uses-permission android:name="org.mozilla.permission.RECEIVE_DOWNLOAD_BROADCAST" />
-
     <application
         android:allowBackup="false"
         android:extractNativeLibs="true"


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847141