### PR TITLE
Bug 1848658 - Make shopping analysis field adjustedRating nullable to…

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/shopping/GeckoProductAnalysis.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/shopping/GeckoProductAnalysis.kt
@@ -23,7 +23,7 @@ data class GeckoProductAnalysis(
     override val productId: String?,
     val analysisURL: String?,
     val grade: String?,
-    val adjustedRating: Double,
+    val adjustedRating: Double?,
     val needsAnalysis: Boolean,
     val lastAnalysisTime: Long,
     val deletedProductReported: Boolean,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapper.kt
@@ -33,7 +33,7 @@ private fun GeckoProductAnalysis.toProductReview(): ProductReviewState =
             ProductReviewState.Error.GenericError
         }
     } else {
-        val mappedRating = adjustedRating.toFloatOrNull()
+        val mappedRating = adjustedRating?.toFloatOrNull()
         val mappedGrade = grade?.toGrade()
         val mappedHighlights = highlights?.toHighlights()?.toSortedMap()
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/ProductAnalysisTestData.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/ProductAnalysisTestData.kt
@@ -16,7 +16,7 @@ object ProductAnalysisTestData {
         productId: String? = "1",
         analysisURL: String = "https://test.com",
         grade: String? = "A",
-        adjustedRating: Double = 4.5,
+        adjustedRating: Double? = 4.5,
         needsAnalysis: Boolean = false,
         lastAnalysisTime: Long = 0L,
         deletedProductReported: Boolean = false,

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapperTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapperTest.kt
@@ -141,7 +141,7 @@ class ProductAnalysisMapperTest {
         val actual =
             ProductAnalysisTestData.productAnalysis(
                 grade = null,
-                adjustedRating = 0.0,
+                adjustedRating = null,
                 highlights = null,
             ).toProductReviewState()
         val expected = ReviewQualityCheckState.OptedIn.ProductReviewState.NoAnalysisPresent()


### PR DESCRIPTION
… allow GV to set the default to null



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1848658