### PR TITLE
Bug 1853013 - Ship 118.2.0 of feature-webcompat

### DIFF
--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/AboutCompat.sys.mjs
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/AboutCompat.sys.mjs
@@ -2,21 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-"use strict";
-
-var EXPORTED_SYMBOLS = ["AboutCompat"];
-
-const Services =
-  globalThis.Services ||
-  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
-
 const addonID = "webcompat@mozilla.org";
 const addonPageRelativeURL = "/about-compat/aboutCompat.html";
 
-function AboutCompat() {
+export function AboutCompat() {
   this.chromeURL =
     WebExtensionPolicy.getByID(addonID).getURL(addonPageRelativeURL);
 }
+
 AboutCompat.prototype = {
   QueryInterface: ChromeUtils.generateQI(["nsIAboutModule"]),
   getURIFlags() {

--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPage.js
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPage.js
@@ -4,11 +4,7 @@
 
 "use strict";
 
-/* global ExtensionAPI, XPCOMUtils */
-
-const Services =
-  globalThis.Services ||
-  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+/* global ExtensionAPI, XPCOMUtils, Services */
 
 XPCOMUtils.defineLazyServiceGetter(
   this,

--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPageProcessScript.js
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/about-compat/aboutPageProcessScript.js
@@ -19,8 +19,8 @@ if (!Cm.isCIDRegistered(classID)) {
   );
 
   const factory = ComponentUtils.generateSingletonFactory(function () {
-    const { AboutCompat } = ChromeUtils.import(
-      "resource://webcompat/AboutCompat.jsm"
+    const { AboutCompat } = ChromeUtils.importESModule(
+      "resource://webcompat/AboutCompat.sys.mjs"
     );
     return new AboutCompat();
   });

--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/data/shims.js
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/data/shims.js
@@ -589,7 +589,6 @@ const AVAILABLE_SHIMS = [
     ],
     contentScripts: [
       {
-        cookieStoreId: "firefox-private",
         js: "firebase.js",
         runAt: "document_start",
         matches: [
@@ -687,6 +686,7 @@ const AVAILABLE_SHIMS = [
       ["*://web.powerva.microsoft.com/*", "*://login.microsoftonline.com/*"],
       ["*://teams.microsoft.com/*", "*://login.microsoftonline.com/*"],
       ["*://*.teams.microsoft.us/*", "*://login.microsoftonline.us/*"],
+      ["*://www.msn.com/*", "*://login.microsoftonline.com/*"],
     ],
     contentScripts: [
       {
@@ -695,6 +695,7 @@ const AVAILABLE_SHIMS = [
           "*://web.powerva.microsoft.com/*",
           "*://teams.microsoft.com/*",
           "*://*.teams.microsoft.us/*",
+          "*://www.msn.com/*",
         ],
         runAt: "document_start",
       },

--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/data/ua_overrides.js
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/data/ua_overrides.js
@@ -486,7 +486,7 @@ const AVAILABLE_UA_OVERRIDES = [
     domain: "granbluefantasy.jp",
     bug: "1722954",
     config: {
-      matches: ["*://*.granbluefantasy.jp/*"],
+      matches: ["*://*.granbluefantasy.jp/*", "*://*.gbf.game.mbga.jp/*"],
       uaTransformer: originalUA => {
         return originalUA + " iPhone OS 12_0 like Mac OS X";
       },

--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Mozilla Android Components - Web Compatibility Interventions",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "118.0.0",
+  "version": "118.2.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "webcompat@mozilla.org",
@@ -65,6 +65,7 @@
 
   "permissions": [
     "mozillaAddons",
+    "scripting",
     "tabs",
     "webNavigation",
     "webRequest",

--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/shims/microsoftLogin.js
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/shims/microsoftLogin.js
@@ -14,7 +14,9 @@ console.warn(
 function init() {
   const observer = new MutationObserver(() => {
     document.body
-      .querySelectorAll("iframe[id^='msalRenewFrame'][sandbox]")
+      .querySelectorAll(
+        `iframe:is([id^='msalRenewFrame'], [src^="https://login.microsoftonline.com"])[sandbox]`
+      )
       .forEach(frame => {
         frame.sandbox.add(SANDBOX_ATTR);
       });


### PR DESCRIPTION
Shipping this now just to give us a little time during the nightly cycle to test a scripting API change, which is meant to help nudge the webcompat addon closer to working well with Fission on Fenix (there are also a few other ride-along changes which may also be good to test early).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
