### PR TITLE
Bug 1852802 - Prevents search suggestion prompt in private mode when felt privacy is enabled

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -163,15 +163,23 @@ class SearchDialogController(
                     settings.shouldShowSearchShortcuts,
             ),
         )
-        fragmentStore.dispatch(
-            SearchFragmentAction.AllowSearchSuggestionsInPrivateModePrompt(
-                text.isNotEmpty() &&
-                    activity.browsingModeManager.mode.isPrivate &&
-                    settings.shouldShowSearchSuggestions &&
-                    !settings.shouldShowSearchSuggestionsInPrivate &&
-                    !settings.showSearchSuggestionsInPrivateOnboardingFinished,
-            ),
-        )
+
+        // For felt private browsing mode we're no longer going to prompt the user to enable search
+        // suggestions while using private browsing mode. The preference to enable them will still
+        // remain in settings.
+        val isFeltPrivacyEnabled = settings.feltPrivateBrowsingEnabled
+
+        if (!isFeltPrivacyEnabled) {
+            fragmentStore.dispatch(
+                SearchFragmentAction.AllowSearchSuggestionsInPrivateModePrompt(
+                    text.isNotEmpty() &&
+                        activity.browsingModeManager.mode.isPrivate &&
+                        settings.shouldShowSearchSuggestions &&
+                        !settings.shouldShowSearchSuggestionsInPrivate &&
+                        !settings.showSearchSuggestionsInPrivateOnboardingFinished,
+                ),
+            )
+        }
     }
 
     override fun handleUrlTapped(url: String, flags: LoadUrlFlags) {

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -426,6 +426,30 @@ class SearchDialogControllerTest {
     }
 
     @Test
+    fun `WHEN felt privacy is enabled THEN do not dispatch AllowSearchSuggestionsInPrivateModePrompt`() {
+        every { settings.feltPrivateBrowsingEnabled } returns true
+
+        val text = "mozilla"
+
+        createController().handleTextChanged(text)
+        val actionSlot = mutableListOf<SearchFragmentAction>()
+        verify { store.dispatch(capture(actionSlot)) }
+        assertFalse(actionSlot.any { it is SearchFragmentAction.AllowSearchSuggestionsInPrivateModePrompt })
+    }
+
+    @Test
+    fun `WHEN felt privacy is disabled THEN dispatch AllowSearchSuggestionsInPrivateModePrompt`() {
+        every { settings.feltPrivateBrowsingEnabled } returns false
+
+        val text = "mozilla"
+
+        createController().handleTextChanged(text)
+        val actionSlot = mutableListOf<SearchFragmentAction>()
+        verify { store.dispatch(capture(actionSlot)) }
+        assertTrue(actionSlot.any { it is SearchFragmentAction.AllowSearchSuggestionsInPrivateModePrompt })
+    }
+
+    @Test
     fun handleUrlTapped() {
         val url = "https://www.google.com/"
         val flags = EngineSession.LoadUrlFlags.all()


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1852802