### PR TITLE
Bug 1807274 - Fix verifyDownloadCompleteNotificationTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -138,6 +138,7 @@ class DownloadTest {
             assertExternalAppOpens(GOOGLE_APPS_PHOTOS)
             mDevice.pressBack()
             mDevice.openNotification()
+            verifySystemNotificationExists("Download completed")
             swipeDownloadNotification(
                 direction = "Left",
                 shouldDismissNotification = true,

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
@@ -117,23 +117,26 @@ class NotificationRobot {
         shouldDismissNotification: Boolean,
         canExpandNotification: Boolean = true,
     ) {
-        // In case it fails, retry max 6x the swipe action on download system notifications
-        for (i in 1..6) {
+        // In case it fails, retry max 3x the swipe action on download system notifications
+        for (i in 1..RETRY_COUNT) {
             try {
-                // Swipe left the download system notification
-                if (direction == "Left") {
-                    itemContainingText(appName)
-                        .also {
-                            it.waitForExists(waitingTime)
-                            it.swipeLeft(3)
-                        }
-                } else {
-                    // Swipe right the download system notification
-                    itemContainingText(appName)
-                        .also {
-                            it.waitForExists(waitingTime)
-                            it.swipeRight(3)
-                        }
+                var retries = 0
+                while (itemContainingText(appName).exists() && retries++ < 3) {
+                    // Swipe left the download system notification
+                    if (direction == "Left") {
+                        itemContainingText(appName)
+                            .also {
+                                it.waitForExists(waitingTime)
+                                it.swipeLeft(3)
+                            }
+                    } else {
+                        // Swipe right the download system notification
+                        itemContainingText(appName)
+                            .also {
+                                it.waitForExists(waitingTime)
+                                it.swipeRight(3)
+                            }
+                    }
                 }
                 // Not all download related system notifications can be dismissed
                 if (shouldDismissNotification) {
@@ -144,7 +147,7 @@ class NotificationRobot {
 
                 break
             } catch (e: AssertionError) {
-                if (i == 6) {
+                if (i == RETRY_COUNT) {
                     throw e
                 } else {
                     notificationShade {
@@ -167,7 +170,7 @@ class NotificationRobot {
 
     fun clickNotification(notificationMessage: String) {
         mDevice.findObject(UiSelector().text(notificationMessage)).waitForExists(waitingTime)
-        mDevice.findObject(UiSelector().text(notificationMessage)).click()
+        mDevice.findObject(UiSelector().text(notificationMessage)).clickAndWaitForNewWindow(waitingTimeShort)
     }
 
     class Transition {


### PR DESCRIPTION
Summary:
There were 2 problems that were causing this UI test to be intermittent:
1. `RootViewWithoutFocusException` caused by some deficient syncing after opening the downloaded file.

- To resolve this problem I've used `clickAndWaitForNewWindow` in `clickNotification` which will wait for 3 seconds for the new window (Google photos app) and properly verify that the app opens.

2. Problems trying to dismiss the "Download completed" notification

- As part of the test matching task, this UI test was refactored (the downloaded file is now opened from the notification, the Google photos app is verified that is properly opened and afterwards the notification tray is opened again to dismiss the notification)

- To be sure that the "Download completed" notification is identified and expanded before performing the swipe gesture I've added an extra step `verifySystemNotificationExists("Download completed")`

- Reduced the number of retries for the for loop and added a while loop in `swipeDownloadNotification`
   The purpose of the while loop is to try to **inject repeatedly and as quickly as possible** the swipe gesture

Successfully passed 150x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807274