### PR TITLE
Bug 1847266 - Implement status message for incompatible add-ons in the manager

### DIFF
--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -450,6 +450,7 @@ class DisabledFlags internal constructor(val value: Int) {
         const val BLOCKLIST: Int = 1 shl 2
         const val APP_SUPPORT: Int = 1 shl 3
         const val SIGNATURE: Int = 1 shl 4
+        const val APP_VERSION: Int = 1 shl 5
 
         /**
          * Selects a combination of flags.
@@ -489,6 +490,14 @@ fun WebExtension.isBlockListed(): Boolean {
 fun WebExtension.isDisabledUnsigned(): Boolean {
     val flags = getMetadata()?.disabledFlags
     return flags?.contains(DisabledFlags.SIGNATURE) == true
+}
+
+/**
+ * Returns whether the extension is disabled because it isn't compatible with the application version.
+ */
+fun WebExtension.isDisabledIncompatible(): Boolean {
+    val flags = getMetadata()?.disabledFlags
+    return flags?.contains(DisabledFlags.APP_VERSION) == true
 }
 
 /**

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/webextension/WebExtensionTest.kt
@@ -69,26 +69,37 @@ class WebExtensionTest {
         assertFalse(extension.isUnsupported())
         assertFalse(extension.isBlockListed())
         assertFalse(extension.isDisabledUnsigned())
+        assertFalse(extension.isDisabledIncompatible())
 
         val metadata: Metadata = mock()
         whenever(extension.getMetadata()).thenReturn(metadata)
         assertFalse(extension.isUnsupported())
         assertFalse(extension.isBlockListed())
         assertFalse(extension.isDisabledUnsigned())
+        assertFalse(extension.isDisabledIncompatible())
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.BLOCKLIST))
         assertFalse(extension.isUnsupported())
         assertTrue(extension.isBlockListed())
         assertFalse(extension.isDisabledUnsigned())
+        assertFalse(extension.isDisabledIncompatible())
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.APP_SUPPORT))
         assertTrue(extension.isUnsupported())
         assertFalse(extension.isBlockListed())
         assertFalse(extension.isDisabledUnsigned())
+        assertFalse(extension.isDisabledIncompatible())
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.SIGNATURE))
         assertFalse(extension.isUnsupported())
         assertFalse(extension.isBlockListed())
         assertTrue(extension.isDisabledUnsigned())
+        assertFalse(extension.isDisabledIncompatible())
+
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(DisabledFlags.APP_VERSION))
+        assertFalse(extension.isUnsupported())
+        assertFalse(extension.isBlockListed())
+        assertFalse(extension.isDisabledUnsigned())
+        assertTrue(extension.isDisabledIncompatible())
     }
 }

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -145,6 +145,11 @@ data class Addon(
          * The [Addon] was disabled because it isn't correctly signed.
          */
         NOT_CORRECTLY_SIGNED,
+
+        /**
+         * The [Addon] was disabled because it isn't compatible with the application version.
+         */
+        INCOMPATIBLE,
     }
 
     /**
@@ -188,6 +193,12 @@ data class Addon(
      * Returns whether this [Addon] is currently disabled because it isn't correctly signed.
      */
     fun isDisabledAsNotCorrectlySigned() = installedState?.disabledReason == DisabledReason.NOT_CORRECTLY_SIGNED
+
+    /**
+     * Returns whether this [Addon] is currently disabled because it isn't compatible
+     * with the application version.
+     */
+    fun isDisabledAsIncompatible() = installedState?.disabledReason == DisabledReason.INCOMPATIBLE
 
     /**
      * Returns whether or not this [Addon] is allowed in private browsing mode.

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
@@ -19,6 +19,7 @@ import mozilla.components.concept.engine.webextension.EnableSource
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webextension.isBlockListed
+import mozilla.components.concept.engine.webextension.isDisabledIncompatible
 import mozilla.components.concept.engine.webextension.isDisabledUnsigned
 import mozilla.components.concept.engine.webextension.isUnsupported
 import mozilla.components.feature.addons.update.AddonUpdater
@@ -384,6 +385,8 @@ internal fun WebExtension.getDisabledReason(): Addon.DisabledReason? {
         Addon.DisabledReason.BLOCKLISTED
     } else if (isDisabledUnsigned()) {
         Addon.DisabledReason.NOT_CORRECTLY_SIGNED
+    } else if (isDisabledIncompatible()) {
+        Addon.DisabledReason.INCOMPATIBLE
     } else if (isUnsupported()) {
         Addon.DisabledReason.UNSUPPORTED
     } else if (getMetadata()?.disabledFlags?.contains(DisabledFlags.USER) == true) {

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -37,6 +37,8 @@ import mozilla.components.feature.addons.ui.CustomViewHolder.FooterViewHolder
 import mozilla.components.feature.addons.ui.CustomViewHolder.SectionViewHolder
 import mozilla.components.feature.addons.ui.CustomViewHolder.UnsupportedSectionViewHolder
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.ktx.android.content.appName
+import mozilla.components.support.ktx.android.content.appVersionName
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import java.io.IOException
 import mozilla.components.ui.icons.R as iconsR
@@ -220,7 +222,12 @@ class AddonsManagerAdapter(
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun bindAddon(holder: AddonViewHolder, addon: Addon) {
+    internal fun bindAddon(
+        holder: AddonViewHolder,
+        addon: Addon,
+        appName: String = holder.itemView.context.appName,
+        appVersion: String = holder.itemView.context.appVersionName,
+    ) {
         val context = holder.itemView.context
         addon.rating?.let {
             val userCount = context.getString(R.string.mozac_feature_addons_user_rating_count_2)
@@ -292,6 +299,16 @@ class AddonsManagerAdapter(
                 )
             }
             holder.statusErrorView.isVisible = true
+        } else if (addon.isDisabledAsIncompatible()) {
+            statusErrorMessage.text = context.getString(
+                R.string.mozac_feature_addons_status_incompatible,
+                addonName,
+                appName,
+                appVersion,
+            )
+            holder.statusErrorView.isVisible = true
+            // There is no link when the add-on is disabled because it isn't compatible with the application version.
+            statusErrorLearnMoreLink.isVisible = false
         }
     }
 

--- a/android-components/components/feature/addons/src/main/res/values/strings.xml
+++ b/android-components/components/feature/addons/src/main/res/values/strings.xml
@@ -237,4 +237,6 @@
     <string name="mozac_feature_addons_status_blocklisted">%1$s has been disabled due to security or stability issues.</string>
     <!-- Status message below an add-on in the add-ons manager when this add-on hasn't been signed correctly. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_status_unsigned">%1$s could not be verified as secure and has been disabled.</string>
+    <!-- Status message below an add-on in the add-ons manager when this add-on isn't compatible with the application version. %1$s is the add-on name, %2$s is the app name and %3$s is the app version. -->
+    <string name="mozac_feature_addons_status_incompatible">%1$s is not compatible with your version of %2$s (version %3$s).</string>
 </resources>

--- a/android-components/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -20,6 +20,7 @@ import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.APP_SUPPORT
+import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.APP_VERSION
 import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.BLOCKLIST
 import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.SIGNATURE
 import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.USER
@@ -842,6 +843,9 @@ class AddonManagerTest {
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(SIGNATURE))
         assertEquals(Addon.DisabledReason.NOT_CORRECTLY_SIGNED, extension.getDisabledReason())
+
+        whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(APP_VERSION))
+        assertEquals(Addon.DisabledReason.INCOMPATIBLE, extension.getDisabledReason())
 
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(0))
         assertNull(extension.getDisabledReason())

--- a/android-components/components/feature/addons/src/test/java/AddonTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonTest.kt
@@ -418,4 +418,20 @@ class AddonTest {
         assertFalse(addon.isDisabledAsNotCorrectlySigned())
         assertTrue(blockListedAddon.isDisabledAsNotCorrectlySigned())
     }
+
+    @Test
+    fun `isDisabledAsIncompatible - true if installed state disabled status equals to INCOMPATIBLE and otherwise false`() {
+        val addon = Addon(id = "id")
+        val blockListedAddon = addon.copy(
+            installedState = Addon.InstalledState(
+                id = "id",
+                version = "1.0",
+                optionsPageUrl = "",
+                disabledReason = Addon.DisabledReason.INCOMPATIBLE,
+            ),
+        )
+
+        assertFalse(addon.isDisabledAsIncompatible())
+        assertTrue(blockListedAddon.isDisabledAsIncompatible())
+    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -132,7 +132,11 @@ class InstalledAddonDetailsFragment : Fragment() {
         switch.setState(addon.isEnabled())
         // When the ad-on is blocklisted or not correctly signed, we do not want to enable the toggle switch
         // because users shouldn't be able to re-enable an add-on in this state.
-        if (addon.isDisabledAsBlocklisted() || addon.isDisabledAsNotCorrectlySigned()) {
+        if (
+            addon.isDisabledAsBlocklisted() ||
+            addon.isDisabledAsNotCorrectlySigned() ||
+            addon.isDisabledAsIncompatible()
+        ) {
             switch.isEnabled = false
             return
         }
@@ -321,6 +325,7 @@ class InstalledAddonDetailsFragment : Fragment() {
             )
         }
     }
+
     private fun bindRemoveButton() {
         binding.removeAddOn.setOnClickListener {
             setAllInteractiveViewsClickable(binding, false)

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragmentTest.kt
@@ -91,6 +91,7 @@ class InstalledAddonDetailsFragmentTest {
         every { fragment.providePrivateBrowsingSwitch() } returns privateBrowsingSwitch
         every { addon.isDisabledAsBlocklisted() } returns false
         every { addon.isDisabledAsNotCorrectlySigned() } returns false
+        every { addon.isDisabledAsIncompatible() } returns false
         every { addon.isEnabled() } returns true
         every { fragment.addon } returns addon
 
@@ -110,6 +111,25 @@ class InstalledAddonDetailsFragmentTest {
         every { addon.isEnabled() } returns true
         every { addon.isDisabledAsBlocklisted() } returns false
         every { addon.isDisabledAsNotCorrectlySigned() } returns true
+        every { fragment.addon } returns addon
+
+        fragment.bindEnableSwitch()
+
+        verify { enableSwitch.isEnabled = false }
+    }
+
+    @Test
+    fun `GIVEN incompatible addon WHEN biding the enable switch THEN disable the switch`() {
+        val addon = mockk<Addon>()
+        val enableSwitch = mockk<SwitchMaterial>(relaxed = true)
+        val privateBrowsingSwitch = mockk<SwitchMaterial>(relaxed = true)
+
+        every { fragment.provideEnableSwitch() } returns enableSwitch
+        every { fragment.providePrivateBrowsingSwitch() } returns privateBrowsingSwitch
+        every { addon.isEnabled() } returns true
+        every { addon.isDisabledAsBlocklisted() } returns false
+        every { addon.isDisabledAsNotCorrectlySigned() } returns false
+        every { addon.isDisabledAsIncompatible() } returns true
         every { fragment.addon } returns addon
 
         fragment.bindEnableSwitch()


### PR DESCRIPTION
~~:warning: Depends on https://phabricator.services.mozilla.com/D189763 and https://github.com/mozilla-mobile/firefox-android/pull/3840~~

---

In order to verify this PR, one has to follow the instructions at https://addons-frontend.readthedocs.io/en/latest/fenix/ in order to allow extensions from AMO stage to be installed. Then:

1. open `about:config` and create a boolean pref named `extensions.checkCompatibility.nightly` set to `false`. This will disabled compatibility checks
2. open the fenix add-ons manager and install a test extension named "extension to verify status bar"
3. go back to `about:config` and set the `extensions.checkCompatibility.nightly` pref to `true`
4. re-open the fenix add-ons manager: you should see the "incompatible" message. Note that this won't work without  https://phabricator.services.mozilla.com/D189763, the extension will be disabled but there won't be any message.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
5. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
6. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
7. Click on `View task in Taskcluster` in the new `DETAILS` section.
8. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847266