### PR TITLE
Bug 1855553 - Add missing copy & update existing review quality info copy

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ext/ProductVendor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ext/ProductVendor.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.ext
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import org.mozilla.fenix.R
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.ProductVendor
+
+/**
+ * Returns the display string corresponding to the particular [ProductVendor].
+ */
+@Composable
+fun ProductVendor.displayName(): String = when (this) {
+    ProductVendor.AMAZON -> stringResource(id = R.string.review_quality_check_retailer_name_amazon)
+    ProductVendor.BEST_BUY -> stringResource(id = R.string.review_quality_check_retailer_name_bestbuy)
+    ProductVendor.WALMART -> stringResource(id = R.string.review_quality_check_retailer_name_walmart)
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckPreferencesMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckPreferencesMiddleware.kt
@@ -53,7 +53,10 @@ class ReviewQualityCheckPreferencesMiddleware(
                         reviewQualityCheckPreferences.productRecommendationsEnabled()
 
                     val updateUserPreferences = if (hasUserOptedIn) {
-                        ReviewQualityCheckAction.OptInCompleted(isProductRecommendationsEnabled)
+                        ReviewQualityCheckAction.OptInCompleted(
+                            isProductRecommendationsEnabled = isProductRecommendationsEnabled,
+                            productVendor = reviewQualityCheckVendorsService.productVendor(),
+                        )
                     } else {
                         val productVendors = reviewQualityCheckVendorsService.productVendors()
                         ReviewQualityCheckAction.OptOutCompleted(productVendors)
@@ -67,7 +70,10 @@ class ReviewQualityCheckPreferencesMiddleware(
                     val isProductRecommendationsEnabled =
                         reviewQualityCheckPreferences.productRecommendationsEnabled()
                     store.dispatch(
-                        ReviewQualityCheckAction.OptInCompleted(isProductRecommendationsEnabled),
+                        ReviewQualityCheckAction.OptInCompleted(
+                            isProductRecommendationsEnabled = isProductRecommendationsEnabled,
+                            productVendor = reviewQualityCheckVendorsService.productVendor(),
+                        ),
                     )
 
                     // Update the preference

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckVendorsService.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckVendorsService.kt
@@ -25,6 +25,11 @@ interface ReviewQualityCheckVendorsService {
      * Returns the list of product vendors in order.
      */
     fun productVendors(): List<ProductVendor>
+
+    /**
+     * Returns the product's vendor.
+     */
+    fun productVendor(): ProductVendor
 }
 
 /**
@@ -53,6 +58,8 @@ class DefaultReviewQualityCheckVendorsService(
             }
         }
     }
+
+    override fun productVendor(): ProductVendor = productVendors().first()
 
     /**
      * Creates list of product vendors using the firstVendor param as the first item in the list.

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
@@ -58,7 +58,10 @@ sealed interface ReviewQualityCheckAction : Action {
      * @property isProductRecommendationsEnabled Reflects the user preference update to display
      * recommended product. Null when product recommendations feature is disabled.
      */
-    data class OptInCompleted(val isProductRecommendationsEnabled: Boolean?) : UpdateAction
+    data class OptInCompleted(
+        val isProductRecommendationsEnabled: Boolean?,
+        val productVendor: ReviewQualityCheckState.ProductVendor,
+    ) : UpdateAction
 
     /**
      * Triggered as a result of [Init] when user has opted out of shopping experience.

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
@@ -46,6 +46,7 @@ sealed interface ReviewQualityCheckState : State {
     data class OptedIn(
         val productReviewState: ProductReviewState = ProductReviewState.Loading,
         val productRecommendationsPreference: Boolean?,
+        val productVendor: ProductVendor,
     ) : ReviewQualityCheckState {
 
         /**

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStore.kt
@@ -47,6 +47,7 @@ private fun mapStateForUpdateAction(
             } else {
                 ReviewQualityCheckState.OptedIn(
                     productRecommendationsPreference = action.isProductRecommendationsEnabled,
+                    productVendor = action.productVendor,
                 )
             }
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/NoAnalysis.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/NoAnalysis.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -39,6 +40,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
  *
  * @param isAnalyzing Whether or not the displayed product is being analyzed.
  * @param productRecommendationsEnabled The current state of the product recommendations toggle.
+ * @param productVendor The vendor of the product.
  * @param onAnalyzeClick Invoked when the user clicks on the check review button.
  * @param onReviewGradeLearnMoreClick Invoked when the user clicks to learn more about review grades.
  * @param onOptOutClick Invoked when the user opts out of the review quality check feature.
@@ -51,6 +53,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
 fun NoAnalysis(
     isAnalyzing: Boolean,
     productRecommendationsEnabled: Boolean?,
+    productVendor: ReviewQualityCheckState.ProductVendor,
     onAnalyzeClick: () -> Unit,
     onReviewGradeLearnMoreClick: () -> Unit,
     onOptOutClick: () -> Unit,
@@ -64,6 +67,7 @@ fun NoAnalysis(
         ReviewQualityNoAnalysisCard(isAnalyzing, onAnalyzeClick)
 
         ReviewQualityInfoCard(
+            productVendor = productVendor,
             onLearnMoreClick = onReviewGradeLearnMoreClick,
         )
 
@@ -173,6 +177,7 @@ private fun NoAnalysisPreview() {
         ) {
             NoAnalysis(
                 isAnalyzing = isAnalyzing,
+                productVendor = ReviewQualityCheckState.ProductVendor.AMAZON,
                 onAnalyzeClick = { isAnalyzing = !isAnalyzing },
                 productRecommendationsEnabled = false,
                 onReviewGradeLearnMoreClick = {},

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
@@ -51,6 +51,7 @@ import java.util.SortedMap
  *
  * @param productRecommendationsEnabled The current state of the product recommendations toggle.
  * @param productAnalysis The product analysis to display.
+ * @param productVendor The vendor of the product.
  * @param onOptOutClick Invoked when the user opts out of the review quality check feature.
  * @param onProductRecommendationsEnabledStateChange Invoked when the user changes the product
  * recommendations toggle state.
@@ -63,6 +64,7 @@ import java.util.SortedMap
 fun ProductAnalysis(
     productRecommendationsEnabled: Boolean?,
     productAnalysis: AnalysisPresent,
+    productVendor: ReviewQualityCheckState.ProductVendor,
     onOptOutClick: () -> Unit,
     onReanalyzeClick: () -> Unit,
     onProductRecommendationsEnabledStateChange: (Boolean) -> Unit,
@@ -121,6 +123,7 @@ fun ProductAnalysis(
         }
 
         ReviewQualityInfoCard(
+            productVendor = productVendor,
             modifier = Modifier.fillMaxWidth(),
             onLearnMoreClick = onReviewGradeLearnMoreClick,
         )
@@ -379,6 +382,7 @@ private enum class Highlight(
 private class ProductAnalysisPreviewModel(
     val productRecommendationsEnabled: Boolean?,
     val productAnalysis: AnalysisPresent,
+    val productVendor: ReviewQualityCheckState.ProductVendor,
 ) {
     constructor(
         productRecommendationsEnabled: Boolean? = false,
@@ -416,6 +420,7 @@ private class ProductAnalysisPreviewModel(
         ),
         recommendedProductState: ReviewQualityCheckState.RecommendedProductState =
             ReviewQualityCheckState.RecommendedProductState.Initial,
+        productVendor: ReviewQualityCheckState.ProductVendor = ReviewQualityCheckState.ProductVendor.AMAZON,
     ) : this(
         productRecommendationsEnabled = productRecommendationsEnabled,
         productAnalysis = AnalysisPresent(
@@ -427,6 +432,7 @@ private class ProductAnalysisPreviewModel(
             highlights = highlights,
             recommendedProductState = recommendedProductState,
         ),
+        productVendor = productVendor,
     )
 }
 
@@ -469,6 +475,7 @@ private fun ProductAnalysisPreview(
             ProductAnalysis(
                 productRecommendationsEnabled = productRecommendationsEnabled,
                 productAnalysis = model.productAnalysis,
+                productVendor = model.productVendor,
                 onOptOutClick = {},
                 onReanalyzeClick = {},
                 onProductRecommendationsEnabledStateChange = {

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysisError.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysisError.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState
 import org.mozilla.fenix.theme.FirefoxTheme
 
@@ -25,6 +26,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
  *
  * @param error The error state to display.
  * @param productRecommendationsEnabled The current state of the product recommendations toggle.
+ * @param productVendor The vendor of the product.
  * @param onReviewGradeLearnMoreClick Invoked when the user clicks to learn more about review grades.
  * @param onOptOutClick Invoked when the user opts out of the review quality check feature.
  * @param onProductRecommendationsEnabledStateChange Invoked when the user changes the product
@@ -37,6 +39,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
 fun ProductAnalysisError(
     error: ProductReviewState.Error,
     productRecommendationsEnabled: Boolean?,
+    productVendor: ReviewQualityCheckState.ProductVendor,
     onReviewGradeLearnMoreClick: () -> Unit,
     onOptOutClick: () -> Unit,
     onProductRecommendationsEnabledStateChange: (Boolean) -> Unit,
@@ -85,6 +88,7 @@ fun ProductAnalysisError(
         )
 
         ReviewQualityInfoCard(
+            productVendor = productVendor,
             onLearnMoreClick = onReviewGradeLearnMoreClick,
         )
 
@@ -114,6 +118,7 @@ private fun ProductAnalysisErrorPreview() {
             ProductAnalysisError(
                 error = ProductReviewState.Error.NetworkError,
                 productRecommendationsEnabled = true,
+                productVendor = ReviewQualityCheckState.ProductVendor.AMAZON,
                 onReviewGradeLearnMoreClick = {},
                 onOptOutClick = {},
                 onProductRecommendationsEnabledStateChange = {},

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckBottomSheet.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckBottomSheet.kt
@@ -116,6 +116,7 @@ private fun ProductReview(
                 ProductAnalysis(
                     productRecommendationsEnabled = state.productRecommendationsPreference,
                     productAnalysis = productReviewState,
+                    productVendor = state.productVendor,
                     onOptOutClick = onOptOutClick,
                     onReanalyzeClick = onReanalyzeClick,
                     onProductRecommendationsEnabledStateChange = onProductRecommendationsEnabledStateChange,
@@ -128,6 +129,7 @@ private fun ProductReview(
                 ProductAnalysisError(
                     error = productReviewState,
                     productRecommendationsEnabled = state.productRecommendationsPreference,
+                    productVendor = state.productVendor,
                     onReviewGradeLearnMoreClick = onReviewGradeLearnMoreClick,
                     onOptOutClick = onOptOutClick,
                     onProductRecommendationsEnabledStateChange = onProductRecommendationsEnabledStateChange,
@@ -142,8 +144,9 @@ private fun ProductReview(
 
             is ReviewQualityCheckState.OptedIn.ProductReviewState.NoAnalysisPresent -> {
                 NoAnalysis(
-                    productRecommendationsEnabled = state.productRecommendationsPreference,
                     isAnalyzing = productReviewState.isReanalyzing,
+                    productRecommendationsEnabled = state.productRecommendationsPreference,
+                    productVendor = state.productVendor,
                     onAnalyzeClick = onReanalyzeClick,
                     onReviewGradeLearnMoreClick = onReviewGradeLearnMoreClick,
                     onOptOutClick = onOptOutClick,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContextualOnboarding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContextualOnboarding.kt
@@ -24,7 +24,10 @@ import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.LinkText
 import org.mozilla.fenix.compose.LinkTextState
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.compose.button.PrimaryButton
+import org.mozilla.fenix.shopping.ext.displayName
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.ProductVendor
 import org.mozilla.fenix.theme.FirefoxTheme
 
@@ -166,25 +169,18 @@ fun ReviewQualityCheckContextualOnboarding(
 private fun createDescriptionString(
     retailers: List<ProductVendor>,
 ) = buildAnnotatedString {
-    val retailerNames = retailers.map {
-        when (it) {
-            ProductVendor.AMAZON -> R.string.review_quality_check_retailer_name_amazon
-            ProductVendor.BEST_BUY -> R.string.review_quality_check_retailer_name_bestbuy
-            ProductVendor.WALMART -> R.string.review_quality_check_retailer_name_walmart
-        }
-    }
+    val retailerNames = retailers.map { it.displayName() }
 
     val description = stringResource(
         id = R.string.review_quality_check_contextual_onboarding_description,
-        stringResource(retailerNames[0]),
+        retailerNames[0],
         stringResource(R.string.app_name),
-        stringResource(retailerNames[1]),
-        stringResource(retailerNames[2]),
+        retailerNames[1],
+        retailerNames[2],
     )
     append(description)
 
-    retailerNames.forEach {
-        val retailer = stringResource(id = it)
+    retailerNames.forEach { retailer ->
         val start = description.indexOf(retailer)
 
         addStyle(
@@ -192,5 +188,24 @@ private fun createDescriptionString(
             start = start,
             end = start + retailer.length,
         )
+    }
+}
+
+@Composable
+@LightDarkPreview
+private fun ProductAnalysisPreview() {
+    FirefoxTheme {
+        ReviewQualityCheckScaffold(
+            onRequestDismiss = {},
+        ) {
+            ReviewQualityCheckContextualOnboarding(
+                productVendors = ReviewQualityCheckState.NotOptedIn().productVendors,
+                onPrimaryButtonClick = {},
+                onLearnMoreClick = {},
+                onPrivacyPolicyClick = {},
+                onTermsOfUseClick = {},
+                onSecondaryButtonClick = {},
+            )
+        }
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityInfoCard.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityInfoCard.kt
@@ -20,22 +20,27 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
-import org.mozilla.fenix.compose.ClickableSubstringLink
+import org.mozilla.fenix.compose.LinkText
+import org.mozilla.fenix.compose.LinkTextState
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.compose.parseHtml
+import org.mozilla.fenix.shopping.ext.displayName
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
  * Info card UI containing an explanation of the review quality.
  *
+ * @param productVendor The vendor of the product.
  * @param modifier Modifier to apply to the layout.
  * @param onLearnMoreClick Invoked when the user clicks to learn more about review grades.
  */
 @Composable
 fun ReviewQualityInfoCard(
+    productVendor: ReviewQualityCheckState.ProductVendor,
     modifier: Modifier = Modifier,
     onLearnMoreClick: () -> Unit,
 ) {
@@ -44,15 +49,17 @@ fun ReviewQualityInfoCard(
         modifier = modifier,
     ) {
         ReviewQualityInfo(
+            productVendor = productVendor,
             modifier = Modifier.fillMaxWidth(),
             onLearnMoreClick = onLearnMoreClick,
         )
     }
 }
 
-@Suppress("Deprecation")
+@Suppress("LongMethod")
 @Composable
 private fun ReviewQualityInfo(
+    productVendor: ReviewQualityCheckState.ProductVendor,
     modifier: Modifier = Modifier,
     onLearnMoreClick: () -> Unit,
 ) {
@@ -60,11 +67,15 @@ private fun ReviewQualityInfo(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {
+        val letterGradeText =
+            stringResource(id = R.string.review_quality_check_info_review_grade_header)
         val adjustedGradingText =
             stringResource(id = R.string.review_quality_check_explanation_body_adjusted_grading)
-        // Any and all text formatting (bullets, inline substring bolding, etc.) will be handled as
-        // follow-up when the copy is finalized.
-        // Bug 1848219
+        val highlightsText = stringResource(
+            id = R.string.review_quality_check_explanation_body_highlights,
+            productVendor.displayName(),
+        )
+
         Text(
             text = stringResource(
                 id = R.string.review_quality_check_explanation_body_reliability,
@@ -74,19 +85,10 @@ private fun ReviewQualityInfo(
             style = FirefoxTheme.typography.body2,
         )
 
-        val link = stringResource(
-            id = R.string.review_quality_check_info_learn_more_link,
-            stringResource(R.string.shopping_product_name),
-        )
-        val text = stringResource(R.string.review_quality_check_info_learn_more, link)
-        val linkStartIndex = text.indexOf(link)
-        val linkEndIndex = linkStartIndex + link.length
-        ClickableSubstringLink(
-            text = text,
-            textStyle = FirefoxTheme.typography.body2,
-            clickableStartIndex = linkStartIndex,
-            clickableEndIndex = linkEndIndex,
-            onClick = onLearnMoreClick,
+        Text(
+            text = remember(letterGradeText) { parseHtml(letterGradeText) },
+            color = FirefoxTheme.colors.textPrimary,
+            style = FirefoxTheme.typography.body2,
         )
 
         ReviewGradingScaleInfo(
@@ -94,7 +96,7 @@ private fun ReviewQualityInfo(
                 ReviewQualityCheckState.Grade.A,
                 ReviewQualityCheckState.Grade.B,
             ),
-            info = stringResource(id = R.string.review_quality_check_info_grade_info_AB),
+            info = stringResource(id = R.string.review_quality_check_info_grade_info_AB_2),
             modifier = Modifier.fillMaxWidth(),
         )
 
@@ -109,7 +111,7 @@ private fun ReviewQualityInfo(
                 ReviewQualityCheckState.Grade.D,
                 ReviewQualityCheckState.Grade.F,
             ),
-            info = stringResource(id = R.string.review_quality_check_info_grade_info_DF),
+            info = stringResource(id = R.string.review_quality_check_info_grade_info_DF_2),
             modifier = Modifier.fillMaxWidth(),
         )
 
@@ -117,6 +119,35 @@ private fun ReviewQualityInfo(
             text = remember(adjustedGradingText) { parseHtml(adjustedGradingText) },
             color = FirefoxTheme.colors.textPrimary,
             style = FirefoxTheme.typography.body2,
+        )
+
+        Text(
+            text = remember(highlightsText) { parseHtml(highlightsText) },
+            color = FirefoxTheme.colors.textPrimary,
+            style = FirefoxTheme.typography.body2,
+        )
+
+        val link = stringResource(
+            id = R.string.review_quality_check_info_learn_more_link,
+            stringResource(R.string.shopping_product_name),
+        )
+        val text = stringResource(R.string.review_quality_check_info_learn_more, link)
+        LinkText(
+            text = text,
+            linkTextStates = listOf(
+                LinkTextState(
+                    text = link,
+                    url = "",
+                    onClick = {
+                        onLearnMoreClick()
+                    },
+                ),
+            ),
+            style = FirefoxTheme.typography.body2.copy(
+                color = FirefoxTheme.colors.textPrimary,
+            ),
+            linkTextColor = FirefoxTheme.colors.textAccent,
+            linkTextDecoration = TextDecoration.Underline,
         )
     }
 }
@@ -159,6 +190,7 @@ private fun ReviewQualityInfoCardPreview() {
                 .padding(all = 16.dp),
         ) {
             ReviewQualityInfoCard(
+                productVendor = ReviewQualityCheckState.ProductVendor.AMAZON,
                 modifier = Modifier.fillMaxWidth(),
                 onLearnMoreClick = {},
             )
@@ -177,6 +209,7 @@ private fun ReviewQualityInfoPreview() {
                 .padding(all = 16.dp),
         ) {
             ReviewQualityInfo(
+                productVendor = ReviewQualityCheckState.ProductVendor.AMAZON,
                 modifier = Modifier.fillMaxWidth(),
                 onLearnMoreClick = {},
             )

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -2120,17 +2120,21 @@
     <!-- Paragraph explaining how we analyze the reliability of a product's reviews. First parameter is the Fakespot product name. In the phrase "Fakespot by Mozilla", "by" can be localized. Does not need to stay by. -->
     <string name="review_quality_check_explanation_body_reliability">We use AI technology from %s by Mozilla to check the reliability of product reviews. This will only help you assess review quality, not product quality. </string>
     <!-- Paragraph explaining the grading system we use to classify the reliability of a product's reviews. -->
-    <string name="review_quality_check_info_review_grade_header" tools:ignore="UnusedResources"><![CDATA[We assign each product’s reviews a <b>letter grade</b> from A to F.]]></string>
+    <string name="review_quality_check_info_review_grade_header"><![CDATA[We assign each product’s reviews a <b>letter grade</b> from A to F.]]></string>
     <!-- Description explaining grades A and B for review quality check adjusted grading. -->
-    <string name="review_quality_check_info_grade_info_AB">Reliable reviews. We believe the reviews are likely from real customers who left honest, unbiased reviews.</string>
+    <string name="review_quality_check_info_grade_info_AB" moz:RemovedIn="120" tools:ignore="UnusedResources">Reliable reviews. We believe the reviews are likely from real customers who left honest, unbiased reviews.</string>
+    <!-- Description explaining grades A and B for review quality check adjusted grading. -->
+    <string name="review_quality_check_info_grade_info_AB_2">We believe the reviews to be reliable.</string>
     <!-- Description explaining grade C for review quality check adjusted grading. -->
     <string name="review_quality_check_info_grade_info_C">We believe there’s a mix of reliable and unreliable reviews.</string>
     <!-- Description explaining grades D and F for review quality check adjusted grading. -->
-    <string name="review_quality_check_info_grade_info_DF">Unreliable reviews. We believe the reviews are likely fake or from biased reviewers.</string>
+    <string name="review_quality_check_info_grade_info_DF" moz:RemovedIn="120" tools:ignore="UnusedResources">Unreliable reviews. We believe the reviews are likely fake or from biased reviewers.</string>
+    <!-- Description explaining grades D and F for review quality check adjusted grading. -->
+    <string name="review_quality_check_info_grade_info_DF_2">We believe the reviews are unreliable.</string>
     <!-- Paragraph explaining how a product's adjusted grading is calculated. -->
     <string name="review_quality_check_explanation_body_adjusted_grading"><![CDATA[The <b>adjusted rating</b> is based only on reviews we believe to be reliable.]]></string>
     <!-- Paragraph explaining product review highlights. First parameter is the name of the retailer (e.g. Amazon). -->
-    <string name="review_quality_check_explanation_body_highlights" tools:ignore="UnusedResources"><![CDATA[<b>Highlights</b> are from %s reviews within the last 80 days that we believe to be reliable.]]></string>
+    <string name="review_quality_check_explanation_body_highlights"><![CDATA[<b>Highlights</b> are from %s reviews within the last 80 days that we believe to be reliable.]]></string>
     <!-- Text for learn more caption presenting a link with information about review quality. First parameter is for clickable text defined in review_quality_check_info_learn_more_link. -->
     <string name="review_quality_check_info_learn_more">Learn more about %s.</string>
     <!-- Clickable text that links to review quality check SuMo page. First parameter is the Fakespot product name. In the phrase "Fakespot by Mozilla", "by" can be localized. Does not need to stay by. -->

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/ReviewQualityCheckBottomSheetStateFeatureTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/ReviewQualityCheckBottomSheetStateFeatureTest.kt
@@ -32,8 +32,12 @@ class ReviewQualityCheckBottomSheetStateFeatureTest {
         )
 
         tested.start()
-        store.dispatch(ReviewQualityCheckAction.OptInCompleted(isProductRecommendationsEnabled = true))
-            .joinBlocking()
+        store.dispatch(
+            ReviewQualityCheckAction.OptInCompleted(
+                isProductRecommendationsEnabled = true,
+                productVendor = ReviewQualityCheckState.ProductVendor.WALMART,
+            ),
+        ).joinBlocking()
         store.dispatch(ReviewQualityCheckAction.OptOutCompleted(emptyList())).joinBlocking()
 
         assertFalse(isInvoked)

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckVendorsService.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckVendorsService.kt
@@ -15,4 +15,6 @@ class FakeReviewQualityCheckVendorsService(
     ),
 ) : ReviewQualityCheckVendorsService {
     override fun productVendors(): List<ProductVendor> = productVendors
+
+    override fun productVendor(): ProductVendor = productVendors().first()
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStoreTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStoreTest.kt
@@ -83,7 +83,10 @@ class ReviewQualityCheckStoreTest {
             tested.waitUntilIdle()
             dispatcher.scheduler.advanceUntilIdle()
 
-            val expected = ReviewQualityCheckState.OptedIn(productRecommendationsPreference = false)
+            val expected = ReviewQualityCheckState.OptedIn(
+                productRecommendationsPreference = false,
+                productVendor = ProductVendor.BEST_BUY,
+            )
             assertEquals(expected, tested.state)
             assertEquals(true, cfrConditionUpdated)
         }
@@ -124,7 +127,10 @@ class ReviewQualityCheckStoreTest {
             dispatcher.scheduler.advanceUntilIdle()
             tested.waitUntilIdle()
 
-            val expected = ReviewQualityCheckState.OptedIn(productRecommendationsPreference = null)
+            val expected = ReviewQualityCheckState.OptedIn(
+                productRecommendationsPreference = null,
+                productVendor = ProductVendor.BEST_BUY,
+            )
             assertEquals(expected, tested.state)
 
             // Even if toggle action is dispatched, state is not changed
@@ -150,7 +156,10 @@ class ReviewQualityCheckStoreTest {
             tested.waitUntilIdle()
             dispatcher.scheduler.advanceUntilIdle()
 
-            val expected = ReviewQualityCheckState.OptedIn(productRecommendationsPreference = true)
+            val expected = ReviewQualityCheckState.OptedIn(
+                productRecommendationsPreference = true,
+                productVendor = ProductVendor.BEST_BUY,
+            )
             assertEquals(expected, tested.state)
         }
 
@@ -171,7 +180,10 @@ class ReviewQualityCheckStoreTest {
             tested.waitUntilIdle()
             dispatcher.scheduler.advanceUntilIdle()
 
-            val expected = ReviewQualityCheckState.OptedIn(productRecommendationsPreference = false)
+            val expected = ReviewQualityCheckState.OptedIn(
+                productRecommendationsPreference = false,
+                productVendor = ProductVendor.BEST_BUY,
+            )
             assertEquals(expected, tested.state)
         }
 
@@ -197,6 +209,7 @@ class ReviewQualityCheckStoreTest {
             val expected = ReviewQualityCheckState.OptedIn(
                 productReviewState = ProductAnalysisTestData.analysisPresent(),
                 productRecommendationsPreference = false,
+                productVendor = ProductVendor.BEST_BUY,
             )
             assertEquals(expected, tested.state)
         }
@@ -221,6 +234,7 @@ class ReviewQualityCheckStoreTest {
             val expected = ReviewQualityCheckState.OptedIn(
                 productReviewState = ReviewQualityCheckState.OptedIn.ProductReviewState.Error.GenericError,
                 productRecommendationsPreference = false,
+                productVendor = ProductVendor.BEST_BUY,
             )
             assertEquals(expected, tested.state)
         }
@@ -245,6 +259,7 @@ class ReviewQualityCheckStoreTest {
             val expected = ReviewQualityCheckState.OptedIn(
                 productReviewState = ReviewQualityCheckState.OptedIn.ProductReviewState.Error.NetworkError,
                 productRecommendationsPreference = false,
+                productVendor = ProductVendor.BEST_BUY,
             )
             assertEquals(expected, tested.state)
         }
@@ -271,6 +286,7 @@ class ReviewQualityCheckStoreTest {
             val expected = ReviewQualityCheckState.OptedIn(
                 productReviewState = ReviewQualityCheckState.OptedIn.ProductReviewState.Error.GenericError,
                 productRecommendationsPreference = false,
+                productVendor = ProductVendor.BEST_BUY,
             )
             assertEquals(expected, tested.state)
         }
@@ -313,6 +329,7 @@ class ReviewQualityCheckStoreTest {
                     analysisStatus = AnalysisStatus.NEEDS_ANALYSIS,
                 ),
                 productRecommendationsPreference = false,
+                productVendor = ProductVendor.BEST_BUY,
             )
             assertEquals(expected, tested.state)
         }
@@ -341,6 +358,7 @@ class ReviewQualityCheckStoreTest {
             val expected = ReviewQualityCheckState.OptedIn(
                 productReviewState = ProductAnalysisTestData.analysisPresent(),
                 productRecommendationsPreference = false,
+                productVendor = ProductVendor.BEST_BUY,
             )
             assertEquals(expected, tested.state)
         }


### PR DESCRIPTION

Changes in this PR:
- Added `ProductVendor` to the `OptedIn` state, so it's now a pseudo top-level property for that entire flow. This required adding the necessary logic to `ReviewQualityCheckPreferencesMiddleware` and `ReviewQualityCheckVendorsService` 
- Added the missing text for two sections of the review quality info card. One was dependent on the first bullet point in order to include the product vendor text.
- Added the string ID to the `ProductVendor` enum.
- Added new strings for the AB and DF rating blocks.
- Removed the deprecated use of `ClickableText` for `LinkText`



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1855553