### PR TITLE
Bug 1807147 - Query FIP results if string longer than one char 

### DIFF
--- a/android-components/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
+++ b/android-components/components/feature/findinpage/src/main/java/mozilla/components/feature/findinpage/view/FindInPageBar.kt
@@ -79,7 +79,7 @@ class FindInPageBar @JvmOverloads constructor(
     }
 
     internal fun onQueryChange(newQuery: String) {
-        if (newQuery.isNotBlank()) {
+        if (newQuery.length > 1) {
             listener?.onFindAll(newQuery)
         } else {
             resultsCountTextView.text = ""
@@ -153,7 +153,7 @@ class FindInPageBar @JvmOverloads constructor(
         val nextButton = findViewById<AppCompatImageButton>(R.id.find_in_page_next_btn)
         nextButton.setIconTintIfNotDefaultValue(styling.buttonsTint)
         nextButton.setOnClickListener {
-            if (queryEditText.text.isNotEmpty()) {
+            if (queryEditText.text.length > 1) {
                 listener?.onNextResult()
             }
         }
@@ -163,7 +163,7 @@ class FindInPageBar @JvmOverloads constructor(
         val previousButton = findViewById<AppCompatImageButton>(R.id.find_in_page_prev_btn)
         previousButton.setIconTintIfNotDefaultValue(styling.buttonsTint)
         previousButton.setOnClickListener {
-            if (queryEditText.text.isNotEmpty()) {
+            if (queryEditText.text.length > 1) {
                 listener?.onPreviousResult()
             }
         }


### PR DESCRIPTION
Currently, the Find in page results do not work as expected when searching for one character. This change finds results only when the string searched for is at least two chars long. Another issue here is that when `SessionFinder` results are invoked in a quick succession, the number of matches is 0.

There is already a GV ticket here:
https://bugzilla.mozilla.org/show_bug.cgi?id=1587856



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807147