### PR TITLE
Bug 1854739 - Catch crash when migrating pref_key_search_widget_installed

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1230,7 +1230,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      */
     fun migrateSearchWidgetInstalledPrefIfNeeded() {
         val oldKey = "pref_key_search_widget_installed"
-        val installedCount = preferences.getInt(oldKey, 0)
+        val installedCount = try {
+            preferences.getInt(oldKey, 0)
+        } catch (e: ClassCastException) {
+            0
+        }
 
         if (installedCount > 0) {
             setSearchWidgetInstalled(true)

--- a/fenix/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -995,4 +995,13 @@ class SettingsTest {
         assertEquals(expectedDefaultValue, settings.preferences.getInt(oldPrefKey, expectedDefaultValue))
         assertFalse(settings.searchWidgetInstalled)
     }
+
+    @Test
+    fun `GIVEN previously stored pref_key_search_widget_installed value is Boolean WHEN calling migrateSearchWidgetInstalledIfNeeded THEN crash should not happen`() {
+        val oldPrefKey = "pref_key_search_widget_installed"
+        settings.preferences.edit().putBoolean(oldPrefKey, false).apply()
+
+        settings.migrateSearchWidgetInstalledPrefIfNeeded()
+        assertFalse(settings.searchWidgetInstalled)
+    }
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1854739