### PR TITLE
Bug 1854739 - Migrate pref_key_search_widget_installed

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -746,6 +746,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             adjustCreative.set(settings.adjustCreative)
             adjustNetwork.set(settings.adjustNetwork)
 
+            settings.migrateSearchWidgetInstalledPrefIfNeeded()
             searchWidgetInstalled.set(settings.searchWidgetInstalled)
 
             val openTabsCount = settings.openTabsCount

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1216,14 +1216,31 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      * exists on home screen or if it has been removed completely.
      */
     fun setSearchWidgetInstalled(installed: Boolean) {
-        val key = appContext.getPreferenceKey(R.string.pref_key_search_widget_installed)
+        val key = appContext.getPreferenceKey(R.string.pref_key_search_widget_installed_2)
         preferences.edit()
             .putBoolean(key, installed)
             .apply()
     }
 
+    /**
+     * In Bug 1853113, we changed the type of [searchWidgetInstalled] from int to boolean without
+     * changing the pref key, now we have to migrate users that were using the previous type int
+     * to the new one boolean. The migration will only happens if pref_key_search_widget_installed
+     * is detected.
+     */
+    fun migrateSearchWidgetInstalledPrefIfNeeded() {
+        val oldKey = "pref_key_search_widget_installed"
+        val installedCount = preferences.getInt(oldKey, 0)
+
+        if (installedCount > 0) {
+            setSearchWidgetInstalled(true)
+            preferences.edit()
+                .remove(oldKey).apply()
+        }
+    }
+
     val searchWidgetInstalled by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_search_widget_installed),
+        appContext.getPreferenceKey(R.string.pref_key_search_widget_installed_2),
         default = false,
     )
 

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -95,7 +95,7 @@
     <string name="pref_key_sign_out" translatable="false">pref_key_sign_out</string>
     <string name="pref_key_sync_sign_in" translatable="false">pref_key_sync_sign_in</string>
     <string name="pref_key_push_project_id" translatable="false">project_id</string>
-    <string name="pref_key_search_widget_installed" translatable="false">pref_key_search_widget_installed</string>
+    <string name="pref_key_search_widget_installed_2" translatable="false">pref_key_search_widget_installed_2</string>
     <string name="pref_key_saved_logins_sorting_strategy" translatable="false">pref_key_saved_logins_sorting_strategy</string>
     <!-- Key for credit cards sync preference in the account settings fragment -->
     <string name="pref_key_sync_credit_cards" translatable="false">pref_key_sync_credit_cards</string>

--- a/fenix/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
@@ -105,7 +105,8 @@ class FenixApplicationTest {
         every { settings.adjustAdGroup } returns "group"
         every { settings.adjustCreative } returns "creative"
         every { settings.adjustNetwork } returns "network"
-        every { settings.searchWidgetInstalled } returns true
+        // Testing [settings.migrateSearchWidgetInstalledPrefIfNeeded]
+        settings.preferences.edit().putInt("pref_key_search_widget_installed", 5).apply()
         every { settings.openTabsCount } returns 1
         every { settings.topSitesSize } returns 2
         every { settings.installedAddonsCount } returns 3


### PR DESCRIPTION
It looks like on https://github.com/mozilla-mobile/firefox-android/commit/f2134f7b79ab12e7c49686c3922fd95d5acf5355 we changed the type of `pref_key_search_widget_installed` without changing the pref key, that caused a mismatch between types which resulted in to `ClassCastException`. 

I was able to replicate the issue locally by installing Fenix with a commit before https://github.com/mozilla-mobile/firefox-android/commit/f2134f7b79ab12e7c49686c3922fd95d5acf5355 (maybe this one https://github.com/mozilla-mobile/firefox-android/commit/b44fb318d54b998672aaecff3fff01e54e6a9066) , and adding the **"Search the web"** Fenix's widget.

<img width="374" alt="image" src="https://github.com/mozilla-mobile/firefox-android/assets/773158/05f098d0-6dcf-4158-b2d6-28ef4142440f">

Then switching to https://github.com/mozilla-mobile/firefox-android/commit/f2134f7b79ab12e7c49686c3922fd95d5acf5355 which it's the commit which introduced the regression.

After you are on the crashing state if you apply this patch and run Fenix the crash should go away.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1854739