### PR TITLE
Bug 1853626 - Fix flaky verifyRenameTopSite UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTopSitesTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTopSitesTest.kt
@@ -16,7 +16,6 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
-import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestHelper.clickSnackbarButton
 import org.mozilla.fenix.helpers.TestHelper.generateRandomString
@@ -46,9 +45,6 @@ class ComposeTopSitesTest {
                 composeTopSitesEnabled = true,
             ),
         ) { it.activity }
-
-    @get:Rule
-    val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -16,7 +16,6 @@ import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.Constants.defaultTopSitesList
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
-import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestHelper.clickSnackbarButton
 import org.mozilla.fenix.helpers.TestHelper.generateRandomString
@@ -41,9 +40,6 @@ class TopSitesTest {
 
     @get:Rule
     val activityIntentTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
-
-    @get:Rule
-    val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTopSitesRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTopSitesRobot.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.ui.robots
 
-import android.widget.EditText
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasAnyChild
@@ -18,15 +17,13 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
-import androidx.test.espresso.Espresso
-import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.matcher.ViewMatchers
-import org.hamcrest.CoreMatchers
-import org.hamcrest.Matchers
-import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
+import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.home.topsites.TopSitesTestTag
 
 /**
@@ -40,7 +37,6 @@ class ComposeTopSitesRobot(private val composeTestRule: HomeActivityComposeTestR
     @OptIn(ExperimentalTestApi::class)
     fun verifyExistingTopSiteItem(vararg titles: String) {
         titles.forEach { title ->
-            itemContainingText(title).waitForExists(waitingTime)
             composeTestRule.waitUntilAtLeastOneExists(hasText(title), waitingTime)
             composeTestRule.topSiteItem(title).assertExists()
         }
@@ -110,15 +106,12 @@ class ComposeTopSitesRobot(private val composeTestRule: HomeActivityComposeTestR
             interact: ComposeTopSitesRobot.() -> Unit,
         ): Transition {
             composeTestRule.contextMenuItemRename().performClick()
-            Espresso.onView(
-                Matchers.allOf(
-                    ViewMatchers.withId(R.id.top_site_title),
-                    CoreMatchers.instanceOf(EditText::class.java),
-                ),
-            )
-                .perform(ViewActions.replaceText(title))
-            Espresso.onView(ViewMatchers.withId(android.R.id.button1))
-                .perform((ViewActions.click()))
+            itemWithResId("$packageName:id/top_site_title")
+                .also {
+                    it.waitForExists(waitingTimeShort)
+                    it.setText(title)
+                }
+            itemWithResIdContainingText("android:id/button1", "OK").click()
 
             ComposeTopSitesRobot(composeTestRule).interact()
             return Transition(composeTestRule)


### PR DESCRIPTION
Bug 1853626 - Fix flaky `verifyRenameTopSite` UI test

Summary:

- The `IllegalStateException` was caused by the fact the rules were not ordered. (Compose and RetryTestRule)

- Ordered the rules but afterwards noticed that the RetryTestRule wasn't actually helping that much, there are 9 UI tests in both test classes, and in 7 of them we add the website as a home screen shortcut using the "Add to shortcuts" button.
On retry, we already have that website added as a shortcut, meaning that "Add to shortcuts" button will be replaced with the "Remove from shortcuts" button causing failures.

- Finally, had to make some changes to `renameTopSite` (setting the new shortcut name and click the "OK" button)

The UI test successfully passed 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1853626