### PR TITLE
Bug 1847266 - Implement status message for blocklisted add-ons in the manager

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
@@ -379,10 +379,10 @@ fun WebExtension.toInstalledState() =
     )
 
 internal fun WebExtension.getDisabledReason(): Addon.DisabledReason? {
-    return if (isUnsupported()) {
-        Addon.DisabledReason.UNSUPPORTED
-    } else if (isBlockListed()) {
+    return if (isBlockListed()) {
         Addon.DisabledReason.BLOCKLISTED
+    } else if (isUnsupported()) {
+        Addon.DisabledReason.UNSUPPORTED
     } else if (getMetadata()?.disabledFlags?.contains(DisabledFlags.USER) == true) {
         Addon.DisabledReason.USER_REQUESTED
     } else {

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterDelegate.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterDelegate.kt
@@ -11,6 +11,16 @@ import mozilla.components.feature.addons.Addon
  */
 interface AddonsManagerAdapterDelegate {
     /**
+     * Defines the different learn more links a user might click.
+     */
+    enum class LearnMoreLinks {
+        /**
+         * The [Addon] is blocklisted and the learn more link should give more information to the user.
+         */
+        BLOCKLISTED_ADDON,
+    }
+
+    /**
      * Handler for when an add-on item is clicked.
      *
      * @param addon The [Addon] that was clicked.
@@ -40,4 +50,9 @@ interface AddonsManagerAdapterDelegate {
      * Handler for when the "find more add-ons" button is clicked.
      */
     fun onFindMoreAddonsButtonClicked() = Unit
+
+    /**
+     * Handler for when a "learn more" link on an add-on item is clicked.
+     */
+    fun onLearnMoreLinkClicked(link: LearnMoreLinks, addon: Addon) = Unit
 }

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/CustomViewHolder.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/CustomViewHolder.kt
@@ -46,6 +46,7 @@ sealed class CustomViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val userCountView: TextView,
         val addButton: ImageView,
         val allowedInPrivateBrowsingLabel: ImageView,
+        val statusBlocklistedView: View,
     ) : CustomViewHolder(view)
 
     /**

--- a/android-components/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
+++ b/android-components/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
@@ -107,6 +107,31 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/add_on_status_blocklisted"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <TextView
+                    android:id="@+id/add_on_status_blocklisted_message"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textSize="14sp"
+                    android:textColor="@color/photonRed70"
+                    tools:text="@string/mozac_feature_addons_status_blocklisted" />
+
+            <TextView
+                android:id="@+id/add_on_status_blocklisted_learn_more_link"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="14sp"
+                android:textColor="?android:attr/textColorLink"
+                android:text="@string/mozac_feature_addons_status_learn_more" />
+        </LinearLayout>
+
     </LinearLayout>
 
     <androidx.appcompat.widget.AppCompatImageView

--- a/android-components/components/feature/addons/src/main/res/values/strings.xml
+++ b/android-components/components/feature/addons/src/main/res/values/strings.xml
@@ -231,4 +231,8 @@
     <string name="mozac_feature_addons_installed_dialog_description">Open it in the menu</string>
     <!-- Confirmation button text for the dialog when add-on installation is completed. -->
     <string name="mozac_feature_addons_installed_dialog_okay_button">Okay, Got it</string>
+    <!-- "Learn more" link displayed below an add-on status message. -->
+    <string name="mozac_feature_addons_status_learn_more">Learn more</string>
+    <!-- Status message below an add-on in the add-ons manager when this add-on has been blocklisted. %1$s is the add-on name. -->
+    <string name="mozac_feature_addons_status_blocklisted">%1$s has been disabled due to security or stability issues.</string>
 </resources>

--- a/fenix/app/src/main/java/org/mozilla/fenix/BrowserDirection.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/BrowserDirection.kt
@@ -40,4 +40,5 @@ enum class BrowserDirection(@IdRes val fragmentId: Int) {
     FromTabsTray(R.id.tabsTrayFragment),
     FromRecentlyClosed(R.id.recentlyClosedFragment),
     FromReviewQualityCheck(R.id.reviewQualityCheckFragment),
+    FromAddonsManagementFragment(R.id.addonsManagementFragment),
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -90,6 +90,7 @@ import org.mozilla.fenix.GleanMetrics.SplashScreen
 import org.mozilla.fenix.GleanMetrics.StartOnHome
 import org.mozilla.fenix.addons.AddonDetailsFragmentDirections
 import org.mozilla.fenix.addons.AddonPermissionsDetailsFragmentDirections
+import org.mozilla.fenix.addons.AddonsManagementFragmentDirections
 import org.mozilla.fenix.addons.ExtensionProcessDisabledController
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
@@ -1037,6 +1038,9 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             customTabSessionId,
         )
         BrowserDirection.FromReviewQualityCheck -> ReviewQualityCheckFragmentDirections.actionGlobalBrowser(
+            customTabSessionId,
+        )
+        BrowserDirection.FromAddonsManagementFragment -> AddonsManagementFragmentDirections.actionGlobalBrowser(
             customTabSessionId,
         )
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -25,6 +25,7 @@ import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.AddonManagerException
 import mozilla.components.feature.addons.ui.AddonsManagerAdapter
+import mozilla.components.feature.addons.ui.AddonsManagerAdapterDelegate
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.BuildConfig
@@ -101,6 +102,7 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
             navController = findNavController(),
             onInstallButtonClicked = ::installAddon,
             onMoreAddonsButtonClicked = ::openAMO,
+            onLearnMoreClicked = ::openLearnMoreLink,
         )
 
         val recyclerView = binding?.addOnsList
@@ -261,10 +263,22 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
     }
 
     private fun openAMO() {
+        openLinkInNewTab(AMO_HOMEPAGE_FOR_ANDROID)
+    }
+
+    private fun openLearnMoreLink(link: AddonsManagerAdapterDelegate.LearnMoreLinks, addon: Addon) {
+        val url = when (link) {
+            AddonsManagerAdapterDelegate.LearnMoreLinks.BLOCKLISTED_ADDON ->
+                "${BuildConfig.AMO_BASE_URL}/android/blocked-addon/${addon.id}/"
+        }
+        openLinkInNewTab(url)
+    }
+
+    private fun openLinkInNewTab(url: String) {
         (activity as HomeActivity).openToBrowserAndLoad(
-            searchTermOrURL = AMO_HOMEPAGE_FOR_ANDROID,
+            searchTermOrURL = url,
             newTab = true,
-            from = BrowserDirection.FromGlobal,
+            from = BrowserDirection.FromAddonsManagementFragment,
         )
     }
 
@@ -274,6 +288,6 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
         // This is locale-less on purpose so that the content negotiation happens on the AMO side because the current
         // user language might not be supported by AMO and/or the language might not be exactly what AMO is expecting
         // (e.g. `en` instead of `en-US`).
-        private const val AMO_HOMEPAGE_FOR_ANDROID = BuildConfig.AMO_BASE_URL + "/android/"
+        private const val AMO_HOMEPAGE_FOR_ANDROID = "${BuildConfig.AMO_BASE_URL}/android/"
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementView.kt
@@ -17,6 +17,7 @@ class AddonsManagementView(
     private val navController: NavController,
     private val onInstallButtonClicked: (Addon) -> Unit,
     private val onMoreAddonsButtonClicked: () -> Unit,
+    private val onLearnMoreClicked: (link: AddonsManagerAdapterDelegate.LearnMoreLinks, addon: Addon) -> Unit,
 ) : AddonsManagerAdapterDelegate {
 
     override fun onAddonItemClicked(addon: Addon) {
@@ -39,6 +40,10 @@ class AddonsManagementView(
 
     override fun onFindMoreAddonsButtonClicked() {
         onMoreAddonsButtonClicked()
+    }
+
+    override fun onLearnMoreLinkClicked(link: AddonsManagerAdapterDelegate.LearnMoreLinks, addon: Addon) {
+        onLearnMoreClicked(link, addon)
     }
 
     private fun showInstalledAddonDetailsFragment(addon: Addon) {

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonsManagementViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonsManagementViewTest.kt
@@ -34,10 +34,21 @@ class AddonsManagementViewTest {
     private var onMoreAddonsButtonClicked: () -> Unit = { moreAddonsButtonClicked = true }
     private var moreAddonsButtonClicked = false
 
+    private var onLearnMoreLinkClicked: (AddonsManagerAdapterDelegate.LearnMoreLinks, Addon) -> Unit = {
+            _: AddonsManagerAdapterDelegate.LearnMoreLinks, _: Addon ->
+        learnMoreLinkClicked = true
+    }
+    private var learnMoreLinkClicked = false
+
     @Before
     fun setup() {
         MockKAnnotations.init(this)
-        managementView = AddonsManagementView(navController, showPermissionDialog, onMoreAddonsButtonClicked)
+        managementView = AddonsManagementView(
+            navController,
+            showPermissionDialog,
+            onMoreAddonsButtonClicked,
+            onLearnMoreLinkClicked,
+        )
     }
 
     @Test
@@ -136,5 +147,12 @@ class AddonsManagementViewTest {
     fun `onFindMoreAddonsButtonClicked calls onMoreAddonsButtonClicked`() {
         managementView.onFindMoreAddonsButtonClicked()
         assertTrue(moreAddonsButtonClicked)
+    }
+
+    @Test
+    fun `onLearnMoreLinkClicked calls onLearnMore`() {
+        val addon: Addon = mockk()
+        managementView.onLearnMoreLinkClicked(AddonsManagerAdapterDelegate.LearnMoreLinks.BLOCKLISTED_ADDON, addon)
+        assertTrue(learnMoreLinkClicked)
     }
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.














### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847266