### PR TITLE
Bug 1853065 - Fix TabsUseCasesTest merge conflict

### DIFF
--- a/android-components/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
+++ b/android-components/components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt
@@ -265,7 +265,6 @@ class TabsUseCasesTest {
     }
 
     @Test
-<<<<<<< HEAD
     @Suppress("DEPRECATION")
     fun `AddNewPrivateTabUseCase will not load URL if flag is set to false`() {
         tabsUseCases.addPrivateTab("https://www.mozilla.org", startLoading = false)
@@ -321,7 +320,16 @@ class TabsUseCasesTest {
             flags = LoadUrlFlags.external(),
             startLoading = true,
             engineSession = session,
-=======
+        )
+
+        store.waitUntilIdle()
+
+        assertEquals(1, store.state.tabs.size)
+        assertEquals("https://www.mozilla.org", store.state.tabs[0].content.url)
+        assertSame(session, store.state.tabs[0].engineState.engineSession)
+    }
+
+    @Test
     fun `GIVEN a search is performed with load URL flags and additional headers WHEN adding a new tab THEN the resulting tab is loaded as a search result with the correct load flags and headers`() {
         val url = "https://www.mozilla.org"
         val flags = LoadUrlFlags.select(LoadUrlFlags.ALLOW_ADDITIONAL_HEADERS)
@@ -332,16 +340,11 @@ class TabsUseCasesTest {
             flags = flags,
             isSearch = true,
             additionalHeaders = additionalHeaders,
->>>>>>> c793b0e1b4 (Bug 1853065)
         )
 
         store.waitUntilIdle()
 
         assertEquals(1, store.state.tabs.size)
-<<<<<<< HEAD
-        assertEquals("https://www.mozilla.org", store.state.tabs[0].content.url)
-        assertSame(session, store.state.tabs[0].engineState.engineSession)
-=======
         assertTrue(store.state.tabs.single().content.isSearch)
         assertEquals(flags, store.state.tabs.single().engineState.initialLoadFlags)
         assertEquals(
@@ -354,7 +357,6 @@ class TabsUseCasesTest {
             flags = flags,
             additionalHeaders = additionalHeaders,
         )
->>>>>>> c793b0e1b4 (Bug 1853065)
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
