### PR TITLE
Bug 1850833 - new telemetry for no-op menu exits

### DIFF
--- a/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
+++ b/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenu.kt
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.browser.menu.BrowserMenu.Orientation.DOWN
 import mozilla.components.browser.menu.BrowserMenu.Orientation.UP
+import mozilla.components.browser.menu.facts.emitMenuClosedFact
 import mozilla.components.browser.menu.view.DynamicWidthRecyclerView
 import mozilla.components.browser.menu.view.ExpandableLayout
 import mozilla.components.browser.menu.view.StickyItemPlacement
@@ -122,6 +123,7 @@ open class BrowserMenu internal constructor(
                 adapter.menu = null
                 currentPopup = null
                 isShown = false
+                emitMenuClosedFact()
                 onDismiss()
             }
 

--- a/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/facts/BrowserMenuFacts.kt
+++ b/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/facts/BrowserMenuFacts.kt
@@ -18,6 +18,8 @@ class BrowserMenuFacts {
      */
     object Items {
         const val WEB_EXTENSION_MENU_ITEM = "web_extension_menu_item"
+        const val MENU_OPEN_ITEM = "menu_open_item"
+        const val MENU_CLOSE_ITEM = "menu_close_item"
     }
 }
 
@@ -41,5 +43,19 @@ internal fun emitOpenMenuItemFact(extensionId: String) {
         Action.CLICK,
         BrowserMenuFacts.Items.WEB_EXTENSION_MENU_ITEM,
         metadata = mapOf("id" to extensionId),
+    )
+}
+
+internal fun emitMenuOpenedFact() {
+    emitMenuFact(
+        Action.OPEN,
+        BrowserMenuFacts.Items.MENU_OPEN_ITEM,
+    )
+}
+
+internal fun emitMenuClosedFact() {
+    emitMenuFact(
+        Action.INTERACTION,
+        BrowserMenuFacts.Items.MENU_CLOSE_ITEM,
     )
 }

--- a/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/MenuButton.kt
+++ b/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/view/MenuButton.kt
@@ -17,6 +17,7 @@ import mozilla.components.browser.menu.BrowserMenu.Orientation
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.R
+import mozilla.components.browser.menu.facts.emitMenuOpenedFact
 import mozilla.components.concept.menu.MenuButton
 import mozilla.components.concept.menu.MenuController
 import mozilla.components.concept.menu.candidate.HighPriorityHighlightEffect
@@ -153,6 +154,7 @@ class MenuButton @JvmOverloads constructor(
                 notifyObservers { onDismiss() }
             }
         }
+        emitMenuOpenedFact()
         notifyObservers { onShow() }
     }
 

--- a/android-components/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
+++ b/android-components/components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt
@@ -713,9 +713,9 @@ class DisplayToolbarTest {
 
             menuView.impl.performClick()
 
-            assertEquals(1, facts.size)
+            assertEquals(2, facts.size)
 
-            val fact = facts[0]
+            val fact = facts[1]
 
             assertEquals(Component.BROWSER_TOOLBAR, fact.component)
             assertEquals(Action.CLICK, fact.action)

--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -7062,6 +7062,23 @@ app_menu:
       tags:
         - Sync
         - Settings
+  user_no_operation_exit:
+    type: event
+    description: | 
+      User has opened and closed the browser menu without interacting with any menu item.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1850833
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/3669
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - Settings
+
 app_theme:
   dark_theme_selected:
     type: event
@@ -9346,6 +9363,22 @@ home_menu:
       tags:
         - Settings
         - MainMenu
+  user_no_operation_exit:
+    type: event
+    description: |
+      User has opened and closed the home page menu without interacting with any menu item.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1850833
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/3669
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - Settings
 
 home_screen:
   home_screen_displayed:

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -39,9 +39,12 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricsHelperService.Companion.BROWSER_ANCHOR
 import org.mozilla.fenix.components.toolbar.BrowserToolbarView
 import org.mozilla.fenix.components.toolbar.ToolbarMenu
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
@@ -436,6 +439,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         val context = requireContext()
         val settings = context.settings()
 
+        context.metrics.track(Event.UsageData.SetMenuAnchorFragment(BROWSER_ANCHOR))
         if (!settings.userKnowsAboutPwas) {
             pwaOnboardingObserver = PwaOnboardingObserver(
                 store = context.components.core.store,

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -31,6 +31,7 @@ import org.mozilla.fenix.components.metrics.DefaultMetricsStorage
 import org.mozilla.fenix.components.metrics.GleanMetricsService
 import org.mozilla.fenix.components.metrics.InstallReferrerMetricsService
 import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.components.metrics.MetricsHelperService
 import org.mozilla.fenix.components.metrics.MetricsStorage
 import org.mozilla.fenix.crashes.CrashFactCollector
 import org.mozilla.fenix.experiments.createNimbus
@@ -153,6 +154,7 @@ class Analytics(
                     crashReporter = crashReporter,
                 ),
                 InstallReferrerMetricsService(context),
+                MetricsHelperService(context),
             ),
             isDataTelemetryEnabled = { context.settings().isTelemetryEnabled },
             isMarketingDataTelemetryEnabled = { context.settings().isMarketingTelemetryEnabled },

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -54,4 +54,29 @@ sealed class Event {
          */
         data class UserActivated(val fromSearch: Boolean) : GrowthData("imgpmr")
     }
+
+    /**
+     * Events related to metric probe calculations.
+     */
+    sealed class UsageData : Event() {
+        /**
+         * Event setting the anchor fragment for the menu.
+         */
+        data class SetMenuAnchorFragment(val anchorFragment: String) : UsageData()
+
+        /**
+         * Event recording when a menu is opened.
+         */
+        object OpenMenu : UsageData()
+
+        /**
+         * Event recording when a menu is closed.
+         */
+        object CloseMenu : UsageData()
+
+        /**
+         * Event recording when a menu item is interacted with.
+         */
+        object InteractedWithMenu : UsageData()
+    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -176,6 +176,11 @@ internal class ReleaseMetricController(
             }
             Unit
         }
+        Component.BROWSER_MENU to BrowserMenuFacts.Items.MENU_CLOSE_ITEM ->
+            track(Event.UsageData.CloseMenu)
+        Component.BROWSER_MENU to BrowserMenuFacts.Items.MENU_OPEN_ITEM ->
+            track(Event.UsageData.OpenMenu)
+
         Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_FORM_DETECTED ->
             CreditCards.formDetected.record(NoExtras())
         Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SUCCESS ->

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricsHelperService.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricsHelperService.kt
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.metrics
+
+import android.content.Context
+import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.fenix.GleanMetrics.AppMenu
+import org.mozilla.fenix.GleanMetrics.HomeMenu
+import org.mozilla.fenix.ext.settings
+
+/**
+ * A helper service for telemetry events that require multiple intermediate
+ *     events to happen in order to send.
+ */
+class MetricsHelperService(private val context: Context) : MetricsService {
+    override val type = MetricServiceType.Data
+
+    val settings = context.settings()
+
+    override fun start() = Unit
+
+    override fun stop() = Unit
+
+    override fun track(event: Event) {
+        when (event) {
+            is Event.UsageData.SetMenuAnchorFragment -> {
+                settings.anchorFragment = event.anchorFragment
+            }
+            is Event.UsageData.OpenMenu -> {
+                settings.noOperationMenuOpen = true
+            }
+            is Event.UsageData.CloseMenu -> {
+                if (settings.noOperationMenuOpen) {
+                    when (settings.anchorFragment) {
+                        HOME_ANCHOR -> {
+                            HomeMenu.userNoOperationExit.record(NoExtras())
+                        }
+                        BROWSER_ANCHOR -> {
+                            AppMenu.userNoOperationExit.record(NoExtras())
+                        }
+                        else -> Unit
+                    }
+                }
+                settings.noOperationMenuOpen = false
+            }
+            is Event.UsageData.InteractedWithMenu -> {
+                settings.noOperationMenuOpen = false
+            }
+            else -> Unit
+        }
+    }
+
+    override fun shouldTrack(event: Event): Boolean {
+        return (event is Event.UsageData)
+    }
+
+    companion object {
+        const val HOME_ANCHOR = "HomeFragment"
+        const val BROWSER_ANCHOR = "BrowserFragment"
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricsStorage.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricsStorage.kt
@@ -100,6 +100,7 @@ internal class DefaultMetricsStorage(
                 is Event.GrowthData.UserActivated -> {
                     hasUserReachedActivatedThreshold()
                 }
+                else -> false
             }
         }
 
@@ -126,6 +127,7 @@ internal class DefaultMetricsStorage(
             is Event.GrowthData.UserActivated -> {
                 settings.growthUserActivatedSent = true
             }
+            else -> Unit
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -45,8 +45,10 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.accounts.AccountState
 import org.mozilla.fenix.components.accounts.FenixFxAEntryPoint
+import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
+import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.ext.openSetDefaultBrowserOption
@@ -422,6 +424,7 @@ class DefaultBrowserToolbarMenuController(
 
     @Suppress("ComplexMethod")
     private fun trackToolbarItemInteraction(item: ToolbarMenu.Item) {
+        activity.metrics.track(Event.UsageData.InteractedWithMenu)
         when (item) {
             is ToolbarMenu.Item.OpenInFenix ->
                 Events.browserMenuAction.record(Events.BrowserMenuActionExtra("open_in_fenix"))

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -86,11 +86,14 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.PrivateShortcutCreateManager
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricsHelperService.Companion.HOME_ANCHOR
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.databinding.FragmentHomeBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.containsQueryParameters
 import org.mozilla.fenix.ext.hideToolbar
+import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.scaleToBottomOfView
@@ -558,7 +561,10 @@ class HomeFragment : Fragment() {
             homeActivity = activity as HomeActivity,
             navController = findNavController(),
             menuButton = WeakReference(binding.menuButton),
-        ).also { it.build() }
+        ).also {
+            it.build()
+            view.context.metrics.track(Event.UsageData.SetMenuAnchorFragment(HOME_ANCHOR))
+        }
 
         tabCounterView = TabCounterView(
             context = requireContext(),

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
@@ -26,6 +26,8 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.accounts.AccountState
 import org.mozilla.fenix.components.accounts.FenixFxAEntryPoint
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.settings.SupportUtils
@@ -103,6 +105,7 @@ class HomeMenuView(
     @Suppress("LongMethod", "ComplexMethod")
     @VisibleForTesting(otherwise = PRIVATE)
     internal fun onItemTapped(item: HomeMenu.Item) {
+        context.metrics.track(Event.UsageData.InteractedWithMenu)
         when (item) {
             HomeMenu.Item.Settings -> {
                 HomeMenuMetrics.settingsItemClicked.record(NoExtras())

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -35,6 +35,7 @@ import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.components.metrics.MetricsHelperService.Companion.BROWSER_ANCHOR
 import org.mozilla.fenix.components.metrics.MozillaProductDetector
 import org.mozilla.fenix.components.settings.counterPreference
 import org.mozilla.fenix.components.settings.featureFlagPreference
@@ -1916,6 +1917,16 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     var hiddenEnginesRestored: Boolean by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_hidden_engines_restored),
         default = false,
+    )
+
+    var noOperationMenuOpen by booleanPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_usage_data_menu_no_operation_open),
+        default = false,
+    )
+
+    var anchorFragment by stringPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_usage_data_menu_anchor_fragment),
+        default = BROWSER_ANCHOR,
     )
 
     /**

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -119,7 +119,7 @@
     <string name="pref_key_show_sponsored_suggestions" translatable="false">pref_key_show_sponsored_suggestions</string>
     <string name="pref_key_show_nonsponsored_suggestions" translatable="false">pref_key_show_nonsponsored_suggestions</string>
     <string name="pref_key_learn_about_fx_suggest" translatable="false">pref_key_learn_about_fx_suggest</string>
-    
+
     <!-- Site Permissions Settings -->
     <string name="pref_key_site_permissions_description" translatable="false">pref_key_site_permissions_description</string>
     <string name="pref_key_show_site_exceptions" translatable="false">pref_key_show_site_exceptions</string>
@@ -386,4 +386,8 @@
     <string name="pref_key_should_show_review_quality_opt_in_time">pref_key_should_show_review_quality_opt_in_time</string>
     <string name="pref_key_should_show_review_quality_cfr_displayed_time">pref_key_should_show_review_quality_cfr_displayed_time</string>
     <string name="pref_key_review_quality_cfr_shown_counter">pref_key_review_quality_cfr_shown_counter</string>
+
+    <!-- Usage Data -->
+    <string name="pref_key_usage_data_menu_anchor_fragment" translatable="false">pref_key_usage_data_menu_anchor_fragment</string>
+    <string name="pref_key_usage_data_menu_no_operation_open" translatable="false">pref_key_usage_data_menu_no_operation_open</string>
 </resources>

--- a/fenix/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsHelperServiceTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsHelperServiceTest.kt
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.metrics
+
+import android.content.Context
+import io.mockk.every
+import mozilla.components.service.glean.testing.GleanTestRule
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.utils.Settings
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class MetricsHelperServiceTest {
+    val context: Context = testContext
+    lateinit var metricsHelperService: MetricsHelperService
+
+    @get:Rule
+    val gleanTestRule = GleanTestRule(testContext)
+
+    @Before
+    fun setup() {
+        every { context.settings() } returns Settings(testContext)
+        metricsHelperService = MetricsHelperService(context)
+    }
+
+    @Test
+    fun `WHEN an Event of type UsageData is sent THEN shouldTrack returns true`() {
+        assertTrue("shouldTrack UsageData", metricsHelperService.shouldTrack(Event.UsageData.OpenMenu))
+    }
+
+    @Test
+    fun `GIVEN default state of noOperationMenuOpen is false WHEN menu is opened THEN noOperationMenuOpen is set to true`() {
+        assertEquals(false, context.settings().noOperationMenuOpen)
+
+        metricsHelperService.track(Event.UsageData.OpenMenu)
+
+        assertEquals(true, context.settings().noOperationMenuOpen)
+    }
+
+    @Test
+    fun `GIVEN menu is opened WHEN menuItem is interacted with THEN noOperationMenuOpen is set to false`() {
+        metricsHelperService.track(Event.UsageData.OpenMenu)
+
+        assertEquals(true, context.settings().noOperationMenuOpen)
+
+        metricsHelperService.track(Event.UsageData.InteractedWithMenu)
+
+        assertEquals(false, context.settings().noOperationMenuOpen)
+    }
+
+    @Test
+    fun `WHEN setMenuAnchorFragment event is sent THEN saved anchor fragment reflects change`() {
+        assertEquals(MetricsHelperService.BROWSER_ANCHOR, context.settings().anchorFragment)
+
+        metricsHelperService.track(Event.UsageData.SetMenuAnchorFragment(MetricsHelperService.HOME_ANCHOR))
+
+        assertEquals(MetricsHelperService.HOME_ANCHOR, context.settings().anchorFragment)
+
+        metricsHelperService.track(Event.UsageData.SetMenuAnchorFragment(MetricsHelperService.BROWSER_ANCHOR))
+
+        assertEquals(MetricsHelperService.BROWSER_ANCHOR, context.settings().anchorFragment)
+    }
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/HomeMenuViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/HomeMenuViewTest.kt
@@ -27,8 +27,10 @@ import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.HomeScreen
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.Analytics
 import org.mozilla.fenix.components.accounts.AccountState
 import org.mozilla.fenix.components.accounts.FenixFxAEntryPoint
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -50,6 +52,7 @@ class HomeMenuViewTest {
     private lateinit var navController: NavController
     private lateinit var menuButton: MenuButton
     private lateinit var homeMenuView: HomeMenuView
+    private lateinit var analytics: Analytics
 
     @Before
     fun setup() {
@@ -57,6 +60,7 @@ class HomeMenuViewTest {
         lifecycleOwner = mockk(relaxed = true)
         homeActivity = mockk(relaxed = true)
         navController = mockk(relaxed = true)
+        analytics = mockk(relaxed = true)
 
         menuButton = spyk(MenuButton(testContext))
 
@@ -68,6 +72,8 @@ class HomeMenuViewTest {
             navController = navController,
             menuButton = WeakReference(menuButton),
         )
+
+        every { testContext.components.analytics } returns analytics
     }
 
     @Test


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






































### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1850833