### PR TITLE
Bug 1852335 - Renamed WebExtensionPopupFeature and ExtensionProcessDi…

### DIFF
--- a/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/ExtensionProcessDisabledPopupObserver.kt
+++ b/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/ExtensionProcessDisabledPopupObserver.kt
@@ -19,7 +19,7 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
  * @property onShowExtensionProcessDisabledPopup a callback invoked when the application should open a
  * popup.
  */
-open class ExtensionProcessDisabledPopupFeature(
+open class ExtensionProcessDisabledPopupObserver(
     private val store: BrowserStore,
     private val onShowExtensionProcessDisabledPopup: () -> Unit = { },
 ) : LifecycleAwareFeature {

--- a/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionPopupObserver.kt
+++ b/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionPopupObserver.kt
@@ -22,7 +22,7 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
  * popup. This is a lambda accepting the [WebExtensionState] of the extension
  * that wants to open a popup.
  */
-class WebExtensionPopupFeature(
+class WebExtensionPopupObserver(
     private val store: BrowserStore,
     private val onOpenPopup: (WebExtensionState) -> Unit = { },
 ) : LifecycleAwareFeature {

--- a/android-components/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionPopupObserverTest.kt
+++ b/android-components/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionPopupObserverTest.kt
@@ -18,7 +18,7 @@ import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 
-class WebExtensionPopupFeatureTest {
+class WebExtensionPopupObserverTest {
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
@@ -34,11 +34,11 @@ class WebExtensionPopupFeatureTest {
         )
 
         var extensionOpeningPopup: WebExtensionState? = null
-        val feature = WebExtensionPopupFeature(store) {
+        val observer = WebExtensionPopupObserver(store) {
             extensionOpeningPopup = it
         }
 
-        feature.start()
+        observer.start()
         assertNull(extensionOpeningPopup)
 
         store.dispatch(WebExtensionAction.UpdatePopupSessionAction(extensionId, popupSession = engineSession)).joinBlocking()
@@ -48,7 +48,7 @@ class WebExtensionPopupFeatureTest {
 
         // Verify that stopped feature does not observe and forward requests to open popup
         extensionOpeningPopup = null
-        feature.stop()
+        observer.stop()
         store.dispatch(WebExtensionAction.UpdatePopupSessionAction(extensionId, popupSession = mock())).joinBlocking()
         assertNull(extensionOpeningPopup)
     }

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/BrowserActivity.kt
@@ -18,7 +18,7 @@ import mozilla.components.feature.intent.ext.getSessionId
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.locale.LocaleAwareAppCompatActivity
 import mozilla.components.support.utils.SafeIntent
-import mozilla.components.support.webextensions.WebExtensionPopupFeature
+import mozilla.components.support.webextensions.WebExtensionPopupObserver
 import org.mozilla.samples.browser.addons.WebExtensionActionPopupActivity
 import org.mozilla.samples.browser.ext.components
 
@@ -26,8 +26,8 @@ import org.mozilla.samples.browser.ext.components
  * Activity that holds the [BrowserFragment].
  */
 open class BrowserActivity : LocaleAwareAppCompatActivity(), ComponentCallbacks2 {
-    private val webExtensionPopupFeature by lazy {
-        WebExtensionPopupFeature(components.store, ::openPopup)
+    private val webExtensionPopupObserver by lazy {
+        WebExtensionPopupObserver(components.store, ::openPopup)
     }
 
     /**
@@ -48,7 +48,7 @@ open class BrowserActivity : LocaleAwareAppCompatActivity(), ComponentCallbacks2
             }
         }
 
-        lifecycle.addObserver(webExtensionPopupFeature)
+        lifecycle.addObserver(webExtensionPopupObserver)
         components.historyStorage.registerStorageMaintenanceWorker()
         components.notificationsDelegate.bindToActivity(this)
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,10 @@ permalink: /changelog/
   * User is NOT syncing their logins with another device
   * User plans to upgrade from v95 to v119 or above
 
+* **support-webextensions**
+  * ⚠️ **This is a breaking change**: Renamed `WebExtensionPopupFeature` to `WebExtensionPopupObserver` [bug #1852335](https://bugzilla.mozilla.org/show_bug.cgi?id=1852335)
+  * Added `ExtensionProcessDisabledPopupObserver` to display to the user a dialog when the extensions process spawning has been disabled. [bug #1846979](https://bugzilla.mozilla.org/show_bug.cgi?id=1846979)
+
 # 118.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v117..releases_v118)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/releases_v118/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -80,7 +80,7 @@ import mozilla.components.support.utils.BrowsersCache
 import mozilla.components.support.utils.ManufacturerCodes
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.utils.toSafeIntent
-import mozilla.components.support.webextensions.WebExtensionPopupFeature
+import mozilla.components.support.webextensions.WebExtensionPopupObserver
 import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.experiments.nimbus.initializeTooling
 import org.mozilla.fenix.GleanMetrics.AppIcon
@@ -190,11 +190,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
 
     private var isToolbarInflated = false
 
-    private val webExtensionPopupFeature by lazy {
-        WebExtensionPopupFeature(components.core.store, ::openPopup)
+    private val webExtensionPopupObserver by lazy {
+        WebExtensionPopupObserver(components.core.store, ::openPopup)
     }
 
-    private val extensionProcessDisabledPopupFeature by lazy {
+    private val extensionProcessDisabledPopupObserver by lazy {
         ExtensionProcessDisabledController(this@HomeActivity, components.core.store)
     }
 
@@ -346,7 +346,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         }
         supportActionBar?.hide()
 
-        lifecycle.addObservers(webExtensionPopupFeature, extensionProcessDisabledPopupFeature, serviceWorkerSupport)
+        lifecycle.addObservers(webExtensionPopupObserver, extensionProcessDisabledPopupObserver, serviceWorkerSupport)
 
         if (shouldAddToRecentsScreen(intent)) {
             intent.removeExtra(START_IN_RECENTS_SCREEN)

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionProcessDisabledController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionProcessDisabledController.kt
@@ -11,7 +11,7 @@ import mozilla.components.browser.state.action.ExtensionProcessDisabledPopupActi
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.support.ktx.android.content.appName
-import mozilla.components.support.webextensions.ExtensionProcessDisabledPopupFeature
+import mozilla.components.support.webextensions.ExtensionProcessDisabledPopupObserver
 import org.mozilla.fenix.GleanMetrics.Addons
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
@@ -72,7 +72,7 @@ class ExtensionProcessDisabledController(
     engine: Engine = context.components.core.engine,
     builder: AlertDialog.Builder = AlertDialog.Builder(context),
     appName: String = context.appName,
-) : ExtensionProcessDisabledPopupFeature(
+) : ExtensionProcessDisabledPopupObserver(
     store,
     { presentDialog(context, store, engine, builder, appName) },
 )


### PR DESCRIPTION
…sabledPopupFeature to observers

Because both `WebExtensionPopupFeature` and `ExtensionProcessDisabledPopupFeature` are not "features" this just updates them to observers. Changelog was also updated and the rename of `WebExtensionPopupFeature` will be a breaking change.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1852335