### PR TITLE
Bug 1811976 - Hide Sync FAB in TabsTray when user not signed in

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/FloatingActionButtonBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/FloatingActionButtonBinding.kt
@@ -21,6 +21,7 @@ class FloatingActionButtonBinding(
     store: TabsTrayStore,
     private val actionButton: ExtendedFloatingActionButton,
     private val interactor: TabsTrayFabInteractor,
+    private val isSignedIn: Boolean,
 ) : AbstractBinding<TabsTrayState>(store) {
 
     override suspend fun onState(flow: Flow<TabsTrayState>) {
@@ -62,20 +63,25 @@ class FloatingActionButtonBinding(
                 }
             }
             Page.SyncedTabs -> {
-                actionButton.apply {
-                    setText(
-                        when (syncing) {
-                            true -> R.string.sync_syncing_in_progress
-                            false -> R.string.tab_drawer_fab_sync
-                        },
-                    )
-                    contentDescription = context.getString(R.string.resync_button_content_description)
-                    extend()
-                    show()
-                    setIconResource(R.drawable.ic_fab_sync)
-                    setOnClickListener {
-                        interactor.onSyncedTabsFabClicked()
+                if (isSignedIn) {
+                    actionButton.apply {
+                        setText(
+                            when (syncing) {
+                                true -> R.string.sync_syncing_in_progress
+                                false -> R.string.tab_drawer_fab_sync
+                            },
+                        )
+                        contentDescription =
+                            context.getString(R.string.resync_button_content_description)
+                        extend()
+                        show()
+                        setIconResource(R.drawable.ic_fab_sync)
+                        setOnClickListener {
+                            interactor.onSyncedTabsFabClicked()
+                        }
                     }
+                } else {
+                    actionButton.hide()
                 }
             }
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFab.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFab.kt
@@ -22,6 +22,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * Floating action button for tabs tray.
  *
  * @param tabsTrayStore [TabsTrayStore] used to listen for changes to [TabsTrayState].
+ * @param isSignedIn Used to know when to show the SYNC FAB when [Page.SyncedTabs] is displayed.
  * @param onNormalTabsFabClicked Invoked when the fab is clicked in [Page.NormalTabs].
  * @param onPrivateTabsFabClicked Invoked when the fab is clicked in [Page.PrivateTabs].
  * @param onSyncedTabsFabClicked Invoked when the fab is clicked in [Page.SyncedTabs].
@@ -29,6 +30,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
 @Composable
 fun TabsTrayFab(
     tabsTrayStore: TabsTrayStore,
+    isSignedIn: Boolean,
     onNormalTabsFabClicked: () -> Unit,
     onPrivateTabsFabClicked: () -> Unit,
     onSyncedTabsFabClicked: () -> Unit,
@@ -75,7 +77,7 @@ fun TabsTrayFab(
         }
     }
 
-    if (isInNormalMode) {
+    if (isInNormalMode && !(currentPage == Page.SyncedTabs && !isSignedIn)) {
         FloatingActionButton(
             icon = icon,
             modifier = Modifier
@@ -99,7 +101,13 @@ private fun TabsTraySyncFabPreview() {
     )
 
     FirefoxTheme {
-        TabsTrayFab(store, {}, {}, {})
+        TabsTrayFab(
+            tabsTrayStore = store,
+            isSignedIn = true,
+            onNormalTabsFabClicked = {},
+            onPrivateTabsFabClicked = {},
+            onSyncedTabsFabClicked = {},
+        )
     }
 }
 
@@ -112,6 +120,12 @@ private fun TabsTrayPrivateFabPreview() {
         ),
     )
     FirefoxTheme {
-        TabsTrayFab(store, {}, {}, {})
+        TabsTrayFab(
+            tabsTrayStore = store,
+            isSignedIn = true,
+            onNormalTabsFabClicked = {},
+            onPrivateTabsFabClicked = {},
+            onSyncedTabsFabClicked = {},
+        )
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -313,6 +313,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                 FirefoxTheme(theme = Theme.getTheme(allowPrivateTheme = false)) {
                     TabsTrayFab(
                         tabsTrayStore = tabsTrayStore,
+                        isSignedIn = requireContext().settings().signedInFxaAccount,
                         onNormalTabsFabClicked = tabsTrayInteractor::onNormalTabsFabClicked,
                         onPrivateTabsFabClicked = tabsTrayInteractor::onPrivateTabsFabClicked,
                         onSyncedTabsFabClicked = tabsTrayInteractor::onSyncedTabsFabClicked,
@@ -463,6 +464,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                     store = tabsTrayStore,
                     actionButton = fabButtonBinding.newTabButton,
                     interactor = tabsTrayInteractor,
+                    isSignedIn = requireContext().settings().signedInFxaAccount,
                 ),
                 owner = this,
                 view = view,

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/FloatingActionButtonBindingTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/FloatingActionButtonBindingTest.kt
@@ -48,6 +48,7 @@ class FloatingActionButtonBindingTest {
             tabsTrayStore,
             actionButton,
             interactor,
+            true,
         )
 
         fabBinding.start()
@@ -65,6 +66,7 @@ class FloatingActionButtonBindingTest {
             tabsTrayStore,
             actionButton,
             interactor,
+            true,
         )
 
         fabBinding.start()
@@ -82,6 +84,7 @@ class FloatingActionButtonBindingTest {
             tabsTrayStore,
             actionButton,
             interactor,
+            true,
         )
 
         fabBinding.start()
@@ -93,12 +96,31 @@ class FloatingActionButtonBindingTest {
     }
 
     @Test
+    fun `GIVEN the selected tab page is sync WHEN the user is not signed in THEN extend and show is called`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.SyncedTabs))
+        val fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore,
+            actionButton,
+            interactor,
+            false,
+        )
+
+        fabBinding.start()
+
+        verify(exactly = 0) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.show() }
+        verify(exactly = 0) { actionButton.shrink() }
+        verify(exactly = 1) { actionButton.hide() }
+    }
+
+    @Test
     fun `WHEN selected page is updated THEN button is updated`() {
         val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
         val fabBinding = FloatingActionButtonBinding(
             tabsTrayStore,
             actionButton,
             interactor,
+            true,
         )
 
         fabBinding.start()


### PR DESCRIPTION
If there is no user signed in, the SYNC FAB should not be displayed in the sync page of the tabs tray.

| Signed out | Signed in |
|----------------|-------------------------------|
| ![Screenshot_20230921_134818](https://github.com/mozilla-mobile/firefox-android/assets/32488956/590d2610-a1a1-4f94-99d1-15df64dffbc3) | ![Screenshot_20230921_134914](https://github.com/mozilla-mobile/firefox-android/assets/32488956/bd0d9efd-1e76-450d-b567-120b5c16b793) |






### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1811976