### PR TITLE
Bug 1853654 - Advanced settings TestRail matching

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -47,9 +47,10 @@ class SettingsAddonsTest {
         mockWebServer.shutdown()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/875780
     // Walks through settings add-ons menu to ensure all items are present
     @Test
-    fun settingsAddonsItemsTest() {
+    fun verifyAddonsListItemsTest() {
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {
@@ -64,9 +65,10 @@ class SettingsAddonsTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/875781
     // Installs an add-on from the Add-ons menu and verifies the prompts
     @Test
-    fun installAddonTest() {
+    fun installAddonFromMainMenuTest() {
         val addonName = "uBlock Origin"
 
         homeScreen {}
@@ -92,9 +94,10 @@ class SettingsAddonsTest {
             }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/561597
     // Installs an addon, then uninstalls it
     @Test
-    fun verifyAddonsCanBeUninstalled() {
+    fun verifyAddonsCanBeUninstalledTest() {
         val addonName = "uBlock Origin"
 
         addonsMenu {
@@ -112,6 +115,7 @@ class SettingsAddonsTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/561600
     // Installs uBlock add-on and checks that the app doesn't crash while loading pages with trackers
     @SmokeTest
     @Test
@@ -133,9 +137,10 @@ class SettingsAddonsTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/561594
     @SmokeTest
     @Test
-    fun useAddonsInPrivateModeTest() {
+    fun verifyUBlockWorksInPrivateModeTest() {
         val addonName = "uBlock Origin"
         val genericPage = getGenericAsset(mockWebServer, 1)
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -50,9 +50,10 @@ class SettingsAdvancedTest {
         mockWebServer.shutdown()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2092699
     // Walks through settings menu and sub-menus to ensure all items are present
     @Test
-    fun settingsAdvancedItemsTest() {
+    fun verifyAdvancedSettingsSectionItemsTest() {
         // ADVANCED
         homeScreen {
         }.openThreeDotMenu {
@@ -71,19 +72,7 @@ class SettingsAdvancedTest {
         }
     }
 
-    @SmokeTest
-    @Test
-    fun verifyOpenLinkInAppViewTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openSettings {
-            verifyOpenLinksInAppsButton()
-            verifySettingsOptionSummary("Open links in apps", "Never")
-        }.openOpenLinksInAppsMenu {
-            verifyOpenLinksInAppsView("Never")
-        }
-    }
-
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2121046
     // Assumes Youtube is installed and enabled
     @SmokeTest
     @Test
@@ -109,6 +98,7 @@ class SettingsAdvancedTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2121052
     // Assumes Youtube is installed and enabled
     @Test
     fun privateBrowsingNeverOpenLinkInAppTest() {
@@ -136,6 +126,7 @@ class SettingsAdvancedTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2121045
     // Assumes Youtube is installed and enabled
     @SmokeTest
     @Test
@@ -167,6 +158,7 @@ class SettingsAdvancedTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2288347
     // Assumes Youtube is installed and enabled
     @SmokeTest
     @Test
@@ -198,6 +190,7 @@ class SettingsAdvancedTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2121051
     // Assumes Youtube is installed and enabled
     @Test
     fun privateBrowsingAskBeforeOpeningLinkInAppCancelTest() {
@@ -231,6 +224,7 @@ class SettingsAdvancedTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2288350
     // Assumes Youtube is installed and enabled
     @Test
     fun privateBrowsingAskBeforeOpeningLinkInAppOpenTest() {
@@ -264,6 +258,7 @@ class SettingsAdvancedTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1058618
     // Assumes Youtube is installed and enabled
     @Test
     fun alwaysOpenLinkInAppTest() {
@@ -292,6 +287,7 @@ class SettingsAdvancedTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1058617
     @Test
     fun dismissOpenLinksInAppCFRTest() {
         activityIntentTestRule.applySettingsExceptions {
@@ -308,6 +304,7 @@ class SettingsAdvancedTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2288331
     @Test
     fun goToSettingsFromOpenLinksInAppCFRTest() {
         activityIntentTestRule.applySettingsExceptions {


### PR DESCRIPTION
These changes are part of our data alignment between testRail and our automated UI tests.

For more information please see this [document](https://docs.google.com/document/d/1i9kftL_BiL3Lw-wrkCEi78T9ikp0H0B0vrKO2Zr4IyY/edit?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1853654