### PR TITLE
Bug 1810047 - Fixup WebExtensionPromptFeature

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/extension/WebExtensionPromptRequest.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/extension/WebExtensionPromptRequest.kt
@@ -39,26 +39,34 @@ sealed class WebExtensionPromptRequest {
      */
     sealed class AfterInstallation(open val extension: WebExtension) : WebExtensionPromptRequest() {
         /**
-         * Value type that represents a request for a permission prompt.
-         * @property extension The [WebExtension] that requested the dialog to be shown.
-         * @property onConfirm A callback indicating whether the permissions were granted or not.
+         * Value type that represents a request for showing a permissions prompt.
          */
-        data class Permissions(
+        sealed class Permissions(
             override val extension: WebExtension,
-            val onConfirm: (Boolean) -> Unit,
-        ) : AfterInstallation(extension)
+            open val onConfirm: (Boolean) -> Unit,
+        ) : AfterInstallation(extension) {
+            /**
+             * Value type that represents a request for a required permissions prompt.
+             * @property extension The [WebExtension] that requested the dialog to be shown.
+             * @property onConfirm A callback indicating whether the permissions were granted or not.
+             */
+            data class Required(
+                override val extension: WebExtension,
+                override val onConfirm: (Boolean) -> Unit,
+            ) : Permissions(extension, onConfirm)
 
-        /**
-         * Value type that represents a request for a (optional) permission prompt.
-         * @property extension The [WebExtension] that requested the dialog to be shown.
-         * @property permissions The optional permissions to list in the dialog.
-         * @property onConfirm A callback indicating whether the permissions were granted or not.
-         */
-        data class OptionalPermissions(
-            override val extension: WebExtension,
-            val permissions: List<String>,
-            val onConfirm: (Boolean) -> Unit,
-        ) : AfterInstallation(extension)
+            /**
+             * Value type that represents a request for an optional permissions prompt.
+             * @property extension The [WebExtension] that requested the dialog to be shown.
+             * @property permissions The optional permissions to list in the dialog.
+             * @property onConfirm A callback indicating whether the permissions were granted or not.
+             */
+            data class Optional(
+                override val extension: WebExtension,
+                val permissions: List<String>,
+                override val onConfirm: (Boolean) -> Unit,
+            ) : Permissions(extension, onConfirm)
+        }
 
         /**
          * Value type that represents a request for showing post-installation prompt.

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt
@@ -392,7 +392,7 @@ class WebExtensionActionTest {
 
         assertNull(store.state.webExtensionPromptRequest)
 
-        val promptRequest = WebExtensionPromptRequest.AfterInstallation.Permissions(mock(), {})
+        val promptRequest = WebExtensionPromptRequest.AfterInstallation.Permissions.Required(mock(), mock())
 
         store.dispatch(WebExtensionAction.UpdatePromptRequestWebExtensionAction(promptRequest))
             .joinBlocking()
@@ -402,7 +402,7 @@ class WebExtensionActionTest {
 
     @Test
     fun `WHEN ConsumePromptRequestWebExtensionAction is dispatched THEN the actual WebExtensionPromptRequest is removed from the store`() {
-        val promptRequest = WebExtensionPromptRequest.AfterInstallation.Permissions(mock(), {})
+        val promptRequest = WebExtensionPromptRequest.AfterInstallation.Permissions.Required(mock(), mock())
 
         val store = BrowserStore(
             initialState = BrowserState(

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragment.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragment.kt
@@ -43,7 +43,7 @@ import mozilla.components.support.utils.ext.getParcelableCompat
 import java.io.IOException
 import mozilla.components.ui.icons.R as iconsR
 
-@VisibleForTesting internal const val KEY_INSTALLED_ADDON = "KEY_ADDON"
+@VisibleForTesting internal const val KEY_INSTALLED_ADDON = "KEY_INSTALLED_ADDON"
 private const val KEY_DIALOG_GRAVITY = "KEY_DIALOG_GRAVITY"
 private const val KEY_DIALOG_WIDTH_MATCH_PARENT = "KEY_DIALOG_WIDTH_MATCH_PARENT"
 private const val KEY_CONFIRM_BUTTON_BACKGROUND_COLOR = "KEY_CONFIRM_BUTTON_BACKGROUND_COLOR"
@@ -80,7 +80,7 @@ class AddonInstallationDialogFragment : AppCompatDialogFragment() {
 
     private val safeArguments get() = requireNotNull(arguments)
 
-    internal val addon get() = requireNotNull(safeArguments.getParcelableCompat(KEY_ADDON, Addon::class.java))
+    internal val addon get() = requireNotNull(safeArguments.getParcelableCompat(KEY_INSTALLED_ADDON, Addon::class.java))
     private var allowPrivateBrowsing: Boolean = false
 
     internal val confirmButtonRadius

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/PermissionsDialogFragment.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/PermissionsDialogFragment.kt
@@ -34,6 +34,7 @@ private const val KEY_POSITIVE_BUTTON_BACKGROUND_COLOR = "KEY_POSITIVE_BUTTON_BA
 private const val KEY_POSITIVE_BUTTON_TEXT_COLOR = "KEY_POSITIVE_BUTTON_TEXT_COLOR"
 private const val KEY_POSITIVE_BUTTON_RADIUS = "KEY_POSITIVE_BUTTON_RADIUS"
 private const val KEY_FOR_OPTIONAL_PERMISSIONS = "KEY_FOR_OPTIONAL_PERMISSIONS"
+internal const val KEY_OPTIONAL_PERMISSIONS = "KEY_OPTIONAL_PERMISSIONS"
 private const val DEFAULT_VALUE = Int.MAX_VALUE
 
 /**
@@ -90,6 +91,8 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
     internal val forOptionalPermissions: Boolean
         get() =
             safeArguments.getBoolean(KEY_FOR_OPTIONAL_PERMISSIONS)
+
+    internal val optionalPermissions get() = requireNotNull(safeArguments.getStringArray(KEY_OPTIONAL_PERMISSIONS))
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val sheetDialog = Dialog(requireContext())
@@ -200,7 +203,11 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
     @VisibleForTesting
     internal fun buildPermissionsText(): String {
         var permissionsText = ""
-        val permissions = addon.translatePermissions(requireContext())
+        val permissions = if (forOptionalPermissions) {
+            Addon.localizePermissions(optionalPermissions.asList(), requireContext())
+        } else {
+            addon.translatePermissions(requireContext())
+        }
 
         if (permissions.isNotEmpty()) {
             permissionsText += if (forOptionalPermissions) {
@@ -223,6 +230,10 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
         /**
          * Returns a new instance of [PermissionsDialogFragment].
          * @param addon The addon to show in the dialog.
+         * @param forOptionalPermissions Whether to show a permission dialog for optional permissions
+         * requested by the extension.
+         * @param optionalPermissions The optional permissions requested by the extension. Only used
+         * when [forOptionalPermissions] is true.
          * @param promptsStyling Styling properties for the dialog.
          * @param onPositiveButtonClicked A lambda called when the allow button is clicked.
          * @param onNegativeButtonClicked A lambda called when the deny button is clicked.
@@ -230,6 +241,7 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
         fun newInstance(
             addon: Addon,
             forOptionalPermissions: Boolean = false,
+            optionalPermissions: List<String> = emptyList(),
             promptsStyling: PromptsStyling? = PromptsStyling(
                 gravity = Gravity.BOTTOM,
                 shouldWidthMatchParent = true,
@@ -243,6 +255,7 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
             arguments.apply {
                 putParcelable(KEY_ADDON, addon)
                 putBoolean(KEY_FOR_OPTIONAL_PERMISSIONS, forOptionalPermissions)
+                putStringArray(KEY_OPTIONAL_PERMISSIONS, optionalPermissions.toTypedArray())
 
                 promptsStyling?.gravity?.apply {
                     putInt(KEY_DIALOG_GRAVITY, this)

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/PermissionsDialogFragmentTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/PermissionsDialogFragmentTest.kt
@@ -158,7 +158,7 @@ class PermissionsDialogFragmentTest {
             translatableName = mapOf(Addon.DEFAULT_LOCALE to "my_addon"),
             permissions = listOf("privacy", "https://example.org/", "tabs"),
         )
-        val fragment = createPermissionsDialogFragment(addon, forOptionalPermissions = true)
+        val fragment = createPermissionsDialogFragment(addon, forOptionalPermissions = true, optionalPermissions = addon.permissions)
 
         doReturn(testContext).`when`(fragment).requireContext()
         val dialog = fragment.onCreateDialog(null)
@@ -208,12 +208,14 @@ class PermissionsDialogFragmentTest {
         addon: Addon,
         promptsStyling: PromptsStyling? = null,
         forOptionalPermissions: Boolean = false,
+        optionalPermissions: List<String> = emptyList(),
     ): PermissionsDialogFragment {
         return spy(
             PermissionsDialogFragment.newInstance(
                 addon = addon,
                 promptsStyling = promptsStyling,
                 forOptionalPermissions = forOptionalPermissions,
+                optionalPermissions = optionalPermissions,
             ),
         ).apply {
             doNothing().`when`(this).dismiss()

--- a/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -288,7 +288,10 @@ object WebExtensionSupport {
                 ) {
                     store.dispatch(
                         WebExtensionAction.UpdatePromptRequestWebExtensionAction(
-                            WebExtensionPromptRequest.AfterInstallation.Permissions(extension, onPermissionsGranted),
+                            WebExtensionPromptRequest.AfterInstallation.Permissions.Required(
+                                extension,
+                                onPermissionsGranted,
+                            ),
                         ),
                     )
                 }
@@ -314,7 +317,7 @@ object WebExtensionSupport {
                 ) {
                     store.dispatch(
                         WebExtensionAction.UpdatePromptRequestWebExtensionAction(
-                            WebExtensionPromptRequest.AfterInstallation.OptionalPermissions(
+                            WebExtensionPromptRequest.AfterInstallation.Permissions.Optional(
                                 extension,
                                 permissions,
                                 onPermissionsGranted,

--- a/android-components/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
+++ b/android-components/components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt
@@ -453,7 +453,7 @@ class WebExtensionSupportTest {
 
         verify(store).dispatch(
             WebExtensionAction.UpdatePromptRequestWebExtensionAction(
-                WebExtensionPromptRequest.AfterInstallation.Permissions(ext, onPermissionsGranted),
+                WebExtensionPromptRequest.AfterInstallation.Permissions.Required(ext, onPermissionsGranted),
             ),
         )
     }
@@ -1000,7 +1000,7 @@ class WebExtensionSupportTest {
         delegateCaptor.value.onOptionalPermissionsRequest(ext, permissions, onPermissionsGranted)
         verify(store).dispatch(
             WebExtensionAction.UpdatePromptRequestWebExtensionAction(
-                WebExtensionPromptRequest.AfterInstallation.OptionalPermissions(ext, permissions, onPermissionsGranted),
+                WebExtensionPromptRequest.AfterInstallation.Permissions.Optional(ext, permissions, onPermissionsGranted),
             ),
         )
     }


### PR DESCRIPTION
Sorry this is something I should have done in https://github.com/mozilla-mobile/firefox-android/pull/3917. Not sure what I was thinking when I landed the PR as is.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1810047