### PR TITLE
Bug 1853304 - Color the shopping icon while the bottom sheet is open

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -216,4 +216,9 @@ sealed class AppAction : Action {
     data class UpdateStandardSnackbarErrorAction(
         val standardSnackbarError: StandardSnackbarError?,
     ) : AppAction()
+
+    /**
+     * [AppAction] used to update the expansion state of the shopping sheet.
+     */
+    data class ShoppingSheetStateUpdated(val expanded: Boolean) : AppAction()
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
@@ -50,6 +50,7 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  * @property pendingDeletionHistoryItems The set of History items marked for removal in the UI,
  * awaiting to be removed once the Undo snackbar hides away.
  * Also serves as an in memory cache of all stories mapped by category allowing for quick stories filtering.
+ * @property shoppingSheetExpanded Boolean indicating if the shopping sheet is expanded and visible.
  */
 data class AppState(
     val isForeground: Boolean = true,
@@ -73,4 +74,5 @@ data class AppState(
     val pendingDeletionHistoryItems: Set<PendingDeletionHistory> = emptySet(),
     val wallpaperState: WallpaperState = WallpaperState.default,
     val standardSnackbarError: StandardSnackbarError? = null,
+    val shoppingSheetExpanded: Boolean = false,
 ) : State

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -231,6 +231,8 @@ internal object AppStoreReducer {
         is AppAction.UpdateStandardSnackbarErrorAction -> state.copy(
             standardSnackbarError = action.standardSnackbarError,
         )
+
+        is AppAction.ShoppingSheetStateUpdated -> state.copy(shoppingSheetExpanded = action.expanded)
     }
 }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFragment.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.shopping
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -17,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.shopping.di.ReviewQualityCheckMiddlewareProvider
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckStore
@@ -79,5 +81,10 @@ class ReviewQualityCheckFragment : BottomSheetDialogFragment() {
             owner = viewLifecycleOwner,
             view = view,
         )
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        requireComponents.appStore.dispatch(AppAction.ShoppingSheetStateUpdated(expanded = false))
     }
 }

--- a/fenix/app/src/main/res/drawable/ic_shopping_selected.xml
+++ b/fenix/app/src/main/res/drawable/ic_shopping_selected.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M13.452,2H6v1.75h7.088l6.629,6.656 1.24,-1.234 -6.885,-6.914a0.875,0.875 0,0 0,-0.62 -0.258zM8.933,12.379l1.414,-1.415L8.933,9.55l-1.415,1.414 1.415,1.415z" >
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:type="linear"
+                android:startX="24"
+                android:startY="0"
+                android:endX="0"
+                android:endY="24"
+                android:startColor="@color/fx_mobile_icon_color_gradient_start"
+                android:endColor="@color/fx_mobile_icon_color_gradient_end"/>
+        </aapt:attr>
+    </path>
+    <path
+        android:pathData="M3.5,6.375c0,-0.483 0.392,-0.875 0.875,-0.875h7.265c0.232,0 0.455,0.092 0.619,0.256l6.735,6.735a2.5,2.5 0,0 1,0 3.536l-5.215,5.215a2.5,2.5 0,0 1,-3.536 0l-6.487,-6.487a0.875,0.875 0,0 1,-0.256 -0.619L3.5,6.375zM5.25,7.25v6.524l6.23,6.23a0.75,0.75 0,0 0,1.061 0l5.215,-5.215a0.75,0.75 0,0 0,0 -1.06L11.278,7.25L5.25,7.25z" >
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:type="linear"
+                android:startX="24"
+                android:startY="0"
+                android:endX="0"
+                android:endY="24"
+                android:startColor="@color/fx_mobile_icon_color_gradient_start"
+                android:endColor="@color/fx_mobile_icon_color_gradient_end"/>
+        </aapt:attr>
+    </path>
+</vector>

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeatureTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeatureTest.kt
@@ -16,6 +16,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.appstate.AppState
 
 class ReviewQualityCheckFeatureTest {
 
@@ -26,11 +29,13 @@ class ReviewQualityCheckFeatureTest {
     fun `WHEN feature is not enabled THEN callback returns false`() {
         var availability: Boolean? = null
         val tested = ReviewQualityCheckFeature(
+            appStore = AppStore(),
             browserStore = BrowserStore(),
             shoppingExperienceFeature = FakeShoppingExperienceFeature(enabled = false),
             onAvailabilityChange = {
                 availability = it
             },
+            onBottomSheetCollapsed = {},
         )
 
         tested.start()
@@ -52,6 +57,7 @@ class ReviewQualityCheckFeatureTest {
                 selectedTabId = tab.id,
             )
             val tested = ReviewQualityCheckFeature(
+                appStore = AppStore(),
                 browserStore = BrowserStore(
                     initialState = browserState,
                 ),
@@ -59,6 +65,7 @@ class ReviewQualityCheckFeatureTest {
                 onAvailabilityChange = {
                     availability = it
                 },
+                onBottomSheetCollapsed = {},
             )
 
             tested.start()
@@ -80,6 +87,7 @@ class ReviewQualityCheckFeatureTest {
                 selectedTabId = tab.id,
             )
             val tested = ReviewQualityCheckFeature(
+                appStore = AppStore(),
                 browserStore = BrowserStore(
                     initialState = browserState,
                 ),
@@ -87,6 +95,7 @@ class ReviewQualityCheckFeatureTest {
                 onAvailabilityChange = {
                     availability = it
                 },
+                onBottomSheetCollapsed = {},
             )
 
             tested.start()
@@ -115,11 +124,13 @@ class ReviewQualityCheckFeatureTest {
                 ),
             )
             val tested = ReviewQualityCheckFeature(
+                appStore = AppStore(),
                 browserStore = browserStore,
                 shoppingExperienceFeature = FakeShoppingExperienceFeature(),
                 onAvailabilityChange = {
                     availability = it
                 },
+                onBottomSheetCollapsed = {},
             )
 
             tested.start()
@@ -151,11 +162,13 @@ class ReviewQualityCheckFeatureTest {
                 ),
             )
             val tested = ReviewQualityCheckFeature(
+                appStore = AppStore(),
                 browserStore = browserStore,
                 shoppingExperienceFeature = FakeShoppingExperienceFeature(),
                 onAvailabilityChange = {
                     availability = it
                 },
+                onBottomSheetCollapsed = {},
             )
 
             tested.start()
@@ -189,12 +202,14 @@ class ReviewQualityCheckFeatureTest {
             )
 
             val tested = ReviewQualityCheckFeature(
+                appStore = AppStore(),
                 browserStore = browserStore,
                 shoppingExperienceFeature = FakeShoppingExperienceFeature(),
                 onAvailabilityChange = {
                     availability = it
                     availabilityCount++
                 },
+                onBottomSheetCollapsed = {},
             )
 
             tested.start()
@@ -205,6 +220,56 @@ class ReviewQualityCheckFeatureTest {
             assertEquals(1, availabilityCount)
             assertFalse(availability!!)
         }
+
+    @Test
+    fun `WHEN the shopping sheet is collapsed THEN the collapsed callback is called`() {
+        val appStore = AppStore(
+            initialState = AppState(
+                shoppingSheetExpanded = true,
+            ),
+        )
+        var callbackCalled = false
+        val tested = ReviewQualityCheckFeature(
+            appStore = appStore,
+            browserStore = BrowserStore(),
+            shoppingExperienceFeature = FakeShoppingExperienceFeature(),
+            onAvailabilityChange = {},
+            onBottomSheetCollapsed = {
+                callbackCalled = true
+            },
+        )
+
+        tested.start()
+
+        appStore.dispatch(AppAction.ShoppingSheetStateUpdated(expanded = false)).joinBlocking()
+
+        assertTrue(callbackCalled)
+    }
+
+    @Test
+    fun `WHEN the shopping sheet is expanded THEN the collapsed callback is not called`() {
+        val appStore = AppStore(
+            initialState = AppState(
+                shoppingSheetExpanded = false,
+            ),
+        )
+        var callbackCalled = false
+        val tested = ReviewQualityCheckFeature(
+            appStore = appStore,
+            browserStore = BrowserStore(),
+            shoppingExperienceFeature = FakeShoppingExperienceFeature(),
+            onAvailabilityChange = {},
+            onBottomSheetCollapsed = {
+                callbackCalled = true
+            },
+        )
+
+        tested.start()
+
+        appStore.dispatch(AppAction.ShoppingSheetStateUpdated(expanded = true)).joinBlocking()
+
+        assertFalse(callbackCalled)
+    }
 }
 
 class FakeShoppingExperienceFeature(


### PR DESCRIPTION
Since the toolbar is in XML and depends upon the state of the shopping bottom sheet, using an `Action` became the only reasonable way to get the shopping icon to reset to its default, unselected state. If the toolbar is later converted to Compose, we'll be able to do more direct observations on this new state variable, rather than having to do it indirectly via `ReviewQualityCheckFeature`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1853304