### PR TITLE
Bug 1825116 - delete trailing whitespace from docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,7 @@ permalink: /changelog/
 
 * **feature-downloads**
   * Added a custom permission `${applicationId}.permission.RECEIVE_DOWNLOAD_BROADCAST` that needs to be used by apps in order to receive download related broadcasts
-  
+
 * **ui-tabcounter**
   * Adds a mask overlay to the tabcounter that can be shown with `toggleCounterMask`.
 
@@ -21,7 +21,7 @@ permalink: /changelog/
   * We will no longer report `RecordNotFoundException` to the `CrashReporter` as it's largely a (web) application side reason why these messages are still trying to be delivered.
 
 * **feature-awesomebar**
- * Search engine suggestions will only be displayed if the user inputs at least 2 characters and matches the starting characters of the search engine name. [bug #1851012](https://bugzilla.mozilla.org/show_bug.cgi?id=1851012) 
+ * Search engine suggestions will only be displayed if the user inputs at least 2 characters and matches the starting characters of the search engine name. [bug #1851012](https://bugzilla.mozilla.org/show_bug.cgi?id=1851012)
 
 # 118.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v117..releases_v118)

--- a/docs/rfcs/0009-remove-interactors-and-controllers.md
+++ b/docs/rfcs/0009-remove-interactors-and-controllers.md
@@ -13,9 +13,9 @@ Now that Fenix has been fully migrated to rely on Android Component's `lib-state
 
 ## Motivation
 
-The `Interactor/Controller` types, as a design pattern, have recently had their usefulness and clarity come into question in reviews and conversations with some regularity. `Interactor`s in particular seem to often be an unnecessary abstraction layer, usually containing methods that call similarly named methods in a `Controller` that share a similar name to the interactor calling them. Interactors that are used solely to delegate to other classes will be referred to as 'passthrough' interactors throughout this document. 
+The `Interactor/Controller` types, as a design pattern, have recently had their usefulness and clarity come into question in reviews and conversations with some regularity. `Interactor`s in particular seem to often be an unnecessary abstraction layer, usually containing methods that call similarly named methods in a `Controller` that share a similar name to the interactor calling them. Interactors that are used solely to delegate to other classes will be referred to as 'passthrough' interactors throughout this document.
 
-The [definition](../../fenix/docs/architecture-overview.md#interactor) of interactors in our architecture overview indicate that this is at least partially intentional: 'Called in response to a direct user action. Delegates to something else'. This is even referenced as a [limitation at the end of the overview](../../fenix/docs/architecture-overview.md#known-limitations). 
+The [definition](../../fenix/docs/architecture-overview.md#interactor) of interactors in our architecture overview indicate that this is at least partially intentional: 'Called in response to a direct user action. Delegates to something else'. This is even referenced as a [limitation at the end of the overview](../../fenix/docs/architecture-overview.md#known-limitations).
 
 Historically, the interactor/controller pattern evolved from a Presenter/Controller/View pattern that originated in Android Components. The underlying motivation of that pattern was to separate code presenting the state from the view (Presenters) and the code that updated the state from the view (Controllers).
 
@@ -46,7 +46,7 @@ An investigation was previously done to provide [further context](https://docs.g
 The proposal is to remove interactors and controllers completely from the codebase. Their usages will be replaced with direct Store observations and direct action dispatches to those Stores. All state changes would be handled by reducers, and side-effects like telemetry or disk writes would be handled in middlewares.
 
 This would address all the goals listed above:
-1. Code comprehensibility should be improved by having a single architectural pattern. All business logic would be discoverable within `Reducer`s, and changes to `State` would be much more explicit. 
+1. Code comprehensibility should be improved by having a single architectural pattern. All business logic would be discoverable within `Reducer`s, and changes to `State` would be much more explicit.
 2. Responsibility would be clearly delineated as all business logic would be handled by `Reducer`s and all side-effects by `Middleware`, instead of being scattered between those components as well as `Interactor`s, `Controller`s, and various utility classes.
 3. `State` management would happen within `Reducer`s and would still accomplish the usual goals around testability.
 4. Refactoring interactors/controllers to instead dispatch actions and react to state changes should be doable on a per-component basis.
@@ -203,8 +203,8 @@ class PocketCategoriesViewHolder(
             categoryColors = categoryColors,
             categories = categories ?: emptyList(),
             categoriesSelections = categoriesSelections ?: emptyList(),
-            onCategoryClick = { name -> 
-                components.appStore.dispatch(AppAction.TogglePocketStoriesCategory(name)) 
+            onCategoryClick = { name ->
+                components.appStore.dispatch(AppAction.TogglePocketStoriesCategory(name))
             },
         )
     }
@@ -219,7 +219,7 @@ This should simplify the search for underlying logic by:
 
 ### Extending the example: separating state and side-effects
 
-To demonstrate the bullets above, here is the method definition in the `DefaultPocketStoriesController` that currently handles the business logic initiated from the `interactor::onCategoryClicked` call above. 
+To demonstrate the bullets above, here is the method definition in the `DefaultPocketStoriesController` that currently handles the business logic initiated from the `interactor::onCategoryClicked` call above.
 
 ```kotlin
     override fun handleCategoryClick(categoryClicked: PocketRecommendedStoriesCategory) {
@@ -366,7 +366,7 @@ Overall, this should convey the following improvements
 
 ### An example refactor: removing interactors and controllers from HistoryFragment
 
-A [small example refactor](https://github.com/mozilla-mobile/firefox-android/pull/2347) was done to demonstrate some of the concepts presented throughout the document by removing interactors and controllers from the `HistoryFragment` and package. This is not necessarily an idealized version of that area, but is instead intended to demonstrate the first steps in creating architectural consistency. 
+A [small example refactor](https://github.com/mozilla-mobile/firefox-android/pull/2347) was done to demonstrate some of the concepts presented throughout the document by removing interactors and controllers from the `HistoryFragment` and package. This is not necessarily an idealized version of that area, but is instead intended to demonstrate the first steps in creating architectural consistency.
 
 ---
 
@@ -387,9 +387,9 @@ To demonstrate some of the concepts discussed in this proposal in more detail, a
 
 Following that, should this proposal be accepted the following suggestions are made for adoption with a focus on increasing the team's familiarity and knowledge of the pattern:
 
-1. Architecture documentation should be updated with guidelines matching this proposal. 
+1. Architecture documentation should be updated with guidelines matching this proposal.
 1. A number (1-3) of refactors should be planned to help demonstrate the pattern, especially in regards to things like using middleware to handle side-effects, how to structure local vs global state, and how to propagate state and actions to Composables and XML views.
-1. Where possible, new feature work should require refactoring to the established architecture before feature implementation. 
+1. Where possible, new feature work should require refactoring to the established architecture before feature implementation.
 1. Investigate further improvements to the architecture. For example, a "single Store" model that more closely follows Redux patterns.
 
 ### Consolidating Stores

--- a/fenix/docs/architecture-overview.md
+++ b/fenix/docs/architecture-overview.md
@@ -16,7 +16,7 @@ A store of State.
 
 See [mozilla.components.lib.state.Store](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/lib/state/src/main/java/mozilla/components/lib/state/Store.kt)
 
-Holds app State. 
+Holds app State.
 
 Receives [Actions](#action), which are used to compute new State using [Reducers](#reducer) and can have [Middlewares](#middleware) attached which respond to and manipulate actions.
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1825116