### PR TITLE
Bug 1853967 - Capture telemetry for the amount of RAM a device has.

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -2539,6 +2539,28 @@ metrics:
     metadata:
       tags:
         - Experiments
+  device_total_ram:
+    type: quantity
+    lifetime: application
+    description: >
+      The total amount of memory this device in bytes, when available will be
+      MemoryInfo.advertisedMem otherwise it will be MemoryInfo.totalMem.
+      This doesn't represent memory available to the application however.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1853967
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/2620
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+    unit: integer
+    metadata:
+      tags:
+        - Performance
   search_page_load_time:
     type: timing_distribution
     time_unit: millisecond

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -798,6 +798,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             )
 
             ramMoreThanThreshold.set(isDeviceRamAboveThreshold)
+            deviceTotalRam.set(getDeviceTotalRAM())
         }
 
         with(AndroidAutofill) {
@@ -846,12 +847,27 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         }
     }
 
-    private fun deviceRamApproxMegabytes(): Long {
+    @VisibleForTesting
+    internal fun getDeviceTotalRAM(): Long {
+        val memoryInfo = getMemoryInfo()
+        return if (SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            memoryInfo.advertisedMem
+        } else {
+            memoryInfo.totalMem
+        }
+    }
+
+    @VisibleForTesting
+    internal fun getMemoryInfo(): ActivityManager.MemoryInfo {
         val memoryInfo = ActivityManager.MemoryInfo()
         val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         activityManager.getMemoryInfo(memoryInfo)
 
-        val deviceRamBytes = memoryInfo.totalMem
+        return memoryInfo
+    }
+
+    private fun deviceRamApproxMegabytes(): Long {
+        val deviceRamBytes = getMemoryInfo().totalMem
         return deviceRamBytes.toRoundedMegabytes()
     }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
@@ -143,6 +143,7 @@ class FenixApplicationTest {
         every { settings.showPocketRecommendationsFeature } returns true
         every { settings.showContileFeature } returns true
         every { application.reportHomeScreenMetrics(settings) } just Runs
+        every { application.getDeviceTotalRAM() } returns 7L
         every { settings.inactiveTabsAreEnabled } returns true
 
         assertTrue(settings.contileContextId.isEmpty())
@@ -193,6 +194,7 @@ class FenixApplicationTest {
         assertEquals(expectedAppInstallSource, Metrics.installSource.testGetValue())
         assertEquals(true, Metrics.defaultWallpaper.testGetValue())
         assertEquals(true, Metrics.ramMoreThanThreshold.testGetValue())
+        assertEquals(7L, Metrics.deviceTotalRam.testGetValue())
 
         val contextId = TopSites.contextId.testGetValue()!!.toString()
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1853967