### PR TITLE
Bug 1854606 - History TestRail matching

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHistoryTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHistoryTest.kt
@@ -75,7 +75,7 @@ class ComposeHistoryTest {
     }
 
     @Test
-    fun noHistoryItemsInCacheTest() {
+    fun verifyEmptyHistoryMenuTest() {
         homeScreen {
         }.openThreeDotMenu {
             verifyHistoryButton()
@@ -87,8 +87,9 @@ class ComposeHistoryTest {
 
     // Test running on beta/release builds in CI:
     // caution when making changes to it, so they don't block the builds
+    @SmokeTest
     @Test
-    fun visitedUrlHistoryTest() {
+    fun verifyHistoryMenuWithHistoryItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -104,6 +105,7 @@ class ComposeHistoryTest {
                 verifyVisitedTimeTitle()
                 verifyFirstTestPageTitle("Test_Page_1")
                 verifyTestPageUrl(firstWebPage.url)
+                verifyDeleteHistoryItemButton("Test_Page_1")
             }
         }
     }
@@ -125,50 +127,6 @@ class ComposeHistoryTest {
             }
             verifyDeleteSnackbarText("Deleted")
             verifyEmptyHistoryView()
-        }
-    }
-
-    @Test
-    fun undoDeleteHistoryItemTest() {
-        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            mDevice.waitForIdle()
-        }.openThreeDotMenu {
-        }.openHistory {
-            verifyHistoryListExists()
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
-            ) {
-                clickDeleteHistoryButton(firstWebPage.url.toString())
-            }
-            verifyUndoDeleteSnackBarButton()
-            clickUndoDeleteButton()
-            verifyHistoryItemExists(true, firstWebPage.url.toString())
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun cancelDeleteAllHistoryTest() {
-        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            mDevice.waitForIdle()
-        }.openThreeDotMenu {
-        }.openHistory {
-            verifyHistoryListExists()
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
-            ) {
-                clickDeleteAllHistoryButton()
-            }
-            verifyDeleteConfirmationMessage()
-            selectEverythingOption()
-            cancelDeleteHistory()
-            verifyHistoryItemExists(true, firstWebPage.url.toString())
         }
     }
 
@@ -226,7 +184,7 @@ class ComposeHistoryTest {
 
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807268")
     @Test
-    fun openHistoryInNewTabTest() {
+    fun openMultipleSelectedHistoryItemsInANewTabTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -255,7 +213,7 @@ class ComposeHistoryTest {
     }
 
     @Test
-    fun openHistoryInPrivateTabTest() {
+    fun openMultipleSelectedHistoryItemsInPrivateTabTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -280,7 +238,7 @@ class ComposeHistoryTest {
     }
 
     @Test
-    fun deleteMultipleSelectionTest() {
+    fun deleteMultipleSelectedHistoryItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
@@ -314,7 +272,7 @@ class ComposeHistoryTest {
     }
 
     @Test
-    fun shareButtonTest() {
+    fun shareMultipleSelectedHistoryItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -73,8 +73,9 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/243285
     @Test
-    fun noHistoryItemsInCacheTest() {
+    fun verifyEmptyHistoryMenuTest() {
         homeScreen {
         }.openThreeDotMenu {
             verifyHistoryButton()
@@ -84,10 +85,12 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2302742
     // Test running on beta/release builds in CI:
     // caution when making changes to it, so they don't block the builds
+    @SmokeTest
     @Test
-    fun visitedUrlHistoryTest() {
+    fun verifyHistoryMenuWithHistoryItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -103,32 +106,14 @@ class HistoryTest {
                 verifyVisitedTimeTitle()
                 verifyFirstTestPageTitle("Test_Page_1")
                 verifyTestPageUrl(firstWebPage.url)
+                verifyDeleteHistoryItemButton("Test_Page_1")
             }
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/243288
     @Test
     fun deleteHistoryItemTest() {
-        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            mDevice.waitForIdle()
-        }.openThreeDotMenu {
-        }.openHistory {
-            verifyHistoryListExists()
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
-            ) {
-                clickDeleteHistoryButton(firstWebPage.url.toString())
-            }
-            verifyDeleteSnackbarText("Deleted")
-            verifyEmptyHistoryView()
-        }
-    }
-
-    @Test
-    fun undoDeleteHistoryItemTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -145,32 +130,13 @@ class HistoryTest {
             verifyUndoDeleteSnackBarButton()
             clickUndoDeleteButton()
             verifyHistoryItemExists(true, firstWebPage.url.toString())
+            clickDeleteHistoryButton(firstWebPage.url.toString())
+            verifyDeleteSnackbarText("Deleted")
+            verifyEmptyHistoryView()
         }
     }
 
-    @SmokeTest
-    @Test
-    fun cancelDeleteAllHistoryTest() {
-        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            mDevice.waitForIdle()
-        }.openThreeDotMenu {
-        }.openHistory {
-            verifyHistoryListExists()
-            registerAndCleanupIdlingResources(
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
-            ) {
-                clickDeleteAllHistoryButton()
-            }
-            verifyDeleteConfirmationMessage()
-            selectEverythingOption()
-            cancelDeleteHistory()
-            verifyHistoryItemExists(true, firstWebPage.url.toString())
-        }
-    }
-
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1848881
     @SmokeTest
     @Test
     fun deleteAllHistoryTest() {
@@ -189,13 +155,18 @@ class HistoryTest {
             }
             verifyDeleteConfirmationMessage()
             selectEverythingOption()
+            cancelDeleteHistory()
+            verifyHistoryItemExists(true, firstWebPage.url.toString())
+            clickDeleteAllHistoryButton()
+            verifyDeleteConfirmationMessage()
+            selectEverythingOption()
             confirmDeleteAllHistory()
             verifyDeleteSnackbarText("Browsing data deleted")
             verifyEmptyHistoryView()
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/339690
     @Test
     fun historyMultiSelectionToolbarItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -223,9 +194,10 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/339696
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807268")
     @Test
-    fun openHistoryInNewTabTest() {
+    fun openMultipleSelectedHistoryItemsInANewTabTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -253,8 +225,9 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/346098
     @Test
-    fun openHistoryInPrivateTabTest() {
+    fun openMultipleSelectedHistoryItemsInPrivateTabTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -278,8 +251,9 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/346099
     @Test
-    fun deleteMultipleSelectionTest() {
+    fun deleteMultipleSelectedHistoryItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
@@ -312,8 +286,9 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/339701
     @Test
-    fun shareButtonTest() {
+    fun shareMultipleSelectedHistoryItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -338,6 +313,7 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715627
     @Test
     fun verifySearchHistoryViewTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -380,6 +356,7 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715631
     @Test
     fun verifyVoiceSearchInHistoryTest() {
         homeScreen {
@@ -392,6 +369,7 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715632
     @Test
     fun verifySearchForHistoryItemsTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -421,6 +399,7 @@ class HistoryTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1715634
     @Test
     fun verifyDeletedHistoryItemsCanNotBeSearchedTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -82,6 +82,9 @@ class HistoryRobot {
         deleteButton(item).click()
     }
 
+    fun verifyDeleteHistoryItemButton(historyItemTitle: String) =
+        deleteButton(historyItemTitle).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
     fun clickDeleteAllHistoryButton() = deleteButton().click()
 
     fun selectEverythingOption() = deleteHistoryEverythingOption().click()

--- a/fenix/automation/taskcluster/androidTest/flank-arm-beta.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-beta.yml
@@ -20,7 +20,7 @@ gcloud:
   performance-metrics: true
 
   test-targets:
-    - class org.mozilla.fenix.ui.HistoryTest#visitedUrlHistoryTest
+    - class org.mozilla.fenix.ui.HistoryTest#verifyHistoryMenuWithHistoryItemsTest
     - class org.mozilla.fenix.ui.SettingsSearchTest#toggleSearchSuggestionsTest
     - class org.mozilla.fenix.ui.CollectionTest#deleteCollectionTest
     - class org.mozilla.fenix.ui.SmokeTest#noHistoryInPrivateBrowsingTest

--- a/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -25,7 +25,7 @@ gcloud:
     - notPackage org.mozilla.fenix.experimentintegration
     - class org.mozilla.fenix.ui.MainMenuTest#goBackTest
     - class org.mozilla.fenix.ui.MainMenuTest#goForwardTest
-    - class org.mozilla.fenix.ui.HistoryTest#visitedUrlHistoryTest
+    - class org.mozilla.fenix.ui.HistoryTest#verifyHistoryMenuWithHistoryItemsTest
     - class org.mozilla.fenix.ui.SettingsSearchTest#toggleSearchSuggestionsTest
     - class org.mozilla.fenix.ui.CollectionTest#deleteCollectionTest
     - class org.mozilla.fenix.ui.SmokeTest#noHistoryInPrivateBrowsingTest

--- a/fenix/automation/taskcluster/androidTest/flank-arm-start-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-start-test.yml
@@ -20,7 +20,7 @@ gcloud:
   performance-metrics: true
 
   test-targets:
-   - class org.mozilla.fenix.ui.HistoryTest#visitedUrlHistoryTest
+   - class org.mozilla.fenix.ui.HistoryTest#verifyHistoryMenuWithHistoryItemsTest
    - class org.mozilla.fenix.ui.SettingsSearchTest#toggleSearchSuggestionsTest
    - class org.mozilla.fenix.ui.CollectionTest#deleteCollectionTest
    - class org.mozilla.fenix.ui.SmokeTest#noHistoryInPrivateBrowsingTest


### PR DESCRIPTION
These changes are part of our data alignment between testRail and our automated UI tests.

For more information please see this [document](https://docs.google.com/document/d/1eRtulddxAlMC5qzjQU77TDhjs7k2f8a6Vbfs7j_UcAg/edit?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1854606