### PR TITLE
Bug 1848527 - Part 1: Enable OutdatedDocumentation detekt rule in Fenix

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixLogSink.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixLogSink.kt
@@ -11,8 +11,8 @@ import mozilla.components.support.base.log.sink.LogSink
 /**
  * Fenix [LogSink] implementation that writes to Android's log, depending on settings.
  *
- * @param logsDebug If set to false, removes logging of debug logs.
- * @param androidLogSink an [AndroidLogSink] that writes to Android's log.
+ * @property logsDebug If set to false, removes logging of debug logs.
+ * @property androidLogSink an [AndroidLogSink] that writes to Android's log.
  */
 class FenixLogSink(
     private val logsDebug: Boolean = true,

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -944,7 +944,17 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
      * Navigates to the browser fragment and loads a URL or performs a search (depending on the
      * value of [searchTermOrURL]).
      *
+     * @param searchTermOrURL The entered search term to search or URL to be loaded.
+     * @param newTab Whether or not to load the URL in a new tab.
+     * @param from The [BrowserDirection] to indicate which fragment the browser is being
+     * opened from.
+     * @param customTabSessionId Optional custom tab session ID if navigating from a custom tab.
+     * @param engine Optional [SearchEngine] to use when performing a search.
+     * @param forceSearch Whether or not to force performing a search.
      * @param flags Flags that will be used when loading the URL (not applied to searches).
+     * @param requestDesktopMode Whether or not to request the desktop mode for the session.
+     * @param historyMetadata The [HistoryMetadataKey] of the new tab in case this tab
+     * was opened from history.
      * @param additionalHeaders The extra headers to use when loading the URL.
      */
     @Suppress("LongParameterList")
@@ -1048,7 +1058,12 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     /**
      * Loads a URL or performs a search (depending on the value of [searchTermOrURL]).
      *
+     * @param searchTermOrURL The entered search term to search or URL to be loaded.
+     * @param newTab Whether or not to load the URL in a new tab.
+     * @param engine Optional [SearchEngine] to use when performing a search.
+     * @param forceSearch Whether or not to force performing a search.
      * @param flags Flags that will be used when loading the URL (not applied to searches).
+     * @param requestDesktopMode Whether or not to request the desktop mode for the session.
      * @param historyMetadata The [HistoryMetadataKey] of the new tab in case this tab
      * was opened from history.
      * @param additionalHeaders The extra headers to use when loading the URL.

--- a/fenix/app/src/main/java/org/mozilla/fenix/ServiceWorkerSupportFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ServiceWorkerSupportFeature.kt
@@ -18,7 +18,7 @@ import org.mozilla.fenix.ext.components
  *
  * Will automatically register callbacks for service workers requests and cleanup when [homeActivity] is destroyed.
  *
- * @param homeActivity [HomeActivity] used for navigating to browser or accessing various app components.
+ * @property homeActivity [HomeActivity] used for navigating to browser or accessing various app components.
  */
 class ServiceWorkerSupportFeature(
     private val homeActivity: HomeActivity,

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionProcessDisabledController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionProcessDisabledController.kt
@@ -19,14 +19,13 @@ import mozilla.components.support.webextensions.ExtensionProcessDisabledPopupObs
 import org.mozilla.fenix.GleanMetrics.Addons
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
-import org.mozilla.geckoview.WebExtensionController
 
 /**
  * Controller for showing the user a dialog when the the extension process spawning has been disabled.
  *
  * @param context to show the AlertDialog
  * @param store The [BrowserStore] which holds the state for showing the dialog
- * @param webExtensionController to call when a user enables the process spawning
+ * @param engine An [Engine] instance used for handling extension process spawning.
  * @param builder to use for creating the dialog which can be styled as needed
  * @param appName to be added to the message. Optional and mainly relevant for testing
  */
@@ -52,12 +51,12 @@ class ExtensionProcessDisabledController(
         /**
          * Present a dialog to the user notifying of extension process spawning disabled and also asking
          * whether they would like to continue trying or disable extensions. If the user chooses to retry,
-         * enable the extension process spawning with [WebExtensionController.enableExtensionProcessSpawning].
-         * Otherwise, call [WebExtensionController.disableExtensionProcessSpawning].
+         * enable the extension process spawning with [Engine.enableExtensionProcessSpawning].
+         * Otherwise, call [Engine.disableExtensionProcessSpawning].
          *
          * @param context to show the AlertDialog
          * @param store The [BrowserStore] which holds the state for showing the dialog
-         * @param webExtensionController to call when the user enables or disables the process spawning
+         * @param engine An [Engine] instance used for handling extension process spawning
          * @param builder to use for creating the dialog which can be styled as needed
          * @param appName to be added to the message. Necessary to be added as a param for testing
          */

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/Extensions.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/Extensions.kt
@@ -12,6 +12,7 @@ import org.mozilla.fenix.components.FenixSnackbar
  *
  * @param view A [View] used to determine a parent for the [FenixSnackbar].
  * @param text The text to display in the [FenixSnackbar].
+ * @param duration The duration to show the [FenixSnackbar] for.
  */
 internal fun showSnackBar(view: View, text: String, duration: Int = FenixSnackbar.LENGTH_SHORT) {
     FenixSnackbar.make(

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/StandardSnackbarErrorBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/StandardSnackbarErrorBinding.kt
@@ -82,7 +82,7 @@ class StandardSnackbarErrorBinding(
 /**
  * Standard Snackbar Error data class.
  *
- * @param message that will appear on the snackbar.
+ * @property message that will appear on the snackbar.
  */
 data class StandardSnackbarError(
     val message: String,

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/infobanner/DynamicInfoBanner.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/infobanner/DynamicInfoBanner.kt
@@ -12,7 +12,15 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
  * [InfoBanner] that will automatically scroll with the top [BrowserToolbar].
  * Only to be used with [BrowserToolbar]s placed at the top of the screen.
  *
- * @param shouldScrollWithTopToolbar whether to follow the Y translation of the top toolbar or not
+ * @property context A [Context] for accessing system resources.
+ * @param container The layout where the banner will be shown.
+ * @property shouldScrollWithTopToolbar whether to follow the Y translation of the top toolbar or not.
+ * @param message The message displayed in the banner.
+ * @param dismissText The text on the dismiss button.
+ * @param actionText The text on the action to perform button.
+ * @param dismissByHiding Whether or not to hide the banner when dismissed.
+ * @param dismissAction  Optional callback invoked when the user dismisses the banner.
+ * @param actionToPerform The action to be performed on action button press.
  */
 @Suppress("LongParameterList")
 class DynamicInfoBanner(

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/infobanner/InfoBanner.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/infobanner/InfoBanner.kt
@@ -17,12 +17,14 @@ import org.mozilla.fenix.ext.settings
  * Displays an Info Banner in the specified container with a message and an optional action.
  * The container can be a placeholder layout inserted in the original screen, or an existing layout.
  *
- * @param context - A [Context] for accessing system resources.
- * @param container - The layout where the banner will be shown
- * @param message - The message displayed in the banner
- * @param dismissText - The text on the dismiss button
- * @param actionText - The text on the action to perform button
- * @param actionToPerform - The action to be performed on action button press
+ * @property context A [Context] for accessing system resources.
+ * @property container The layout where the banner will be shown.
+ * @property message The message displayed in the banner.
+ * @property dismissText The text on the dismiss button.
+ * @property actionText The text on the action to perform button.
+ * @property dismissByHiding Whether or not to hide the banner when dismissed.
+ * @property dismissAction  Optional callback invoked when the user dismisses the banner.
+ * @property actionToPerform The action to be performed on action button press.
  */
 @SuppressWarnings("LongParameterList")
 open class InfoBanner(

--- a/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationController.kt
@@ -64,11 +64,11 @@ fun List<Tab>.toTabSessionStateList(store: BrowserStore): List<TabSessionState> 
 }
 
 /**
- * @param store Store used to hold in-memory collection state.
- * @param browserStore The global `BrowserStore` instance.
- * @param dismiss Callback to dismiss the collection creation dialog.
- * @param tabCollectionStorage Storage used to save tab collections to disk.
- * @param scope Coroutine scope to launch coroutines.
+ * @property store Store used to hold in-memory collection state.
+ * @property browserStore The global `BrowserStore` instance.
+ * @property dismiss Callback to dismiss the collection creation dialog.
+ * @property tabCollectionStorage Storage used to save tab collections to disk.
+ * @property scope Coroutine scope to launch coroutines.
  */
 class DefaultCollectionCreationController(
     private val store: CollectionCreationStore,

--- a/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionsDialog.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionsDialog.kt
@@ -39,6 +39,8 @@ typealias OnNegativeButtonClick = () -> Unit
 /**
  * A data class for creating a dialog to prompt adding/creating a collection. See also [show].
  *
+ * @property storage An instance of [TabCollectionStorage] to retrieve and modify collections.
+ * @property sessionList List of [TabSessionState] to add to a collection.
  * @property onPositiveButtonClick Invoked when a user clicks on a confirmation button in the dialog.
  * @property onNegativeButtonClick Invoked when a user clicks on a cancel button in the dialog.
  */

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/AccountAbnormalities.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/AccountAbnormalities.kt
@@ -48,7 +48,10 @@ internal abstract class AbnormalFxaEvent : Exception() {
  *
  * See [AbnormalFxaEvent] for types of abnormal events this class detects.
  *
- * @param crashReporter An instance of [CrashReporter] used for reporting detected abnormalities.
+ * @param context An Android [Context].
+ * @property crashReporter An instance of [CrashReporter] used for reporting detected abnormalities.
+ * @param strictMode An instance of [StrictModeManager] used to manage strict mode settings for the
+ * application.
  */
 class AccountAbnormalities(
     context: Context,

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/FenixSnackbarBehavior.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/FenixSnackbarBehavior.kt
@@ -19,7 +19,7 @@ import org.mozilla.fenix.components.toolbar.ToolbarPosition
  * such that it will be shown on top (vertically) of other siblings that may obstruct it's view.
  *
  * @param context [Context] used for various system interactions.
- * @param toolbarPosition Where the toolbar is positioned on the screen.
+ * @property toolbarPosition Where the toolbar is positioned on the screen.
  * Depending on it's position (top / bottom) the snackbar will be shown below / above the toolbar.
  */
 class FenixSnackbarBehavior<V : View>(

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
@@ -22,11 +22,12 @@ import org.mozilla.fenix.components.FindInPageIntegration.ToolbarInfo
 /**
  * BrowserFragment delegate to handle all layout updates needed to show or hide the find in page bar.
  *
- * @param store [BrowserStore]
- * @param sessionId ID of the [store] session in which the query will be performed.
- * @param engineView the browser in which the queries will be made and which needs to be better positioned
+ * @property store The [BrowserStore] used to look up the current selected tab.
+ * @property sessionId ID of the [store] session in which the query will be performed.
+ * @property view The [FindInPageBar] view to display.
+ * @property engineView the browser in which the queries will be made and which needs to be better positioned
  * to suit the find in page bar.
- * @param toolbarInfo [ToolbarInfo] used to configure the [BrowserToolbar] while the find in page bar is shown.
+ * @property toolbarInfo [ToolbarInfo] used to configure the [BrowserToolbar] while the find in page bar is shown.
  */
 class FindInPageIntegration(
     private val store: BrowserStore,

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/PermissionStorage.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/PermissionStorage.kt
@@ -22,16 +22,19 @@ class PermissionStorage(
 
     /**
      * Persists the [sitePermissions] provided as a parameter.
-     * @param sitePermissions the [sitePermissions] to be stored.
+     *
+     * @param sitePermissions The [SitePermissions] to be stored.
+     * @param private Indicates if the [SitePermissions] belongs to a private session.
      */
     suspend fun add(sitePermissions: SitePermissions, private: Boolean) = withContext(dispatcher) {
         permissionsStorage.save(sitePermissions, private = private)
     }
 
     /**
-     * Finds all SitePermissions that match the [origin].
-     * @param origin the site to be used as filter in the search.
-     * @param private indicates if the [origin] belongs to a private session.
+     * Finds all [SitePermissions] that match the [origin].
+     *
+     * @param origin The site to be used as filter in the search.
+     * @param private Indicates if the [origin] belongs to a private session.
      */
     suspend fun findSitePermissionsBy(origin: String, private: Boolean): SitePermissions? =
         withContext(dispatcher) {
@@ -39,9 +42,10 @@ class PermissionStorage(
         }
 
     /**
-     * Replaces an existing SitePermissions with the values of [sitePermissions] provided as a parameter.
-     * @param sitePermissions the sitePermissions to be updated.
-     * @param private indicates if the [SitePermissions] belongs to a private session.
+     * Replaces an existing SitePermissions with the values of provided [sitePermissions].
+     *
+     * @param sitePermissions The [SitePermissions] to be updated.
+     * @param private Indicates if the [SitePermissions] belongs to a private session.
      */
     suspend fun updateSitePermissions(sitePermissions: SitePermissions, private: Boolean) =
         withContext(dispatcher) {
@@ -63,7 +67,7 @@ class PermissionStorage(
 
     /**
      * Deletes all sitePermissions that match the sitePermissions provided as a parameter.
-     * @param sitePermissions the sitePermissions to be deleted from the storage.
+     * @param sitePermissions The [SitePermissions] to be deleted from the storage.
      */
     suspend fun deleteSitePermissions(sitePermissions: SitePermissions) = withContext(dispatcher) {
         permissionsStorage.remove(sitePermissions, private = false)

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/StoreProvider.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/StoreProvider.kt
@@ -33,7 +33,7 @@ class StoreProvider<T : Store<*, *>>(
 /**
  * ViewModel factory to create [StoreProvider] instances.
  *
- * @param createStore Callback to create a new [Store], used when the [ViewModel] is first created.
+ * @property createStore Callback to create a new [Store], used when the [ViewModel] is first created.
  */
 @VisibleForTesting
 class StoreProviderFactory<T : Store<*, *>>(

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
@@ -28,13 +28,14 @@ import org.mozilla.fenix.wallpapers.WallpaperState
 /**
  * Value type that represents the state of the tabs tray.
  *
+ * @property isForeground Whether or not the app is in the foreground.
  * @property inactiveTabsExpanded A flag to know if the Inactive Tabs section of the Tabs Tray
  * should be expanded when the tray is opened.
  * @property firstFrameDrawn Flag indicating whether the first frame of the homescreen has been drawn.
  * @property nonFatalCrashes List of non-fatal crashes that allow the app to continue being used.
  * @property collections The list of [TabCollection] to display in the [HomeFragment].
  * @property expandedCollections A set containing the ids of the [TabCollection] that are expanded
- *                               in the [HomeFragment].
+ * in the [HomeFragment].
  * @property mode The state of the [HomeFragment] UI.
  * @property topSites The list of [TopSite] in the [HomeFragment].
  * @property showCollectionPlaceholder If true, shows a placeholder when there are no collections.
@@ -50,6 +51,8 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  * @property pendingDeletionHistoryItems The set of History items marked for removal in the UI,
  * awaiting to be removed once the Undo snackbar hides away.
  * Also serves as an in memory cache of all stories mapped by category allowing for quick stories filtering.
+ * @property wallpaperState The [WallpaperState] to display in the [HomeFragment].
+ * @property standardSnackbarError A snackbar error message to display.
  * @property shoppingSheetExpanded Boolean indicating if the shopping sheet is expanded and visible.
  */
 data class AppState(

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/bookmarks/BookmarksUseCase.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/bookmarks/BookmarksUseCase.kt
@@ -51,8 +51,8 @@ class BookmarksUseCase(
     /**
      * Uses for retrieving recently added bookmarks.
      *
-     * @param bookmarksStorage [BookmarksStorage] to retrieve the bookmark data.
-     * @param historyStorage Optional [HistoryStorage] to retrieve the preview image of a visited
+     * @property bookmarksStorage [BookmarksStorage] to retrieve the bookmark data.
+     * @property historyStorage Optional [HistoryStorage] to retrieve the preview image of a visited
      * page associated with a bookmark.
      */
     class RetrieveRecentBookmarksUseCase internal constructor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
@@ -81,7 +81,8 @@ interface PagedHistoryProvider {
 }
 
 /**
- * @param historyStorage
+ * @property historyStorage An instance [PlacesHistoryStorage] that provides read/write methods for
+ * history data.
  */
 class DefaultPagedHistoryProvider(
     private val historyStorage: PlacesHistoryStorage,

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserMenuSignIn.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserMenuSignIn.kt
@@ -20,8 +20,8 @@ import org.mozilla.fenix.ext.components
  * A menu item for displaying account information. The item computes the label on every bind call,
  * to provide each menu with the latest account manager state.
  *
+ * @property textColorResource ID of color resource to tint the text.
  * @param imageResource ID of a drawable resource to be shown as icon.
- * @param textColorResource Optional ID of color resource to tint the text.
  * @param listener Callback to be invoked when this menu item is clicked.
  */
 class BrowserMenuSignIn(

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarCFRPresenter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarCFRPresenter.kt
@@ -60,13 +60,14 @@ private const val CFR_MINIMUM_NUMBER_OPENED_TABS = 5
 /**
  * Delegate for handling all the business logic for showing CFRs in the toolbar.
  *
- * @param context used for various Android interactions.
- * @param browserStore will be observed for tabs updates
- * @param settings used to read and write persistent user settings
- * @param toolbar will serve as anchor for the CFRs
- * @param sessionId optional custom tab id used to identify the custom tab in which to show a CFR.
- * @param onShoppingCfrActionClicked Triggered when the user taps on the shopping CFR action.
- * @param shoppingExperienceFeature Used to determine if [ShoppingExperienceFeature] is enabled.
+ * @property context used for various Android interactions.
+ * @property browserStore will be observed for tabs updates
+ * @property settings used to read and write persistent user settings
+ * @property toolbar will serve as anchor for the CFRs
+ * @property isPrivate Whether or not the session is private.
+ * @property sessionId optional custom tab id used to identify the custom tab in which to show a CFR.
+ * @property onShoppingCfrActionClicked Triggered when the user taps on the shopping CFR action.
+ * @property shoppingExperienceFeature Used to determine if [ShoppingExperienceFeature] is enabled.
  */
 class BrowserToolbarCFRPresenter(
     private val context: Context,

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -44,14 +44,14 @@ import org.mozilla.fenix.theme.ThemeManager
 
 /**
  * Builds the toolbar object used with the 3-dot menu in the browser fragment.
- * @param context a [Context] for accessing system resources.
- * @param store reference to the application's [BrowserStore].
+ * @property context a [Context] for accessing system resources.
+ * @property store reference to the application's [BrowserStore].
  * @param hasAccountProblem If true, there was a problem signing into the Firefox account.
- * @param onItemTapped Called when a menu item is tapped.
- * @param lifecycleOwner View lifecycle owner used to determine when to cancel UI jobs.
- * @param bookmarksStorage Used to check if a page is bookmarked.
- * @param pinnedSiteStorage Used to check if the current url is a pinned site.
- * @param isPinningSupported true if the launcher supports adding shortcuts.
+ * @property onItemTapped Called when a menu item is tapped.
+ * @property lifecycleOwner View lifecycle owner used to determine when to cancel UI jobs.
+ * @property bookmarksStorage Used to check if a page is bookmarked.
+ * @property pinnedSiteStorage Used to check if the current url is a pinned site.
+ * @property isPinningSupported true if the launcher supports adding shortcuts.
  */
 @Suppress("LargeClass", "LongParameterList", "TooManyFunctions")
 open class DefaultToolbarMenu(

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/Chip.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/Chip.kt
@@ -95,10 +95,10 @@ fun SelectableChip(
 /**
  * Wrapper for the color parameters of [SelectableChip].
  *
- * @param selectedBackgroundColor Background [Color] when the chip is selected.
- * @param unselectedBackgroundColor Background [Color] when the chip is not selected.
- * @param selectedTextColor Text [Color] when the chip is selected.
- * @param unselectedTextColor Text [Color] when the chip is not selected.
+ * @property selectedBackgroundColor Background [Color] when the chip is selected.
+ * @property unselectedBackgroundColor Background [Color] when the chip is not selected.
+ * @property selectedTextColor Text [Color] when the chip is selected.
+ * @property unselectedTextColor Text [Color] when the chip is not selected.
  */
 data class SelectableChipColors(
     val selectedBackgroundColor: Color,

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ClickableSubstringLink.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ClickableSubstringLink.kt
@@ -21,7 +21,8 @@ import org.mozilla.fenix.theme.FirefoxTheme
 /**
  * [Text] containing a substring styled as an URL informing when this is clicked.
  *
- * @param text Full text that will be displayed
+ * @param text Full text that will be displayed.
+ * @param textStyle The [TextStyle] to apply to the text.
  * @param textColor [Color] of the normal text. The URL substring will have a default URL style applied.
  * @param linkTextColor [Color] of the link text.
  * @param linkTextDecoration The decorations to paint on the link text (e.g., an underline).

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/ComposeViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/ComposeViewHolder.kt
@@ -17,7 +17,7 @@ import org.mozilla.fenix.theme.Theme
 /**
  * [RecyclerView.ViewHolder] used for Jetpack Compose UI content .
  *
- * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
+ * @property composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param viewLifecycleOwner [LifecycleOwner] life cycle owner for the view.
  */
 abstract class ComposeViewHolder(

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/MessageCard.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/MessageCard.kt
@@ -157,12 +157,12 @@ private fun MessageCardIconButton(
 /**
  * Wrapper for the color parameters of [MessageCard].
  *
- * @param backgroundColor The background [Color] of the message.
- * @param titleTextColor [Color] to apply to the message's title, or the body text when there is no title.
- * @param messageTextColor [Color] to apply to the message's body text.
- * @param iconColor [Color] to apply to the message's icon.
- * @param buttonColor The background [Color] of the message's button.
- * @param buttonTextColor [Color] to apply to the button text.
+ * @property backgroundColor The background [Color] of the message.
+ * @property titleTextColor [Color] to apply to the message's title, or the body text when there is no title.
+ * @property messageTextColor [Color] to apply to the message's body text.
+ * @property iconColor [Color] to apply to the message's icon.
+ * @property buttonColor The background [Color] of the message's button.
+ * @property buttonTextColor [Color] to apply to the button text.
  */
 data class MessageCardColors(
     val backgroundColor: Color,

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/PagerIndicator.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/PagerIndicator.kt
@@ -35,9 +35,6 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * indicators to show progress, instead of just showing the current one as active.
  *
  * @param pagerState The state object of your [HorizontalPager] to be used to observe the list's state.
- * @param pageCount The size of indicators should be displayed, defaults to [PagerState.pageCount].
- * If you are implementing a looping pager with a much larger [PagerState.pageCount]
- * than indicators should displayed, e.g. [Int.MAX_VALUE], specify you real size in this param.
  * @param modifier The modifier to apply to this layout.
  * @param activeColor The color of the active page indicator, and the color of previous page
  * indicators in case [leaveTrail] is set to true.

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/button/FloatingActionButton.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/button/FloatingActionButton.kt
@@ -33,6 +33,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
  *
  * @param icon [Painter] icon to be displayed inside the action button.
  * @param modifier [Modifier] to be applied to the action button.
+ * @param contentDescription The content description to describe the icon.
  * @param label Text to be displayed next to the icon.
  * @param onClick Invoked when the button is clicked.
  */

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
@@ -75,6 +75,7 @@ fun HomeSectionHeader(
  * Homepage header content.
  *
  * @param headerText The header string.
+ * @param textColor [Color] to apply to the text.
  * @param description The content description for the "Show all" button.
  * @param showAllTextColor [Color] for the "Show all" button.
  * @param onShowAllClick Invoked when "Show all" button is clicked.

--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabGridItem.kt
@@ -272,6 +272,8 @@ private fun clickableColor() = when (isSystemInDarkTheme()) {
  * Thumbnail specific for the [TabGridItem], which can be selected.
  *
  * @param tab Tab, containing the thumbnail to be displayed.
+ * @param size Size of the thumbnail.
+ * @param storage [ThumbnailStorage] to obtain tab thumbnail bitmaps from.
  * @param multiSelectionSelected Whether or not the multiple selection is enabled.
  */
 @Composable

--- a/fenix/app/src/main/java/org/mozilla/fenix/crashes/CrashContentIntegration.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/crashes/CrashContentIntegration.kt
@@ -24,17 +24,17 @@ import org.mozilla.fenix.utils.Settings
 /**
  * Helper for observing [BrowserStore] and show an in-app crash reporter for tabs with content crashes.
  *
- * @param browserStore [BrowserStore] observed for any changes related to [EngineState.crashed].
- * @param appStore [AppStore] that tracks all content crashes in the current app session until the user
+ * @property browserStore [BrowserStore] observed for any changes related to [EngineState.crashed].
+ * @property appStore [AppStore] that tracks all content crashes in the current app session until the user
  * decides to either send or dismiss all crash reports.
- * @param toolbar [BrowserToolbar] that will be expanded when showing the in-app crash reporter.
- * @param isToolbarPlacedAtTop [Boolean] based allowing the in-app crash reporter to be shown as
+ * @property toolbar [BrowserToolbar] that will be expanded when showing the in-app crash reporter.
+ * @property isToolbarPlacedAtTop [Boolean] based allowing the in-app crash reporter to be shown as
  * immediately below or above the toolbar.
- * @param crashReporterView [CrashContentView] which will be shown if the current tab is marked as crashed.
- * @param components [Components] allowing interactions with other app features.
- * @param settings [Settings] allowing to check whether crash reporting is enabled or not.
- * @param navController [NavController] used to navigate to other parts of the app.
- * @param sessionId [String] Id of the tab or custom tab which should be observed for [EngineState.crashed]
+ * @property crashReporterView [CrashContentView] which will be shown if the current tab is marked as crashed.
+ * @property components [Components] allowing interactions with other app features.
+ * @property settings [Settings] allowing to check whether crash reporting is enabled or not.
+ * @property navController [NavController] used to navigate to other parts of the app.
+ * @property sessionId [String] Id of the tab or custom tab which should be observed for [EngineState.crashed]
  * depending on which [crashReporterView] will be shown or hidden.
  */
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -31,11 +31,13 @@ import java.util.Locale
 
 /**
  * Builds the toolbar object used with the 3-dot menu in the custom tab browser fragment.
- * @param store reference to the application's [BrowserStore].
- * @param sessionId ID of the open custom tab session.
- * @param shouldReverseItems If true, reverse the menu items.
- * @param isSandboxCustomTab If true, menu should not show the "Open in Firefox" and "POWERED BY FIREFOX" items.
- * @param onItemTapped Called when a menu item is tapped.
+ *
+ * @property context An Android [Context].
+ * @property store reference to the application's [BrowserStore].
+ * @property sessionId ID of the open custom tab session.
+ * @property shouldReverseItems If true, reverse the menu items.
+ * @property isSandboxCustomTab If true, menu should not show the "Open in Firefox" and "POWERED BY FIREFOX" items.
+ * @property onItemTapped Called when a menu item is tapped.
  */
 class CustomTabToolbarMenu(
     private val context: Context,

--- a/fenix/app/src/main/java/org/mozilla/fenix/downloads/StartDownloadDialog.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/downloads/StartDownloadDialog.kt
@@ -34,7 +34,7 @@ import org.mozilla.fenix.ext.settings
 /**
  * Parent of all download views that can mimic a modal [Dialog].
  *
- * @param activity The [Activity] in which the dialog will be shown.
+ * @property activity The [Activity] in which the dialog will be shown.
  * Used to update the activity [Window] to best mimic a modal dialog.
  */
 abstract class StartDownloadDialog(
@@ -153,13 +153,13 @@ abstract class StartDownloadDialog(
 /**
  * A download view mimicking a modal dialog that allows the user to download a file with the current application.
  *
- * @param activity The [Activity] in which the dialog will be shown.
+ * @property activity The [Activity] in which the dialog will be shown.
  * Used to update the activity [Window] to best mimic a modal dialog.
- * @param filename Name of the file to be downloaded. It wil be shown without any modification.
- * @param contentSize Size of the file to be downloaded expressed as a number of bytes.
+ * @property filename Name of the file to be downloaded. It wil be shown without any modification.
+ * @property contentSize Size of the file to be downloaded expressed as a number of bytes.
  * It will automatically be parsed to the appropriate kilobyte or megabyte value before being shown.
- * @param positiveButtonAction Callback for when the user interacts with the dialog to start the download.
- * @param negativeButtonAction Callback for when the user interacts with the dialog to dismiss it.
+ * @property positiveButtonAction Callback for when the user interacts with the dialog to start the download.
+ * @property negativeButtonAction Callback for when the user interacts with the dialog to dismiss it.
  */
 class FirstPartyDownloadDialog(
     private val activity: Activity,
@@ -212,11 +212,11 @@ class FirstPartyDownloadDialog(
  * A download view mimicking a modal dialog that presents the user with a list of all apps
  * that can handle the download request.
  *
- * @param activity The [Activity] in which the dialog will be shown.
+ * @property activity The [Activity] in which the dialog will be shown.
  * Used to update the activity [Window] to best mimic a modal dialog.
- * @param downloaderApps List of all applications that can handle the download request.
- * @param onAppSelected Callback for when the user chooses a specific application to handle the download request.
- * @param negativeButtonAction Callback for when the user interacts with the dialog to dismiss it.
+ * @property downloaderApps List of all applications that can handle the download request.
+ * @property onAppSelected Callback for when the user chooses a specific application to handle the download request.
+ * @property negativeButtonAction Callback for when the user interacts with the dialog to dismiss it.
  */
 class ThirdPartyDownloadDialog(
     private val activity: Activity,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
@@ -37,12 +37,13 @@ import org.mozilla.fenix.GleanMetrics.HomeMenu as HomeMenuMetrics
  * Helper class for building the [HomeMenu].
  *
  * @property view The [View] to attach the snackbar to.
- * @property context  An Android [Context].
+ * @property context An Android [Context].
  * @property lifecycleOwner [LifecycleOwner] for the view.
  * @property homeActivity [HomeActivity] used to open URLs in a new tab.
  * @property navController [NavController] used for navigation.
  * @property menuButton The [MenuButton] that will be used to create a menu when the button is
  * clicked.
+ * @property fxaEntrypoint The source entry point to FxA.
  */
 @Suppress("LongParameterList")
 class HomeMenuView(

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/PocketUpdatesMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/PocketUpdatesMiddleware.kt
@@ -29,10 +29,10 @@ import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesSelectedCategory
 /**
  * [AppStore] middleware reacting in response to Pocket related [Action]s.
  *
- * @param pocketStoriesService [PocketStoriesService] used for updating details about the Pocket recommended stories.
- * @param selectedPocketCategoriesDataStore [DataStore] used for reading or persisting details about the
+ * @property pocketStoriesService [PocketStoriesService] used for updating details about the Pocket recommended stories.
+ * @property selectedPocketCategoriesDataStore [DataStore] used for reading or persisting details about the
  * currently selected Pocket recommended stories categories.
- * @param coroutineScope [CoroutineScope] used for long running operations like disk IO.
+ * @property coroutineScope [CoroutineScope] used for long running operations like disk IO.
  */
 class PocketUpdatesMiddleware(
     private val pocketStoriesService: PocketStoriesService,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistHandler.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistHandler.kt
@@ -15,7 +15,7 @@ import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
 import org.mozilla.fenix.utils.Settings
 
 /**
- * Class for interacting with the a blocklist stored in [settings].
+ * Class for interacting with the blocklist stored in [settings].
  * The blocklist is a set of SHA1 hashed URLs, which are stripped
  * of protocols and common subdomains like "www" or "mobile".
  *

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistMiddleware.kt
@@ -14,7 +14,8 @@ import org.mozilla.fenix.home.recenttabs.RecentTab
  * This [Middleware] reacts to item removals from the home screen, adding them to a blocklist.
  * Additionally, it reacts to state changes in order to filter them by the blocklist.
  *
- * @param settings Blocklist is stored here as a string set
+ * @property blocklistHandler An instance of [BlocklistHandler] for interacting with the blocklist
+ * stored in shared preferences.
  */
 class BlocklistMiddleware(
     private val blocklistHandler: BlocklistHandler,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/collections/CollectionViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/collections/CollectionViewHolder.kt
@@ -36,7 +36,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
- * @param interactor [CollectionInteractor] callback for user interactions.
+ * @property interactor [CollectionInteractor] callback for user interactions.
  */
 class CollectionViewHolder(
     composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/collections/TabInCollectionViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/collections/TabInCollectionViewHolder.kt
@@ -25,7 +25,7 @@ import org.mozilla.fenix.home.sessioncontrol.CollectionInteractor
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
- * @param interactor [CollectionInteractor] callback for user interactions.
+ * @property interactor [CollectionInteractor] callback for user interactions.
  */
 class TabInCollectionViewHolder(
     composeView: ComposeView,
@@ -51,11 +51,10 @@ class TabInCollectionViewHolder(
                     tab = tab,
                     isLastInCollection = tabInfo.value.isLastInCollection,
                     onClick = { interactor.onCollectionOpenTabClicked(tab) },
-                    onRemove = { wasSwiped ->
+                    onRemove = {
                         interactor.onCollectionRemoveTab(
                             collection = collection,
                             tab = tab,
-                            wasSwiped = wasSwiped,
                         )
                     },
                 )

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketCategoriesViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketCategoriesViewHolder.kt
@@ -35,7 +35,7 @@ internal const val POCKET_CATEGORIES_SELECTED_AT_A_TIME_COUNT = 8
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
- * @param interactor [PocketStoriesInteractor] callback for user interaction.
+ * @property interactor [PocketStoriesInteractor] callback for user interaction.
  */
 class PocketCategoriesViewHolder(
     composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketRecommendationsHeaderViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketRecommendationsHeaderViewHolder.kt
@@ -32,7 +32,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
- * @param interactor [PocketStoriesInteractor] callback for user interaction.
+ * @property interactor [PocketStoriesInteractor] callback for user interaction.
  */
 class PocketRecommendationsHeaderViewHolder(
     composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesController.kt
@@ -68,8 +68,8 @@ interface PocketStoriesController {
 /**
  * Default behavior for handling all user interactions with the Pocket recommended stories feature.
  *
- * @param homeActivity [HomeActivity] used to open URLs in a new tab.
- * @param appStore [AppStore] from which to read the current Pocket recommendations and dispatch new actions on.
+ * @property homeActivity [HomeActivity] used to open URLs in a new tab.
+ * @property appStore [AppStore] from which to read the current Pocket recommendations and dispatch new actions on.
  */
 internal class DefaultPocketStoriesController(
     private val homeActivity: HomeActivity,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesViewHolder.kt
@@ -34,7 +34,7 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
- * @param interactor [PocketStoriesInteractor] callback for user interaction.
+ * @property interactor [PocketStoriesInteractor] callback for user interaction.
  */
 class PocketStoriesViewHolder(
     composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/RecentBookmarksFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/RecentBookmarksFeature.kt
@@ -14,16 +14,17 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.bookmarks.BookmarksUseCase
+import org.mozilla.fenix.home.HomeFragment
 
 /**
  * View-bound feature that retrieves a list of recently added [BookmarkNode]s and dispatches
  * updates to the [AppStore].
  *
- * @param appStore the [AppStore]
- * @param bookmarksUseCase the [BookmarksUseCase] for retrieving the list of recently saved
+ * @property appStore the [AppStore] that holds the state of the [HomeFragment].
+ * @property bookmarksUseCase the [BookmarksUseCase] for retrieving the list of recently saved
  * bookmarks from storage.
- * @param scope the [CoroutineScope] used to fetch the bookmarks list
- * @param ioDispatcher the [CoroutineDispatcher] for performing read/write operations.
+ * @property scope the [CoroutineScope] used to fetch the bookmarks list
+ * @property ioDispatcher the [CoroutineDispatcher] for performing read/write operations.
  */
 class RecentBookmarksFeature(
     private val appStore: AppStore,
@@ -48,9 +49,9 @@ class RecentBookmarksFeature(
 /**
  * A bookmark that was recently added.
  *
- * @param title The title of the bookmark.
- * @param url The url of the bookmark.
- * @param previewImageUrl A preview image of the page (a.k.a. the hero image), if available.
+ * @property title The title of the bookmark.
+ * @property url The url of the bookmark.
+ * @property previewImageUrl A preview image of the page (a.k.a. the hero image), if available.
  */
 data class RecentBookmark(
     val title: String? = null,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksHeaderViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksHeaderViewHolder.kt
@@ -23,7 +23,8 @@ import org.mozilla.fenix.home.recentbookmarks.interactor.RecentBookmarksInteract
  * View holder for the recent bookmarks header and "Show all" button.
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
- * @param interactor [RecentBookmarksInteractor] which will have delegated to all user interactions.
+ * @param viewLifecycleOwner [LifecycleOwner] life cycle owner for the view.
+ * @property interactor [RecentBookmarksInteractor] which will have delegated to all user interactions.
  */
 class RecentBookmarksHeaderViewHolder(
     composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit
 /**
  * Delegate to handle layout updates and dispatch actions related to the recent synced tab.
  *
+ * @property context An Android [Context].
  * @property appStore Store to dispatch actions to when synced tabs are updated or errors encountered.
  * @property syncStore Store to observe for changes to Sync and account status.
  * @property storage Storage layer for synced tabs.
@@ -224,10 +225,11 @@ sealed class RecentSyncedTabState {
 /**
  * A tab that was recently viewed on a synced device.
  *
- * @param deviceDisplayName The device the tab was viewed on.
- * @param title The title of the tab.
- * @param url The url of the tab.
- * @param previewImageUrl The url used to retrieve the preview image of the tab.
+ * @property deviceDisplayName The device the tab was viewed on.
+ * @property deviceType The type of a device the tab was viewed on - mobile, desktop.
+ * @property title The title of the tab.
+ * @property url The url of the tab.
+ * @property previewImageUrl The url used to retrieve the preview image of the tab.
  */
 data class RecentSyncedTab(
     val deviceDisplayName: String,
@@ -240,8 +242,8 @@ data class RecentSyncedTab(
 /**
  * Class representing a tab from a synced device.
  *
- * @param device The synced [Device].
- * @param tab The tab from the synced device.
+ * @property device The synced [Device].
+ * @property tab The tab from the synced device.
  */
 private data class SyncedDeviceTab(
     val device: Device,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/controller/RecentSyncedTabController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/controller/RecentSyncedTabController.kt
@@ -10,6 +10,7 @@ import org.mozilla.fenix.GleanMetrics.RecentSyncedTabs
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.home.recentsyncedtabs.interactor.RecentSyncedTabInteractor
@@ -43,6 +44,8 @@ interface RecentSyncedTabController {
  *
  * @property tabsUseCase Use cases to open the synced tab when clicked.
  * @property navController [NavController] to navigate to synced tabs tray.
+ * @property accessPoint The action or screen that was used to navigate to the tabs tray.
+ * @property appStore The [AppStore] that holds the state of the [HomeFragment].
  */
 class DefaultRecentSyncedTabController(
     private val tabsUseCase: TabsUseCases,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
@@ -23,7 +23,8 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  * View holder for a recent synced tab item.
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
- * @param recentSyncedTabInteractor [RecentSyncedTabInteractor] which will have delegated to all
+ * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
+ * @property recentSyncedTabInteractor [RecentSyncedTabInteractor] which will have delegated to all
  * recent synced tab user interactions.
  */
 class RecentSyncedTabViewHolder(

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/RecentTabsListFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/RecentTabsListFeature.kt
@@ -41,7 +41,7 @@ sealed class RecentTab {
     /**
      * A tab that was recently viewed
      *
-     * @param state Recently viewed [TabSessionState]
+     * @property state Recently viewed [TabSessionState]
      */
     data class Tab(val state: TabSessionState) : RecentTab()
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
@@ -11,6 +11,7 @@ import org.mozilla.fenix.GleanMetrics.RecentTabs
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
@@ -39,8 +40,9 @@ interface RecentTabController {
 /**
  * The default implementation of [RecentTabController].
  *
- * @param selectTabUseCase [SelectTabUseCase] used selecting a tab.
- * @param navController [NavController] used for navigation.
+ * @property selectTabUseCase [SelectTabUseCase] used selecting a tab.
+ * @property navController [NavController] used for navigation.
+ * @property appStore The [AppStore] that holds the state of the [HomeFragment].
  */
 class DefaultRecentTabsController(
     private val selectTabUseCase: SelectTabUseCase,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
@@ -20,9 +20,9 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  * View holder for a recent tab item.
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
- * @param recentTabInteractor [RecentTabInteractor] which will have delegated to all user recent
+ * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
+ * @property recentTabInteractor [RecentTabInteractor] which will have delegated to all user recent
  * tab interactions.
- * recent synced tab interactions.
  */
 class RecentTabViewHolder(
     composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -72,6 +72,7 @@ private const val THUMBNAIL_SIZE = 108
  *
  * @param recentTabs List of [RecentTab] to display.
  * @param menuItems List of [RecentTabMenuItem] shown long clicking a [RecentTab].
+ * @param storage [ThumbnailStorage] to obtain tab thumbnail bitmaps from.
  * @param backgroundColor The background [Color] of each item.
  * @param onRecentTabClick Invoked when the user clicks on a recent tab.
  */
@@ -113,6 +114,8 @@ fun RecentTabs(
  * A recent tab item.
  *
  * @param tab [RecentTab.Tab] that was recently viewed.
+ * @param storage [ThumbnailStorage] to obtain tab thumbnail bitmaps from.
+ * @param menuItems List of [RecentTabMenuItem] to be shown in a menu.
  * @param backgroundColor The background [Color] of the item.
  * @param onRecentTabClick Invoked when the user clicks on a recent tab.
  */
@@ -217,6 +220,7 @@ private fun RecentTabItem(
  * A recent tab image.
  *
  * @param tab [RecentTab] that was recently viewed.
+ * @param storage [ThumbnailStorage] to obtain tab thumbnail bitmaps from.
  * @param modifier [Modifier] used to draw the image content.
  * @param contentScale [ContentScale] used to draw image content.
  */

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabsHeaderViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabsHeaderViewHolder.kt
@@ -22,7 +22,9 @@ import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
 /**
  * View holder for the recent tabs header and "Show all" button.
  *
- * @param interactor [RecentTabInteractor] which will have delegated to all user interactions.
+ * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
+ * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
+ * @property interactor [RecentTabInteractor] which will have delegated to all user interactions.
  */
 class RecentTabsHeaderViewHolder(
     composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/RecentVisitsFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/RecentVisitsFeature.kt
@@ -38,12 +38,12 @@ import kotlin.math.max
  * which will be mapped to [RecentlyVisitedItem]s and then dispatched to [AppStore]
  * to be displayed on the home screen.
  *
- * @param appStore The [AppStore] that holds the state of the [HomeFragment].
- * @param historyMetadataStorage The storage that manages [HistoryMetadata].
- * @param historyHighlightsStorage The storage that manages [PlacesHistoryStorage].
- * @param scope The [CoroutineScope] used for IO operations related to querying history
+ * @property appStore The [AppStore] that holds the state of the [HomeFragment].
+ * @property historyMetadataStorage The storage that manages [HistoryMetadata].
+ * @property historyHighlightsStorage The storage that manages [PlacesHistoryStorage].
+ * @property scope The [CoroutineScope] used for IO operations related to querying history
  * and then for dispatching updates.
- * @param ioDispatcher The [CoroutineDispatcher] for performing read/write operations.
+ * @property ioDispatcher The [CoroutineDispatcher] for performing read/write operations.
  */
 class RecentVisitsFeature(
     private val appStore: AppStore,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/RecentlyVisitedItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/RecentlyVisitedItem.kt
@@ -14,8 +14,8 @@ sealed class RecentlyVisitedItem {
     /**
      * A history highlight - previously accessed webpage of particular importance.
      *
-     * @param title The title of the webpage. May be [url] if the title is unavailable.
-     * @param url The URL of the webpage.
+     * @property title The title of the webpage. May be [url] if the title is unavailable.
+     * @property url The URL of the webpage.
      */
     data class RecentHistoryHighlight(
         val title: String,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentVisitsHeaderViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentVisitsHeaderViewHolder.kt
@@ -22,6 +22,8 @@ import org.mozilla.fenix.home.recentvisits.interactor.RecentVisitsInteractor
 /**
  * View holder for the "Recent visits" section header with the "Show all" button.
  *
+ * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
+ * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
  * @property interactor [RecentVisitsInteractor] which will have delegated to all user
  * interactions.
  */

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisitedViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisitedViewHolder.kt
@@ -26,6 +26,7 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  * View holder for [RecentlyVisitedItem]s.
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
+ * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
  * @property interactor [RecentVisitsInteractor] which will have delegated to all user interactions.
  */
 class RecentlyVisitedViewHolder(

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -83,7 +83,7 @@ interface SessionControlController {
     /**
      * @see [CollectionInteractor.onCollectionRemoveTab]
      */
-    fun handleCollectionRemoveTab(collection: TabCollection, tab: ComponentTab, wasSwiped: Boolean)
+    fun handleCollectionRemoveTab(collection: TabCollection, tab: ComponentTab)
 
     /**
      * @see [CollectionInteractor.onCollectionShareTabsClicked]
@@ -244,7 +244,6 @@ class DefaultSessionControlController(
     override fun handleCollectionRemoveTab(
         collection: TabCollection,
         tab: ComponentTab,
-        wasSwiped: Boolean,
     ) {
         Collections.tabRemoved.record(NoExtras())
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -83,7 +83,7 @@ interface CollectionInteractor {
      * @param collection The collection of tabs that will be modified.
      * @param tab The tab to remove from the tab collection.
      */
-    fun onCollectionRemoveTab(collection: TabCollection, tab: Tab, wasSwiped: Boolean)
+    fun onCollectionRemoveTab(collection: TabCollection, tab: Tab)
 
     /**
      * Shares the tabs in the given tab collection. Called when a user clicks on the Collection
@@ -261,8 +261,8 @@ class SessionControlInteractor(
         controller.handleCollectionOpenTabsTapped(collection)
     }
 
-    override fun onCollectionRemoveTab(collection: TabCollection, tab: Tab, wasSwiped: Boolean) {
-        controller.handleCollectionRemoveTab(collection, tab, wasSwiped)
+    override fun onCollectionRemoveTab(collection: TabCollection, tab: Tab) {
+        controller.handleCollectionRemoveTab(collection, tab)
     }
 
     override fun onCollectionShareTabsClicked(collection: TabCollection) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolder.kt
@@ -36,7 +36,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param viewLifecycleOwner [LifecycleOwner] life cycle owner for the view.
- * @param interactor [PrivateBrowsingInteractor] which will have delegated to all user interactions.
+ * @property interactor [PrivateBrowsingInteractor] which will have delegated to all user interactions.
  */
 class PrivateBrowsingDescriptionViewHolder(
     composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/MessageCardViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/MessageCardViewHolder.kt
@@ -27,6 +27,8 @@ import org.mozilla.fenix.wallpapers.WallpaperState
 /**
  * View holder for the Nimbus Message Card.
  *
+ * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
+ * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
  * @property interactor [SessionControlInteractor] which will have delegated to all user
  * interactions.
  */

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSites.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSites.kt
@@ -90,6 +90,7 @@ private const val TOP_SITES_FAVICON_SIZE = 36
  * @param onSettingsClicked Invoked when the user clicks on the "Settings" menu item.
  * @param onSponsorPrivacyClicked Invoked when the user clicks on the "Our sponsors & your privacy"
  * menu item.
+ * @param onTopSitesItemBound Invoked during the composition of a top site item.
  */
 @OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 @Composable
@@ -242,6 +243,7 @@ data class TopSiteColors(
  * @param topSiteColors The color set defined by [TopSiteColors] used to style a top site.
  * @param onTopSiteClick Invoked when the user clicks on a top site.
  * @param onTopSiteLongClick Invoked when the user long clicks on a top site.
+ * @param onTopSitesItemBound Invoked during the composition of a top site item.
  */
 @Suppress("LongParameterList", "LongMethod")
 @OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesViewHolder.kt
@@ -21,7 +21,7 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
- * @param interactor [TopSiteInteractor] which will have delegated to all user top sites
+ * @property interactor [TopSiteInteractor] which will have delegated to all user top sites
  * interactions.
  */
 class TopSitesViewHolder(

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
@@ -15,8 +15,6 @@ import org.mozilla.fenix.components.metrics.MetricsUtils
  * Interactor for the Bookmarks screen.
  * Provides implementations for the BookmarkViewInteractor.
  *
- * @property bookmarkStore bookmarks state
- * @property viewModel view state
  * @property bookmarksController view controller
  */
 @SuppressWarnings("TooManyFunctions")

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragmentStore.kt
@@ -50,9 +50,12 @@ sealed class DownloadFragmentAction : Action {
 }
 
 /**
- * The state for the Download Screen
- * @property items List of DownloadItem to display
- * @property mode Current Mode of Download
+ * The state of the Download screen.
+ *
+ * @property items List of [DownloadItem] to display.
+ * @property mode Current [Mode] of the Download screen.
+ * @property pendingDeletionIds Set of [DownloadItem] IDs that are waiting to be deleted.
+ * @property isDeletingItems Whether or not download items are being deleted.
  */
 data class DownloadFragmentState(
     val items: List<DownloadItem>,
@@ -64,7 +67,7 @@ data class DownloadFragmentState(
         open val selectedItems = emptySet<DownloadItem>()
 
         object Normal : Mode()
-        data class Editing(override val selectedItems: Set<DownloadItem>) : DownloadFragmentState.Mode()
+        data class Editing(override val selectedItems: Set<DownloadItem>) : Mode()
     }
 }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
@@ -182,9 +182,14 @@ sealed class HistoryFragmentAction : Action {
 }
 
 /**
- * The state for the History Screen
+ * The state for the History Screen.
+ *
  * @property items List of History to display
  * @property mode Current Mode of History
+ * @property pendingDeletionItems The set of [PendingDeletionHistory] marked for removal.
+ * @property isEmpty Whether or not the screen is empty.
+ * @property isDeletingItems Whether or not the history items are currently in the process of being
+ * deleted.
  */
 data class HistoryFragmentState(
     val items: List<History>,

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistoryNavigationMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistoryNavigationMiddleware.kt
@@ -17,6 +17,7 @@ import org.mozilla.fenix.library.history.History
 import org.mozilla.fenix.library.history.HistoryFragmentAction
 import org.mozilla.fenix.library.history.HistoryFragmentDirections
 import org.mozilla.fenix.library.history.HistoryFragmentState
+import org.mozilla.fenix.library.history.HistoryFragmentStore
 
 /**
  * A [Middleware] for initiating navigation events based on [HistoryFragmentAction]s that are
@@ -24,6 +25,8 @@ import org.mozilla.fenix.library.history.HistoryFragmentState
  *
  * @property navController [NavController] for handling navigation events
  * @property openToBrowser Callback to open history items in a browser window.
+ * @property onBackPressed Callback to handle back press actions.
+ * @property scope [CoroutineScope] used to launch coroutines.
  */
 class HistoryNavigationMiddleware(
     private val navController: NavController,

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragmentStore.kt
@@ -7,8 +7,10 @@ package org.mozilla.fenix.library.historymetadata
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.library.history.History
 import org.mozilla.fenix.library.history.PendingDeletionHistory
+import org.mozilla.fenix.library.historymetadata.view.HistoryMetadataGroupView
 
 /**
  * The [Store] for holding the [HistoryMetadataGroupFragmentState] and applying
@@ -21,7 +23,7 @@ class HistoryMetadataGroupFragmentStore(initialState: HistoryMetadataGroupFragme
     )
 
 /**
- * Actions to dispatch through the [HistoryMetadataGroupFragmentStore to modify the
+ * Actions to dispatch through the [HistoryMetadataGroupFragmentStore] to modify the
  * [HistoryMetadataGroupFragmentState] through the [historyStateReducer].
  */
 sealed class HistoryMetadataGroupFragmentAction : Action {
@@ -31,7 +33,7 @@ sealed class HistoryMetadataGroupFragmentAction : Action {
     data class Deselect(val item: History.Metadata) : HistoryMetadataGroupFragmentAction()
 
     /**
-     * Updates the set of items marked for removal from the [org.mozilla.fenix.components.AppStore]
+     * Updates the set of items marked for removal from the [AppStore]
      * to the [HistoryMetadataGroupFragmentStore], to be hidden from the UI.
      */
     data class UpdatePendingDeletionItems(val pendingDeletionItems: Set<PendingDeletionHistory>) :
@@ -41,7 +43,7 @@ sealed class HistoryMetadataGroupFragmentAction : Action {
     object DeleteAll : HistoryMetadataGroupFragmentAction()
 
     /**
-     * Updates the empty state of [org.mozilla.fenix.library.historymetadata.view.HistoryMetadataGroupView].
+     * Updates the empty state of [HistoryMetadataGroupView].
      */
     data class ChangeEmptyState(val isEmpty: Boolean) : HistoryMetadataGroupFragmentAction()
 }
@@ -50,6 +52,8 @@ sealed class HistoryMetadataGroupFragmentAction : Action {
  * The state for [HistoryMetadataGroupFragment].
  *
  * @property items The list of [History.Metadata] to display.
+ * @property pendingDeletionItems The set of [PendingDeletionHistory] marked for removal.
+ * @property isEmpty Whether or not the screen is empty.
  */
 data class HistoryMetadataGroupFragmentState(
     val items: List<History.Metadata>,

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/historymetadata/view/HistoryMetadataGroupItemViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/historymetadata/view/HistoryMetadataGroupItemViewHolder.kt
@@ -41,7 +41,9 @@ class HistoryMetadataGroupItemViewHolder(
 
     /**
      * Displays the data of the given history record.
-     * @param isPendingDeletion hides the item unless user evokes Undo snackbar action.
+     *
+     * @param item The [History.Metadata] to display.
+     * @param isPendingDeletion Whether or not the [item] is pending deletion.
      */
     fun bind(item: History.Metadata, isPendingDeletion: Boolean) {
         binding.historyLayout.isVisible = !isPendingDeletion

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragmentStore.kt
@@ -30,8 +30,10 @@ sealed class RecentlyClosedFragmentAction : Action {
 }
 
 /**
- * The state for the Recently Closed Screen
- * @property items List of recently closed tabs to display
+ * The state for the Recently Closed Screen.
+ *
+ * @property items List of recently closed tabs to display.
+ * @property selectedTabs List of selected recently closed tabs.
  */
 data class RecentlyClosedFragmentState(
     val items: List<TabState> = emptyList(),

--- a/fenix/app/src/main/java/org/mozilla/fenix/messaging/MessagingState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/messaging/MessagingState.kt
@@ -9,8 +9,9 @@ import mozilla.components.service.nimbus.messaging.MessageSurfaceId
 
 /**
  * Represent all the state related to the Messaging framework.
- * @param messages Indicates all the available messages.
- * @param messageToShow Indicates the message that should be shown to users,
+ *
+ * @property messages Indicates all the available messages.
+ * @property messageToShow Indicates the message that should be shown to users,
  * if it is null means there is not message that is eligible to be shown to users.
  */
 data class MessagingState(

--- a/fenix/app/src/main/java/org/mozilla/fenix/nimbus/NimbusBranchesStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/nimbus/NimbusBranchesStore.kt
@@ -39,8 +39,8 @@ sealed class NimbusBranchesAction : Action {
     /**
      * Updates the list of Nimbus branches and selected branch.
      *
-     * @param branches The list of [Branch]s to display in the branches list.
-     * @param selectedBranch The selected [Branch] slug for a Nimbus experiment.
+     * @property branches The list of [Branch]s to display in the branches list.
+     * @property selectedBranch The selected [Branch] slug for a Nimbus experiment.
      */
     data class UpdateBranches(val branches: List<Branch>, val selectedBranch: String) :
         NimbusBranchesAction()
@@ -48,7 +48,7 @@ sealed class NimbusBranchesAction : Action {
     /**
      * Updates the selected branch.
      *
-     * @param selectedBranch The selected [Branch] slug for a Nimbus experiment.
+     * @property selectedBranch The selected [Branch] slug for a Nimbus experiment.
      */
     data class UpdateSelectedBranch(val selectedBranch: String) : NimbusBranchesAction()
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/nimbus/NimbusExperimentsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/nimbus/NimbusExperimentsFragment.kt
@@ -39,7 +39,7 @@ class NimbusExperimentsFragment : Fragment() {
 
                 NimbusExperiments(
                     experiments = experiments,
-                    onSelectedExperiment = { experiment ->
+                    onExperimentClick = { experiment ->
                         val directions =
                             NimbusExperimentsFragmentDirections.actionNimbusExperimentsFragmentToNimbusBranchesFragment(
                                 experimentId = experiment.slug,

--- a/fenix/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
@@ -16,6 +16,7 @@ import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.navigateWithBreadcrumb
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.nimbus.NimbusBranchesAction
+import org.mozilla.fenix.nimbus.NimbusBranchesFragment
 import org.mozilla.fenix.nimbus.NimbusBranchesFragmentDirections
 import org.mozilla.fenix.nimbus.NimbusBranchesStore
 
@@ -23,10 +24,12 @@ import org.mozilla.fenix.nimbus.NimbusBranchesStore
  * [NimbusBranchesFragment] controller. This implements [NimbusBranchesAdapterDelegate] to handle
  * interactions with a Nimbus branch.
  *
- * @param nimbusBranchesStore An instance of [NimbusBranchesStore] for dispatching
+ * @property context An Android [Context].
+ * @property navController [NavController] used for navigation.
+ * @property nimbusBranchesStore An instance of [NimbusBranchesStore] for dispatching
  * [NimbusBranchesAction]s.
- * @param experiments An instance of [NimbusApi] for interacting with the Nimbus experiments.
- * @param experimentId The string experiment-id or "slug" for a Nimbus experiment.
+ * @property experiments An instance of [NimbusApi] for interacting with the Nimbus experiments.
+ * @property experimentId The string experiment-id or "slug" for a Nimbus experiment.
  */
 class NimbusBranchesController(
     private val context: Context,

--- a/fenix/app/src/main/java/org/mozilla/fenix/nimbus/view/NimbusExperiments.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/nimbus/view/NimbusExperiments.kt
@@ -23,7 +23,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
 @Composable
 fun NimbusExperiments(
     experiments: List<AvailableExperiment> = listOf(),
-    onSelectedExperiment: (AvailableExperiment) -> Unit,
+    onExperimentClick: (AvailableExperiment) -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -34,7 +34,7 @@ fun NimbusExperiments(
                 description = experiment.userFacingDescription,
                 maxDescriptionLines = Int.MAX_VALUE,
                 onClick = {
-                    onSelectedExperiment(experiment)
+                    onExperimentClick(experiment)
                 },
             )
         }
@@ -60,7 +60,7 @@ private fun NimbusExperimentsPreview() {
                 testExperiment,
                 testExperiment,
             ),
-            onSelectedExperiment = {},
+            onExperimentClick = {},
         )
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/HomeCFRPresenter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/HomeCFRPresenter.kt
@@ -34,8 +34,8 @@ private const val CFR_TO_ANCHOR_VERTICAL_PADDING = -16
 /**
  * Delegate for handling the Home Onboarding CFR.
  *
- * @param context [Context] used for various Android interactions.
- * @param recyclerView [RecyclerView] will serve as anchor for the CFR.
+ * @property context [Context] used for various Android interactions.
+ * @property recyclerView [RecyclerView] will serve as anchor for the CFR.
  */
 class HomeCFRPresenter(
     private val context: Context,

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPageUiData.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingPageUiData.kt
@@ -21,7 +21,8 @@ data class OnboardingPageUiData(
 ) {
     /**
      * Model for different types of Onboarding Pages.
-     * @param telemetryId Identifier for the page, used in telemetry.
+     *
+     * @property telemetryId Identifier for the page, used in telemetry.
      */
     enum class Type(
         val telemetryId: String,

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -72,35 +72,37 @@ sealed class SearchEngineSource {
 /**
  * The state for the Search Screen
  *
- * @property query The current search query string
- * @property url The current URL of the tab (if this fragment is shown for an already existing tab)
+ * @property query The current search query string.
+ * @property url The current URL of the tab (if this fragment is shown for an already existing tab).
  * @property searchTerms The search terms used to search previously in this tab (if this fragment is shown
- * for an already existing tab)
- * @property searchEngineSource The current selected search engine with the context of how it was selected
- * @property defaultEngine The current default search engine (or null if none is available yet)
- * @property showSearchSuggestions Whether or not to show search suggestions from the search engine in the AwesomeBar
- * @property showSearchSuggestionsHint Whether or not to show search suggestions in private hint panel
- * @property showSearchShortcuts Whether or not to show search shortcuts in the AwesomeBar
+ * for an already existing tab).
+ * @property searchEngineSource The current selected search engine with the context of how it was selected.
+ * @property defaultEngine The current default search engine (or null if none is available yet).
+ * @property showSearchSuggestions Whether or not to show search suggestions from the search engine in the AwesomeBar.
+ * @property showSearchSuggestionsHint Whether or not to show search suggestions in private hint panel.
+ * @property showSearchShortcuts Whether or not to show search shortcuts in the AwesomeBar.
  * @property areShortcutsAvailable Whether or not there are >=2 search engines installed
  * so to know to present users with certain options or not.
  * @property showSearchShortcutsSetting Whether the setting for showing search shortcuts is enabled
  * or disabled.
- * @property showClipboardSuggestions Whether or not to show clipboard suggestion in the AwesomeBar
+ * @property showClipboardSuggestions Whether or not to show clipboard suggestion in the AwesomeBar.
  * @property showSearchTermHistory Whether or not to show suggestions based on the previously used search terms
  * with the currently selected search engine.
  * @property showHistorySuggestionsForCurrentEngine Whether or not to show history suggestions for only
  * the current search engine.
- * @property showAllHistorySuggestions Whether or not to show history suggestions in the AwesomeBar
+ * @property showAllHistorySuggestions Whether or not to show history suggestions in the AwesomeBar.
  * @property showBookmarksSuggestionsForCurrentEngine Whether or not to show bookmarks suggestions for only
  * the current search engine.
- * @property showAllBookmarkSuggestions Whether or not to show the bookmark suggestion in the AwesomeBar
+ * @property showAllBookmarkSuggestions Whether or not to show the bookmark suggestion in the AwesomeBar.
  * @property showSyncedTabsSuggestionsForCurrentEngine Whether or not to show synced tabs suggestions for only
  * the current search engine.
- * @property showAllSyncedTabsSuggestions Whether or not to show the synced tabs suggestion in the AwesomeBar
+ * @property showAllSyncedTabsSuggestions Whether or not to show the synced tabs suggestion in the AwesomeBar.
  * @property showSessionSuggestionsForCurrentEngine Whether or not to show local tabs suggestions for only
  * the current search engine.
- * @property showAllSessionSuggestions Whether or not to show the session suggestion in the AwesomeBar
- * @property pastedText The text pasted from the long press toolbar menu
+ * @property showAllSessionSuggestions Whether or not to show the session suggestion in the AwesomeBar.
+ * @property tabId The ID of the current tab.
+ * @property pastedText The text pasted from the long press toolbar menu.
+ * @property searchAccessPoint The source of the performed search.
  * @property clipboardHasUrl Indicates if the clipboard contains an URL.
  */
 data class SearchFragmentState(

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarInteractor.kt
@@ -16,6 +16,7 @@ interface AwesomeBarInteractor {
     /**
      * Called whenever a suggestion containing a URL is tapped
      * @param url the url the suggestion was providing
+     * @param flags the [LoadUrlFlags] to use when loading the provided url.
      */
     fun onUrlTapped(url: String, flags: LoadUrlFlags = LoadUrlFlags.none())
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorMenu.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorMenu.kt
@@ -43,7 +43,7 @@ class SearchSelectorMenu(
         /**
          * The menu item to display a search engine.
          *
-         * @param searchEngine The [SearchEngine] that was selected.
+         * @property searchEngine The [SearchEngine] that was selected.
          */
         data class SearchEngine(val searchEngine: MozSearchEngine) : Item()
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarAction.kt
@@ -32,6 +32,7 @@ import org.mozilla.fenix.search.SearchDialogFragmentStore
  * A [Toolbar.Action] implementation that shows a [SearchSelector].
  *
  * @property store [SearchDialogFragmentStore] containing the complete state of the search dialog.
+ * @property defaultSearchEngine The user selected or default [SearchEngine].
  * @property menu An instance of [SearchSelectorMenu] to display a popup menu for the search
  * selections.
  */

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SyncPreferenceView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SyncPreferenceView.kt
@@ -20,14 +20,14 @@ import mozilla.components.service.fxa.manager.SyncEnginesStorage
  * that manages the sync account authentication. A toggle will be also added
  * depending on the sync account status.
  *
- * @param syncPreference The sync [SyncPreference] to update and handle navigation.
+ * @property syncPreference The sync [SyncPreference] to update and handle navigation.
  * @param lifecycleOwner View lifecycle owner used to determine when to cancel UI jobs.
  * @param accountManager An instance of [FxaAccountManager].
- * @param syncEngine The sync engine that will be used for the sync status lookup.
- * @param loggedOffTitle Text label for the setting when user is not logged in.
- * @param loggedInTitle Text label for the setting when user is logged in.
- * @param onSyncSignInClicked A callback executed when the sync sign in [syncPreference] is clicked.
- * @param onReconnectClicked A callback executed when the [syncPreference] is clicked with a
+ * @property syncEngine The sync engine that will be used for the sync status lookup.
+ * @property loggedOffTitle Text label for the setting when user is not logged in.
+ * @property loggedInTitle Text label for the setting when user is logged in.
+ * @property onSyncSignInClicked A callback executed when the sync sign in [syncPreference] is clicked.
+ * @property onReconnectClicked A callback executed when the [syncPreference] is clicked with a
  * preference status of "Reconnect".
  */
 @Suppress("LongParameterList")

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsInteractor.kt
@@ -11,19 +11,21 @@ import org.mozilla.fenix.ext.nav
 interface AccountSettingsUserActions {
 
     /**
-     * Called whenever the "Sync now" button is tapped
+     * Called whenever the "Sync now" button is tapped.
      */
     fun onSyncNow()
 
     /**
-     * Called whenever user sets a new device name
-     * @param newDeviceName the device name to change to
-     * @return Boolean indicating whether the new device name has been accepted or not
+     * Called whenever user sets a new device name.
+     *
+     * @param newDeviceName The new device name to change to.
+     * @param invalidNameResponse Lambda invoked when the new synced device is not found.
+     * @return Boolean indicating whether the new device name has been accepted or not.
      */
     fun onChangeDeviceName(newDeviceName: String, invalidNameResponse: () -> Unit): Boolean
 
     /**
-     * Called whenever the "Sign out" button is tapped
+     * Called whenever the "Sign out" button is tapped.
      */
     fun onSignOut()
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/account/DefaultSyncInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/account/DefaultSyncInteractor.kt
@@ -11,7 +11,7 @@ interface SyncInteractor {
 /**
  * Interactor for [TurnOnSyncFragment].
  *
- * @param syncController Handles the interactions
+ * @property syncController Handles the interactions
  */
 class DefaultSyncInteractor(private val syncController: DefaultSyncController) : SyncInteractor {
     override fun onCameraPermissionsNeeded() {

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/address/AddressUtils.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/address/AddressUtils.kt
@@ -28,6 +28,8 @@ internal const val DEFAULT_COUNTRY = "US"
  *
  * @property countryCode The country code used to lookup the address data. Should match desktop entries.
  * @property displayName The name to display when selected.
+ * @property subregionTitleResource The string resource for the subregion title.
+ * @property subregions THe list of subregions.
  */
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal data class Country(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/address/controller/AddressEditorController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/address/controller/AddressEditorController.kt
@@ -43,10 +43,10 @@ interface AddressEditorController {
 /**
  * The default implementation of [AddressEditorController].
  *
- * @param storage An instance of the [AutofillCreditCardsAddressesStorage] for adding and retrieving
+ * @property storage An instance of the [AutofillCreditCardsAddressesStorage] for adding and retrieving
  * addresses.
- * @param lifecycleScope [CoroutineScope] scope to launch coroutines.
- * @param navController [NavController] used for navigation.
+ * @property lifecycleScope [CoroutineScope] scope to launch coroutines.
+ * @property navController [NavController] used for navigation.
  */
 class DefaultAddressEditorController(
     private val storage: AutofillCreditCardsAddressesStorage,

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/address/controller/AddressManagementController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/address/controller/AddressManagementController.kt
@@ -30,7 +30,7 @@ interface AddressManagementController {
 /**
  * The default implementation of [AddressManagementController].
  *
- * @param navController [NavController] used for navigation.
+ * @property navController [NavController] used for navigation.
  */
 class DefaultAddressManagementController(
     private val navController: NavController,

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/address/interactor/AddressEditorInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/address/interactor/AddressEditorInteractor.kt
@@ -39,6 +39,7 @@ interface AddressEditorInteractor {
      * Updates the provided address in the autofill storage. Called when a user
      * taps on the update menu item or "Update" button.
      *
+     * @param guid The unique identifier for the [Address] record to update.
      * @param addressFields A [UpdatableAddressFields] record to add.
      */
     fun onUpdateAddress(guid: String, addressFields: UpdatableAddressFields)
@@ -47,7 +48,7 @@ interface AddressEditorInteractor {
 /**
  * The default implementation of [AddressEditorInteractor].
  *
- * @param controller An instance of [AddressEditorController] which will be delegated for all
+ * @property controller An instance of [AddressEditorController] which will be delegated for all
  * user interactions.
  */
 class DefaultAddressEditorInteractor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/address/interactor/AddressManagementInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/address/interactor/AddressManagementInteractor.kt
@@ -30,7 +30,7 @@ interface AddressManagementInteractor {
 /**
  * The default implementation of [AddressManagementInteractor].
  *
- * @param controller An instance of [AddressManagementController] which will be delegated for
+ * @property controller An instance of [AddressManagementController] which will be delegated for
  * all user interactions.
  */
 class DefaultAddressManagementInteractor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/address/view/AddressEditorView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/address/view/AddressEditorView.kt
@@ -31,10 +31,10 @@ import org.mozilla.fenix.settings.address.toCountryCode
 /**
  * An address editor for adding or updating an address.
  *
- * @param binding The binding used to display the view.
- * @param interactor [AddressEditorInteractor] used to respond to any user interactions.
- * @param region If the [RegionState] is available, it will be used to set the country when adding a new address.
- * @param address An [Address] to edit.
+ * @property binding The binding used to display the view.
+ * @property interactor [AddressEditorInteractor] used to respond to any user interactions.
+ * @property region If the [RegionState] is available, it will be used to set the country when adding a new address.
+ * @property address An [Address] to edit.
  */
 class AddressEditorView(
     private val binding: FragmentAddressEditorBinding,

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/autofill/AutofillFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/autofill/AutofillFragmentStore.kt
@@ -41,14 +41,14 @@ sealed class AutofillAction : Action {
     /**
      * Updates the list of addresses with the provided [addresses].
      *
-     * @param addresses The list of [Address]es to display in the address list.
+     * @property addresses The list of [Address]es to display in the address list.
      */
     data class UpdateAddresses(val addresses: List<Address>) : AutofillAction()
 
     /**
      * Updates the list of credit cards with the provided [creditCards].
      *
-     * @param creditCards The list of [CreditCard]s to display in the credit card list.
+     * @property creditCards The list of [CreditCard]s to display in the credit card list.
      */
     data class UpdateCreditCards(val creditCards: List<CreditCard>) : AutofillAction()
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/biometric/BiometricPromptFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/biometric/BiometricPromptFeature.kt
@@ -22,10 +22,10 @@ import org.mozilla.fenix.settings.biometric.ext.isHardwareAvailable
 /**
  * A [LifecycleAwareFeature] for the Android Biometric API to prompt for user authentication.
  *
- * @param context Android context.
- * @param fragment The fragment on which this feature will live.
- * @param onAuthSuccess A success callback.
- * @param onAuthFailure A failure callback if authentication failed.
+ * @property context Android context.
+ * @property fragment The fragment on which this feature will live.
+ * @property onAuthFailure A failure callback if authentication failed.
+ * @property onAuthSuccess A success callback.
  */
 class BiometricPromptFeature(
     private val context: Context,

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/biometric/BiometricPromptPreferenceFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/biometric/BiometricPromptPreferenceFragment.kt
@@ -95,6 +95,7 @@ abstract class BiometricPromptPreferenceFragment : PreferenceFragmentCompat() {
     /**
      * Use [BiometricPromptFeature] or [KeyguardManager] to confirm device security.
      *
+     * @param context An Android [Context].
      * @param prefList a list of [Preference]s to disable while authentication is happening.
      */
     fun verifyCredentialsOrShowSetupWarning(context: Context, prefList: List<Int>) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/creditcards/controller/CreditCardEditorController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/creditcards/controller/CreditCardEditorController.kt
@@ -48,12 +48,12 @@ interface CreditCardEditorController {
 /**
  * The default implementation of [CreditCardEditorController].
  *
- * @param storage An instance of the [AutofillCreditCardsAddressesStorage] for adding and retrieving
+ * @property storage An instance of the [AutofillCreditCardsAddressesStorage] for adding and retrieving
  * credit cards.
- * @param lifecycleScope [CoroutineScope] scope to launch coroutines.
- * @param navController [NavController] used for navigation.
- * @param ioDispatcher [CoroutineDispatcher] used for executing async tasks. Defaults to [Dispatchers.IO].
- * @param showDeleteDialog [DialogInterface.OnClickListener] used to display a confirmation dialog
+ * @property lifecycleScope [CoroutineScope] scope to launch coroutines.
+ * @property navController [NavController] used for navigation.
+ * @property ioDispatcher [CoroutineDispatcher] used for executing async tasks. Defaults to [Dispatchers.IO].
+ * @property showDeleteDialog [DialogInterface.OnClickListener] used to display a confirmation dialog
  * before removing credit card.
  */
 class DefaultCreditCardEditorController(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/creditcards/interactor/CreditCardEditorInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/creditcards/interactor/CreditCardEditorInteractor.kt
@@ -48,7 +48,7 @@ interface CreditCardEditorInteractor {
 /**
  * The default implementation of [CreditCardEditorInteractor].
  *
- * @param controller An instance of [CreditCardEditorController] which will be delegated for all
+ * @property controller An instance of [CreditCardEditorController] which will be delegated for all
  * user interactions.
  */
 class DefaultCreditCardEditorInteractor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/creditcards/interactor/CreditCardsManagementInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/creditcards/interactor/CreditCardsManagementInteractor.kt
@@ -32,7 +32,7 @@ interface CreditCardsManagementInteractor {
 /**
  * The default implementation of [CreditCardsManagementInteractor].
  *
- * @param controller An instance of [CreditCardsManagementController] which will be delegated for
+ * @property controller An instance of [CreditCardsManagementController] which will be delegated for
  * all user interactions.
  */
 class DefaultCreditCardsManagementInteractor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
@@ -64,14 +64,17 @@ sealed class LoginsAction : Action {
 }
 
 /**
- * The state for the Saved Logins Screen
- * @property loginList Filterable list of logins to display
- * @property currentItem The last item that was opened into the detail view
- * @property searchedForText String used by the user to filter logins
- * @property sortingStrategy sorting strategy selected by the user (Currently we support
- * sorting alphabetically and by last used)
- * @property highlightedItem The current selected sorting strategy from the sort menu
- * @property duplicateLogin Duplicate login for the current add/save login form
+ * The state for the Saved Logins Screen.
+ *
+ * @property isLoading Whether or not the list of logins are being loaded.
+ * @property loginList Filterable list of [SavedLogin]s that persist in storage.
+ * @property filteredItems Filtered list of [SavedLogin]s to display.
+ * @property currentItem The last item that was opened in the detail view.
+ * @property searchedForText String used by the user to filter logins.
+ * @property sortingStrategy Sorting strategy selected by the user. Currently, we support
+ * sorting alphabetically and by last used.
+ * @property highlightedItem The current selected sorting strategy from the sort menu.
+ * @property duplicateLogin Duplicate login for the current add/save login form.
  */
 data class LoginsListState(
     val isLoading: Boolean = false,

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/controller/LoginsListController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/controller/LoginsListController.kt
@@ -19,10 +19,10 @@ import org.mozilla.fenix.utils.Settings
 /**
  * Controller for the saved logins list
  *
- * @param loginsFragmentStore Store used to hold in-memory collection state.
- * @param navController NavController manages app navigation within a NavHost.
- * @param browserNavigator Controller allowing browser navigation to any Uri.
- * @param settings SharedPreferences wrapper for easier usage.
+ * @property loginsFragmentStore Store used to hold in-memory collection state.
+ * @property navController NavController manages app navigation within a NavHost.
+ * @property browserNavigator Controller allowing browser navigation to any Uri.
+ * @property settings SharedPreferences wrapper for easier usage.
  */
 class LoginsListController(
     private val loginsFragmentStore: LoginsFragmentStore,

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/interactor/SavedLoginsInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/interactor/SavedLoginsInteractor.kt
@@ -12,9 +12,9 @@ import org.mozilla.fenix.settings.logins.controller.SavedLoginsStorageController
 /**
  * Interactor for the saved logins screen
  *
- * @param loginsListController [LoginsListController] which will be delegated for all
+ * @property loginsListController [LoginsListController] which will be delegated for all
  * user interactions.
- * @param savedLoginsStorageController [SavedLoginsStorageController] which will be delegated
+ * @property savedLoginsStorageController [SavedLoginsStorageController] which will be delegated
  * for all calls to the password storage component
  */
 class SavedLoginsInteractor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ClearSiteDataView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ClearSiteDataView.kt
@@ -36,9 +36,13 @@ interface ClearSiteDataViewInteractor {
 /**
  * MVI View to access the dialog to clear site cookies and data.
  *
- * @param containerView [ViewGroup] in which this View will inflate itself.
- * @param interactor [TrackingProtectionInteractor] which will have delegated to all user
+ * @property context An Android [Context].
+ * @property ioScope [CoroutineScope] with an IO dispatcher used for structured concurrency.
+ * @property containerView [ViewGroup] in which this View will inflate itself.
+ * @property containerDivider Divider [View] to manipulate.
+ * @property interactor [ClearSiteDataViewInteractor] which will have delegated to all user
  * interactions.
+ * @property navController [NavController] used for navigation.
  */
 class ClearSiteDataView(
     val context: Context,

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsInteractor.kt
@@ -10,7 +10,7 @@ package org.mozilla.fenix.settings.quicksettings
  * Implements callbacks for each of [ConnectionPanelDialogFragment]'s Views declared possible user interactions,
  * delegates all such user events to the [ConnectionDetailsController].
  *
- * @param controller [ConnectionDetailsController] which will be delegated for all users interactions,
+ * @property controller [ConnectionDetailsController] which will be delegated for all users interactions,
  * it expected to contain all business logic for how to act in response.
  */
 class ConnectionDetailsInteractor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsView.kt
@@ -20,13 +20,13 @@ import org.mozilla.fenix.ext.loadIntoView
  * Currently it does not support any user interaction.
  *
  * @param container [ViewGroup] in which this View will inflate itself.
- * @param icons Icons component for loading, caching and processing website icons.
- * @param interactor [WebSiteInfoInteractor] which will have delegated to all user interactions.
+ * @property icons Icons component for loading, caching and processing website icons.
+ * @property interactor [WebSiteInfoInteractor] which will have delegated to all user interactions.
  */
 class ConnectionDetailsView(
     container: ViewGroup,
     private val icons: BrowserIcons,
-    val interactor: WebSiteInfoInteractor,
+    private val interactor: WebSiteInfoInteractor,
 ) {
     val binding = ConnectionDetailsWebsiteInfoBinding.inflate(
         LayoutInflater.from(container.context),

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsController.kt
@@ -91,18 +91,21 @@ interface QuickSettingsController {
 /**
  * Default behavior of [QuickSettingsController]. Other implementations are possible.
  *
- * @param context [Context] used for various Android interactions.
- * @param quickSettingsStore [QuickSettingsFragmentStore] holding the State for all Views displayed
+ * @property context [Context] used for various Android interactions.
+ * @property quickSettingsStore [QuickSettingsFragmentStore] holding the State for all Views displayed
  * in this Controller's Fragment.
- * @param ioScope [CoroutineScope] with an IO dispatcher used for structured concurrency.
- * @param navController NavController] used for navigation.
- * @param sitePermissions [SitePermissions]? list of website permissions and their status.
- * @param settings [Settings] application settings.
- * @param permissionStorage [PermissionStorage] app state for website permissions exception.
- * @param reload [ReloadUrlUseCase] callback allowing for reloading the current web page.
- * @param requestRuntimePermissions [OnNeedToRequestPermissions] callback allowing for requesting
+ * @property browserStore The application's [BrowserStore].
+ * @property ioScope [CoroutineScope] with an IO dispatcher used for structured concurrency.
+ * @property navController NavController] used for navigation.
+ * @property sessionId ID of the session to manipulate.
+ * @property sitePermissions [SitePermissions]? list of website permissions and their status.
+ * @property settings [Settings] application settings.
+ * @property permissionStorage [PermissionStorage] app state for website permissions exception.
+ * @property reload [ReloadUrlUseCase] callback allowing for reloading the current web page.
+ * @property requestRuntimePermissions [OnNeedToRequestPermissions] callback allowing for requesting
  * specific Android runtime permissions.
- * @param displayPermissions callback for when [WebsitePermissionsView] needs to be displayed.
+ * @property displayPermissions callback for when [WebsitePermissionsView] needs to be displayed.
+ * @property engine An [Engine] instance used for clearing the browsing data.
  */
 @Suppress("TooManyFunctions", "LongParameterList")
 class DefaultQuickSettingsController(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentAction.kt
@@ -25,11 +25,11 @@ sealed class WebsitePermissionAction(open val updatedFeature: PhoneFeature) : Qu
     /**
      * Change resulting from toggling a specific [WebsitePermission] for the current website.
      *
-     * @param updatedFeature [PhoneFeature] backing a certain [WebsitePermission].
+     * @property updatedFeature [PhoneFeature] backing a certain [WebsitePermission].
      * Allows to easily identify which permission changed
      * **Must be the name of one of the properties of [WebsitePermissionsState]**.
-     * @param updatedStatus [String] the new [WebsitePermission#status] which will be shown to the user.
-     * @param updatedEnabledStatus [Boolean] the new [WebsitePermission#enabled] which will be shown to the user.
+     * @property updatedStatus [String] the new [WebsitePermission#status] which will be shown to the user.
+     * @property updatedEnabledStatus [Boolean] the new [WebsitePermission#enabled] which will be shown to the user.
      */
     class TogglePermission(
         override val updatedFeature: PhoneFeature,
@@ -40,7 +40,7 @@ sealed class WebsitePermissionAction(open val updatedFeature: PhoneFeature) : Qu
     /**
      * Change resulting from changing a specific [WebsitePermission.Autoplay] for the current website.
      *
-     * @param autoplayValue [AutoplayValue] backing a certain [WebsitePermission.Autoplay].
+     * @property autoplayValue [AutoplayValue] backing a certain [WebsitePermission.Autoplay].
      * Allows to easily identify which permission changed
      */
     class ChangeAutoplay(
@@ -55,7 +55,7 @@ sealed class TrackingProtectionAction : QuickSettingsFragmentAction() {
     /**
      * Toggles the enabled state of tracking protection.
      *
-     * @param isTrackingProtectionEnabled Whether or not tracking protection is enabled.
+     * @property isTrackingProtectionEnabled Whether or not tracking protection is enabled.
      */
     data class ToggleTrackingProtectionEnabled(val isTrackingProtectionEnabled: Boolean) :
         TrackingProtectionAction()

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentState.kt
@@ -31,9 +31,10 @@ data class QuickSettingsFragmentState(
 /**
  * [State] to be rendered by [WebsiteInfoView] indicating whether the connection is secure or not.
  *
- * @param websiteUrl [String] the URL of the current web page.
- * @param websiteTitle [String] the title of the current web page.
- * @param websiteSecurityUiValues UI values to represent the security of the website.
+ * @property websiteUrl [String] the URL of the current web page.
+ * @property websiteTitle [String] the title of the current web page.
+ * @property websiteSecurityUiValues UI values to represent the security of the website.
+ * @property certificateName the certificate name of the current web page.
  */
 data class WebsiteInfoState(
     val websiteUrl: String,
@@ -50,7 +51,7 @@ data class WebsiteInfoState(
          * @param websiteUrl [String] the URL of the current web page.
          * @param websiteTitle [String] the title of the current web page.
          * @param isSecured [Boolean] whether the connection is secured (TLS) or not.
-         * @param certificateName [String] the certificate name of the current web  page.
+         * @param certificateName [String] the certificate name of the current web page.
          */
         fun createWebsiteInfoState(
             websiteUrl: String,
@@ -91,6 +92,7 @@ typealias WebsitePermissionsState = Map<PhoneFeature, WebsitePermission>
  * Contains a limited number of implementations because there is a known, finite number of permissions
  * we need to display to the user.
  *
+ * @property phoneFeature The Android phone feature available for the current website.
  * @property status The *allowed* / *blocked* permission status to be shown to the user.
  * @property isVisible Whether this permission should be shown to the user.
  * @property isEnabled Visual indication about whether this permission is *enabled* / *disabled*

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStore.kt
@@ -19,6 +19,7 @@ import org.mozilla.fenix.settings.quicksettings.QuickSettingsFragmentStore.Compa
 import org.mozilla.fenix.settings.quicksettings.WebsiteInfoState.Companion.createWebsiteInfoState
 import org.mozilla.fenix.settings.quicksettings.ext.shouldBeEnabled
 import org.mozilla.fenix.settings.quicksettings.ext.shouldBeVisible
+import org.mozilla.fenix.settings.quicksettings.protections.ProtectionsView
 import org.mozilla.fenix.trackingprotection.CookieBannerUIMode
 import org.mozilla.fenix.trackingprotection.ProtectionsState
 import org.mozilla.fenix.utils.Settings
@@ -50,13 +51,17 @@ class QuickSettingsFragmentStore(
          * @param context [Context] used for access to various Android resources.
          * @param websiteUrl [String] the URL of the current web page.
          * @param websiteTitle [String] the title of the current web page.
+         * @param certificateName [String] the certificate name of the current web page.
          * @param isSecured [Boolean] whether the connection is secured (TLS) or not.
          * @param permissions [SitePermissions]? list of website permissions and their status.
+         * @param permissionHighlights [PermissionHighlightsState] Current state of the website
+         * permissions.
          * @param settings [Settings] application settings.
-         * @param certificateName [String] the certificate name of the current web page.
          * @param sessionId [String] The current session ID.
          * @param isTrackingProtectionEnabled [Boolean] Current status of tracking protection
          * for this session.
+         * @param cookieBannerUIMode [CookieBannerUIMode] The current cookie banner state to
+         * display.
          */
         @Suppress("LongParameterList")
         fun createStore(
@@ -96,14 +101,15 @@ class QuickSettingsFragmentStore(
         )
 
         /**
-         * Construct an initial [WebsitePermissions
-         * State] to be rendered by [WebsitePermissionsView]
+         * Construct an initial [WebsitePermissionsState] to be rendered by [WebsitePermissionsView]
          * containing the permissions requested by the current website.
          *
          * Users can modify the returned [WebsitePermissionsState] after it is initially displayed.
          *
          * @param context [Context] used for various Android interactions.
          * @param permissions [SitePermissions]? list of website permissions and their status.
+         * @param permissionHighlights [PermissionHighlightsState] Current state of the website
+         * permissions.
          * @param settings [Settings] application settings.
          */
         @VisibleForTesting
@@ -134,8 +140,8 @@ class QuickSettingsFragmentStore(
          * @param websiteUrl [String] the URL of the current web page.
          * @param isTrackingProtectionEnabled [Boolean] Current status of tracking protection
          * for this session.
-         * @param isCookieHandlingEnabled [Boolean] Current status of cookie banner handling
-         * for this session.
+         * @param cookieBannerUIMode [CookieBannerUIMode] The current cookie banner state to
+         * display.
          */
         @VisibleForTesting
         fun createTrackingProtectionState(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsInteractor.kt
@@ -12,7 +12,7 @@ import org.mozilla.fenix.settings.quicksettings.protections.ProtectionsInteracto
  * Implements callbacks for each of [QuickSettingsSheetDialogFragment]'s Views declared possible user interactions,
  * delegates all such user events to the [QuickSettingsController].
  *
- * @param controller [QuickSettingsController] which will be delegated for all users interactions,
+ * @property controller [QuickSettingsController] which will be delegated for all users interactions,
  * it expected to contain all business logic for how to act in response.
  */
 class QuickSettingsInteractor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoView.kt
@@ -20,13 +20,13 @@ import org.mozilla.fenix.ext.loadIntoView
  * Currently it does not support any user interaction.
  *
  * @param container [ViewGroup] in which this View will inflate itself.
- * @param icons Icons component for loading, caching and processing website icons.
- * @param interactor [WebSiteInfoInteractor] which will have delegated to all user interactions.
+ * @property icons Icons component for loading, caching and processing website icons.
+ * @property interactor [WebSiteInfoInteractor] which will have delegated to all user interactions.
  */
 class WebsiteInfoView(
     container: ViewGroup,
     private val icons: BrowserIcons = container.context.components.core.icons,
-    val interactor: WebSiteInfoInteractor,
+    private val interactor: WebSiteInfoInteractor,
 ) {
     val binding = QuicksettingsWebsiteInfoBinding.inflate(
         LayoutInflater.from(container.context),

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
@@ -62,11 +62,11 @@ interface WebsitePermissionInteractor {
  * - camera
  *
  * @param containerView [ViewGroup] in which this View will inflate itself.
- * @param interactor [WebsitePermissionInteractor] which will have delegated to all user interactions.
+ * @property interactor [WebsitePermissionInteractor] which will have delegated to all user interactions.
  */
 class WebsitePermissionsView(
     containerView: ViewGroup,
-    val interactor: WebsitePermissionInteractor,
+    private val interactor: WebsitePermissionInteractor,
 ) {
     private val context = containerView.context
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/ProtectionsView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/ProtectionsView.kt
@@ -40,12 +40,11 @@ import org.mozilla.fenix.utils.Settings
  * MVI View that displays the tracking protection, cookie banner handling toggles and the navigation
  * to additional tracking protection details.
  *
- * @param containerView [ViewGroup] in which this View will inflate itself.
- * @param trackingProtectionDivider trackingProtectionDivider The divider line between tracking protection layout
+ * @property containerView [ViewGroup] in which this View will inflate itself.
+ * @property trackingProtectionDivider trackingProtectionDivider The divider line between tracking protection layout
  * and other views from [QuickSettingsSheetDialogFragment].
- * @param interactor [ProtectionsInteractor] which will have delegated to all user
- * @param settings [Settings] application settings.
- * interactions.
+ * @property interactor [ProtectionsInteractor] which will have delegated to all user interactions.
+ * @property settings [Settings] application settings.
  */
 class ProtectionsView(
     val containerView: ViewGroup,

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerDetailsInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerDetailsInteractor.kt
@@ -30,7 +30,7 @@ interface CookieBannerDetailsInteractor {
  * Implements callbacks for each of [CookieBannerPanelDialogFragment]'s Views declared possible user interactions,
  * delegates all such user events to the [CookieBannerDetailsController].
  *
- * @param controller [CookieBannerDetailsController] which will be delegated for all users interactions,
+ * @property controller [CookieBannerDetailsController] which will be delegated for all users interactions,
  * it expected to contain all business logic for how to act in response.
  */
 class DefaultCookieBannerDetailsInteractor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerHandlingDetailsView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerHandlingDetailsView.kt
@@ -26,15 +26,18 @@ import org.mozilla.fenix.trackingprotection.ProtectionsState
  * MVI View that knows how to display cookie banner handling details for a site.
  *
  * @param container [ViewGroup] in which this View will inflate itself.
- * @param publicSuffixList To show short url.
- * @param interactor [CookieBannerDetailsInteractor] which will have delegated to all user interactions.
+ * @property context An Android [Context].
+ * @property ioScope [CoroutineScope] with an IO dispatcher used for structured concurrency.
+ * @property publicSuffixList To show short url.
+ * @property interactor [CookieBannerDetailsInteractor] which will have delegated to all user interactions.
+ * @property onDismiss Lambda invoked to dismiss the cookie banner.
  */
 class CookieBannerHandlingDetailsView(
     container: ViewGroup,
     private val context: Context,
     private val ioScope: CoroutineScope,
     private val publicSuffixList: PublicSuffixList,
-    val interactor: CookieBannerDetailsInteractor,
+    private val interactor: CookieBannerDetailsInteractor,
     private val onDismiss: () -> Unit,
 ) {
     val binding = ComponentCookieBannerDetailsPanelBinding.inflate(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/studies/StudiesAdapter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/studies/StudiesAdapter.kt
@@ -37,7 +37,7 @@ private const val VIEW_HOLDER_TYPE_STUDY = 1
  * @param studies The list of studies.
  *  * @property studiesDelegate Delegate that will provides method for handling
  * the studies actions items.
- * @param shouldSubmitOnInit The sole purpose of this property is to prevent the submitList function
+ * @property shouldSubmitOnInit The sole purpose of this property is to prevent the submitList function
  * to run on init, it should only be used from tests.
  */
 @Suppress("LargeClass")
@@ -174,7 +174,8 @@ class StudiesAdapter(
 
     /**
      * Removes the portion of the list that contains the provided [study].
-     * @property study The study to be removed.
+     *
+     * @param study The study to be removed.
      */
     fun removeStudy(study: EnrolledExperiment) {
         studiesMap.remove(study.slug)

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -59,9 +59,9 @@ import org.mozilla.fenix.wallpapers.Wallpaper
  * a snackbar will be displayed.
  *
  * @param wallpaperGroups Wallpapers groups to add to grid.
- * @param selectedWallpaper The currently selected wallpaper.
  * @param defaultWallpaper The default wallpaper.
  * @param loadWallpaperResource Callback to handle loading a wallpaper bitmap. Only optional in the default case.
+ * @param selectedWallpaper The currently selected wallpaper.
  * @param onSelectWallpaper Callback for when a new wallpaper is selected.
  * @param onLearnMoreClick Callback for when the learn more action is clicked from the group description.
  * Parameters are the URL that is clicked and the name of the collection.
@@ -187,10 +187,10 @@ private fun WallpaperGroupHeading(
  *
  * @param wallpapers Wallpapers to add to grid.
  * @param defaultWallpaper The default wallpaper.
- * @param loadWallpaperResource Callback to handle loading a wallpaper bitmap. Only optional in the default case.
  * @param selectedWallpaper The currently selected wallpaper.
- * @param numColumns The number of columns that will occupy the grid.
+ * @param loadWallpaperResource Callback to handle loading a wallpaper bitmap. Only optional in the default case.
  * @param onSelectWallpaper Action to take when a new wallpaper is selected.
+ * @param numColumns The number of columns that will occupy the grid.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -240,7 +240,6 @@ fun WallpaperThumbnails(
  * @param isSelected Whether the wallpaper is currently selected.
  * @param isLoading Whether the wallpaper is currently downloading.
  * @param aspectRatio The ratio of height to width of the thumbnail.
- * @param onSelect Action to take when this wallpaper is selected.
  * @param loadingOpacity Opacity of the currently downloading wallpaper.
  * @param onSelect Action to take when a new wallpaper is selected.
  */

--- a/fenix/app/src/main/java/org/mozilla/fenix/share/SaveToPDFMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/SaveToPDFMiddleware.kt
@@ -32,7 +32,9 @@ import java.io.IOException
 
 /**
  * [BrowserAction] middleware reacting in response to Save to PDF related [Action]s.
+ *
  * @property context An Application context.
+ * @property mainScope Coroutine scope to launch coroutines.
  */
 class SaveToPDFMiddleware(
     private val context: Context,
@@ -120,7 +122,7 @@ class SaveToPDFMiddleware(
     /**
      * Use to generate extra sources for Save To PDF telemetry.
      *
-     * @param isPdfViewer - If the page has a PDF viewer or not.
+     * @param isPdfViewer If the page has a PDF viewer or not.
      * @return processed page source type to send in telemetry.
      */
     @VisibleForTesting // package
@@ -136,8 +138,8 @@ class SaveToPDFMiddleware(
     /**
      * Indicates the Print or Save As PDF action was requested and posts telemetry via Glean.
      *
-     * @param isPrint - if the telemetry is for printing
-     * @param tab - tab state to use for page source category
+     * @param tab tab state to use for page source category
+     * @param isPrint if the telemetry is for printing
      */
     private fun postTelemetryTapped(tab: TabSessionState?, isPrint: Boolean) {
         mainScope.launch {
@@ -179,8 +181,8 @@ class SaveToPDFMiddleware(
     /**
      * Indicates the Print or Save As PDF action completed and generated a PDF and posts telemetry via Glean.
      *
-     * @param isPrint - if the telemetry is for printing
-     * @param tab - tab state to use for page source category
+     * @param tab tab state to use for page source category
+     * @param isPrint if the telemetry is for printing
      */
     private fun postTelemetryCompleted(tab: TabSessionState?, isPrint: Boolean) {
         mainScope.launch {
@@ -222,9 +224,9 @@ class SaveToPDFMiddleware(
     /**
      * Indicates the Print or Save As PDF action failed and the reason for failure and posts telemetry via Glean.
      *
-     * @param isPrint - if the telemetry is for printing
-     * @param tab - tab state to use for page source category
-     * @param throwable - failure state to use for failure reason category
+     * @param tab tab state to use for page source category
+     * @param throwable failure state to use for failure reason category
+     * @param isPrint if the telemetry is for printing
      */
     private fun postTelemetryFailed(tab: TabSessionState?, throwable: Throwable, isPrint: Boolean) {
         val telFailureReason = telemetryErrorReason(throwable as Exception)

--- a/fenix/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -74,14 +74,19 @@ interface ShareController {
 /**
  * Default behavior of [ShareController]. Other implementations are possible.
  *
- * @param context [Context] used for various Android interactions.
- * @param shareSubject desired message subject used when sharing through 3rd party apps, like email clients.
- * @param shareData the list of [ShareData]s that can be shared.
- * @param sendTabUseCases instance of [SendTabUseCases] which allows sending tabs to account devices.
- * @param snackbar - instance of [FenixSnackbar] for displaying styled snackbars
- * @param navController - [NavController] used for navigation.
- * @param fxaEntrypoint - the entrypoint if we need to authenticate, it will be reported in telemetry
- * @param dismiss - callback signalling sharing can be closed.
+ * @property context [Context] used for various Android interactions.
+ * @property shareSubject Desired message subject used when sharing through 3rd party apps, like email clients.
+ * @property shareData The list of [ShareData]s that can be shared.
+ * @property sendTabUseCases Instance of [SendTabUseCases] which allows sending tabs to account devices.
+ * @property saveToPdfUseCase Instance of [SessionUseCases.SaveToPdfUseCase] to generate a PDF of a given tab.
+ * @property printUseCase Instance of [SessionUseCases.PrintContentUseCase] to print content of a given tab.
+ * @property snackbar Instance of [FenixSnackbar] for displaying styled snackbars.
+ * @property navController [NavController] used for navigation.
+ * @property recentAppsStorage Instance of [RecentAppsStorage] for storing and retrieving the most recent apps.
+ * @property viewLifecycleScope [CoroutineScope] used for retrieving the most recent apps in the background.
+ * @property dispatcher Dispatcher used to execute suspending functions.
+ * @property fxaEntrypoint The entrypoint if we need to authenticate, it will be reported in telemetry.
+ * @property dismiss Callback signalling sharing can be closed.
  */
 @Suppress("TooManyFunctions", "LongParameterList")
 class DefaultShareController(

--- a/fenix/app/src/main/java/org/mozilla/fenix/share/ShareViewModel.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/ShareViewModel.kt
@@ -168,7 +168,9 @@ class ShareViewModel(application: Application) : AndroidViewModel(application) {
 
     /**
      * Returns a list of apps that can be shared to.
+     *
      * @param intentActivities List of activities from [getIntentActivities].
+     * @param context Android context.
      */
     @VisibleForTesting
     @WorkerThread

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckBottomSheetStateFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckBottomSheetStateFeature.kt
@@ -16,7 +16,7 @@ import org.mozilla.fenix.shopping.store.ReviewQualityCheckStore
  * from [ReviewQualityCheckState.Initial] to [ReviewQualityCheckState.NotOptedIn].
  *
  * @param store The store to observe.
- * @param onRequestStateExpanded Callback to request the bottom sheet to be expanded.
+ * @property onRequestStateExpanded Callback to request the bottom sheet to be expanded.
  */
 class ReviewQualityCheckBottomSheetStateFeature(
     store: ReviewQualityCheckStore,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeature.kt
@@ -26,6 +26,7 @@ import org.mozilla.fenix.components.AppStore
  * @property shoppingExperienceFeature Reference to the [ShoppingExperienceFeature].
  * @property onAvailabilityChange Invoked when availability of this feature changes based on feature
  * flag and when the loaded page is a supported product page.
+ * @property onBottomSheetCollapsed Invoked when the bottom sheet is collapsed.
  */
 class ReviewQualityCheckFeature(
     private val appStore: AppStore,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckPreferences.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckPreferences.kt
@@ -44,7 +44,7 @@ interface ReviewQualityCheckPreferences {
  * Implementation of [ReviewQualityCheckPreferences] that uses [Settings] to store/fetch
  * preferences.
  *
- * @param settings The [Settings] instance to use.
+ * @property settings The [Settings] instance to use.
  */
 class DefaultReviewQualityCheckPreferences(
     private val settings: Settings,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckPreferencesMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckPreferencesMiddleware.kt
@@ -15,8 +15,11 @@ import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 /**
  * Middleware for getting and setting review quality check user preferences.
  *
- * @param reviewQualityCheckPreferences The [ReviewQualityCheckPreferences] instance to use.
- * @param scope The [CoroutineScope] to use for launching coroutines.
+ * @property reviewQualityCheckPreferences The [ReviewQualityCheckPreferences] instance to get and
+ * set preferences for the review quality check feature.
+ * @property reviewQualityCheckVendorsService The [ReviewQualityCheckVendorsService] instance for
+ * getting the list of product vendors.
+ * @property scope The [CoroutineScope] to use for launching coroutines.
  */
 class ReviewQualityCheckPreferencesMiddleware(
     private val reviewQualityCheckPreferences: ReviewQualityCheckPreferences,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
@@ -57,6 +57,7 @@ sealed interface ReviewQualityCheckAction : Action {
      *
      * @property isProductRecommendationsEnabled Reflects the user preference update to display
      * recommended product. Null when product recommendations feature is disabled.
+     * @property productVendor The vendor of the product.
      */
     data class OptInCompleted(
         val isProductRecommendationsEnabled: Boolean?,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
@@ -42,6 +42,7 @@ sealed interface ReviewQualityCheckState : State {
      * @property productRecommendationsPreference User preference whether to show product
      * recommendations. True if product recommendations should be shown. Null indicates that product
      * recommendations are disabled.
+     * @property productVendor The vendor of the product.
      */
     data class OptedIn(
         val productReviewState: ProductReviewState = ProductReviewState.Loading,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
@@ -53,6 +53,7 @@ import java.util.SortedMap
  * @param productAnalysis The product analysis to display.
  * @param productVendor The vendor of the product.
  * @param onOptOutClick Invoked when the user opts out of the review quality check feature.
+ * @param onReanalyzeClick Invoked when the user clicks to re-analyze a product.
  * @param onProductRecommendationsEnabledStateChange Invoked when the user changes the product
  * recommendations toggle state.
  * @param onReviewGradeLearnMoreClick Invoked when the user clicks to learn more about review grades.

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckCards.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckCards.kt
@@ -107,6 +107,7 @@ fun ReviewQualityCheckExpandableCard(
  * @param modifier Modifier to be applied to the card.
  * @param backgroundColor The background color of the card.
  * @param elevation The elevation of the card.
+ * @param contentPadding Padding used within the card container.
  * @param content The content of the card.
  */
 @Composable

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckInfoCard.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckInfoCard.kt
@@ -191,8 +191,8 @@ enum class ReviewQualityCheckInfoType {
 /**
  * Model for the optional button in a [ReviewQualityCheckInfoCard].
  *
- * @param text The text to show in the button.
- * @param onClick The callback to invoke when the button is clicked.
+ * @property text The text to show in the button.
+ * @property onClick The callback to invoke when the button is clicked.
  */
 data class InfoCardButtonText(
     val text: String,

--- a/fenix/app/src/main/java/org/mozilla/fenix/sync/SyncedTabsIntegration.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/sync/SyncedTabsIntegration.kt
@@ -14,8 +14,9 @@ import org.mozilla.fenix.ext.components
 
 /**
  * Starts and stops SyncedTabsStorage based on the authentication state.
- * @param context Used to get synced tabs storage, due to cyclic dependency.
- * @param accountManager Used to check and observe account authentication state.
+ *
+ * @property context Used to get synced tabs storage, due to cyclic dependency.
+ * @property accountManager Used to check and observe account authentication state.
  */
 class SyncedTabsIntegration(
     private val context: Context,

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabSheetBehaviorManager.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabSheetBehaviorManager.kt
@@ -30,11 +30,11 @@ private const val DIM_CONVERSION = 1000f
 /**
  * Helper class for updating how the tray looks and behaves depending on app state / internal tray state.
  *
- * @param behavior [BottomSheetBehavior] that will actually control the tray.
+ * @property behavior [BottomSheetBehavior] that will actually control the tray.
  * @param orientation current Configuration.ORIENTATION_* of the device.
- * @param maxNumberOfTabs highest number of tabs in each tray page.
- * @param numberForExpandingTray limit depending on which the tray should be collapsed or expanded.
- * @param displayMetrics [DisplayMetrics] used for adapting resources to the current display.
+ * @property maxNumberOfTabs highest number of tabs in each tray page.
+ * @property numberForExpandingTray limit depending on which the tray should be collapsed or expanded.
+ * @property displayMetrics [DisplayMetrics] used for adapting resources to the current display.
  */
 internal class TabSheetBehaviorManager(
     private val behavior: BottomSheetBehavior<out View>,

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -175,11 +175,12 @@ interface TabsTrayController : SyncedTabsController, InactiveTabsController, Tab
  * @property activity [HomeActivity] used to perform top-level app actions.
  * @property appStore [AppStore] used to dispatch any [AppAction].
  * @property tabsTrayStore [TabsTrayStore] used to read/update the [TabsTrayState].
- * @property settings [Settings] used to update any user preferences.
  * @property browserStore [BrowserStore] used to read/update the current [BrowserState].
+ * @property settings [Settings] used to update any user preferences.
  * @property browsingModeManager [BrowsingModeManager] used to read/update the current [BrowsingMode].
  * @property navController [NavController] used to navigate away from the tabs tray.
  * @property navigateToHomeAndDeleteSession Lambda used to return to the Homescreen and delete the current session.
+ * @property profiler [Profiler] used to add profiler markers.
  * @property navigationInteractor [NavigationInteractor] used to perform navigation actions with side effects.
  * @property tabsUseCases Use case wrapper for interacting with tabs.
  * @property bookmarksUseCase Use case wrapper for interacting with bookmarks.

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
@@ -30,6 +30,7 @@ interface TabsTrayInteractor :
     /**
      * Invoked when the user confirmed tab removal that would lead to cancelled private downloads.
      *
+     * @param tabId ID of the tab being removed.
      * @param source is the app feature from which the [TabSessionState] with [tabId] was closed.
      */
     fun onDeletePrivateTabWarningAccepted(tabId: String, source: String? = null)

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayStore.kt
@@ -21,6 +21,7 @@ import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsListItem
  * @property inactiveTabs The list of tabs are considered inactive.
  * @property normalTabs The list of normal tabs that do not fall under [inactiveTabs].
  * @property privateTabs The list of tabs that are [ContentState.private].
+ * @property syncedTabs The list of synced tabs.
  * @property syncing Whether the Synced Tabs feature should fetch the latest tabs from paired devices.
  */
 data class TabsTrayState(

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTabLayouts.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayTabLayouts.kt
@@ -60,7 +60,7 @@ const val HEADER_ITEM_KEY = "header"
  * @param selectedTabId The ID of the currently selected tab.
  * @param selectionMode [TabsTrayState.Mode] indicating whether the Tabs Tray is in single selection
  * or multi-selection and contains the set of selected tabs.
- * @param modifier
+ * @param modifier [Modifier] to be applied to the layout.
  * @param onTabClose Invoked when the user clicks to close a tab.
  * @param onTabMediaClick Invoked when the user interacts with a tab's media controls.
  * @param onTabClick Invoked when the user clicks on a tab.

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolder.kt
@@ -48,10 +48,11 @@ import org.mozilla.fenix.tabstray.ext.toDisplayTitle
  * A RecyclerView ViewHolder implementation for "tab" items.
  *
  * @param itemView [View] that displays a "tab".
- * @param imageLoader [ImageLoader] used to load tab thumbnails.
- * @param trayStore [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
- * @param featureName [String] representing the name of the feature displaying tabs. Used in telemetry reporting.
- * @param store [BrowserStore] containing the complete state of the browser and methods to update that.
+ * @property imageLoader [ImageLoader] used to load tab thumbnails.
+ * @property trayStore [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
+ * @property selectionHolder [SelectionHolder] instance containing the selected tabs in the tabs tray.
+ * @property featureName [String] representing the name of the feature displaying tabs. Used in telemetry reporting.
+ * @property store [BrowserStore] containing the complete state of the browser and methods to update that.
  */
 @Suppress("LongParameterList")
 abstract class AbstractBrowserTabViewHolder(

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabViewHolder.kt
@@ -26,7 +26,7 @@ sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(item
      * A RecyclerView ViewHolder implementation for "tab" items with grid layout.
      *
      * @param imageLoader [ImageLoader] used to load tab thumbnails.
-     * @param interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
+     * @property interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
      * @param store [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
      * @param selectionHolder [SelectionHolder]<[TabSessionState]> for helping with selecting
      * any number of displayed [TabSessionState]s.
@@ -80,7 +80,7 @@ sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(item
      * A RecyclerView ViewHolder implementation for "tab" items with list layout.
      *
      * @param imageLoader [ImageLoader] used to load tab thumbnails.
-     * @param interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
+     * @property interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
      * @param store [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
      * @param selectionHolder [SelectionHolder]<[TabSessionState]> for helping with selecting
      * any number of displayed [TabSessionState]s.

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabsAdapter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabsAdapter.kt
@@ -29,11 +29,11 @@ import org.mozilla.fenix.tabstray.browser.compose.ComposeListViewHolder
 /**
  * A [RecyclerView.Adapter] for browser tabs.
  *
- * @param context [Context] used for various platform interactions or accessing [Components]
- * @param interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
- * @param store [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
- * @param featureName [String] representing the name of the feature displaying tabs. Used in telemetry reporting.
- * @param viewLifecycleOwner [LifecycleOwner] life cycle owner for the view.
+ * @property context [Context] used for various platform interactions or accessing [Components]
+ * @property interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
+ * @property store [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
+ * @property featureName [String] representing the name of the feature displaying tabs. Used in telemetry reporting.
+ * @property viewLifecycleOwner [LifecycleOwner] life cycle owner for the view.
  */
 class BrowserTabsAdapter(
     private val context: Context,

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
@@ -30,8 +30,8 @@ import org.mozilla.fenix.GleanMetrics.TabsTray as TabsTrayMetrics
  *
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param lifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
- * @param tabsTrayStore [TabsTrayStore] used to listen for changes to [TabsTrayState.inactiveTabs].
- * @param interactor [InactiveTabsInteractor] used to respond to interactions with the inactive tabs header
+ * @property tabsTrayStore [TabsTrayStore] used to listen for changes to [TabsTrayState.inactiveTabs].
+ * @property interactor [InactiveTabsInteractor] used to respond to interactions with the inactive tabs header
  * and the auto close dialog.
  */
 @Suppress("LongParameterList")

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
@@ -29,7 +29,8 @@ import org.mozilla.fenix.tabstray.ext.showWithTheme
  * A binding that shows/hides the multi-select banner of the selected count of tabs.
  *
  * @property context An Android context.
- * @property [TabsTrayStore] used to listen for changes to [TabsTrayState] and dispatch actions.
+ * @property binding The binding used to display the view.
+ * @property store [TabsTrayStore] used to listen for changes to [TabsTrayState] and dispatch actions.
  * @property interactor [TabsTrayInteractor] for responding to user actions.
  * @property backgroundView The background view that we want to alter when changing [Mode].
  * @property showOnSelectViews A variable list of views that will be made visible when in select mode.

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabsTouchHelper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabsTouchHelper.kt
@@ -33,7 +33,11 @@ typealias OnViewHolderToDraw = (RecyclerView.ViewHolder) -> Boolean
 /**
  * An [ItemTouchHelper] for handling tab swiping to delete.
  *
+ * @param interactionDelegate [TabsTray.Delegate] for handling all user interactions.
  * @param onViewHolderTouched See [OnViewHolderTouched].
+ * @param onViewHolderDraw See [OnViewHolderToDraw].
+ * @param featureNameHolder Contains the identifying name of the feature.
+ * @param delegate The Callback which controls the behavior of this touch helper.
  */
 class TabsTouchHelper(
     interactionDelegate: TabsTray.Delegate,
@@ -46,7 +50,11 @@ class TabsTouchHelper(
 /**
  * An [ItemTouchHelper.Callback] for drawing custom layouts on [RecyclerView.ViewHolder] interactions.
  *
- * @param onViewHolderTouched invoked when a tab is about to be swiped. See [OnViewHolderTouched].
+ * @param delegate [TabsTray.Delegate] for handling all user interactions.
+ * @property onViewHolderTouched Invoked when a tab is about to be swiped. See [OnViewHolderTouched].
+ * @property onViewHolderDraw Invoked when a tab is drawn. See [OnViewHolderToDraw].
+ * @param featureNameHolder Contains the identifying name of the feature.
+ * @param onRemove A callback invoked when a tab is removed.
  */
 class TouchCallback(
     delegate: TabsTray.Delegate,

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ComposeAbstractTabViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ComposeAbstractTabViewHolder.kt
@@ -20,8 +20,8 @@ import org.mozilla.fenix.theme.Theme
 /**
  * [RecyclerView.ViewHolder] used for Jetpack Compose UI content .
  *
- * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
- * @param viewLifecycleOwner [LifecycleOwner] life cycle owner for the view.
+ * @property composeView [ComposeView] which will be populated with Jetpack Compose UI content.
+ * @property viewLifecycleOwner [LifecycleOwner] life cycle owner for the view.
  */
 abstract class ComposeAbstractTabViewHolder(
     private val composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ComposeGridViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ComposeGridViewHolder.kt
@@ -24,10 +24,10 @@ import org.mozilla.fenix.tabstray.TabsTrayStore
 /**
  * A Compose ViewHolder implementation for "tab" items with grid layout.
  *
- * @param interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
- * @param store [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
+ * @property interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
+ * @property store [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
  * @param composeItemView that displays a "tab".
- * @param featureName [String] representing the name of the feature displaying tabs. Used in telemetry reporting.
+ * @property featureName [String] representing the name of the feature displaying tabs. Used in telemetry reporting.
  * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
  */
 class ComposeGridViewHolder(

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ComposeListViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ComposeListViewHolder.kt
@@ -24,10 +24,10 @@ import org.mozilla.fenix.tabstray.TabsTrayStore
 /**
  * A Compose ViewHolder implementation for "tab" items with list layout.
  *
- * @param interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
- * @param tabsTrayStore [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
+ * @property interactor [TabsTrayInteractor] handling tabs interactions in a tab tray.
+ * @property tabsTrayStore [TabsTrayStore] containing the complete state of tabs tray and methods to update that.
  * @param composeItemView that displays a "tab".
- * @param featureName [String] representing the name of the feature displaying tabs. Used in telemetry reporting.
+ * @property featureName [String] representing the name of the feature displaying tabs. Used in telemetry reporting.
  * @param viewLifecycleOwner [LifecycleOwner] to which this Composable will be tied to.
  */
 class ComposeListViewHolder(

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ReorderableGrid.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ReorderableGrid.kt
@@ -77,14 +77,14 @@ fun createGridReorderState(
 /**
  * Class containing details about the current state of dragging in grid.
  *
- * @param gridState State of the grid.
- * @param scope [CoroutineScope] used for scrolling to the target item.
- * @param hapticFeedback [HapticFeedback] used for performing haptic feedback on item long press.
- * @param touchSlop Distance in pixels the user can wander until we consider they started dragging.
- * @param onMove Callback to be invoked when switching between two items.
- * @param onLongPress Optional callback to be invoked when long pressing an item.
- * @param onExitLongPress Optional callback to be invoked when the item is dragged after long press.
- * @param ignoredItems List of keys for non-draggable items.
+ * @property gridState State of the grid.
+ * @property scope [CoroutineScope] used for scrolling to the target item.
+ * @property hapticFeedback [HapticFeedback] used for performing haptic feedback on item long press.
+ * @property touchSlop Distance in pixels the user can wander until we consider they started dragging.
+ * @property onMove Callback to be invoked when switching between two items.
+ * @property onLongPress Optional callback to be invoked when long pressing an item.
+ * @property onExitLongPress Optional callback to be invoked when the item is dragged after long press.
+ * @property ignoredItems List of keys for non-draggable items.
  */
 class GridReorderState internal constructor(
     private val gridState: LazyGridState,

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ReorderableList.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/compose/ReorderableList.kt
@@ -72,14 +72,14 @@ fun createListReorderState(
 /**
  * Class containing details about the current state of dragging in list.
  *
- * @param listState State of the list.
- * @param scope [CoroutineScope] used for scrolling to the target item.
- * @param hapticFeedback [HapticFeedback] used for performing haptic feedback on item long press.
- * @param touchSlop Distance in pixels the user can wander until we consider they started dragging.
- * @param onMove Callback to be invoked when switching between two items.
- * @param onLongPress Optional callback to be invoked when long pressing an item.
- * @param onExitLongPress Optional callback to be invoked when the item is dragged after long press.
- * @param ignoredItems List of keys for non-draggable items.
+ * @property listState State of the list.
+ * @property scope [CoroutineScope] used for scrolling to the target item.
+ * @property hapticFeedback [HapticFeedback] used for performing haptic feedback on item long press.
+ * @property touchSlop Distance in pixels the user can wander until we consider they started dragging.
+ * @property onMove Callback to be invoked when switching between two items.
+ * @property ignoredItems List of keys for non-draggable items.
+ * @property onLongPress Optional callback to be invoked when long pressing an item.
+ * @property onExitLongPress Optional callback to be invoked when the item is dragged after long press.
  */
 @Suppress("LongParameterList")
 class ListReorderState internal constructor(

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabsIntegration.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabsIntegration.kt
@@ -24,9 +24,9 @@ import org.mozilla.fenix.tabstray.ext.toSyncedTabsListItem
 /**
  * TabsTrayFragment delegate to handle all layout updates needed to display synced tabs and any errors.
  *
- * @param store [TabsTrayStore]
- * @param context Fragment context.
- * @param navController The controller used to handle any navigation necessary for error scenarios.
+ * @property store An instance of [TabsTrayStore] used to manage the tabs tray state.
+ * @property context Fragment context.
+ * @property navController The controller used to handle any navigation necessary for error scenarios.
  * @param storage An instance of [SyncedTabsStorage] used for retrieving synced tabs.
  * @param accountManager An instance of [FxaAccountManager] used for synced tabs authentication.
  * @param lifecycleOwner View lifecycle owner used to determine when to cancel UI jobs.

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabsListItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabsListItem.kt
@@ -14,24 +14,24 @@ sealed class SyncedTabsListItem {
     /**
      * A device header for displaying a synced device.
      *
-     * @param displayName The user's custom name of their synced device.
+     * @property displayName The user's custom name of their synced device.
      */
     data class Device(val displayName: String) : SyncedTabsListItem()
 
     /**
      * A section for displaying a synced device and its tabs.
      *
-     * @param displayName The user's custom name of their synced device.
-     * @param tabs The user's tabs from their synced device.
+     * @property displayName The user's custom name of their synced device.
+     * @property tabs The user's tabs from their synced device.
      */
     data class DeviceSection(val displayName: String, val tabs: List<Tab>) : SyncedTabsListItem()
 
     /**
      * A tab that was synced.
      *
-     * @param displayTitle The title of the tab's web page.
-     * @param displayURL The tab's URL up to BrowserToolbar.MAX_URI_LENGTH characters long.
-     * @param tab The underlying SyncTab object passed when the tab is clicked.
+     * @property displayTitle The title of the tab's web page.
+     * @property displayURL The tab's URL up to BrowserToolbar.MAX_URI_LENGTH characters long.
+     * @property tab The underlying SyncTab object passed when the tab is clicked.
      */
     data class Tab(
         val displayTitle: String,
@@ -47,8 +47,8 @@ sealed class SyncedTabsListItem {
     /**
      * A message displayed if an error was encountered.
      *
-     * @param errorText The text to be displayed to the user.
-     * @param errorButton Optional class to set up and handle any clicks in the Error UI.
+     * @property errorText The text to be displayed to the user.
+     * @property errorButton Optional class to set up and handle any clicks in the Error UI.
      */
     data class Error(
         val errorText: String,
@@ -58,9 +58,8 @@ sealed class SyncedTabsListItem {
     /**
      * A button displayed if an error has optional interaction.
      *
-     * @param buttonText The error button's text and accessibility hint.
-     * @param onClick Lambda called when the button is clicked.
-     *
+     * @property buttonText The error button's text and accessibility hint.
+     * @property onClick Lambda called when the button is clicked.
      */
     data class ErrorButton(
         val buttonText: String,

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/viewholders/SyncedTabsPageViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/viewholders/SyncedTabsPageViewHolder.kt
@@ -18,9 +18,9 @@ import org.mozilla.fenix.theme.Theme
 /**
  * Temporary ViewHolder to render [SyncedTabsList] until all of the Tabs Tray is written in Compose.
  *
- * @param composeView Root ComposeView passed-in from TrayPagerAdapter.
- * @param tabsTrayStore Store used as a Composable State to listen for changes to [TabsTrayState.syncedTabs].
- * @param interactor [SyncedTabsInteractor] used to respond to interactions with synced tabs.
+ * @property composeView Root ComposeView passed-in from TrayPagerAdapter.
+ * @property tabsTrayStore Store used as a Composable State to listen for changes to [TabsTrayState.syncedTabs].
+ * @property interactor [SyncedTabsInteractor] used to respond to interactions with synced tabs.
  */
 class SyncedTabsPageViewHolder(
     private val composeView: ComposeView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
@@ -37,8 +37,10 @@ private const val PROGRESS_COMPLETE = 100
 /**
  * [Middleware] to record telemetry in response to [BrowserAction]s.
  *
+ * @property context An Android [Context].
  * @property settings reference to the application [Settings].
- * @property metrics [MetricController] to pass events that have been mapped from actions
+ * @property metrics [MetricController] to pass events that have been mapped from actions.
+ * @property crashReporting An instance of [CrashReporting] to report caught exceptions.
  * @property nimbusSearchEngine The Nimbus search engine.
  * @property searchState Map that stores the [TabSessionState.id] & [TimerId].
  * @property timerId The [TimerId] for the [Metrics.searchPageLoadTime].

--- a/fenix/app/src/main/java/org/mozilla/fenix/theme/FenixTypography.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/theme/FenixTypography.kt
@@ -21,17 +21,17 @@ import androidx.compose.ui.unit.sp
 /**
  * A custom typography for Mozilla Firefox for Android (Fenix).
  *
- * @param headline5 Currently not in-use.
- * @param headline6 Used for headings on Onboarding Modals and App Bar Titles.
- * @param headline7 Used for headings on Cards, Dialogs, Banners, and Homepage.
- * @param headline8 Used for Small Headings.
- * @param subtitle1 Used for Lists.
- * @param subtitle2 Currently not in-use.
- * @param body1 Currently not in-use.
- * @param body2 Used for body text.
- * @param button Used for Buttons.
- * @param caption Used for captions.
- * @param overline Used for Sheets.
+ * @property headline5 Currently not in-use.
+ * @property headline6 Used for headings on Onboarding Modals and App Bar Titles.
+ * @property headline7 Used for headings on Cards, Dialogs, Banners, and Homepage.
+ * @property headline8 Used for Small Headings.
+ * @property subtitle1 Used for Lists.
+ * @property subtitle2 Currently not in-use.
+ * @property body1 Currently not in-use.
+ * @property body2 Used for body text.
+ * @property button Used for Buttons.
+ * @property caption Used for captions.
+ * @property overline Used for Sheets.
  */
 @Suppress("LongParameterList")
 class FenixTypography(

--- a/fenix/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
@@ -59,6 +59,7 @@ enum class Theme {
  * The theme for Mozilla Firefox for Android (Fenix).
  *
  * @param theme The current [Theme] that is displayed.
+ * @param content The children composables to be laid out.
  */
 @Composable
 fun FirefoxTheme(

--- a/fenix/app/src/main/java/org/mozilla/fenix/trackingprotection/ProtectionsStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/trackingprotection/ProtectionsStore.kt
@@ -42,7 +42,7 @@ sealed class ProtectionsAction : Action {
     /**
      * Toggles the enabled state of cookie banner handling protection.
      *
-     * @param cookieBannerUIMode the current status of the cookie banner handling mode.
+     * @property cookieBannerUIMode the current status of the cookie banner handling mode.
      */
     data class ToggleCookieBannerHandlingProtectionEnabled(val cookieBannerUIMode: CookieBannerUIMode) :
         ProtectionsAction()
@@ -50,7 +50,7 @@ sealed class ProtectionsAction : Action {
     /**
      * Reports a site domain where cookie banner reducer didn't work.
      *
-     * @param url to report.
+     * @property url to report.
      */
     data class RequestReportSiteDomain(
         val url: String,

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -61,7 +61,8 @@ private const val AUTOPLAY_USER_SETTING = "AUTOPLAY_USER_SETTING"
 
 /**
  * A simple wrapper for SharedPreferences that makes reading preference a little bit easier.
- * @param appContext Reference to application context.
+ *
+ * @property appContext Reference to application context.
  */
 @Suppress("LargeClass", "TooManyFunctions")
 class Settings(private val appContext: Context) : PreferencesHolder {

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
@@ -41,6 +41,8 @@ fun Context.getUndoDelay(): Long {
  * @param onCancel A suspend block to execute in case of cancellation.
  * @param operation A suspend block to execute if user doesn't cancel via the displayed [FenixSnackbar].
  * @param anchorView A [View] to which [FenixSnackbar] should be anchored.
+ * @param elevation The elevation of the [FenixSnackbar].
+ * @param paddedForBottomToolbar Whether or not [FenixSnackbar] is displayed with the bottom toolbar.
  */
 @Suppress("LongParameterList")
 fun CoroutineScope.allowUndo(

--- a/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
@@ -12,12 +12,13 @@ import java.util.Date
  *
  * @property name The name of the wallpaper.
  * @property collection The name of the collection the wallpaper belongs to.
- * is not restricted.
  * @property textColor The 8 digit hex code color that should be used for text overlaying the wallpaper.
  * @property cardColorLight The 8 digit hex code color that should be used for cards overlaying the wallpaper
  * when the user's theme is set to Light.
  * @property cardColorDark The 8 digit hex code color that should be used for cards overlaying the wallpaper
  * when the user's theme is set to Dark.
+ * @property thumbnailFileState The download state of the wallpaper thumbnail.
+ * @property assetsFileState The download state of the wallpaper assets.
  */
 data class Wallpaper(
     val name: String,
@@ -32,6 +33,8 @@ data class Wallpaper(
      * Type that represents a collection that a [Wallpaper] belongs to.
      *
      * @property name The name of the collection the wallpaper belongs to.
+     * @property heading The heading of the collection.
+     * @property description The description of the collection.
      * @property learnMoreUrl The URL that can be visited to learn more about a collection, if any.
      * @property availableLocales The locales that this wallpaper is restricted to. If null, the wallpaper
      * is not restricted.
@@ -107,8 +110,8 @@ data class Wallpaper(
         /**
          * Defines the standard path at which a wallpaper resource is kept on disk.
          *
-         * @param type The type of image that should be retrieved.
          * @param name The name of the wallpaper.
+         * @param type The type of image that should be retrieved.
          */
         fun getLocalPath(name: String, type: ImageType) = "wallpapers/$name/${type.lowercase()}.png"
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
@@ -18,9 +18,9 @@ import java.lang.IllegalStateException
 /**
  * Can download wallpapers from a remote host.
  *
- * @param storageRootDirectory The top level app-local storage directory.
- * @param client Required for fetching files from network.
- * @param dispatcher Dispatcher used to execute suspending functions. Default parameter
+ * @property storageRootDirectory The top level app-local storage directory.
+ * @property client Required for fetching files from network.
+ * @property dispatcher Dispatcher used to execute suspending functions. Default parameter
  * should be likely be used except for when under test.
  */
 class WallpaperDownloader(

--- a/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
@@ -17,7 +17,7 @@ import java.io.File
  * Manages various functions related to the locally-stored wallpaper assets.
  *
  * @property storageRootDirectory The top level app-local storage directory.
- * @param coroutineDispatcher Dispatcher used to execute suspending functions. Default parameter
+ * @property coroutineDispatcher Dispatcher used to execute suspending functions. Default parameter
  * should be likely be used except for when under test.
  */
 class WallpaperFileManager(

--- a/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/WallpapersUseCases.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/wallpapers/WallpapersUseCases.kt
@@ -27,11 +27,6 @@ import java.util.Date
  * @param client Handles downloading wallpapers and their metadata.
  * @param storageRootDirectory The top level app-local storage directory.
  * @param currentLocale The locale currently being used on the device.
- *
- * @property initialize Usecase for initializing wallpaper feature. Should usually be called early
- * in the app's lifetime to ensure that any potential long-running tasks can complete quickly.
- * @property loadBitmap Usecase for loading specific wallpaper bitmaps.
- * @property selectWallpaper Usecase for selecting a new wallpaper.
  */
 class WallpapersUseCases(
     context: Context,
@@ -42,6 +37,9 @@ class WallpapersUseCases(
 ) {
     private val downloader = WallpaperDownloader(storageRootDirectory, client)
     private val fileManager = WallpaperFileManager(storageRootDirectory)
+
+    // Use case for initializing wallpaper feature. Should usually be called early
+    // in the app's lifetime to ensure that any potential long-running tasks can complete quickly.
     val initialize: InitializeWallpapersUseCase by lazy {
         val metadataFetcher = WallpaperMetadataFetcher(client)
         val migrationHelper = LegacyWallpaperMigration(
@@ -59,15 +57,20 @@ class WallpapersUseCases(
             currentLocale = currentLocale,
         )
     }
+
+    // Use case for loading specific wallpaper bitmaps.
     val loadBitmap: LoadBitmapUseCase by lazy {
         DefaultLoadBitmapUseCase(
             filesDir = context.filesDir,
             getOrientation = { context.resources.configuration.orientation },
         )
     }
+
     val loadThumbnail: LoadThumbnailUseCase by lazy {
         DefaultLoadThumbnailUseCase(storageRootDirectory)
     }
+
+    // Use case for selecting a new wallpaper.
     val selectWallpaper: SelectWallpaperUseCase by lazy {
         DefaultSelectWallpaperUseCase(context.settings(), appStore, fileManager, downloader)
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -326,7 +326,7 @@ class DefaultSessionControlControllerTest {
             removeCollectionWithUndo = { collection ->
                 actualCollection = collection
             },
-        ).handleCollectionRemoveTab(expectedCollection, tab, false)
+        ).handleCollectionRemoveTab(expectedCollection, tab)
 
         assertNotNull(Collections.tabRemoved.testGetValue())
         val recordedEvents = Collections.tabRemoved.testGetValue()!!
@@ -340,7 +340,7 @@ class DefaultSessionControlControllerTest {
     fun `handleCollectionRemoveTab multiple tabs`() {
         val collection: TabCollection = mockk(relaxed = true)
         val tab: ComponentTab = mockk(relaxed = true)
-        createController().handleCollectionRemoveTab(collection, tab, false)
+        createController().handleCollectionRemoveTab(collection, tab)
 
         assertNotNull(Collections.tabRemoved.testGetValue())
         val recordedEvents = Collections.tabRemoved.testGetValue()!!

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -85,8 +85,8 @@ class SessionControlInteractorTest {
     fun onCollectionRemoveTab() {
         val collection: TabCollection = mockk(relaxed = true)
         val tab: Tab = mockk(relaxed = true)
-        interactor.onCollectionRemoveTab(collection, tab, false)
-        verify { controller.handleCollectionRemoveTab(collection, tab, false) }
+        interactor.onCollectionRemoveTab(collection, tab)
+        verify { controller.handleCollectionRemoveTab(collection, tab) }
     }
 
     @Test

--- a/fenix/config/detekt.yml
+++ b/fenix/config/detekt.yml
@@ -72,8 +72,8 @@ comments:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
   OutdatedDocumentation:
-    active: false
-    matchTypeParameters: true
+    active: true # Enabled in https://bugzilla.mozilla.org/show_bug.cgi?id=1848527
+    matchTypeParameters: false # (Default: true) Disabled in https://bugzilla.mozilla.org/show_bug.cgi?id=1848527
     matchDeclarationsOrder: true
     allowParamOnConstructorProperties: false
   UndocumentedPublicClass:


### PR DESCRIPTION
This PR enables the `OutdatedDocumentation` rule which will warn us about when our kDocs are out of sync with the parameter list. In addition, the changes goes through Fenix to correct all the existing reported issues from detekt with this new rule - this mostly consists of either correcting the @param/@property usage, and updating the parameter list docs where necessary.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1848527