### PR TITLE
Bug 1852984 - Show the right theme for the extensions process crash dialog

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionProcessDisabledController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionProcessDisabledController.kt
@@ -4,9 +4,9 @@
 
 package org.mozilla.fenix.addons
 
-import android.app.AlertDialog
 import android.content.Context
 import androidx.annotation.UiContext
+import androidx.appcompat.app.AlertDialog
 import mozilla.components.browser.state.action.ExtensionProcessDisabledPopupAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
@@ -70,7 +70,7 @@ class ExtensionProcessDisabledController(
     @UiContext context: Context,
     store: BrowserStore,
     engine: Engine = context.components.core.engine,
-    builder: AlertDialog.Builder = AlertDialog.Builder(context, R.style.DialogStyleNormal),
+    builder: AlertDialog.Builder = AlertDialog.Builder(context),
     appName: String = context.appName,
 ) : ExtensionProcessDisabledPopupFeature(
     store,

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/ExtensionProcessDisabledControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/ExtensionProcessDisabledControllerTest.kt
@@ -4,9 +4,9 @@
 
 package org.mozilla.fenix.addons
 
-import android.app.AlertDialog
 import android.content.Context
 import android.content.DialogInterface.OnClickListener
+import androidx.appcompat.app.AlertDialog
 import mozilla.components.browser.state.action.ExtensionProcessDisabledPopupAction
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine


### PR DESCRIPTION
The root cause of the issue is the `import androidx.appcompat.app.AlertDialog` vs `import android.app.AlertDialog`, where `androidx` version is picking the right them while the `android.app`is not, we will follow up by adding a lint check to avoid possible future issues, we will follow up on [bug #1852992](https://bugzilla.mozilla.org/show_bug.cgi?id=1852992).


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1852984