### PR TITLE
Bug 1856708 - Fix ReaderView to use `storage.session` correctly

### DIFF
--- a/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
+++ b/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
@@ -17,11 +17,11 @@ browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
        });
        break;
      case 'addSerializedDoc':
-        storage.session.set(sender.contextId.toString(), message.doc);
+        browser.storage.session.set(sender.contextId.toString(), message.doc);
         break;
      case 'getSerializedDoc':
-       let doc = await storage.session.get(message.id);
-       storage.session.delete(message.id);
+       let doc = await browser.storage.session.get(message.id);
+       browser.storage.session.remove(message.id);
        sendResponse(doc);
        break;
      default:


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1856708