### PR TITLE
Bug 1854429 - Temporarily remove Pixel3 for low capacity

### DIFF
--- a/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -41,9 +41,6 @@ gcloud:
     - model: Pixel2.arm
       version: 27
       locale: en_US
-    - model: blueline
-      version: 28
-      locale: en_US
     - model: x1q
       version: 29
       locale: en_US

--- a/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
@@ -23,9 +23,6 @@ gcloud:
     - model: dreamlte
       version: 28
       locale: en_US
-    - model: blueline
-      version: 28
-      locale: en_US
     - model: x1q
       version: 29
       locale: en_US


### PR DESCRIPTION
Currently the `blueline` is either backed up or moved to low capacity on Test Lab and is timing out Tasks exceeding the `7200` second timeout.

Opened a thread on Firebase Community. In the mean-time, temporarily remove.
https://bugzilla.mozilla.org/show_bug.cgi?id=1854429