### PR TITLE
Bug 1853311 - Add review checker reanalysis logic

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFragment.kt
@@ -35,7 +35,7 @@ class ReviewQualityCheckFragment : BottomSheetDialogFragment() {
             middleware = ReviewQualityCheckMiddlewareProvider.provideMiddleware(
                 settings = requireComponents.settings,
                 browserStore = requireComponents.core.store,
-                context = requireContext(),
+                context = requireContext().applicationContext,
                 openLink = { link, shouldOpenInNewTab ->
                     (requireActivity() as HomeActivity).openToBrowserAndLoad(
                         searchTermOrURL = link,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapper.kt
@@ -27,7 +27,11 @@ fun ProductAnalysis?.toProductReviewState(): ProductReviewState =
 
 private fun GeckoProductAnalysis.toProductReview(): ProductReviewState =
     if (productId == null) {
-        ProductReviewState.NoAnalysisPresent()
+        if (needsAnalysis) {
+            ProductReviewState.NoAnalysisPresent()
+        } else {
+            ProductReviewState.Error.GenericError
+        }
     } else {
         val mappedRating = adjustedRating.toFloatOrNull()
         val mappedGrade = grade?.toGrade()

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/Retry.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/Retry.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.middleware
+
+import kotlinx.coroutines.delay
+
+private const val MAX_RETRIES = 10
+private const val INITIAL_DELAY_MS = 2000L
+private const val MAX_DELAY_MS = 20000L
+private const val FACTOR = 2.0
+
+/**
+ * Retry a suspend function until it returns a value that satisfies the predicate.
+ *
+ * @param maxRetries The maximum number of retries.
+ * @param initialDelayMs The initial delay in milliseconds.
+ * @param maxDelayMs The maximum delay in milliseconds.
+ * @param factor The factor to increase the delay by.
+ * @param predicate The predicate to check the result against.
+ * @param block The function to retry.
+ */
+suspend fun <T> retry(
+    maxRetries: Int = MAX_RETRIES,
+    initialDelayMs: Long = INITIAL_DELAY_MS,
+    maxDelayMs: Long = MAX_DELAY_MS,
+    factor: Double = FACTOR,
+    predicate: (T) -> Boolean,
+    block: suspend () -> T,
+): T {
+    var delayTime = initialDelayMs
+    var data: T = block()
+
+    repeat(maxRetries - 1) {
+        if (predicate(data)) {
+            delay(delayTime)
+            data = block()
+            delayTime = (delayTime * factor).toLong().coerceAtMost(maxDelayMs)
+        } else {
+            return data
+        }
+    }
+    return data
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckService.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckService.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.withContext
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.shopping.ProductAnalysis
+import mozilla.components.support.base.log.logger.Logger
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -23,6 +24,20 @@ interface ReviewQualityCheckService {
      * @return [ProductAnalysis] if the request succeeds, null otherwise.
      */
     suspend fun fetchProductReview(): ProductAnalysis?
+
+    /**
+     * Triggers a reanalysis of the product review for the current tab.
+     *
+     * @return [AnalysisStatusDto] if the request succeeds, null otherwise.
+     */
+    suspend fun reanalyzeProduct(): AnalysisStatusDto?
+
+    /**
+     * Fetches the status of the product review for the current tab.
+     *
+     * @return [AnalysisStatusDto] if the request succeeds, null otherwise.
+     */
+    suspend fun analysisStatus(): AnalysisStatusDto?
 }
 
 /**
@@ -34,15 +49,94 @@ class DefaultReviewQualityCheckService(
     private val browserStore: BrowserStore,
 ) : ReviewQualityCheckService {
 
+    private val logger = Logger("DefaultReviewQualityCheckService")
+
     override suspend fun fetchProductReview(): ProductAnalysis? = withContext(Dispatchers.Main) {
         suspendCoroutine { continuation ->
             browserStore.state.selectedTab?.let { tab ->
                 tab.engineState.engineSession?.requestProductAnalysis(
                     url = tab.content.url,
-                    onResult = { continuation.resume(it) },
-                    onException = { continuation.resume(null) },
+                    onResult = {
+                        continuation.resume(it)
+                    },
+                    onException = {
+                        logger.error("Error fetching product review", it)
+                        continuation.resume(null)
+                    },
                 )
             }
         }
     }
+
+    override suspend fun reanalyzeProduct(): AnalysisStatusDto? = withContext(Dispatchers.Main) {
+        suspendCoroutine { continuation ->
+            browserStore.state.selectedTab?.let { tab ->
+                tab.engineState.engineSession?.reanalyzeProduct(
+                    url = tab.content.url,
+                    onResult = {
+                        continuation.resume(it.asEnumOrDefault<AnalysisStatusDto>())
+                    },
+                    onException = {
+                        logger.error("Error starting reanalysis", it)
+                        continuation.resume(null)
+                    },
+                )
+            }
+        }
+    }
+
+    override suspend fun analysisStatus(): AnalysisStatusDto? = withContext(Dispatchers.Main) {
+        suspendCoroutine { continuation ->
+            browserStore.state.selectedTab?.let { tab ->
+                tab.engineState.engineSession?.requestAnalysisStatus(
+                    url = tab.content.url,
+                    onResult = {
+                        continuation.resume(it.asEnumOrDefault<AnalysisStatusDto>())
+                    },
+                    onException = {
+                        logger.error("Error fetching analysis status", it)
+                        continuation.resume(null)
+                    },
+                )
+            }
+        }
+    }
+
+    private inline fun <reified T : Enum<T>> String.asEnumOrDefault(defaultValue: T? = null): T? =
+        enumValues<T>().firstOrNull { it.name.equals(this, ignoreCase = true) } ?: defaultValue
+}
+
+/**
+ * Enum that represents the status of the product review analysis.
+ */
+enum class AnalysisStatusDto {
+    /**
+     * Analysis is waiting to be picked up.
+     */
+    PENDING,
+
+    /**
+     * Analysis is in progress.
+     */
+    IN_PROGRESS,
+
+    /**
+     * Analysis is completed.
+     */
+    COMPLETED,
+
+    /**
+     * Product can not be analyzed.
+     */
+    NOT_ANALYZABLE,
+
+    /**
+     * Current analysis status with provided params not found.
+     */
+    NOT_FOUND,
+
+    /**
+     * Wrong product params provided.
+     */
+    UNPROCESSABLE,
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeNetworkChecker.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeNetworkChecker.kt
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.fake
+
+import org.mozilla.fenix.shopping.middleware.NetworkChecker
+
+class FakeNetworkChecker(
+    private val isConnected: Boolean,
+) : NetworkChecker {
+    override fun isConnected(): Boolean = isConnected
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckPreferences.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckPreferences.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.fake
+
+import org.mozilla.fenix.shopping.middleware.ReviewQualityCheckPreferences
+
+class FakeReviewQualityCheckPreferences(
+    private val isEnabled: Boolean = false,
+    private val isProductRecommendationsEnabled: Boolean? = false,
+    private val updateCFRCallback: () -> Unit = { },
+) : ReviewQualityCheckPreferences {
+    override suspend fun enabled(): Boolean = isEnabled
+
+    override suspend fun productRecommendationsEnabled(): Boolean? = isProductRecommendationsEnabled
+
+    override suspend fun setEnabled(isEnabled: Boolean) {
+    }
+
+    override suspend fun setProductRecommendationsEnabled(isEnabled: Boolean) {
+    }
+
+    override suspend fun updateCFRCondition(time: Long) {
+        updateCFRCallback()
+    }
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckService.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckService.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.fake
+
+import mozilla.components.concept.engine.shopping.ProductAnalysis
+import org.mozilla.fenix.shopping.middleware.AnalysisStatusDto
+import org.mozilla.fenix.shopping.middleware.ReviewQualityCheckService
+
+class FakeReviewQualityCheckService(
+    private val productAnalysis: (Int) -> ProductAnalysis? = { null },
+    private val reanalysis: AnalysisStatusDto? = null,
+    private val status: AnalysisStatusDto? = null,
+) : ReviewQualityCheckService {
+
+    private var analysisCount = 0
+
+    override suspend fun fetchProductReview(): ProductAnalysis? {
+        return productAnalysis(analysisCount).also {
+            analysisCount++
+        }
+    }
+
+    override suspend fun reanalyzeProduct(): AnalysisStatusDto? = reanalysis
+
+    override suspend fun analysisStatus(): AnalysisStatusDto? = status
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapperTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapperTest.kt
@@ -113,10 +113,25 @@ class ProductAnalysisMapperTest {
     }
 
     @Test
-    fun `WHEN product id is null THEN it is mapped to no analysis present`() {
+    fun `WHEN product id is null and needs analysis is true THEN it is mapped to no analysis present`() {
         val actual =
-            ProductAnalysisTestData.productAnalysis(productId = null).toProductReviewState()
+            ProductAnalysisTestData.productAnalysis(
+                productId = null,
+                needsAnalysis = true,
+            ).toProductReviewState()
         val expected = ReviewQualityCheckState.OptedIn.ProductReviewState.NoAnalysisPresent()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN product id is null and needs analysis is false THEN it is mapped to no generic error`() {
+        val actual =
+            ProductAnalysisTestData.productAnalysis(
+                productId = null,
+                needsAnalysis = false,
+            ).toProductReviewState()
+        val expected = ReviewQualityCheckState.OptedIn.ProductReviewState.Error.GenericError
 
         assertEquals(expected, actual)
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/RetryKtTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/RetryKtTest.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.middleware
+
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class RetryKtTest {
+
+    @Test
+    fun `WHEN predicate is false THEN return data on first attempt`() = runTest {
+        var count = 0
+
+        val actual = retry(predicate = { false }) {
+            count += 1
+            count
+        }
+        val expected = 1
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN predicate is true THEN retry max times`() = runTest {
+        var count = 0
+
+        val actual = retry(
+            maxRetries = 10,
+            predicate = { true },
+        ) {
+            count += 1
+            count
+        }
+
+        val expected = 10
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN predicate changes to false from true THEN return data on that attempt`() = runTest {
+        var count = 0
+
+        val actual = retry(
+            maxRetries = 10,
+            predicate = { it < 5 },
+        ) {
+            count += 1
+            count
+        }
+
+        val expected = 5
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
### What
– Integrate `reanalyzeProduct` and `requestAnalysisStatus` APIs in `ReviewQualityCheckService` and middleware.
– Add polling logic for analysis status.
– Create a generic retry function.
– Add an edge case in mapper and test.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.














### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1853311