### PR TITLE
Bug 1850783 - Add button to open AMO from the fenix add-on manager

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterDelegate.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterDelegate.kt
@@ -30,4 +30,14 @@ interface AddonsManagerAdapterDelegate {
      * @param unsupportedAddons The list of unsupported [Addon].
      */
     fun onNotYetSupportedSectionClicked(unsupportedAddons: List<Addon>) = Unit
+
+    /**
+     * Handler to determine whether to show the "find more add-ons" button in the add-ons manager.
+     */
+    fun shouldShowFindMoreAddonsButton(): Boolean = false
+
+    /**
+     * Handler for when the "find more add-ons" button is clicked.
+     */
+    fun onFindMoreAddonsButtonClicked() = Unit
 }

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/CustomViewHolder.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/CustomViewHolder.kt
@@ -47,4 +47,9 @@ sealed class CustomViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val addButton: ImageView,
         val allowedInPrivateBrowsingLabel: ImageView,
     ) : CustomViewHolder(view)
+
+    /**
+     * A view holder for displaying a section below the list of add-ons.
+     */
+    class FooterViewHolder(view: View) : CustomViewHolder(view)
 }

--- a/android-components/components/feature/addons/src/main/res/layout/mozac_feature_addons_footer_section_item.xml
+++ b/android-components/components/feature/addons/src/main/res/layout/mozac_feature_addons_footer_section_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<Button xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:layout_marginStart="12dp"
+    android:layout_marginEnd="12dp"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="12dp"
+    android:text="@string/mozac_feature_addons_find_more_addons_button_text"
+    android:textAlignment="center"
+    android:textAllCaps="false"
+    android:textSize="14sp" />

--- a/android-components/components/feature/addons/src/main/res/values/strings.xml
+++ b/android-components/components/feature/addons/src/main/res/values/strings.xml
@@ -135,6 +135,8 @@
     <string name="mozac_feature_addons_addons">Add-ons</string>
     <!-- Label for add-ons sub menu item for add-ons manager-->
     <string name="mozac_feature_addons_addons_manager">Add-ons Manager</string>
+    <!-- Button in the add-ons manager that opens AMO in a tab -->
+    <string name="mozac_feature_addons_find_more_addons_button_text">Find more add-ons</string>
     <!-- The label of the allow button, this will be shown to the user when an add-on needs new permissions, with the button the user will indicate that they want to accept the new permissions and update the add-on-->
     <string name="mozac_feature_addons_updater_notification_allow_button">Allow</string>
     <!-- The label of the deny button on a notification, this will be shown to the user when an add-on needs new permissions. Indicates the user denies the new permissions and prevents the add-on from be updated-->

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
@@ -539,4 +539,37 @@ class AddonsManagerAdapterTest {
         unsupportedSectionViewHolder.itemView.performClick()
         verify(addonsManagerAdapterDelegate).onNotYetSupportedSectionClicked(unsupportedAddons)
     }
+
+    @Test
+    fun bindFooterButton() {
+        val addonsManagerAdapterDelegate: AddonsManagerAdapterDelegate = mock()
+        val adapter = AddonsManagerAdapter(mock(), addonsManagerAdapterDelegate, emptyList())
+        val view = View(testContext)
+        val viewHolder = CustomViewHolder.FooterViewHolder(view)
+        adapter.bindFooterButton(viewHolder)
+
+        viewHolder.itemView.performClick()
+        verify(addonsManagerAdapterDelegate).onFindMoreAddonsButtonClicked()
+    }
+
+    @Test
+    fun testFindMoreAddonsButtonIsHidden() {
+        val addonsManagerAdapterDelegate: AddonsManagerAdapterDelegate = mock()
+        whenever(addonsManagerAdapterDelegate.shouldShowFindMoreAddonsButton()).thenReturn(false)
+        val adapter = AddonsManagerAdapter(mock(), addonsManagerAdapterDelegate, emptyList())
+
+        val itemsWithSections = adapter.createListWithSections(emptyList())
+        assertTrue(itemsWithSections.isEmpty())
+    }
+
+    @Test
+    fun testFindMoreAddonsButtonIsVisible() {
+        val addonsManagerAdapterDelegate: AddonsManagerAdapterDelegate = mock()
+        whenever(addonsManagerAdapterDelegate.shouldShowFindMoreAddonsButton()).thenReturn(true)
+        val adapter = AddonsManagerAdapter(mock(), addonsManagerAdapterDelegate, emptyList())
+
+        val itemsWithSections = adapter.createListWithSections(emptyList())
+        assertFalse(itemsWithSections.isEmpty())
+        assertEquals(AddonsManagerAdapter.FooterSection, itemsWithSections.last())
+    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -26,8 +26,10 @@ import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.AddonManagerException
 import mozilla.components.feature.addons.ui.AddonsManagerAdapter
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
+import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.databinding.FragmentAddOnsManagementBinding
@@ -98,6 +100,7 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
         val managementView = AddonsManagementView(
             navController = findNavController(),
             onInstallButtonClicked = ::installAddon,
+            onMoreAddonsButtonClicked = ::openAMO,
         )
 
         val recyclerView = binding?.addOnsList
@@ -257,7 +260,20 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
         }
     }
 
+    private fun openAMO() {
+        (activity as HomeActivity).openToBrowserAndLoad(
+            searchTermOrURL = AMO_HOMEPAGE_FOR_ANDROID,
+            newTab = true,
+            from = BrowserDirection.FromGlobal,
+        )
+    }
+
     companion object {
         private const val BUNDLE_KEY_INSTALL_EXTERNAL_ADDON_COMPLETE = "INSTALL_EXTERNAL_ADDON_COMPLETE"
+
+        // This is locale-less on purpose so that the content negotiation happens on the AMO side because the current
+        // user language might not be supported by AMO and/or the language might not be exactly what AMO is expecting
+        // (e.g. `en` instead of `en-US`).
+        private const val AMO_HOMEPAGE_FOR_ANDROID = "https://addons.mozilla.org/android/"
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementView.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.addons
 import androidx.navigation.NavController
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.ui.AddonsManagerAdapterDelegate
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.navigateSafe
 
@@ -16,6 +17,7 @@ import org.mozilla.fenix.ext.navigateSafe
 class AddonsManagementView(
     private val navController: NavController,
     private val onInstallButtonClicked: (Addon) -> Unit,
+    private val onMoreAddonsButtonClicked: () -> Unit,
 ) : AddonsManagerAdapterDelegate {
 
     override fun onAddonItemClicked(addon: Addon) {
@@ -32,6 +34,14 @@ class AddonsManagementView(
 
     override fun onNotYetSupportedSectionClicked(unsupportedAddons: List<Addon>) {
         showNotYetSupportedAddonFragment(unsupportedAddons)
+    }
+
+    override fun shouldShowFindMoreAddonsButton(): Boolean {
+        return !Config.channel.isRelease
+    }
+
+    override fun onFindMoreAddonsButtonClicked() {
+        onMoreAddonsButtonClicked()
     }
 
     private fun showInstalledAddonDetailsFragment(addon: Addon) {

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonsManagementViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonsManagementViewTest.kt
@@ -31,10 +31,13 @@ class AddonsManagementViewTest {
     private var showPermissionDialog: (Addon) -> Unit = { permissionDialogDisplayed = true }
     private var permissionDialogDisplayed = false
 
+    private var onMoreAddonsButtonClicked: () -> Unit = { moreAddonsButtonClicked = true }
+    private var moreAddonsButtonClicked = false
+
     @Before
     fun setup() {
         MockKAnnotations.init(this)
-        managementView = AddonsManagementView(navController, showPermissionDialog)
+        managementView = AddonsManagementView(navController, showPermissionDialog, onMoreAddonsButtonClicked)
     }
 
     @Test
@@ -127,5 +130,11 @@ class AddonsManagementViewTest {
         verify {
             navController.navigate(directionsEq(expected))
         }
+    }
+
+    @Test
+    fun `onFindMoreAddonsButtonClicked calls onMoreAddonsButtonClicked`() {
+        managementView.onFindMoreAddonsButtonClicked()
+        assertTrue(moreAddonsButtonClicked)
     }
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- ~~[ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one~~
- ~~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features~~

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1850783