### PR TITLE
Bug 1844557 - Disable the switch control when the add-on is blockedlisted.

### DIFF
--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -475,6 +475,14 @@ fun WebExtension.isUnsupported(): Boolean {
 }
 
 /**
+ * Returns whether or not the extension is disabled because it has been blocklisted.
+ */
+fun WebExtension.isBlockListed(): Boolean {
+    val flags = getMetadata()?.disabledFlags
+    return flags?.contains(DisabledFlags.BLOCKLIST) == true
+}
+
+/**
  * An unexpected event that occurs when trying to perform an action on the extension like
  * (but not exclusively) installing/uninstalling, removing or updating.
  */

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
@@ -74,8 +74,10 @@ class WebExtensionTest {
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.BLOCKLIST))
         assertFalse(extension.isUnsupported())
+        assertTrue(extension.isBlockListed())
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.APP_SUPPORT))
         assertTrue(extension.isUnsupported())
+        assertFalse(extension.isBlockListed())
     }
 }

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -99,6 +99,7 @@ data class Addon(
      * defaults to false.
      * @property supported Indicates if this [Addon] is supported by the browser or not, defaults
      * to true.
+     * @property disabledReason Indicates why the [Addon] was disabled.
      * @property optionsPageUrl the URL of the page displaying the
      * options page (options_ui in the extension's manifest).
      * @property allowedInPrivateBrowsing true if this addon should be allowed to run in private
@@ -115,10 +116,31 @@ data class Addon(
         val openOptionsPageInTab: Boolean = false,
         val enabled: Boolean = false,
         val supported: Boolean = true,
-        val disabledAsUnsupported: Boolean = false,
+        val disabledReason: DisabledReason? = null,
         val allowedInPrivateBrowsing: Boolean = false,
         val icon: Bitmap? = null,
     ) : Parcelable
+
+    /**
+     * Enum containing all reasons why an [Addon] was disabled.
+     */
+    enum class DisabledReason {
+
+        /**
+         * The [Addon] was disabled because it is unsupported.
+         */
+        UNSUPPORTED,
+
+        /**
+         * The [Addon] was disabled because is it is blocklisted.
+         */
+        BLOCKLISTED,
+
+        /**
+         * The [Addon] was disabled by the user.
+         */
+        USER_REQUESTED,
+    }
 
     /**
      * Returns a list of localized Strings per each item on the [permissions] list.
@@ -149,7 +171,13 @@ data class Addon(
      * addon can be disabled as unsupported and later become supported, so
      * both [isSupported] and [isDisabledAsUnsupported] can be true.
      */
-    fun isDisabledAsUnsupported() = installedState?.disabledAsUnsupported == true
+    fun isDisabledAsUnsupported() = installedState?.disabledReason == DisabledReason.UNSUPPORTED
+
+    /**
+     * Returns whether or not this [Addon] is currently disabled because it is part of
+     * the blocklist. This is based on the installed extension state in the engine.
+     */
+    fun isDisabledAsBlocklisted() = installedState?.disabledReason == DisabledReason.BLOCKLISTED
 
     /**
      * Returns whether or not this [Addon] is allowed in private browsing mode.

--- a/android-components/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -19,6 +19,9 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.DisabledFlags
+import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.APP_SUPPORT
+import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.BLOCKLIST
+import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.USER
 import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.Metadata
 import mozilla.components.concept.engine.webextension.WebExtension
@@ -819,5 +822,28 @@ class AddonManagerTest {
         assertNotNull(throwable!!)
         assertEquals("test", throwable!!.localizedMessage)
         assertTrue(manager.pendingAddonActions.isEmpty())
+    }
+
+    @Test
+    fun `getDisabledReason cases`() {
+        val extension: WebExtension = mock()
+        val metadata: Metadata = mock()
+
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(BLOCKLIST))
+        whenever(extension.getMetadata()).thenReturn(metadata)
+
+        assertEquals(Addon.DisabledReason.BLOCKLISTED, extension.getDisabledReason())
+
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(APP_SUPPORT))
+
+        assertEquals(Addon.DisabledReason.UNSUPPORTED, extension.getDisabledReason())
+
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(USER))
+
+        assertEquals(Addon.DisabledReason.USER_REQUESTED, extension.getDisabledReason())
+
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(0))
+
+        assertNull(extension.getDisabledReason())
     }
 }

--- a/android-components/components/feature/addons/src/test/java/AddonTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonTest.kt
@@ -386,4 +386,20 @@ class AddonTest {
         assertEquals("some description", addon.translatableDescription[Addon.DEFAULT_LOCALE])
         assertEquals("some description", addon.translatableSummary[Addon.DEFAULT_LOCALE])
     }
+
+    @Test
+    fun `isDisabledAsBlocklisted - true if installed state disabled status equals to BLOCKLISTED and otherwise false`() {
+        val addon = Addon(id = "id")
+        val blockListedAddon = addon.copy(
+            installedState = Addon.InstalledState(
+                id = "id",
+                version = "1.0",
+                optionsPageUrl = "",
+                disabledReason = Addon.DisabledReason.BLOCKLISTED,
+            ),
+        )
+
+        assertFalse(addon.isDisabledAsBlocklisted())
+        assertTrue(blockListedAddon.isDisabledAsBlocklisted())
+    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -118,11 +118,24 @@ class InstalledAddonDetailsFragment : Fragment() {
         bindRemoveButton()
     }
 
+    @VisibleForTesting
+    internal fun provideEnableSwitch() = binding.enableSwitch
+
+    @VisibleForTesting
+    internal fun providePrivateBrowsingSwitch() = binding.allowInPrivateBrowsingSwitch
+
+    @VisibleForTesting
     @SuppressWarnings("LongMethod")
-    private fun bindEnableSwitch() {
-        val switch = binding.enableSwitch
-        val privateBrowsingSwitch = binding.allowInPrivateBrowsingSwitch
+    internal fun bindEnableSwitch() {
+        val switch = provideEnableSwitch()
+        val privateBrowsingSwitch = providePrivateBrowsingSwitch()
         switch.setState(addon.isEnabled())
+        // When the ad-on is blocklisted, we do not want to enable the toggle switch
+        // because users shouldn't be able to re-enable a blocklisted add-on.
+        if (addon.isDisabledAsBlocklisted()) {
+            switch.isEnabled = false
+            return
+        }
         switch.setOnCheckedChangeListener { v, isChecked ->
             val addonManager = v.context.components.addonManager
             switch.isClickable = false

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragmentTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.addons
 
+import com.google.android.material.switchmaterial.SwitchMaterial
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -61,5 +62,39 @@ class InstalledAddonDetailsFragmentTest {
 
         verify { addonManager.enableAddon(addon, EnableSource.APP_SUPPORT, any(), any()) }
         verify { addonManager.enableAddon(capturedAddon.captured, EnableSource.USER, any(), any()) }
+    }
+
+    @Test
+    fun `GIVEN blocklisted addon WHEN biding the enable switch THEN disable the switch`() {
+        val addon = mockk<Addon>()
+        val enableSwitch = mockk<SwitchMaterial>(relaxed = true)
+        val privateBrowsingSwitch = mockk<SwitchMaterial>(relaxed = true)
+
+        every { fragment.provideEnableSwitch() } returns enableSwitch
+        every { fragment.providePrivateBrowsingSwitch() } returns privateBrowsingSwitch
+        every { addon.isEnabled() } returns true
+        every { addon.isDisabledAsBlocklisted() } returns true
+        every { fragment.addon } returns addon
+
+        fragment.bindEnableSwitch()
+
+        verify { enableSwitch.isEnabled = false }
+    }
+
+    @Test
+    fun `GIVEN enabled addon WHEN biding the enable switch THEN do not disable the switch`() {
+        val addon = mockk<Addon>()
+        val enableSwitch = mockk<SwitchMaterial>(relaxed = true)
+        val privateBrowsingSwitch = mockk<SwitchMaterial>(relaxed = true)
+
+        every { fragment.provideEnableSwitch() } returns enableSwitch
+        every { fragment.providePrivateBrowsingSwitch() } returns privateBrowsingSwitch
+        every { addon.isDisabledAsBlocklisted() } returns false
+        every { addon.isEnabled() } returns true
+        every { fragment.addon } returns addon
+
+        fragment.bindEnableSwitch()
+
+        verify(exactly = 0) { enableSwitch.isEnabled = false }
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1844557