### PR TITLE
Bug 1847569 - Create analysis loading card

### DIFF
--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -2171,7 +2171,7 @@
     <!-- Clickable text for warning card informing the user that the current product is currently not available. Clicking this should inform the server that the product is available. -->
     <string name="review_quality_check_product_availability_warning_action" tools:ignore="UnusedResources">Report this product is back in stock</string>
     <!-- Title for warning card informing the user that the current product's re-analysis is still processing. -->
-    <string name="review_quality_check_reanalysis_in_progress_warning_title" tools:ignore="UnusedResources">Checking review quality</string>
+    <string name="review_quality_check_reanalysis_in_progress_warning_title">Checking review quality</string>
     <!-- Title for warning card informing the user that the current product's analysis is still processing. -->
     <string name="review_quality_check_analysis_in_progress_warning_title" tools:ignore="UnusedResources">Checking review quality</string>
     <!-- Text for body of warning card informing the user that the current product's analysis is still processing. -->


### PR DESCRIPTION
Opening this as a draft so the Compose code can be reviewed, but this can't land until the reanalysis API changes are incorporated.

I took this ticket as an opporutnity to refactor the previews of `ProductAnalysis`. Now, thanks to preview parameters, we can create any number of state permutations with very few lines of code. The original preview is now the default state for the preview parameters.

https://github.com/mozilla-mobile/firefox-android/assets/87384386/4ecad45e-228f-49b9-a659-a978e90aa816



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847569