### PR TITLE
Bug 1856731 - Moves showing reader mode from the content / background script to the Feature.

### DIFF
--- a/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
+++ b/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
@@ -7,21 +7,12 @@
 
 browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
   switch (message.action) {
-     case 'show':
-       let readerViewUrl = new URL(browser.runtime.getURL("/readerview.html"));
-       readerViewUrl.searchParams.append("id", sender.contextId);
-       readerViewUrl.searchParams.append("url", message.url);
-       readerViewUrl.searchParams.append("colorScheme", message.options.colorScheme);
-       browser.tabs.update({url: readerViewUrl.href}).catch((e) => {
-           console.error("Failed to open reader view", e, e.stack);
-       });
-       break;
      case 'addSerializedDoc':
-        storage.session.set(sender.contextId.toString(), message.doc);
+        browser.storage.session.set({ [message.id]: message.doc });
         break;
      case 'getSerializedDoc':
-       let doc = await storage.session.get(message.id);
-       storage.session.delete(message.id);
+       let doc = await browser.storage.session.get(message.id);
+       browser.storage.session.remove(message.id);
        sendResponse(doc);
        break;
      default:

--- a/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-content.js
+++ b/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-content.js
@@ -44,14 +44,12 @@ function connectNativePort() {
   let port = browser.runtime.connectNative("mozacReaderview");
   port.onMessage.addListener((message) => {
      switch (message.action) {
-       case 'show':
-         browser.runtime.sendMessage({action: "show", options: message.value, url: location.href});
-
+       case 'cachePage':
          let serializedDoc = new XMLSerializer().serializeToString(document);
-         browser.runtime.sendMessage({action: "addSerializedDoc", doc: serializedDoc});
+         browser.runtime.sendMessage({action: "addSerializedDoc", doc: serializedDoc, id: message.id});
          break;
        case 'checkReaderState':
-         port.postMessage({baseUrl: browser.runtime.getURL("/"), readerable: isReaderable()});
+         port.postMessage({type: 'checkReaderState', baseUrl: browser.runtime.getURL("/"), readerable: isReaderable()});
          break;
        default:
          console.error(`Received unsupported action ${message.action}`);

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,10 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **feature-readerview**
+  * Adds `UUIDCreator` to `ReaderViewFeature` to create UUIDs for cache keys.
+  * Moves the implementation of presenting Reader Mode from the content scripts to `ReaderViewFeature`
+
 * **browser-state**
   * `SessionState.isProductUrl` is not affected for private tabs as shopping mode is disabled in private tabs. [Bug 1847063](https://bugzilla.mozilla.org/show_bug.cgi?id=1847063)
   * `SessionState.isProductUrl` has been moved to `ContentState.isProductUrl`. [Bug 1857287](https://bugzilla.mozilla.org/show_bug.cgi?id=1857287)


### PR DESCRIPTION
Also fixes Bug 1856708 - Fixes ReaderView to use new storage.session APIs

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1856731
https://bugzilla.mozilla.org/show_bug.cgi?id=1856708