### PR TITLE
Bug 1855942 - Create compose version of CFRPopupFullscreenLayout

### DIFF
--- a/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/CFRPopup.kt
+++ b/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/CFRPopup.kt
@@ -26,6 +26,8 @@ import java.lang.ref.WeakReference
  * If more colors are provided they will be used in a gradient.
  * @property popupVerticalOffset Vertical distance between the indicator arrow and the anchor.
  * This only applies if [overlapAnchor] is `false`.
+ * @property focusable Whether the popup is focusable. When true, the popup will receive IME events and key presses,
+ * such as when the back button is pressed.
  * @property dismissButtonColor The tint color that should be applied to the dismiss button.
  * @property dismissOnBackPress Whether the popup can be dismissed by pressing the back button.
  * If true, pressing the back button will also call onDismiss().
@@ -45,6 +47,7 @@ data class CFRPopupProperties(
     val popupBodyColors: List<Int> = listOf(Color.Blue.toArgb()),
     val popupVerticalOffset: Dp = CFRPopup.DEFAULT_VERTICAL_OFFSET.dp,
     val showDismissButton: Boolean = true,
+    val focusable: Boolean = true,
     val dismissButtonColor: Int = Color.Black.toArgb(),
     val dismissOnBackPress: Boolean = false,
     val dismissOnClickOutside: Boolean = false,

--- a/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/CFRPopupForCompose.kt
+++ b/android-components/components/compose/cfr/src/main/java/mozilla/components/compose/cfr/CFRPopupForCompose.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.compose.cfr
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+
+/**
+ * UI for displaying a CFR in compose exclusive layouts when an anchor
+ * cannot be passed as parameter
+ *
+ * @param alignment [Alignment] define the alignment of the CFR in relation to parent.
+ * @param offset [IntOffset] define the offset of the Popup in relation to parent. Default (0,0)
+ * @param properties [CFRPopupProperties] allowing to customize the popup appearance and behavior.
+ * @param onDismiss Callback for when the popup is dismissed indicating also if the dismissal
+ * was explicit - by tapping the "X" button or not.
+ * @param text [Text] already styled and ready to be shown in the popup.
+ * @param action Optional other composable to show just below the popup text.
+ */
+@Composable
+@Suppress("MagicNumber")
+fun CFRPopupForCompose(
+    alignment: Alignment,
+    offset: IntOffset = IntOffset(0, 0),
+    properties: CFRPopupProperties,
+    onDismiss: () -> Unit,
+    text: @Composable (() -> Unit),
+    action: @Composable (() -> Unit) = {},
+) {
+    var popupControl by remember { mutableStateOf(true) }
+
+    if (popupControl) {
+        Popup(
+            alignment = alignment,
+            offset = offset,
+            properties = PopupProperties(
+                focusable = properties.focusable,
+                dismissOnBackPress = properties.dismissOnBackPress,
+                dismissOnClickOutside = properties.dismissOnClickOutside,
+            ),
+        ) {
+            CFRPopupContent(
+                popupBodyColors = properties.popupBodyColors,
+                showDismissButton = properties.showDismissButton,
+                dismissButtonColor = properties.dismissButtonColor,
+                indicatorDirection = properties.indicatorDirection,
+                indicatorArrowStartOffset = with(LocalDensity.current) {
+                    properties.indicatorArrowStartOffset
+                },
+                onDismiss = {
+                    onDismiss()
+                    popupControl = false
+                },
+                popupWidth = properties.popupWidth,
+                text = text,
+                action = action,
+            )
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
@@ -61,6 +61,7 @@ import mozilla.components.browser.storage.sync.Tab as SyncTab
  * @param displayTabsInGrid Whether the normal and private tabs should be displayed in a grid.
  * @param isInDebugMode True for debug variant or if secret menu is enabled for this session.
  * @param shouldShowTabAutoCloseBanner Whether the tab auto closer banner should be displayed.
+ * @param shouldShowInactiveTabsCFR Whether the CFR for Inactive tabs should be displayed.
  * @param shouldShowInactiveTabsAutoCloseDialog Whether the inactive tabs auto close dialog should be displayed.
  * @param onTabPageClick Invoked when the user clicks on the Normal, Private, or Synced tabs page button.
  * @param onTabClose Invoked when the user clicks to close a tab.
@@ -95,6 +96,8 @@ import mozilla.components.browser.storage.sync.Tab as SyncTab
  * @param onTabAutoCloseBannerDismiss Invoked when the user clicks to dismiss the auto close banner.
  * @param onTabAutoCloseBannerShown Invoked when the auto close banner has been shown to the user.
  * @param onMove Invoked after the drag and drop gesture completed. Swaps positions of two tabs.
+ * @param onDismissInactiveTabsCFR Invoked after tapping "X" button on Inactive Tabs CFR.
+ * @param onActionInactiveTabsCFR Invoked after tapping "Turn off in settings" Action Text on Inactive Tabs CFR.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Suppress("LongMethod", "LongParameterList", "ComplexMethod")
@@ -107,6 +110,7 @@ fun TabsTray(
     displayTabsInGrid: Boolean,
     isInDebugMode: Boolean,
     shouldShowTabAutoCloseBanner: Boolean,
+    shouldShowInactiveTabsCFR: Boolean,
     shouldShowInactiveTabsAutoCloseDialog: (Int) -> Boolean,
     onTabPageClick: (Page) -> Unit,
     onTabClose: (TabSessionState) -> Unit,
@@ -136,6 +140,8 @@ fun TabsTray(
     onTabAutoCloseBannerDismiss: () -> Unit,
     onTabAutoCloseBannerShown: () -> Unit,
     onMove: (String, String?, Boolean) -> Unit,
+    onDismissInactiveTabsCFR: () -> Unit,
+    onActionInactiveTabsCFR: () -> Unit,
 ) {
     val multiselectMode = tabsTrayStore
         .observeAsComposableState { state -> state.mode }.value ?: TabsTrayState.Mode.Normal
@@ -202,6 +208,7 @@ fun TabsTray(
                             tabsTrayStore = tabsTrayStore,
                             storage = storage,
                             displayTabsInGrid = displayTabsInGrid,
+                            shouldShowInactiveTabsCFR = shouldShowInactiveTabsCFR,
                             onTabClose = onTabClose,
                             onTabMediaClick = onTabMediaClick,
                             onTabClick = onTabClick,
@@ -215,6 +222,8 @@ fun TabsTray(
                             onInactiveTabClick = onInactiveTabClick,
                             onInactiveTabClose = onInactiveTabClose,
                             onMove = onMove,
+                            onDismissInactiveTabsCFR = onDismissInactiveTabsCFR,
+                            onActionInactiveTabsCFR = onActionInactiveTabsCFR,
                         )
                     }
 
@@ -252,6 +261,7 @@ private fun NormalTabsPage(
     tabsTrayStore: TabsTrayStore,
     storage: ThumbnailStorage,
     displayTabsInGrid: Boolean,
+    shouldShowInactiveTabsCFR: Boolean,
     onTabClose: (TabSessionState) -> Unit,
     onTabMediaClick: (TabSessionState) -> Unit,
     onTabClick: (TabSessionState) -> Unit,
@@ -265,6 +275,8 @@ private fun NormalTabsPage(
     onInactiveTabClick: (TabSessionState) -> Unit,
     onInactiveTabClose: (TabSessionState) -> Unit,
     onMove: (String, String?, Boolean) -> Unit,
+    onDismissInactiveTabsCFR: () -> Unit,
+    onActionInactiveTabsCFR: () -> Unit,
 ) {
     val inactiveTabsExpanded = appStore
         .observeAsComposableState { state -> state.inactiveTabsExpanded }.value ?: false
@@ -290,6 +302,7 @@ private fun NormalTabsPage(
                     inactiveTabs = inactiveTabs,
                     expanded = inactiveTabsExpanded,
                     showAutoCloseDialog = showAutoCloseDialog,
+                    showInactiveTabsCFR = shouldShowInactiveTabsCFR,
                     onHeaderClick = onInactiveTabsHeaderClick,
                     onDeleteAllButtonClick = onDeleteAllInactiveTabsClick,
                     onAutoCloseDismissClick = {
@@ -302,6 +315,12 @@ private fun NormalTabsPage(
                     },
                     onTabClick = onInactiveTabClick,
                     onTabCloseClick = onInactiveTabClose,
+                    onDismissInactiveTabsCFR = {
+                        onDismissInactiveTabsCFR()
+                    },
+                    onActionInactiveTabsCFR = {
+                        onActionInactiveTabsCFR()
+                    },
                 )
             }
         }
@@ -536,6 +555,7 @@ private fun TabsTrayPreviewRoot(
             isInDebugMode = false,
             shouldShowInactiveTabsAutoCloseDialog = { true },
             shouldShowTabAutoCloseBanner = showTabAutoCloseBanner,
+            shouldShowInactiveTabsCFR = false,
             onTabPageClick = { page ->
                 selectedPageState = page
             },
@@ -591,6 +611,8 @@ private fun TabsTrayPreviewRoot(
             onTabAutoCloseBannerDismiss = {},
             onTabAutoCloseBannerShown = {},
             onMove = { _, _, _ -> },
+            onDismissInactiveTabsCFR = {},
+            onActionInactiveTabsCFR = {},
         )
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TrayPagerAdapter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TrayPagerAdapter.kt
@@ -26,6 +26,7 @@ class TrayPagerAdapter(
     internal val lifecycleOwner: LifecycleOwner,
     internal val tabsTrayStore: TabsTrayStore,
     internal val interactor: TabsTrayInteractor,
+    internal val navigationInteractor: NavigationInteractor,
     internal val browserStore: BrowserStore,
     internal val appStore: AppStore,
 ) : RecyclerView.Adapter<AbstractPageViewHolder>() {
@@ -41,6 +42,7 @@ class TrayPagerAdapter(
                 lifecycleOwner = lifecycleOwner,
                 tabsTrayStore = tabsTrayStore,
                 interactor = interactor,
+                navigationInteractor = navigationInteractor,
                 featureName = INACTIVE_TABS_FEATURE_NAME,
             ),
             BrowserTabsAdapter(context, interactor, tabsTrayStore, TABS_TRAY_FEATURE_NAME, lifecycleOwner),

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsAdapter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsAdapter.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.RecyclerView
+import org.mozilla.fenix.tabstray.NavigationInteractor
 import org.mozilla.fenix.tabstray.TabsTrayState
 import org.mozilla.fenix.tabstray.TabsTrayStore
 
@@ -18,6 +19,7 @@ import org.mozilla.fenix.tabstray.TabsTrayStore
  * @property tabsTrayStore [TabsTrayStore] used to listen for changes to [TabsTrayState.inactiveTabs].
  * @property interactor [InactiveTabsInteractor] used to respond to interactions with the inactive tabs header
  * and the auto close dialog.
+ * @property navigationInteractor [NavigationInteractor] used to perform navigation actions with side effects.
  * @property featureName [String] representing the name of the inactive tabs feature for telemetry reporting.
  */
 @Suppress("LongParameterList")
@@ -25,6 +27,7 @@ class InactiveTabsAdapter(
     private val lifecycleOwner: LifecycleOwner,
     private val tabsTrayStore: TabsTrayStore,
     private val interactor: InactiveTabsInteractor,
+    private val navigationInteractor: NavigationInteractor,
     override val featureName: String,
 ) : RecyclerView.Adapter<InactiveTabViewHolder>(), FeatureNameHolder {
 
@@ -36,6 +39,7 @@ class InactiveTabsAdapter(
             lifecycleOwner = lifecycleOwner,
             tabsTrayStore = tabsTrayStore,
             interactor = interactor,
+            navigationInteractor = navigationInteractor,
         )
     }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
@@ -224,6 +224,7 @@ class TabsTrayFragmentTest {
         val store: TabsTrayStore = mockk()
         val lifecycleOwner = mockk<LifecycleOwner>(relaxed = true)
         val trayInteractor: TabsTrayInteractor = mockk()
+        val navigationInteractor: NavigationInteractor = mockk()
         val browserStore: BrowserStore = mockk()
         every { context.components.core.store } returns browserStore
 
@@ -232,6 +233,7 @@ class TabsTrayFragmentTest {
             lifecycleOwner = lifecycleOwner,
             store = store,
             trayInteractor = trayInteractor,
+            navigationInteractor = navigationInteractor,
         )
 
         val adapter = (tabsTrayBinding.tabsTray.adapter as TrayPagerAdapter)


### PR DESCRIPTION
The current CFRPopup requires an anchor as parameter in order to find the right position for placing the CFR. This current implementation will not work on compose exclusive views due to the lack of xml views to be used as anchor. This patch aims to introduce a new CFR which can be displayed in compose layouts without requiring a xml view.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1855942