### PR TITLE
Bug 1854712 - Update `information_fill` icon

### DIFF
--- a/android-components/components/ui/icons/src/main/res/drawable/mozac_ic_information_fill_24.xml
+++ b/android-components/components/ui/icons/src/main/res/drawable/mozac_ic_information_fill_24.xml
@@ -1,13 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="14dp"
-    android:height="14dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
     <path
+        android:pathData="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm0.875-15v1.75h-1.75V7h1.75zm0 10v-6.25h-1.75V17h1.75z"
         android:fillColor="@color/mozac_ui_icons_fill"
-        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z" />
+        android:fillType="evenOdd"
+        tools:targetApi="n"
+        tools:ignore="VectorRaster" />
 </vector>

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckInfoCard.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckInfoCard.kt
@@ -75,10 +75,7 @@ fun ReviewQualityCheckInfoCard(
                 ReviewQualityCheckInfoType.Info,
                 ReviewQualityCheckInfoType.AnalysisUpdate,
                 -> {
-                    InfoCardIcon(
-                        iconId = R.drawable.mozac_ic_information_fill_24,
-                        modifier = Modifier.size(24.dp),
-                    )
+                    InfoCardIcon(iconId = R.drawable.mozac_ic_information_fill_24)
                 }
 
                 ReviewQualityCheckInfoType.Loading -> {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1854712