### PR TITLE
Bug 1840113 - Display review checker info cards

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
@@ -116,7 +116,7 @@ sealed interface ReviewQualityCheckState : State {
                  * The status of the product analysis.
                  */
                 enum class AnalysisStatus {
-                    NEEDS_ANALYSIS, REANALYZING, UP_TO_DATE, COMPLETED
+                    NEEDS_ANALYSIS, REANALYZING, UP_TO_DATE
                 }
             }
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStore.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.shopping.store
 
 import mozilla.components.lib.state.Store
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent.AnalysisStatus
 
 /**
@@ -74,20 +75,20 @@ private fun mapStateForUpdateAction(
 
         ReviewQualityCheckAction.FetchProductAnalysis, ReviewQualityCheckAction.RetryProductAnalysis -> {
             state.mapIfOptedIn {
-                it.copy(productReviewState = ReviewQualityCheckState.OptedIn.ProductReviewState.Loading)
+                it.copy(productReviewState = ProductReviewState.Loading)
             }
         }
 
         ReviewQualityCheckAction.ReanalyzeProduct -> {
             state.mapIfOptedIn {
                 when (it.productReviewState) {
-                    is ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent -> {
+                    is ProductReviewState.AnalysisPresent -> {
                         val productReviewState =
                             it.productReviewState.copy(analysisStatus = AnalysisStatus.REANALYZING)
                         it.copy(productReviewState = productReviewState)
                     }
 
-                    is ReviewQualityCheckState.OptedIn.ProductReviewState.NoAnalysisPresent -> {
+                    is ProductReviewState.NoAnalysisPresent -> {
                         it.copy(productReviewState = it.productReviewState.copy(isReanalyzing = true))
                     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
@@ -84,13 +84,25 @@ fun ProductAnalysis(
                 ReanalysisInProgressCard()
             }
 
-            AnalysisStatus.COMPLETED -> {
-                // TBD
-            }
-
             AnalysisStatus.UP_TO_DATE -> {
                 // no-op
             }
+        }
+
+        if (productAnalysis.notEnoughReviewsCardVisible) {
+            ReviewQualityCheckInfoCard(
+                title = stringResource(id = R.string.review_quality_check_no_reviews_warning_title),
+                description = stringResource(id = R.string.review_quality_check_no_reviews_warning_body),
+                type = ReviewQualityCheckInfoType.Info,
+                modifier = Modifier.fillMaxWidth(),
+                icon = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.mozac_ic_information_fill_24),
+                        contentDescription = null,
+                        tint = FirefoxTheme.colors.iconPrimary,
+                    )
+                },
+            )
         }
 
         if (productAnalysis.reviewGrade != null) {
@@ -447,9 +459,6 @@ private class ProductAnalysisPreviewModelParameterProvider :
             ),
             ProductAnalysisPreviewModel(
                 analysisStatus = AnalysisStatus.REANALYZING,
-            ),
-            ProductAnalysisPreviewModel(
-                analysisStatus = AnalysisStatus.COMPLETED,
             ),
             ProductAnalysisPreviewModel(
                 reviewGrade = null,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysisError.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysisError.kt
@@ -10,15 +10,21 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
  * Product analysis error UI
  *
+ * @param error The error state to display.
  * @param productRecommendationsEnabled The current state of the product recommendations toggle.
  * @param onReviewGradeLearnMoreClick Invoked when the user clicks to learn more about review grades.
  * @param onOptOutClick Invoked when the user opts out of the review quality check feature.
@@ -28,7 +34,9 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * @param modifier Modifier to apply to the layout.
  */
 @Composable
+@Suppress("LongParameterList")
 fun ProductAnalysisError(
+    error: ProductReviewState.Error,
     productRecommendationsEnabled: Boolean?,
     onReviewGradeLearnMoreClick: (String) -> Unit,
     onOptOutClick: () -> Unit,
@@ -40,7 +48,52 @@ fun ProductAnalysisError(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        // Error UI to be done in Bug 1840113
+        when (error) {
+            ProductReviewState.Error.GenericError ->
+                ReviewQualityCheckInfoCard(
+                    title = stringResource(id = R.string.review_quality_check_generic_error_title),
+                    description = stringResource(id = R.string.review_quality_check_generic_error_body),
+                    type = ReviewQualityCheckInfoType.Warning,
+                    modifier = Modifier.fillMaxWidth(),
+                    icon = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.mozac_ic_warning_fill_24),
+                            contentDescription = null,
+                            tint = FirefoxTheme.colors.iconPrimary,
+                        )
+                    },
+                )
+
+            ProductReviewState.Error.NetworkError ->
+                ReviewQualityCheckInfoCard(
+                    title = stringResource(id = R.string.review_quality_check_no_connection_title),
+                    description = stringResource(id = R.string.review_quality_check_no_connection_body),
+                    type = ReviewQualityCheckInfoType.Warning,
+                    modifier = Modifier.fillMaxWidth(),
+                    icon = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.mozac_ic_warning_fill_24),
+                            contentDescription = null,
+                            tint = FirefoxTheme.colors.iconPrimary,
+                        )
+                    },
+                )
+
+            ProductReviewState.Error.UnsupportedProductTypeError ->
+                ReviewQualityCheckInfoCard(
+                    title = stringResource(id = R.string.review_quality_check_not_analyzable_info_title),
+                    description = stringResource(id = R.string.review_quality_check_not_analyzable_info_body),
+                    type = ReviewQualityCheckInfoType.Info,
+                    modifier = Modifier.fillMaxWidth(),
+                    icon = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.mozac_ic_information_fill_24),
+                            contentDescription = null,
+                            tint = FirefoxTheme.colors.iconPrimary,
+                        )
+                    },
+                )
+        }
 
         ReviewQualityInfoCard(
             onLearnMoreClick = onReviewGradeLearnMoreClick,
@@ -70,6 +123,7 @@ private fun ProductAnalysisErrorPreview() {
                 .padding(all = 16.dp),
         ) {
             ProductAnalysisError(
+                error = ProductReviewState.Error.NetworkError,
                 productRecommendationsEnabled = true,
                 onReviewGradeLearnMoreClick = {},
                 onOptOutClick = {},

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckBottomSheet.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckBottomSheet.kt
@@ -119,6 +119,7 @@ private fun ProductReview(
 
             is ReviewQualityCheckState.OptedIn.ProductReviewState.Error -> {
                 ProductAnalysisError(
+                    error = productReviewState,
                     productRecommendationsEnabled = state.productRecommendationsPreference,
                     onReviewGradeLearnMoreClick = onReviewGradeLearnMoreClick,
                     onOptOutClick = onOptOutClick,

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -2163,9 +2163,9 @@
     <!-- Text for button from warning card informing the user that the current analysis is outdated. Clicking this should trigger the product's re-analysis. -->
     <string name="review_quality_check_outdated_analysis_warning_action" tools:ignore="UnusedResources">Check now</string>
     <!-- Title for warning card informing the user that the current product does not have enough reviews for a review analysis. -->
-    <string name="review_quality_check_no_reviews_warning_title" tools:ignore="UnusedResources">Not enough reviews yet</string>
+    <string name="review_quality_check_no_reviews_warning_title">Not enough reviews yet</string>
     <!-- Text for body of warning card informing the user that the current product does not have enough reviews for a review analysis. -->
-    <string name="review_quality_check_no_reviews_warning_body" tools:ignore="UnusedResources">When this product has more reviews, we’ll be able to check their quality.</string>
+    <string name="review_quality_check_no_reviews_warning_body">When this product has more reviews, we’ll be able to check their quality.</string>
     <!-- Title for warning card informing the user that the current product is currently not available. -->
     <string name="review_quality_check_product_availability_warning_title" tools:ignore="UnusedResources">Product is not available</string>
     <!-- Text for the body of warning card informing the user that the current product is currently not available. -->
@@ -2183,9 +2183,9 @@
     <!-- Text for body of info card displayed after the user reports a product is back in stock. -->
     <string name="review_quality_check_analysis_requested_info_body" tools:ignore="UnusedResources">We should have info about this product’s reviews within 24 hours. Please check back.</string>
     <!-- Title for info card displayed when the user review checker while on a product that Fakespot does not analyze (e.g. gift cards, music). -->
-    <string name="review_quality_check_not_analyzable_info_title" tools:ignore="UnusedResources">We can’t check these reviews</string>
+    <string name="review_quality_check_not_analyzable_info_title">We can’t check these reviews</string>
     <!-- Text for body of info card displayed when the user review checker while on a product that Fakespot does not analyze (e.g. gift cards, music). -->
-    <string name="review_quality_check_not_analyzable_info_body" tools:ignore="UnusedResources">Unfortunately, we can’t check the review quality for certain types of products. For example, gift cards and streaming video, music, and games.</string>
+    <string name="review_quality_check_not_analyzable_info_body">Unfortunately, we can’t check the review quality for certain types of products. For example, gift cards and streaming video, music, and games.</string>
     <!-- Title for info card displayed when another user reported the displayed product is back in stock. -->
     <string name="review_quality_check_analysis_requested_other_user_info_title" tools:ignore="UnusedResources">Info coming soon</string>
     <!-- Text for body of info card displayed when another user reported the displayed product is back in stock. -->
@@ -2195,13 +2195,13 @@
     <!-- Text for the action button from info card displayed to the user when analysis finished updating. -->
     <string name="review_quality_check_analysis_updated_confirmation_action" tools:ignore="UnusedResources">Got it</string>
     <!-- Title for error card displayed to the user when an error occurred. -->
-    <string name="review_quality_check_generic_error_title" tools:ignore="UnusedResources">No info available right now</string>
+    <string name="review_quality_check_generic_error_title">No info available right now</string>
     <!-- Text for body of error card displayed to the user when an error occurred. -->
-    <string name="review_quality_check_generic_error_body" tools:ignore="UnusedResources">We’re working to resolve the issue. Please check back soon.</string>
+    <string name="review_quality_check_generic_error_body">We’re working to resolve the issue. Please check back soon.</string>
     <!-- Title for error card displayed to the user when the device is disconnected from the network. -->
-    <string name="review_quality_check_no_connection_title" tools:ignore="UnusedResources">No network connection</string>
+    <string name="review_quality_check_no_connection_title">No network connection</string>
     <!-- Text for body of error card displayed to the user when the device is disconnected from the network. -->
-    <string name="review_quality_check_no_connection_body" tools:ignore="UnusedResources">Check your network connection and then try reloading the page.</string>
+    <string name="review_quality_check_no_connection_body">Check your network connection and then try reloading the page.</string>
     <!-- Title for card displayed to the user for products whose reviews were not analyzed yet. -->
     <string name="review_quality_check_no_analysis_title">No info about these reviews yet</string>
     <!-- Text for the body of card displayed to the user for products whose reviews were not analyzed yet. -->

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStateTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStateTest.kt
@@ -228,7 +228,7 @@ class ReviewQualityCheckStateTest {
         val analysisWithoutGrade = ProductAnalysisTestData.analysisPresent(
             reviewGrade = null,
             adjustedRating = 3.2f,
-            analysisStatus = AnalysisStatus.COMPLETED,
+            analysisStatus = AnalysisStatus.UP_TO_DATE,
         )
 
         val analysisWithoutRatings = ProductAnalysisTestData.analysisPresent(


### PR DESCRIPTION
### How
– Use the error types to display error [cards](https://www.figma.com/file/VE5xayz3yOSB5qOATUU9Im/Mobile-Shopping-Experience-MVP?type=design&node-id=2678-62307&mode=design&t=qIXMuZllp8FQINlt-0 :
1. "No network connection" when error is `NetworkError`
2. "We can't check these reviews" when error is `UnsupportedProductTypeError`
3. "No info available at this time"  when error is `GenericError`

– Display "Not enough reviews" when `productAnalysis.notEnoughReviewsCardVisible` is true.

~– Display analysis completed card when when `analysisStatus` is `AnalysisStatus.COMPLETED`~
~– Add `AnalysisCompleteConfirmation` action, when triggered, updates the `analysisState` from `COMPLETED` to `UP_TO_DATE`, dismissing the card when user clicks the confirmation button.~

[Figma for all the cards](https://www.figma.com/file/VE5xayz3yOSB5qOATUU9Im/Mobile-Shopping-Experience-MVP?type=design&node-id=5384-23225&mode=design&t=89pSv0BeQyfe5y2I-0)


### What's next
– Add analysis loading and update preview to include all cases with preview params with ~#3652~ #3715 
– Integrate reanalysis apis in network middleware with [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1853311).


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
5. Click on `View task in Taskcluster` in the new `DETAILS` section.
6. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1840113