### PR TITLE
Bug 1852305 - Add review grade info to all error states

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
@@ -30,18 +30,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
-import org.mozilla.fenix.compose.ClickableSubstringLink
-import org.mozilla.fenix.compose.SwitchWithLabel
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.compose.button.SecondaryButton
-import org.mozilla.fenix.compose.parseHtml
-import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.HighlightType
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent
@@ -101,21 +96,16 @@ fun ProductAnalysis(
             )
         }
 
-        ReviewQualityCheckExpandableCard(
-            title = stringResource(id = R.string.review_quality_check_explanation_title),
+        ReviewQualityInfoCard(
             modifier = Modifier.fillMaxWidth(),
-        ) {
-            ReviewQualityInfo(
-                modifier = Modifier.fillMaxWidth(),
-                onLearnMoreClick = onReviewGradeLearnMoreClick,
-            )
-        }
+            onLearnMoreClick = onReviewGradeLearnMoreClick,
+        )
 
-        SettingsCard(
-            modifier = Modifier.fillMaxWidth(),
+        ReviewQualityCheckSettingsCard(
             productRecommendationsEnabled = productRecommendationsEnabled,
             onProductRecommendationsEnabledStateChange = onProductRecommendationsEnabledStateChange,
             onTurnOffReviewQualityCheckClick = onOptOutClick,
+            modifier = Modifier.fillMaxWidth(),
         )
     }
 }
@@ -316,143 +306,6 @@ private fun HighlightTitle(highlightType: HighlightType) {
     }
 }
 
-@Composable
-private fun SettingsCard(
-    productRecommendationsEnabled: Boolean,
-    onProductRecommendationsEnabledStateChange: (Boolean) -> Unit,
-    onTurnOffReviewQualityCheckClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    ReviewQualityCheckExpandableCard(
-        modifier = modifier,
-        title = stringResource(R.string.review_quality_check_settings_title),
-    ) {
-        Column {
-            Spacer(modifier = Modifier.height(8.dp))
-
-            SwitchWithLabel(
-                checked = productRecommendationsEnabled,
-                onCheckedChange = onProductRecommendationsEnabledStateChange,
-                label = stringResource(R.string.review_quality_check_settings_recommended_products),
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            SecondaryButton(
-                text = stringResource(R.string.review_quality_check_settings_turn_off),
-                onClick = onTurnOffReviewQualityCheckClick,
-            )
-        }
-    }
-}
-
-@Suppress("Deprecation")
-@Composable
-private fun ReviewQualityInfo(
-    modifier: Modifier = Modifier,
-    onLearnMoreClick: (String) -> Unit,
-) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(24.dp),
-    ) {
-        val adjustedGradingText =
-            stringResource(id = R.string.review_quality_check_explanation_body_adjusted_grading)
-        // Any and all text formatting (bullets, inline substring bolding, etc.) will be handled as
-        // follow-up when the copy is finalized.
-        // Bug 1848219
-        Text(
-            text = stringResource(
-                id = R.string.review_quality_check_explanation_body_reliability,
-                stringResource(R.string.shopping_product_name),
-            ),
-            color = FirefoxTheme.colors.textPrimary,
-            style = FirefoxTheme.typography.body2,
-        )
-
-        val link = stringResource(
-            id = R.string.review_quality_check_info_learn_more_link,
-            stringResource(R.string.shopping_product_name),
-        )
-        val text = stringResource(R.string.review_quality_check_info_learn_more, link)
-        val context = LocalContext.current
-        val linkStartIndex = text.indexOf(link)
-        val linkEndIndex = linkStartIndex + link.length
-        ClickableSubstringLink(
-            text = text,
-            textStyle = FirefoxTheme.typography.body2,
-            clickableStartIndex = linkStartIndex,
-            clickableEndIndex = linkEndIndex,
-            onClick = {
-                onLearnMoreClick(
-                    // Placeholder Sumo page
-                    SupportUtils.getSumoURLForTopic(
-                        context,
-                        SupportUtils.SumoTopic.HELP,
-                    ),
-                )
-            },
-        )
-
-        ReviewGradingScaleInfo(
-            reviewGrades = listOf(
-                ReviewQualityCheckState.Grade.A,
-                ReviewQualityCheckState.Grade.B,
-            ),
-            info = stringResource(id = R.string.review_quality_check_info_grade_info_AB),
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        ReviewGradingScaleInfo(
-            reviewGrades = listOf(ReviewQualityCheckState.Grade.C),
-            info = stringResource(id = R.string.review_quality_check_info_grade_info_C),
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        ReviewGradingScaleInfo(
-            reviewGrades = listOf(
-                ReviewQualityCheckState.Grade.D,
-                ReviewQualityCheckState.Grade.F,
-            ),
-            info = stringResource(id = R.string.review_quality_check_info_grade_info_DF),
-            modifier = Modifier.fillMaxWidth(),
-        )
-
-        Text(
-            text = remember(adjustedGradingText) { parseHtml(adjustedGradingText) },
-            color = FirefoxTheme.colors.textPrimary,
-            style = FirefoxTheme.typography.body2,
-        )
-    }
-}
-
-@Composable
-private fun ReviewGradingScaleInfo(
-    reviewGrades: List<ReviewQualityCheckState.Grade>,
-    info: String,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier.semantics(mergeDescendants = true) {},
-        verticalAlignment = Alignment.Top,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        reviewGrades.forEach { grade ->
-            ReviewGradeCompact(grade = grade)
-        }
-
-        if (reviewGrades.size == 1) {
-            Spacer(modifier = Modifier.width(24.dp))
-        }
-
-        Text(
-            text = info,
-            color = FirefoxTheme.colors.textPrimary,
-            style = FirefoxTheme.typography.body2,
-        )
-    }
-}
-
 private fun HighlightType.toHighlight() =
     when (this) {
         HighlightType.QUALITY -> Highlight.QUALITY
@@ -539,24 +392,6 @@ private fun ProductAnalysisPreview() {
                     productRecommendationsEnabled.value = it
                 },
                 onReviewGradeLearnMoreClick = {},
-            )
-        }
-    }
-}
-
-@Composable
-@LightDarkPreview
-private fun ReviewQualityInfoPreview() {
-    FirefoxTheme {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(color = FirefoxTheme.colors.layer1)
-                .padding(all = 16.dp),
-        ) {
-            ReviewQualityInfo(
-                modifier = Modifier.fillMaxWidth(),
-                onLearnMoreClick = {},
             )
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysisError.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysisError.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Product analysis error UI
+ *
+ * @param productRecommendationsEnabled The current state of the product recommendations toggle.
+ * @param onReviewGradeLearnMoreClick Invoked when the user clicks to learn more about review grades.
+ * @param onOptOutClick Invoked when the user opts out of the review quality check feature.
+ * @param onProductRecommendationsEnabledStateChange Invoked when the user changes the product
+ * recommendations toggle state.
+ * @param modifier Modifier to apply to the layout.
+ */
+@Composable
+fun ProductAnalysisError(
+    productRecommendationsEnabled: Boolean,
+    onReviewGradeLearnMoreClick: (String) -> Unit,
+    onOptOutClick: () -> Unit,
+    onProductRecommendationsEnabledStateChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // Error UI to be done in Bug 1840113
+
+        ReviewQualityInfoCard(
+            onLearnMoreClick = onReviewGradeLearnMoreClick,
+        )
+
+        ReviewQualityCheckSettingsCard(
+            productRecommendationsEnabled = productRecommendationsEnabled,
+            onProductRecommendationsEnabledStateChange = onProductRecommendationsEnabledStateChange,
+            onTurnOffReviewQualityCheckClick = onOptOutClick,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun ProductAnalysisErrorPreview() {
+    FirefoxTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = FirefoxTheme.colors.layer1)
+                .padding(all = 16.dp),
+        ) {
+            ProductAnalysisError(
+                productRecommendationsEnabled = true,
+                onReviewGradeLearnMoreClick = {},
+                onOptOutClick = {},
+                onProductRecommendationsEnabledStateChange = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckBottomSheet.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckBottomSheet.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.shopping.ui
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -105,7 +106,13 @@ private fun ProductReview(
             }
 
             is ReviewQualityCheckState.OptedIn.ProductReviewState.Error -> {
-                // Bug 1840113
+                ProductAnalysisError(
+                    productRecommendationsEnabled = state.productRecommendationsPreference,
+                    onReviewGradeLearnMoreClick = onReviewGradeLearnMoreClick,
+                    onOptOutClick = onOptOutClick,
+                    onProductRecommendationsEnabledStateChange = onProductRecommendationsEnabledStateChange,
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
 
             is ReviewQualityCheckState.OptedIn.ProductReviewState.Loading -> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckSettingsCard.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckSettingsCard.kt
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.R
+import org.mozilla.fenix.compose.SwitchWithLabel
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.compose.button.SecondaryButton
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Review quality check settings card UI. Contains toggles to disable product recommendations and
+ * the entire review quality check feature.
+ *
+ * @param productRecommendationsEnabled The current state of the product recommendations toggle.
+ * @param onProductRecommendationsEnabledStateChange Invoked when the user changes the product
+ * recommendations toggle state.
+ * @param onTurnOffReviewQualityCheckClick Invoked when the user opts out of the review quality check feature.
+ * @param modifier Modifier to apply to the layout.
+ */
+@Composable
+fun ReviewQualityCheckSettingsCard(
+    productRecommendationsEnabled: Boolean,
+    onProductRecommendationsEnabledStateChange: (Boolean) -> Unit,
+    onTurnOffReviewQualityCheckClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ReviewQualityCheckExpandableCard(
+        modifier = modifier,
+        title = stringResource(R.string.review_quality_check_settings_title),
+    ) {
+        SettingsContent(
+            productRecommendationsEnabled = productRecommendationsEnabled,
+            onProductRecommendationsEnabledStateChange = onProductRecommendationsEnabledStateChange,
+            onTurnOffReviewQualityCheckClick = onTurnOffReviewQualityCheckClick,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun SettingsContent(
+    productRecommendationsEnabled: Boolean,
+    onProductRecommendationsEnabledStateChange: (Boolean) -> Unit,
+    onTurnOffReviewQualityCheckClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Spacer(modifier = Modifier.height(8.dp))
+
+        SwitchWithLabel(
+            checked = productRecommendationsEnabled,
+            onCheckedChange = onProductRecommendationsEnabledStateChange,
+            label = stringResource(R.string.review_quality_check_settings_recommended_products),
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        SecondaryButton(
+            text = stringResource(R.string.review_quality_check_settings_turn_off),
+            onClick = onTurnOffReviewQualityCheckClick,
+        )
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun ReviewQualityCheckSettingsCardPreview() {
+    FirefoxTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = FirefoxTheme.colors.layer1)
+                .padding(all = 16.dp),
+        ) {
+            ReviewQualityCheckSettingsCard(
+                productRecommendationsEnabled = true,
+                onProductRecommendationsEnabledStateChange = {},
+                onTurnOffReviewQualityCheckClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@LightDarkPreview
+@Composable
+private fun SettingsContentPreview() {
+    FirefoxTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = FirefoxTheme.colors.layer1)
+                .padding(all = 16.dp),
+        ) {
+            SettingsContent(
+                productRecommendationsEnabled = true,
+                onProductRecommendationsEnabledStateChange = {},
+                onTurnOffReviewQualityCheckClick = {},
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityInfoCard.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityInfoCard.kt
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.R
+import org.mozilla.fenix.compose.ClickableSubstringLink
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.compose.parseHtml
+import org.mozilla.fenix.settings.SupportUtils
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Info card UI containing an explanation of the review quality.
+ *
+ * @param modifier Modifier to apply to the layout.
+ * @param onLearnMoreClick Invoked when the user clicks to learn more about review grades.
+ */
+@Composable
+fun ReviewQualityInfoCard(
+    modifier: Modifier = Modifier,
+    onLearnMoreClick: (String) -> Unit,
+) {
+    ReviewQualityCheckExpandableCard(
+        title = stringResource(id = R.string.review_quality_check_explanation_title),
+        modifier = modifier,
+    ) {
+        ReviewQualityInfo(
+            modifier = Modifier.fillMaxWidth(),
+            onLearnMoreClick = onLearnMoreClick,
+        )
+    }
+}
+
+@Suppress("Deprecation")
+@Composable
+private fun ReviewQualityInfo(
+    modifier: Modifier = Modifier,
+    onLearnMoreClick: (String) -> Unit,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        val adjustedGradingText =
+            stringResource(id = R.string.review_quality_check_explanation_body_adjusted_grading)
+        // Any and all text formatting (bullets, inline substring bolding, etc.) will be handled as
+        // follow-up when the copy is finalized.
+        // Bug 1848219
+        Text(
+            text = stringResource(
+                id = R.string.review_quality_check_explanation_body_reliability,
+                stringResource(R.string.shopping_product_name),
+            ),
+            color = FirefoxTheme.colors.textPrimary,
+            style = FirefoxTheme.typography.body2,
+        )
+
+        val link = stringResource(
+            id = R.string.review_quality_check_info_learn_more_link,
+            stringResource(R.string.shopping_product_name),
+        )
+        val text = stringResource(R.string.review_quality_check_info_learn_more, link)
+        val context = LocalContext.current
+        val linkStartIndex = text.indexOf(link)
+        val linkEndIndex = linkStartIndex + link.length
+        ClickableSubstringLink(
+            text = text,
+            textStyle = FirefoxTheme.typography.body2,
+            clickableStartIndex = linkStartIndex,
+            clickableEndIndex = linkEndIndex,
+            onClick = {
+                onLearnMoreClick(
+                    // Placeholder Sumo page
+                    SupportUtils.getSumoURLForTopic(
+                        context,
+                        SupportUtils.SumoTopic.HELP,
+                    ),
+                )
+            },
+        )
+
+        ReviewGradingScaleInfo(
+            reviewGrades = listOf(
+                ReviewQualityCheckState.Grade.A,
+                ReviewQualityCheckState.Grade.B,
+            ),
+            info = stringResource(id = R.string.review_quality_check_info_grade_info_AB),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        ReviewGradingScaleInfo(
+            reviewGrades = listOf(ReviewQualityCheckState.Grade.C),
+            info = stringResource(id = R.string.review_quality_check_info_grade_info_C),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        ReviewGradingScaleInfo(
+            reviewGrades = listOf(
+                ReviewQualityCheckState.Grade.D,
+                ReviewQualityCheckState.Grade.F,
+            ),
+            info = stringResource(id = R.string.review_quality_check_info_grade_info_DF),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Text(
+            text = remember(adjustedGradingText) { parseHtml(adjustedGradingText) },
+            color = FirefoxTheme.colors.textPrimary,
+            style = FirefoxTheme.typography.body2,
+        )
+    }
+}
+
+@Composable
+private fun ReviewGradingScaleInfo(
+    reviewGrades: List<ReviewQualityCheckState.Grade>,
+    info: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.semantics(mergeDescendants = true) {},
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        reviewGrades.forEach { grade ->
+            ReviewGradeCompact(grade = grade)
+        }
+
+        if (reviewGrades.size == 1) {
+            Spacer(modifier = Modifier.width(24.dp))
+        }
+
+        Text(
+            text = info,
+            color = FirefoxTheme.colors.textPrimary,
+            style = FirefoxTheme.typography.body2,
+        )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun ReviewQualityInfoCardPreview() {
+    FirefoxTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = FirefoxTheme.colors.layer1)
+                .padding(all = 16.dp),
+        ) {
+            ReviewQualityInfoCard(
+                modifier = Modifier.fillMaxWidth(),
+                onLearnMoreClick = {},
+            )
+        }
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun ReviewQualityInfoPreview() {
+    FirefoxTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = FirefoxTheme.colors.layer1)
+                .padding(all = 16.dp),
+        ) {
+            ReviewQualityInfo(
+                modifier = Modifier.fillMaxWidth(),
+                onLearnMoreClick = {},
+            )
+        }
+    }
+}


### PR DESCRIPTION
TLDR: The changes in this PR
- Made a `ProductAnalysisError` Composable to serve as the container for the error state UI to mirror `ProductAnalysis`.
- Refactored the review grade info UI to its own file.
- Added the review grade info to `ProductAnalysisError`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1852305