### PR TITLE
Bug 1855516 - Call `disableExtensionProcessSpawning()` when the user clicks the "continue without add-ons" button

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -517,6 +517,13 @@ class GeckoEngine(
     }
 
     /**
+     * See [Engine.disableExtensionProcessSpawning].
+     */
+    override fun disableExtensionProcessSpawning() {
+        runtime.webExtensionController.disableExtensionProcessSpawning()
+    }
+
+    /**
      * See [Engine.registerWebNotificationDelegate].
      */
     override fun registerWebNotificationDelegate(

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
@@ -153,4 +153,10 @@ interface WebExtensionRuntime {
      */
     fun enableExtensionProcessSpawning(): Unit =
         throw UnsupportedOperationException("Enabling extension process spawning is not available in this engine")
+
+    /**
+     * Disable the extensions process spawning.
+     */
+    fun disableExtensionProcessSpawning(): Unit =
+        throw UnsupportedOperationException("Disabling extension process spawning is not available in this engine")
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionProcessDisabledController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionProcessDisabledController.kt
@@ -53,10 +53,11 @@ class ExtensionProcessDisabledController(
          * Present a dialog to the user notifying of extension process spawning disabled and also asking
          * whether they would like to continue trying or disable extensions. If the user chooses to retry,
          * enable the extension process spawning with [WebExtensionController.enableExtensionProcessSpawning].
+         * Otherwise, call [WebExtensionController.disableExtensionProcessSpawning].
          *
          * @param context to show the AlertDialog
          * @param store The [BrowserStore] which holds the state for showing the dialog
-         * @param webExtensionController to call when a user enables the process spawning
+         * @param webExtensionController to call when the user enables or disables the process spawning
          * @param builder to use for creating the dialog which can be styled as needed
          * @param appName to be added to the message. Necessary to be added as a param for testing
          */
@@ -84,6 +85,7 @@ class ExtensionProcessDisabledController(
                     onDismissDialog?.invoke()
                 }
                 findViewById<Button>(R.id.negative)?.setOnClickListener {
+                    engine.disableExtensionProcessSpawning()
                     Addons.extensionsProcessUiDisable.add()
                     store.dispatch(ExtensionProcessDisabledPopupAction(false))
                     onDismissDialog?.invoke()

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/ExtensionProcessDisabledControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/ExtensionProcessDisabledControllerTest.kt
@@ -63,6 +63,7 @@ class ExtensionProcessDisabledControllerTest {
         store.waitUntilIdle()
 
         verify(engine).enableExtensionProcessSpawning()
+        verify(engine, never()).disableExtensionProcessSpawning()
         assertFalse(store.state.showExtensionProcessDisabledPopup)
         verify(dialog).dismiss()
     }
@@ -97,6 +98,7 @@ class ExtensionProcessDisabledControllerTest {
 
         assertFalse(store.state.showExtensionProcessDisabledPopup)
         verify(engine, never()).enableExtensionProcessSpawning()
+        verify(engine).disableExtensionProcessSpawning()
         verify(dialog).dismiss()
     }
 


### PR DESCRIPTION
Depends on https://phabricator.services.mozilla.com/D189350 in GV.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1855516