### PR TITLE
Bug 1847266 - Implement status message for add-ons not signed correctly in the manager

### DIFF
--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -449,6 +449,7 @@ class DisabledFlags internal constructor(val value: Int) {
         const val USER: Int = 1 shl 1
         const val BLOCKLIST: Int = 1 shl 2
         const val APP_SUPPORT: Int = 1 shl 3
+        const val SIGNATURE: Int = 1 shl 4
 
         /**
          * Selects a combination of flags.
@@ -480,6 +481,14 @@ fun WebExtension.isUnsupported(): Boolean {
 fun WebExtension.isBlockListed(): Boolean {
     val flags = getMetadata()?.disabledFlags
     return flags?.contains(DisabledFlags.BLOCKLIST) == true
+}
+
+/**
+ * Returns whether the extension is disabled because it isn't correctly signed.
+ */
+fun WebExtension.isDisabledUnsigned(): Boolean {
+    val flags = getMetadata()?.disabledFlags
+    return flags?.contains(DisabledFlags.SIGNATURE) == true
 }
 
 /**

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
@@ -64,20 +64,31 @@ class WebExtensionTest {
     }
 
     @Test
-    fun `unsupported check`() {
+    fun `disabled checks`() {
         val extension: WebExtension = mock()
         assertFalse(extension.isUnsupported())
+        assertFalse(extension.isBlockListed())
+        assertFalse(extension.isDisabledUnsigned())
 
         val metadata: Metadata = mock()
         whenever(extension.getMetadata()).thenReturn(metadata)
         assertFalse(extension.isUnsupported())
+        assertFalse(extension.isBlockListed())
+        assertFalse(extension.isDisabledUnsigned())
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.BLOCKLIST))
         assertFalse(extension.isUnsupported())
         assertTrue(extension.isBlockListed())
+        assertFalse(extension.isDisabledUnsigned())
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.APP_SUPPORT))
         assertTrue(extension.isUnsupported())
         assertFalse(extension.isBlockListed())
+        assertFalse(extension.isDisabledUnsigned())
+
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.SIGNATURE))
+        assertFalse(extension.isUnsupported())
+        assertFalse(extension.isBlockListed())
+        assertTrue(extension.isDisabledUnsigned())
     }
 }

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -140,6 +140,11 @@ data class Addon(
          * The [Addon] was disabled by the user.
          */
         USER_REQUESTED,
+
+        /**
+         * The [Addon] was disabled because it isn't correctly signed.
+         */
+        NOT_CORRECTLY_SIGNED,
     }
 
     /**
@@ -178,6 +183,11 @@ data class Addon(
      * the blocklist. This is based on the installed extension state in the engine.
      */
     fun isDisabledAsBlocklisted() = installedState?.disabledReason == DisabledReason.BLOCKLISTED
+
+    /**
+     * Returns whether this [Addon] is currently disabled because it isn't correctly signed.
+     */
+    fun isDisabledAsNotCorrectlySigned() = installedState?.disabledReason == DisabledReason.NOT_CORRECTLY_SIGNED
 
     /**
      * Returns whether or not this [Addon] is allowed in private browsing mode.

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
@@ -19,6 +19,7 @@ import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webextension.isBlockListed
+import mozilla.components.concept.engine.webextension.isDisabledUnsigned
 import mozilla.components.concept.engine.webextension.isUnsupported
 import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.feature.addons.update.AddonUpdater.Status
@@ -381,6 +382,8 @@ fun WebExtension.toInstalledState() =
 internal fun WebExtension.getDisabledReason(): Addon.DisabledReason? {
     return if (isBlockListed()) {
         Addon.DisabledReason.BLOCKLISTED
+    } else if (isDisabledUnsigned()) {
+        Addon.DisabledReason.NOT_CORRECTLY_SIGNED
     } else if (isUnsupported()) {
         Addon.DisabledReason.UNSUPPORTED
     } else if (getMetadata()?.disabledFlags?.contains(DisabledFlags.USER) == true) {

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -136,7 +136,7 @@ class AddonsManagerAdapter(
         val userCountView = view.findViewById<TextView>(R.id.users_count)
         val addButton = view.findViewById<ImageView>(R.id.add_button)
         val allowedInPrivateBrowsingLabel = view.findViewById<ImageView>(R.id.allowed_in_private_browsing_label)
-        val statusBlocklistedView = view.findViewById<View>(R.id.add_on_status_blocklisted)
+        val statusErrorView = view.findViewById<View>(R.id.add_on_status_error)
         return AddonViewHolder(
             view,
             iconView,
@@ -147,7 +147,7 @@ class AddonsManagerAdapter(
             userCountView,
             addButton,
             allowedInPrivateBrowsingLabel,
-            statusBlocklistedView,
+            statusErrorView,
         )
     }
 
@@ -270,21 +270,28 @@ class AddonsManagerAdapter(
         style?.maybeSetAddonNameTextColor(holder.titleView)
         style?.maybeSetAddonSummaryTextColor(holder.summaryView)
 
+        val statusErrorMessage = holder.statusErrorView.findViewById<TextView>(R.id.add_on_status_error_message)
+        val statusErrorLearnMoreLink = holder.statusErrorView.findViewById<TextView>(
+            R.id.add_on_status_error_learn_more_link,
+        )
         if (addon.isDisabledAsBlocklisted()) {
-            holder.statusBlocklistedView.findViewById<TextView>(R.id.add_on_status_blocklisted_message).text =
-                context.getString(
-                    R.string.mozac_feature_addons_status_blocklisted,
-                    addonName,
-                )
-            holder.statusBlocklistedView.findViewById<TextView>(
-                R.id.add_on_status_blocklisted_learn_more_link,
-            ).setOnClickListener {
+            statusErrorMessage.text = context.getString(R.string.mozac_feature_addons_status_blocklisted, addonName)
+            statusErrorLearnMoreLink.setOnClickListener {
                 addonsManagerDelegate.onLearnMoreLinkClicked(
                     AddonsManagerAdapterDelegate.LearnMoreLinks.BLOCKLISTED_ADDON,
                     addon,
                 )
             }
-            holder.statusBlocklistedView.isVisible = true
+            holder.statusErrorView.isVisible = true
+        } else if (addon.isDisabledAsNotCorrectlySigned()) {
+            statusErrorMessage.text = context.getString(R.string.mozac_feature_addons_status_unsigned, addonName)
+            statusErrorLearnMoreLink.setOnClickListener {
+                addonsManagerDelegate.onLearnMoreLinkClicked(
+                    AddonsManagerAdapterDelegate.LearnMoreLinks.ADDON_NOT_CORRECTLY_SIGNED,
+                    addon,
+                )
+            }
+            holder.statusErrorView.isVisible = true
         }
     }
 

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterDelegate.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterDelegate.kt
@@ -18,6 +18,11 @@ interface AddonsManagerAdapterDelegate {
          * The [Addon] is blocklisted and the learn more link should give more information to the user.
          */
         BLOCKLISTED_ADDON,
+
+        /**
+         * The [Addon] is not correctly signed and the learn more link should give more information to the user.
+         */
+        ADDON_NOT_CORRECTLY_SIGNED,
     }
 
     /**

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/CustomViewHolder.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/CustomViewHolder.kt
@@ -46,7 +46,7 @@ sealed class CustomViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val userCountView: TextView,
         val addButton: ImageView,
         val allowedInPrivateBrowsingLabel: ImageView,
-        val statusBlocklistedView: View,
+        val statusErrorView: View,
     ) : CustomViewHolder(view)
 
     /**

--- a/android-components/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
+++ b/android-components/components/feature/addons/src/main/res/layout/mozac_feature_addons_item.xml
@@ -108,7 +108,7 @@
         </LinearLayout>
 
         <LinearLayout
-            android:id="@+id/add_on_status_blocklisted"
+            android:id="@+id/add_on_status_error"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="6dp"
@@ -116,15 +116,15 @@
             android:visibility="gone">
 
             <TextView
-                    android:id="@+id/add_on_status_blocklisted_message"
+                    android:id="@+id/add_on_status_error_message"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:textSize="14sp"
-                    android:textColor="@color/photonRed70"
+                    android:textColor="@color/mozac_feature_addons_error_text_color"
                     tools:text="@string/mozac_feature_addons_status_blocklisted" />
 
             <TextView
-                android:id="@+id/add_on_status_blocklisted_learn_more_link"
+                android:id="@+id/add_on_status_error_learn_more_link"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textSize="14sp"

--- a/android-components/components/feature/addons/src/main/res/values/colors.xml
+++ b/android-components/components/feature/addons/src/main/res/values/colors.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~  License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+
+<resources>
+    <!-- Color for the text of the error statuses in the add-ons manager. -->
+    <color name="mozac_feature_addons_error_text_color">#ff0000</color>
+</resources>

--- a/android-components/components/feature/addons/src/main/res/values/strings.xml
+++ b/android-components/components/feature/addons/src/main/res/values/strings.xml
@@ -235,4 +235,6 @@
     <string name="mozac_feature_addons_status_learn_more">Learn more</string>
     <!-- Status message below an add-on in the add-ons manager when this add-on has been blocklisted. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_status_blocklisted">%1$s has been disabled due to security or stability issues.</string>
+    <!-- Status message below an add-on in the add-ons manager when this add-on hasn't been signed correctly. %1$s is the add-on name. -->
+    <string name="mozac_feature_addons_status_unsigned">%1$s could not be verified as secure and has been disabled.</string>
 </resources>

--- a/android-components/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -21,6 +21,7 @@ import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.APP_SUPPORT
 import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.BLOCKLIST
+import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.SIGNATURE
 import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.USER
 import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.Metadata
@@ -828,22 +829,21 @@ class AddonManagerTest {
     fun `getDisabledReason cases`() {
         val extension: WebExtension = mock()
         val metadata: Metadata = mock()
-
-        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(BLOCKLIST))
         whenever(extension.getMetadata()).thenReturn(metadata)
 
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(BLOCKLIST))
         assertEquals(Addon.DisabledReason.BLOCKLISTED, extension.getDisabledReason())
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(APP_SUPPORT))
-
         assertEquals(Addon.DisabledReason.UNSUPPORTED, extension.getDisabledReason())
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(USER))
-
         assertEquals(Addon.DisabledReason.USER_REQUESTED, extension.getDisabledReason())
 
-        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(0))
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(SIGNATURE))
+        assertEquals(Addon.DisabledReason.NOT_CORRECTLY_SIGNED, extension.getDisabledReason())
 
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(0))
         assertNull(extension.getDisabledReason())
     }
 }

--- a/android-components/components/feature/addons/src/test/java/AddonTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonTest.kt
@@ -402,4 +402,20 @@ class AddonTest {
         assertFalse(addon.isDisabledAsBlocklisted())
         assertTrue(blockListedAddon.isDisabledAsBlocklisted())
     }
+
+    @Test
+    fun `isDisabledAsNotCorrectlySigned - true if installed state disabled status equals to NOT_CORRECTLY_SIGNED and otherwise false`() {
+        val addon = Addon(id = "id")
+        val blockListedAddon = addon.copy(
+            installedState = Addon.InstalledState(
+                id = "id",
+                version = "1.0",
+                optionsPageUrl = "",
+                disabledReason = Addon.DisabledReason.NOT_CORRECTLY_SIGNED,
+            ),
+        )
+
+        assertFalse(addon.isDisabledAsNotCorrectlySigned())
+        assertTrue(blockListedAddon.isDisabledAsNotCorrectlySigned())
+    }
 }

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
@@ -200,7 +200,7 @@ class AddonsManagerAdapterTest {
         val view = View(testContext)
         val allowedInPrivateBrowsingLabel = ImageView(testContext)
         val addonsManagerAdapterDelegate: AddonsManagerAdapterDelegate = mock()
-        val statusBlocklistedView: View = mock()
+        val statusErrorView: View = mock()
         val addonViewHolder = CustomViewHolder.AddonViewHolder(
             view = view,
             iconView = mock(),
@@ -211,7 +211,7 @@ class AddonsManagerAdapterTest {
             userCountView = userCountView,
             addButton = addButton,
             allowedInPrivateBrowsingLabel = allowedInPrivateBrowsingLabel,
-            statusBlocklistedView = statusBlocklistedView,
+            statusErrorView = statusErrorView,
         )
         val addon = Addon(
             id = "id",
@@ -375,7 +375,7 @@ class AddonsManagerAdapterTest {
         val view = View(testContext)
         val allowedInPrivateBrowsingLabel = ImageView(testContext)
         val addonsManagerAdapterDelegate: AddonsManagerAdapterDelegate = mock()
-        val statusBlocklistedView: View = mock()
+        val statusErrorView: View = mock()
         val addonViewHolder = CustomViewHolder.AddonViewHolder(
             view = view,
             iconView = mock(),
@@ -386,7 +386,7 @@ class AddonsManagerAdapterTest {
             userCountView = mock(),
             addButton = mock(),
             allowedInPrivateBrowsingLabel = allowedInPrivateBrowsingLabel,
-            statusBlocklistedView = statusBlocklistedView,
+            statusErrorView = statusErrorView,
         )
         val addon = Addon(
             id = "id",
@@ -584,13 +584,13 @@ class AddonsManagerAdapterTest {
         whenever(titleView.context).thenReturn(testContext)
         val summaryView: TextView = mock()
         whenever(summaryView.context).thenReturn(testContext)
-        val statusBlocklistedView: View = mock()
+        val statusErrorView: View = mock()
         val messageTextView: TextView = mock()
         val learnMoreTextView = TextView(testContext)
-        whenever(statusBlocklistedView.findViewById<TextView>(R.id.add_on_status_blocklisted_message)).thenReturn(
+        whenever(statusErrorView.findViewById<TextView>(R.id.add_on_status_error_message)).thenReturn(
             messageTextView,
         )
-        whenever(statusBlocklistedView.findViewById<TextView>(R.id.add_on_status_blocklisted_learn_more_link)).thenReturn(
+        whenever(statusErrorView.findViewById<TextView>(R.id.add_on_status_error_learn_more_link)).thenReturn(
             learnMoreTextView,
         )
         val addonViewHolder = CustomViewHolder.AddonViewHolder(
@@ -603,15 +603,15 @@ class AddonsManagerAdapterTest {
             userCountView = mock(),
             addButton = mock(),
             allowedInPrivateBrowsingLabel = mock(),
-            statusBlocklistedView = statusBlocklistedView,
+            statusErrorView = statusErrorView,
         )
         val addonName = "some addon name"
-        val addon = makeBlocklistedAddon(addonName)
+        val addon = makeDisabledAddon(Addon.DisabledReason.BLOCKLISTED, addonName)
         val adapter = AddonsManagerAdapter(mock(), addonsManagerAdapterDelegate, emptyList())
 
         adapter.bindAddon(addonViewHolder, addon)
 
-        verify(statusBlocklistedView).isVisible = true
+        verify(statusErrorView).isVisible = true
         verify(messageTextView).text = "$addonName has been disabled due to security or stability issues."
 
         // Verify that a click on the "learn more" link actually does something.
@@ -629,12 +629,12 @@ class AddonsManagerAdapterTest {
         whenever(titleView.context).thenReturn(testContext)
         val summaryView: TextView = mock()
         whenever(summaryView.context).thenReturn(testContext)
-        val statusBlocklistedView: View = mock()
+        val statusErrorView: View = mock()
         val messageTextView: TextView = mock()
-        whenever(statusBlocklistedView.findViewById<TextView>(R.id.add_on_status_blocklisted_message)).thenReturn(
+        whenever(statusErrorView.findViewById<TextView>(R.id.add_on_status_error_message)).thenReturn(
             messageTextView,
         )
-        whenever(statusBlocklistedView.findViewById<TextView>(R.id.add_on_status_blocklisted_learn_more_link)).thenReturn(
+        whenever(statusErrorView.findViewById<TextView>(R.id.add_on_status_error_learn_more_link)).thenReturn(
             mock(),
         )
         val addonViewHolder = CustomViewHolder.AddonViewHolder(
@@ -647,20 +647,101 @@ class AddonsManagerAdapterTest {
             userCountView = mock(),
             addButton = mock(),
             allowedInPrivateBrowsingLabel = mock(),
-            statusBlocklistedView = statusBlocklistedView,
+            statusErrorView = statusErrorView,
         )
-        val addon = makeBlocklistedAddon()
+        val addon = makeDisabledAddon(Addon.DisabledReason.BLOCKLISTED)
         val adapter = AddonsManagerAdapter(mock(), addonsManagerAdapterDelegate, emptyList())
 
         adapter.bindAddon(addonViewHolder, addon)
 
-        verify(statusBlocklistedView).isVisible = true
+        verify(statusErrorView).isVisible = true
         verify(messageTextView).text = "${addon.id} has been disabled due to security or stability issues."
     }
 
-    private fun makeBlocklistedAddon(name: String? = null): Addon {
+    @Test
+    fun `bind add-on not correctly signed`() {
+        val addonsManagerAdapterDelegate: AddonsManagerAdapterDelegate = mock()
+        val titleView: TextView = mock()
+        whenever(titleView.context).thenReturn(testContext)
+        val summaryView: TextView = mock()
+        whenever(summaryView.context).thenReturn(testContext)
+        val statusErrorView: View = mock()
+        val messageTextView: TextView = mock()
+        val learnMoreTextView = TextView(testContext)
+        whenever(statusErrorView.findViewById<TextView>(R.id.add_on_status_error_message)).thenReturn(
+            messageTextView,
+        )
+        whenever(statusErrorView.findViewById<TextView>(R.id.add_on_status_error_learn_more_link)).thenReturn(
+            learnMoreTextView,
+        )
+        val addonViewHolder = CustomViewHolder.AddonViewHolder(
+            view = View(testContext),
+            iconView = mock(),
+            titleView = titleView,
+            summaryView = summaryView,
+            ratingView = mock(),
+            ratingAccessibleView = mock(),
+            userCountView = mock(),
+            addButton = mock(),
+            allowedInPrivateBrowsingLabel = mock(),
+            statusErrorView = statusErrorView,
+        )
+        val addonName = "some addon name"
+        val addon = makeDisabledAddon(Addon.DisabledReason.NOT_CORRECTLY_SIGNED, addonName)
+        val adapter = AddonsManagerAdapter(mock(), addonsManagerAdapterDelegate, emptyList())
+
+        adapter.bindAddon(addonViewHolder, addon)
+
+        verify(statusErrorView).isVisible = true
+        verify(messageTextView).text = "$addonName could not be verified as secure and has been disabled."
+
+        // Verify that a click on the "learn more" link actually does something.
+        learnMoreTextView.performClick()
+        verify(addonsManagerAdapterDelegate).onLearnMoreLinkClicked(
+            AddonsManagerAdapterDelegate.LearnMoreLinks.ADDON_NOT_CORRECTLY_SIGNED,
+            addon,
+        )
+    }
+
+    @Test
+    fun `bind add-on not correctly signed and without a name`() {
+        val addonsManagerAdapterDelegate: AddonsManagerAdapterDelegate = mock()
+        val titleView: TextView = mock()
+        whenever(titleView.context).thenReturn(testContext)
+        val summaryView: TextView = mock()
+        whenever(summaryView.context).thenReturn(testContext)
+        val statusErrorView: View = mock()
+        val messageTextView: TextView = mock()
+        whenever(statusErrorView.findViewById<TextView>(R.id.add_on_status_error_message)).thenReturn(
+            messageTextView,
+        )
+        whenever(statusErrorView.findViewById<TextView>(R.id.add_on_status_error_learn_more_link)).thenReturn(
+            mock(),
+        )
+        val addonViewHolder = CustomViewHolder.AddonViewHolder(
+            view = View(testContext),
+            iconView = mock(),
+            titleView = titleView,
+            summaryView = summaryView,
+            ratingView = mock(),
+            ratingAccessibleView = mock(),
+            userCountView = mock(),
+            addButton = mock(),
+            allowedInPrivateBrowsingLabel = mock(),
+            statusErrorView = statusErrorView,
+        )
+        val addon = makeDisabledAddon(Addon.DisabledReason.NOT_CORRECTLY_SIGNED)
+        val adapter = AddonsManagerAdapter(mock(), addonsManagerAdapterDelegate, emptyList())
+
+        adapter.bindAddon(addonViewHolder, addon)
+
+        verify(statusErrorView).isVisible = true
+        verify(messageTextView).text = "${addon.id} could not be verified as secure and has been disabled."
+    }
+
+    private fun makeDisabledAddon(disabledReason: Addon.DisabledReason, name: String? = null): Addon {
         val installedState: Addon.InstalledState = mock()
-        whenever(installedState.disabledReason).thenReturn(Addon.DisabledReason.BLOCKLISTED)
+        whenever(installedState.disabledReason).thenReturn(disabledReason)
         return Addon(
             id = "@some-addon-id",
             translatableName = if (name != null) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -40,6 +40,7 @@ import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.extension.WebExtensionPromptFeature
+import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.theme.ThemeManager
 
 /**
@@ -270,6 +271,8 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
         val url = when (link) {
             AddonsManagerAdapterDelegate.LearnMoreLinks.BLOCKLISTED_ADDON ->
                 "${BuildConfig.AMO_BASE_URL}/android/blocked-addon/${addon.id}/"
+            AddonsManagerAdapterDelegate.LearnMoreLinks.ADDON_NOT_CORRECTLY_SIGNED ->
+                SupportUtils.getSumoURLForTopic(requireContext(), SupportUtils.SumoTopic.UNSIGNED_ADDONS)
         }
         openLinkInNewTab(url)
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -130,9 +130,9 @@ class InstalledAddonDetailsFragment : Fragment() {
         val switch = provideEnableSwitch()
         val privateBrowsingSwitch = providePrivateBrowsingSwitch()
         switch.setState(addon.isEnabled())
-        // When the ad-on is blocklisted, we do not want to enable the toggle switch
-        // because users shouldn't be able to re-enable a blocklisted add-on.
-        if (addon.isDisabledAsBlocklisted()) {
+        // When the ad-on is blocklisted or not correctly signed, we do not want to enable the toggle switch
+        // because users shouldn't be able to re-enable an add-on in this state.
+        if (addon.isDisabledAsBlocklisted() || addon.isDisabledAsNotCorrectlySigned()) {
             switch.isEnabled = false
             return
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -56,6 +56,7 @@ object SupportUtils {
         SPONSOR_PRIVACY("sponsor-privacy"),
         HTTPS_ONLY_MODE("https-only-mode-firefox-android"),
         COOKIE_BANNER("cookie-banner-reduction-firefox-android"),
+        UNSIGNED_ADDONS("unsigned-addons"),
     }
 
     enum class MozillaPage(internal val path: String) {

--- a/fenix/app/src/main/res/values-night/colors.xml
+++ b/fenix/app/src/main/res/values-night/colors.xml
@@ -165,4 +165,7 @@
     <!-- Tab Counter colors -->
     <color name="mozac_ui_tabcounter_default_tint" tools:ignore="UnusedResources">@color/fx_mobile_icon_color_primary</color>
     <color name="mozac_ui_tabcounter_default_text" tools:ignore="UnusedResources">@color/fx_mobile_text_color_primary</color>
+
+    <!-- Add-ons colors -->
+    <color name="mozac_feature_addons_error_text_color">@color/photonRed20</color>
 </resources>

--- a/fenix/app/src/main/res/values/colors.xml
+++ b/fenix/app/src/main/res/values/colors.xml
@@ -353,4 +353,7 @@
 
     <!-- Material Design colors -->
     <color name="material_scrim_color">#52000000</color>
+
+    <!-- Add-ons colors -->
+    <color name="mozac_feature_addons_error_text_color" tools:ignore="UnusedResources">@color/photonRed70</color>
 </resources>

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragmentTest.kt
@@ -90,11 +90,30 @@ class InstalledAddonDetailsFragmentTest {
         every { fragment.provideEnableSwitch() } returns enableSwitch
         every { fragment.providePrivateBrowsingSwitch() } returns privateBrowsingSwitch
         every { addon.isDisabledAsBlocklisted() } returns false
+        every { addon.isDisabledAsNotCorrectlySigned() } returns false
         every { addon.isEnabled() } returns true
         every { fragment.addon } returns addon
 
         fragment.bindEnableSwitch()
 
         verify(exactly = 0) { enableSwitch.isEnabled = false }
+    }
+
+    @Test
+    fun `GIVEN addon not correctly signed WHEN biding the enable switch THEN disable the switch`() {
+        val addon = mockk<Addon>()
+        val enableSwitch = mockk<SwitchMaterial>(relaxed = true)
+        val privateBrowsingSwitch = mockk<SwitchMaterial>(relaxed = true)
+
+        every { fragment.provideEnableSwitch() } returns enableSwitch
+        every { fragment.providePrivateBrowsingSwitch() } returns privateBrowsingSwitch
+        every { addon.isEnabled() } returns true
+        every { addon.isDisabledAsBlocklisted() } returns false
+        every { addon.isDisabledAsNotCorrectlySigned() } returns true
+        every { fragment.addon } returns addon
+
+        fragment.bindEnableSwitch()
+
+        verify { enableSwitch.isEnabled = false }
     }
 }


### PR DESCRIPTION
~~:warning: Depends on https://github.com/mozilla-mobile/firefox-android/pull/3805 and https://phabricator.services.mozilla.com/D189423~~

To verify this PR, we can (1) install an add-on, (2) set the `xpinstall.signatures.dev-root` (boolean) pref to `true` and (3) use remote debugging to run the following code snippet:

```js
{
  const { XPIDatabase } = ChromeUtils.import("resource://gre/modules/addons/XPIDatabase.jsm");
  XPIDatabase.verifySignatures();
}
```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847266