### PR TITLE
Bug 1854354 - Bookmarks TestRail matching

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -27,7 +27,6 @@ import org.mozilla.fenix.helpers.MockBrowserDataHelper.createBookmarkItem
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.clickSnackbarButton
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
@@ -81,6 +80,7 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/522919
     @Test
     fun verifyEmptyBookmarksMenuTest() {
         homeScreen {
@@ -93,18 +93,6 @@ class BookmarksTest {
                 verifyAddFolderButton()
                 verifyCloseButton()
                 verifyBookmarkTitle("Desktop Bookmarks")
-            }
-        }
-    }
-
-    @Test
-    fun defaultDesktopBookmarksFoldersTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
-            ) {
                 selectFolder("Desktop Bookmarks")
                 verifyFolderTitle("Bookmarks Menu")
                 verifyFolderTitle("Bookmarks Toolbar")
@@ -116,54 +104,31 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2301370
     @Test
-    fun verifyBookmarkButtonTest() {
+    fun verifyAddBookmarkButtonTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openThreeDotMenu {
         }.bookmarkPage {
+            verifySnackBarText("Bookmark saved!")
         }.openThreeDotMenu {
             verifyEditBookmarkButton()
-        }
-    }
-
-    @Test
-    fun addBookmarkTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        browserScreen {
-            createBookmark(defaultWebPage.url)
-        }.openThreeDotMenu {
         }.openBookmarks {
             registerAndCleanupIdlingResources(
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
             ) {
+                verifyBookmarksMenuView()
+                verifyBookmarkTitle(defaultWebPage.title)
                 verifyBookmarkedURL(defaultWebPage.url.toString())
                 verifyBookmarkFavicon(defaultWebPage.url)
             }
         }
     }
 
-    @Test
-    fun createBookmarkFolderTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
-            ) {
-                clickAddFolderButton()
-                verifyKeyboardVisible()
-                addNewFolderName(bookmarksFolderName)
-                saveNewFolder()
-                verifyFolderTitle(bookmarksFolderName)
-                verifyKeyboardHidden()
-            }
-        }
-    }
-
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/522920
     @Test
     fun cancelCreateBookmarkFolderTest() {
         homeScreen {
@@ -177,9 +142,9 @@ class BookmarksTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2299619
     @Test
-    fun cancelEditBookmarkTest() {
+    fun cancelingChangesInEditModeAreNotSavedTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -202,9 +167,10 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/325633
     @SmokeTest
     @Test
-    fun editBookmarkTest() {
+    fun editBookmarksNameAndUrlTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -229,6 +195,7 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/341696
     @Test
     fun copyBookmarkURLTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -255,8 +222,9 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/325634
     @Test
-    fun threeDotMenuShareBookmarkTest() {
+    fun shareBookmarkTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -275,6 +243,7 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/325636
     @Test
     fun openBookmarkInNewTabTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -293,9 +262,10 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1919261
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807268")
     @Test
-    fun openAllInTabsTest() {
+    fun verifyOpenAllInNewTabsOptionTest() {
         val webPages = listOf(
             TestAssetHelper.getGenericAsset(mockWebServer, 1),
             TestAssetHelper.getGenericAsset(mockWebServer, 2),
@@ -336,9 +306,10 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1919262
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807268")
     @Test
-    fun openAllInPrivateTabsTest() {
+    fun verifyOpenAllInPrivateTabsTest() {
         val webPages = listOf(
             TestAssetHelper.getGenericAsset(mockWebServer, 1),
             TestAssetHelper.getGenericAsset(mockWebServer, 2),
@@ -372,6 +343,7 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/325637
     @Test
     fun openBookmarkInPrivateTabTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -390,28 +362,9 @@ class BookmarksTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/325635
     @Test
     fun deleteBookmarkTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        browserScreen {
-            createBookmark(defaultWebPage.url)
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
-            ) {}
-        }.openThreeDotMenu(defaultWebPage.title) {
-        }.clickDelete {
-            verifyDeleteSnackBarText()
-            verifyUndoDeleteSnackBarButton()
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun undoDeleteBookmarkTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -431,10 +384,13 @@ class BookmarksTest {
             ) {
                 verifyBookmarkedURL(defaultWebPage.url.toString())
             }
+        }.openThreeDotMenu(defaultWebPage.title) {
+        }.clickDelete {
+            verifyBookmarkIsDeleted(defaultWebPage.title)
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2300275
     @Test
     fun bookmarksMultiSelectionToolbarItemsTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -460,9 +416,10 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2300276
     @SmokeTest
     @Test
-    fun openSelectionInNewTabTest() {
+    fun openMultipleSelectedBookmarksInANewTabTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -489,9 +446,9 @@ class BookmarksTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2300277
     @Test
-    fun openSelectionInPrivateTabTest() {
+    fun openMultipleSelectedBookmarksInPrivateTabTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -513,38 +470,10 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/325644
     @SmokeTest
     @Test
-    fun deleteMultipleSelectionTest() {
-        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
-
-        browserScreen {
-            createBookmark(firstWebPage.url)
-            createBookmark(secondWebPage.url)
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 3),
-            ) {
-                longTapSelectItem(firstWebPage.url)
-                longTapSelectItem(secondWebPage.url)
-            }
-            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
-        }
-
-        multipleSelectionToolbar {
-            clickMultiSelectionDelete()
-        }
-
-        bookmarksMenu {
-            verifyDeleteMultipleBookmarksSnackBar()
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun undoDeleteMultipleSelectionTest() {
+    fun deleteMultipleSelectedBookmarksTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
@@ -571,11 +500,27 @@ class BookmarksTest {
             clickUndoDeleteButton()
             verifyBookmarkedURL(firstWebPage.url.toString())
             verifyBookmarkedURL(secondWebPage.url.toString())
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 3),
+            ) {
+                longTapSelectItem(firstWebPage.url)
+                longTapSelectItem(secondWebPage.url)
+            }
+            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+        }
+
+        multipleSelectionToolbar {
+            clickMultiSelectionDelete()
+        }
+
+        bookmarksMenu {
+            verifyDeleteMultipleBookmarksSnackBar()
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2301355
     @Test
-    fun multipleSelectionShareButtonTest() {
+    fun shareMultipleSelectedBookmarksTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -598,43 +543,9 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/325639
     @Test
-    fun multipleBookmarkDeletionsTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            createFolder("1")
-            getInstrumentation().waitForIdleSync()
-            createFolder("2")
-            getInstrumentation().waitForIdleSync()
-            createFolder("3")
-            getInstrumentation().waitForIdleSync()
-        }.openThreeDotMenu("1") {
-        }.clickDelete {
-            verifyDeleteFolderConfirmationMessage()
-            confirmDeletion()
-            verifyDeleteSnackBarText()
-        }.openThreeDotMenu("2") {
-        }.clickDelete {
-            verifyDeleteFolderConfirmationMessage()
-            confirmDeletion()
-            verifyDeleteSnackBarText()
-            verifyFolderTitle("3")
-            // On some devices we need to wait for the Snackbar to be gone before continuing
-            TestHelper.waitUntilSnackbarGone()
-        }.closeMenu {
-        }
-
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            verifyFolderTitle("3")
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun changeBookmarkParentFolderTest() {
+    fun createBookmarkFolderTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -643,13 +554,13 @@ class BookmarksTest {
         }.openBookmarks {
             registerAndCleanupIdlingResources(
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
-            ) {
-                createFolder(bookmarksFolderName)
-            }
+            ) {}
         }.openThreeDotMenu(defaultWebPage.title) {
         }.clickEdit {
             clickParentFolderSelector()
-            selectFolder(bookmarksFolderName)
+            clickAddNewFolderButtonFromSelectFolderView()
+            addNewFolderName(bookmarksFolderName)
+            saveNewFolder()
             navigateUp()
             saveEditBookmark()
             selectFolder(bookmarksFolderName)
@@ -657,6 +568,7 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/325645
     @Test
     fun navigateBookmarksFoldersTest() {
         homeScreen {
@@ -680,8 +592,9 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/374855
     @Test
-    fun cantSelectDesktopFoldersTest() {
+    fun cantSelectDefaultFoldersTest() {
         homeScreen {
         }.openThreeDotMenu {
         }.openBookmarks {
@@ -694,16 +607,7 @@ class BookmarksTest {
         }
     }
 
-    @Test
-    fun verifyCloseMenuTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-        }.closeMenu {
-            verifyHomeScreen()
-        }
-    }
-
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2299703
     @Test
     fun deleteBookmarkInEditModeTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -726,31 +630,7 @@ class BookmarksTest {
         }
     }
 
-    @SmokeTest
-    @Test
-    fun undoDeleteBookmarkFolderTest() {
-        browserScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
-            ) {
-                createFolder("My Folder")
-                verifyFolderTitle("My Folder")
-            }
-        }.openThreeDotMenu("My Folder") {
-        }.clickDelete {
-            cancelFolderDeletion()
-            verifyFolderTitle("My Folder")
-        }.openThreeDotMenu("My Folder") {
-        }.clickDelete {
-            confirmDeletion()
-            verifyDeleteSnackBarText()
-            clickUndoDeleteButton()
-            verifyFolderTitle("My Folder")
-        }
-    }
-
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715710
     @Test
     fun verifySearchBookmarksViewTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -788,6 +668,7 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715712
     @Test
     fun verifySearchForBookmarkedItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -817,6 +698,7 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715711
     @Test
     fun verifyVoiceSearchInBookmarksTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -832,8 +714,9 @@ class BookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715714
     @Test
-    fun verifyDeletedBookmarksCanNotBeSearchedTest() {
+    fun verifyDeletedBookmarksAreNotDisplayedAsSearchResultsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
         val thirdWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 3)
@@ -866,6 +749,53 @@ class BookmarksTest {
             // Search for a valid term
             typeSearch("generic")
             verifySuggestionsAreNotDisplayed(activityTestRule, thirdWebPage.url.toString())
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/325642
+    @SmokeTest
+    @Test
+    fun deleteBookmarkFoldersTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        browserScreen {
+            createBookmark(website.url)
+        }.openThreeDotMenu {
+        }.openBookmarks {
+            verifyBookmarkTitle("Test_Page_1")
+            createFolder("My Folder")
+            verifyFolderTitle("My Folder")
+        }.openThreeDotMenu("Test_Page_1") {
+        }.clickEdit {
+            clickParentFolderSelector()
+            selectFolder("My Folder")
+            navigateUp()
+            saveEditBookmark()
+            createFolder("My Folder 2")
+            verifyFolderTitle("My Folder 2")
+        }.openThreeDotMenu("My Folder 2") {
+        }.clickEdit {
+            clickParentFolderSelector()
+            selectFolder("My Folder")
+            navigateUp()
+            saveEditBookmark()
+        }.openThreeDotMenu("My Folder") {
+        }.clickDelete {
+            cancelFolderDeletion()
+            verifyFolderTitle("My Folder")
+        }.openThreeDotMenu("My Folder") {
+        }.clickDelete {
+            confirmDeletion()
+            verifyDeleteSnackBarText()
+            clickUndoDeleteButton()
+            verifyFolderTitle("My Folder")
+        }.openThreeDotMenu("My Folder") {
+        }.clickDelete {
+            confirmDeletion()
+            verifyDeleteSnackBarText()
+            verifyBookmarkIsDeleted("My Folder")
+            verifyBookmarkIsDeleted("My Folder 2")
+            verifyBookmarkIsDeleted("Test_Page_1")
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeBookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeBookmarksTest.kt
@@ -24,7 +24,6 @@ import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.clickSnackbarButton
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
@@ -91,18 +90,6 @@ class ComposeBookmarksTest {
                 verifyAddFolderButton()
                 verifyCloseButton()
                 verifyBookmarkTitle("Desktop Bookmarks")
-            }
-        }
-    }
-
-    @Test
-    fun defaultDesktopBookmarksFoldersTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
-            ) {
                 selectFolder("Desktop Bookmarks")
                 verifyFolderTitle("Bookmarks Menu")
                 verifyFolderTitle("Bookmarks Toolbar")
@@ -111,54 +98,6 @@ class ComposeBookmarksTest {
             }
         }.clickSingInToSyncButton {
             verifyTurnOnSyncToolbarTitle()
-        }
-    }
-
-    @Test
-    fun verifyBookmarkButtonTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-        }.openThreeDotMenu {
-        }.bookmarkPage {
-        }.openThreeDotMenu {
-            verifyEditBookmarkButton()
-        }
-    }
-
-    @Test
-    fun addBookmarkTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        browserScreen {
-            createBookmark(defaultWebPage.url)
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
-            ) {
-                verifyBookmarkedURL(defaultWebPage.url.toString())
-                verifyBookmarkFavicon(defaultWebPage.url)
-            }
-        }
-    }
-
-    @Test
-    fun createBookmarkFolderTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
-            ) {
-                clickAddFolderButton()
-                verifyKeyboardVisible()
-                addNewFolderName(bookmarksFolderName)
-                saveNewFolder()
-                verifyFolderTitle(bookmarksFolderName)
-                verifyKeyboardHidden()
-            }
         }
     }
 
@@ -175,9 +114,8 @@ class ComposeBookmarksTest {
         }
     }
 
-    @SmokeTest
     @Test
-    fun cancelEditBookmarkTest() {
+    fun cancelingChangesInEditModeAreNotSavedTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -202,7 +140,7 @@ class ComposeBookmarksTest {
 
     @SmokeTest
     @Test
-    fun editBookmarkTest() {
+    fun editBookmarksNameAndUrlTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -292,7 +230,7 @@ class ComposeBookmarksTest {
     }
 
     @Test
-    fun openAllInTabsTest() {
+    fun verifyOpenAllInNewTabsOptionTest() {
         val webPages = listOf(
             TestAssetHelper.getGenericAsset(mockWebServer, 1),
             TestAssetHelper.getGenericAsset(mockWebServer, 2),
@@ -334,7 +272,7 @@ class ComposeBookmarksTest {
     }
 
     @Test
-    fun openAllInPrivateTabsTest() {
+    fun verifyOpenAllInPrivateTabsTest() {
         val webPages = listOf(
             TestAssetHelper.getGenericAsset(mockWebServer, 1),
             TestAssetHelper.getGenericAsset(mockWebServer, 2),
@@ -386,28 +324,8 @@ class ComposeBookmarksTest {
         }
     }
 
-    @SmokeTest
     @Test
     fun deleteBookmarkTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        browserScreen {
-            createBookmark(defaultWebPage.url)
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
-            ) {}
-        }.openThreeDotMenu(defaultWebPage.title) {
-        }.clickDelete {
-            verifyDeleteSnackBarText()
-            verifyUndoDeleteSnackBarButton()
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun undoDeleteBookmarkTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -427,10 +345,12 @@ class ComposeBookmarksTest {
             ) {
                 verifyBookmarkedURL(defaultWebPage.url.toString())
             }
+        }.openThreeDotMenu(defaultWebPage.title) {
+        }.clickDelete {
+            verifyBookmarkIsDeleted(defaultWebPage.title)
         }
     }
 
-    @SmokeTest
     @Test
     fun bookmarksMultiSelectionToolbarItemsTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -458,7 +378,7 @@ class ComposeBookmarksTest {
 
     @SmokeTest
     @Test
-    fun openSelectionInNewTabTest() {
+    fun openMultipleSelectedBookmarksInANewTabTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -486,9 +406,8 @@ class ComposeBookmarksTest {
         }
     }
 
-    @SmokeTest
     @Test
-    fun openSelectionInPrivateTabTest() {
+    fun openMultipleSelectedBookmarksInPrivateTabTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -512,36 +431,7 @@ class ComposeBookmarksTest {
 
     @SmokeTest
     @Test
-    fun deleteMultipleSelectionTest() {
-        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
-
-        browserScreen {
-            createBookmark(firstWebPage.url)
-            createBookmark(secondWebPage.url)
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 3),
-            ) {
-                longTapSelectItem(firstWebPage.url)
-                longTapSelectItem(secondWebPage.url)
-            }
-            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
-        }
-
-        multipleSelectionToolbar {
-            clickMultiSelectionDelete()
-        }
-
-        bookmarksMenu {
-            verifyDeleteMultipleBookmarksSnackBar()
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun undoDeleteMultipleSelectionTest() {
+    fun deleteMultipleSelectedBookmarksTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
@@ -568,6 +458,21 @@ class ComposeBookmarksTest {
             clickUndoDeleteButton()
             verifyBookmarkedURL(firstWebPage.url.toString())
             verifyBookmarkedURL(secondWebPage.url.toString())
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 3),
+            ) {
+                longTapSelectItem(firstWebPage.url)
+                longTapSelectItem(secondWebPage.url)
+            }
+            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+        }
+
+        multipleSelectionToolbar {
+            clickMultiSelectionDelete()
+        }
+
+        bookmarksMenu {
+            verifyDeleteMultipleBookmarksSnackBar()
         }
     }
 
@@ -596,42 +501,7 @@ class ComposeBookmarksTest {
     }
 
     @Test
-    fun multipleBookmarkDeletionsTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            createFolder("1")
-            getInstrumentation().waitForIdleSync()
-            createFolder("2")
-            getInstrumentation().waitForIdleSync()
-            createFolder("3")
-            getInstrumentation().waitForIdleSync()
-        }.openThreeDotMenu("1") {
-        }.clickDelete {
-            verifyDeleteFolderConfirmationMessage()
-            confirmDeletion()
-            verifyDeleteSnackBarText()
-        }.openThreeDotMenu("2") {
-        }.clickDelete {
-            verifyDeleteFolderConfirmationMessage()
-            confirmDeletion()
-            verifyDeleteSnackBarText()
-            verifyFolderTitle("3")
-            // On some devices we need to wait for the Snackbar to be gone before continuing
-            TestHelper.waitUntilSnackbarGone()
-        }.closeMenu {
-        }
-
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            verifyFolderTitle("3")
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun changeBookmarkParentFolderTest() {
+    fun createBookmarkFolderTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         browserScreen {
@@ -640,13 +510,13 @@ class ComposeBookmarksTest {
         }.openBookmarks {
             registerAndCleanupIdlingResources(
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
-            ) {
-                createFolder(bookmarksFolderName)
-            }
+            ) {}
         }.openThreeDotMenu(defaultWebPage.title) {
         }.clickEdit {
             clickParentFolderSelector()
-            selectFolder(bookmarksFolderName)
+            clickAddNewFolderButtonFromSelectFolderView()
+            addNewFolderName(bookmarksFolderName)
+            saveNewFolder()
             navigateUp()
             saveEditBookmark()
             selectFolder(bookmarksFolderName)
@@ -692,16 +562,6 @@ class ComposeBookmarksTest {
     }
 
     @Test
-    fun verifyCloseMenuTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-        }.closeMenu {
-            verifyHomeScreen()
-        }
-    }
-
-    @Test
     fun deleteBookmarkInEditModeTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
@@ -720,31 +580,6 @@ class ComposeBookmarksTest {
             confirmDeletion()
             verifyDeleteSnackBarText()
             verifyBookmarkIsDeleted("Test_Page_1")
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun undoDeleteBookmarkFolderTest() {
-        browserScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
-            ) {
-                createFolder("My Folder")
-                verifyFolderTitle("My Folder")
-            }
-        }.openThreeDotMenu("My Folder") {
-        }.clickDelete {
-            cancelFolderDeletion()
-            verifyFolderTitle("My Folder")
-        }.openThreeDotMenu("My Folder") {
-        }.clickDelete {
-            confirmDeletion()
-            verifyDeleteSnackBarText()
-            clickUndoDeleteButton()
-            verifyFolderTitle("My Folder")
         }
     }
 
@@ -788,6 +623,7 @@ class ComposeBookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715712
     @Test
     fun verifySearchForBookmarkedItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -833,8 +669,9 @@ class ComposeBookmarksTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715714
     @Test
-    fun verifyDeletedBookmarksCanNotBeSearchedTest() {
+    fun verifyDeletedBookmarksAreNotDisplayedAsSearchResultsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
         val thirdWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 3)
@@ -867,6 +704,54 @@ class ComposeBookmarksTest {
             // Search for a valid term
             typeSearch("generic")
             verifySuggestionsAreNotDisplayed(activityTestRule, thirdWebPage.url.toString())
+        }
+    }
+
+    // Verifies that deleting a Bookmarks folder also removes the item from inside it.
+    @SmokeTest
+    @Test
+    fun deleteBookmarkFoldersTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        browserScreen {
+            createBookmark(website.url)
+        }.openThreeDotMenu {
+        }.openBookmarks {
+            verifyBookmarkTitle("Test_Page_1")
+            createFolder("My Folder")
+            verifyFolderTitle("My Folder")
+        }.openThreeDotMenu("Test_Page_1") {
+        }.clickEdit {
+            clickParentFolderSelector()
+            selectFolder("My Folder")
+            navigateUp()
+            saveEditBookmark()
+            createFolder("My Folder 2")
+            verifyFolderTitle("My Folder 2")
+        }.openThreeDotMenu("My Folder 2") {
+        }.clickEdit {
+            clickParentFolderSelector()
+            selectFolder("My Folder")
+            navigateUp()
+            saveEditBookmark()
+        }.openThreeDotMenu("My Folder") {
+        }.clickDelete {
+            cancelFolderDeletion()
+            verifyFolderTitle("My Folder")
+        }.openThreeDotMenu("My Folder") {
+        }.clickDelete {
+            confirmDeletion()
+            verifyDeleteSnackBarText()
+            clickUndoDeleteButton()
+            verifyFolderTitle("My Folder")
+        }.openThreeDotMenu("My Folder") {
+        }.clickDelete {
+            confirmDeletion()
+            verifyDeleteSnackBarText()
+            verifyBookmarkIsDeleted("My Folder")
+            verifyBookmarkIsDeleted("My Folder 2")
+            verifyBookmarkIsDeleted("Test_Page_1")
+            navigateUp()
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
@@ -85,52 +85,6 @@ class ComposeSmokeTest {
         mockWebServer.shutdown()
     }
 
-    // Verifies that deleting a Bookmarks folder also removes the item from inside it.
-    @Test
-    fun deleteNonEmptyBookmarkFolderTest() {
-        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        browserScreen {
-            createBookmark(website.url)
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            verifyBookmarkTitle("Test_Page_1")
-            createFolder("My Folder")
-            verifyFolderTitle("My Folder")
-        }.openThreeDotMenu("Test_Page_1") {
-        }.clickEdit {
-            clickParentFolderSelector()
-            selectFolder("My Folder")
-            navigateUp()
-            saveEditBookmark()
-            createFolder("My Folder 2")
-            verifyFolderTitle("My Folder 2")
-        }.openThreeDotMenu("My Folder 2") {
-        }.clickEdit {
-            clickParentFolderSelector()
-            selectFolder("My Folder")
-            navigateUp()
-            saveEditBookmark()
-        }.openThreeDotMenu("My Folder") {
-        }.clickDelete {
-            cancelFolderDeletion()
-            verifyFolderTitle("My Folder")
-        }.openThreeDotMenu("My Folder") {
-        }.clickDelete {
-            confirmDeletion()
-            verifyDeleteSnackBarText()
-            verifyBookmarkIsDeleted("My Folder")
-            verifyBookmarkIsDeleted("My Folder 2")
-            verifyBookmarkIsDeleted("Test_Page_1")
-            navigateUp()
-        }
-
-        browserScreen {
-        }.openThreeDotMenu {
-            verifyAddBookmarkButton()
-        }
-    }
-
     @Test
     fun shareTabsFromTabsTrayTest() {
         val firstWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.ui
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -574,6 +575,7 @@ class CreditCardAutofillTest {
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1512791
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1854566")
     @Test
     fun verifyCreditCardRedirectionsToAutofillSectionAfterInterruptionTest() {
         homeScreen {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -83,52 +83,6 @@ class SmokeTest {
         mockWebServer.shutdown()
     }
 
-    // Verifies that deleting a Bookmarks folder also removes the item from inside it.
-    @Test
-    fun deleteNonEmptyBookmarkFolderTest() {
-        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        browserScreen {
-            createBookmark(website.url)
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            verifyBookmarkTitle("Test_Page_1")
-            createFolder("My Folder")
-            verifyFolderTitle("My Folder")
-        }.openThreeDotMenu("Test_Page_1") {
-        }.clickEdit {
-            clickParentFolderSelector()
-            selectFolder("My Folder")
-            navigateUp()
-            saveEditBookmark()
-            createFolder("My Folder 2")
-            verifyFolderTitle("My Folder 2")
-        }.openThreeDotMenu("My Folder 2") {
-        }.clickEdit {
-            clickParentFolderSelector()
-            selectFolder("My Folder")
-            navigateUp()
-            saveEditBookmark()
-        }.openThreeDotMenu("My Folder") {
-        }.clickDelete {
-            cancelFolderDeletion()
-            verifyFolderTitle("My Folder")
-        }.openThreeDotMenu("My Folder") {
-        }.clickDelete {
-            confirmDeletion()
-            verifyDeleteSnackBarText()
-            verifyBookmarkIsDeleted("My Folder")
-            verifyBookmarkIsDeleted("My Folder 2")
-            verifyBookmarkIsDeleted("Test_Page_1")
-            navigateUp()
-        }
-
-        browserScreen {
-        }.openThreeDotMenu {
-            verifyAddBookmarkButton()
-        }
-    }
-
     @Test
     fun shareTabsFromTabsTrayTest() {
         val firstWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -188,6 +188,13 @@ class BookmarksRobot {
         addFolderButton().click()
     }
 
+    fun clickAddNewFolderButtonFromSelectFolderView() =
+        itemWithResId("$packageName:id/add_folder_button")
+            .also {
+                it.waitForExists(waitingTime)
+                it.click()
+            }
+
     fun addNewFolderName(name: String) {
         addFolderTitleField()
             .click()


### PR DESCRIPTION
These changes are part of our data alignment between testRail and our automated UI tests.

For more information please see this [document](https://docs.google.com/document/d/1lRN75vjmqFHqT4aG21JPSriQbUSahCxJplWSi2ec-lw/edit?usp=sharing)

Deleted the following UI tests that don't have any coresponding manual test in TestRail:
- `verifyBookmarkButtonTest` 
- `addBookmarkTest`
- `multipleBookmarkDeletionsTest`
- `verifyCloseMenuTest` 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1854354
https://bugzilla.mozilla.org/show_bug.cgi?id=1854566