### PR TITLE
Bug 1855421 - Glean: Pass through enableEventTimestamps and add nimbus variable for it

### DIFF
--- a/android-components/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
+++ b/android-components/components/service/glean/src/main/java/mozilla/components/service/glean/config/Configuration.kt
@@ -25,6 +25,7 @@ data class Configuration @JvmOverloads constructor(
     val serverEndpoint: String = DEFAULT_TELEMETRY_ENDPOINT,
     val channel: String? = null,
     val maxEvents: Int? = null,
+    val enableEventTimestamps: Boolean = false,
 ) {
     // The following is required to support calling our API from Java.
     companion object {
@@ -38,6 +39,12 @@ data class Configuration @JvmOverloads constructor(
      * @return a [mozilla.telemetry.glean.config.Configuration] instance.
      */
     fun toWrappedConfiguration(): GleanCoreConfiguration {
-        return GleanCoreConfiguration(serverEndpoint, channel, maxEvents, httpClient)
+        return GleanCoreConfiguration(
+            serverEndpoint = serverEndpoint,
+            channel = channel,
+            maxEvents = maxEvents,
+            httpClient = httpClient,
+            enableEventTimestamps = enableEventTimestamps,
+        )
     }
 }

--- a/fenix/app/.experimenter.yaml
+++ b/fenix/app/.experimenter.yaml
@@ -28,6 +28,9 @@ glean:
   hasExposure: true
   exposureDescription: ""
   variables:
+    event-timestamps-enabled:
+      type: boolean
+      description: Whether Glean reports all events with precise wall-clock timestamps
     metrics-enabled:
       type: json
       description: "A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric."

--- a/fenix/app/nimbus.fml.yaml
+++ b/fenix/app/nimbus.fml.yaml
@@ -332,6 +332,10 @@ features:
         description: "A map of metric base-identifiers to booleans representing the state of the 'enabled' flag for that metric."
         type: Map<String, Boolean>
         default: {}
+      enable-event-timestamps:
+        description: "Enables precise event timestamps for Glean events"
+        type: Boolean
+        default: false
 
   splash-screen:
     description: "A feature that extends splash screen duration, allowing additional data fetching time for the app's initial run."

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -203,6 +203,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             httpClient = ConceptFetchHttpUploader(
                 lazy(LazyThreadSafetyMode.NONE) { components.core.client },
             ),
+            enableEventTimestamps = FxNimbus.features.glean.value().enableEventTimestamps,
         )
 
         Glean.initialize(


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1855421