### PR TITLE
Bug 1853687 - Disable frequent failing test - get history metadata between

### DIFF
--- a/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
+++ b/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt
@@ -44,6 +44,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -961,6 +962,7 @@ class PlacesHistoryStorageTest {
         }
     }
 
+    @Ignore("Disabled: https://bugzilla.mozilla.org/show_bug.cgi?id=1853687")
     @Test
     fun `get history metadata between`() = runTestOnMain {
         assertEquals(0, history.getHistoryMetadataBetween(-1, 0).size)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1853687

This test started failing frequently since [A-S 119.20230915050340 merged](https://github.com/mozilla-mobile/firefox-android/pull/3659), it's impacting the stability of CI for GV bumps and nightly builds.


The test is racy, the current suspect is a [rust version bump in the A-S repo](https://github.com/mozilla/application-services/pull/5821) introduced a different performance profile, where a slower path is now faster.
