### PR TITLE
Bug 1807536 - When user presses "Stay in private browsing" button from "Cancel private download" popup the tab should remain open.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -604,6 +604,13 @@ class TabsTrayFragment : AppCompatDialogFragment() {
             ),
 
             onPositiveButtonClicked = ::onCancelDownloadWarningAccepted,
+            onNegativeButtonClicked = {
+                tabsTrayStore.dispatch(
+                    TabsTrayAction.UpdatePrivateTabs(
+                        requireComponents.core.store.state.privateTabs,
+                    ),
+                )
+            },
         )
         dialog.show(parentFragmentManager, DOWNLOAD_CANCEL_DIALOG_FRAGMENT_TAG)
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
@@ -22,6 +22,7 @@ import io.mockk.verifyOrder
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
+import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.TabSessionState
@@ -226,7 +227,10 @@ class DefaultTabsTrayControllerTest {
                 },
             ),
         )
-        val tab: TabSessionState = mockk { every { content.private } returns true }
+        val tab: TabSessionState = mockk {
+            every { content.private } returns true
+            every { id } returns "testTabId"
+        }
         every { browserStore.state } returns mockk()
         every { browserStore.state.downloads } returns mapOf(
             "1" to DownloadState(
@@ -243,6 +247,10 @@ class DefaultTabsTrayControllerTest {
             every { browserStore.state.selectedTabId } returns "testTabId"
 
             controller.handleTabDeletion("testTabId", "unknown")
+
+            val privateTabs = browserStore.state.privateTabs.filter { privateTab -> privateTab.id != "testTabId" }
+
+            verify { trayStore.dispatch(TabsTrayAction.UpdatePrivateTabs(privateTabs)) }
 
             assertTrue(showCancelledDownloadWarningInvoked)
         } finally {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807536