### PR TITLE
Bug 1857232 - Linkify author of an add-on in the details view

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -17,7 +17,7 @@ import mozilla.components.concept.engine.webextension.WebExtension
  * https://addons.mozilla.org/en-US/firefox/
  *
  * @property id The unique ID of this add-on.
- * @property authors List holding information about the add-on authors.
+ * @property author Information about the add-on author.
  * @property categories List of categories the add-on belongs to.
  * @property downloadId The unique ID of the latest version of the add-on (xpi) file.
  * @property downloadUrl The (absolute) URL to download the latest version of the add-on file.
@@ -42,7 +42,7 @@ import mozilla.components.concept.engine.webextension.WebExtension
 @Parcelize
 data class Addon(
     val id: String,
-    val authors: List<Author> = emptyList(),
+    val author: Author? = null,
     val categories: List<String> = emptyList(),
     val downloadId: String = "",
     val downloadUrl: String = "",
@@ -62,18 +62,14 @@ data class Addon(
     /**
      * Represents an add-on author.
      *
-     * @property id The id of the author (creator) of the add-on.
      * @property name The name of the author.
-     * @property url The link to the profile page for of the author.
-     * @property username The username of the author.
+     * @property url The link to the profile page of the author.
      */
     @SuppressLint("ParcelCreator")
     @Parcelize
     data class Author(
-        val id: String,
         val name: String,
         val url: String,
-        val username: String,
     ) : Parcelable
 
     /**
@@ -291,8 +287,16 @@ data class Addon(
             val permissions = extension.getMetadata()?.permissions.orEmpty() +
                 extension.getMetadata()?.hostPermissions.orEmpty()
 
+            val developerName = extension.getMetadata()?.developerName.orEmpty()
+            val author = if (developerName.isNotBlank()) {
+                Author(name = developerName, url = extension.getMetadata()?.developerUrl.orEmpty())
+            } else {
+                null
+            }
+
             return Addon(
                 id = extension.id,
+                author = author,
                 version = extension.getMetadata()?.version.orEmpty(),
                 permissions = permissions,
                 downloadUrl = extension.url,

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AMOAddonsProvider.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AMOAddonsProvider.kt
@@ -418,7 +418,7 @@ internal fun JSONObject.toAddon(language: String? = null): Addon {
         val isLanguageInTranslations = summary.containsKey(safeLanguage)
         Addon(
             id = getSafeString("guid"),
-            authors = getAuthors(),
+            author = getAuthor(),
             categories = getCategories(),
             createdAt = getSafeString("created"),
             updatedAt = getCurrentVersionCreated(),
@@ -497,17 +497,18 @@ internal fun JSONObject.getDownloadUrl(): String {
     return getFile()?.getSafeString("url").orEmpty()
 }
 
-internal fun JSONObject.getAuthors(): List<Addon.Author> {
+internal fun JSONObject.getAuthor(): Addon.Author? {
     val authorsJson = getSafeJSONArray("authors")
-    return (0 until authorsJson.length()).map { index ->
-        val authorJson = authorsJson.getJSONObject(index)
+    // We only consider the first author in the AMO API response, mainly because Gecko does the same.
+    val authorJson = authorsJson.optJSONObject(0)
 
+    return if (authorJson != null) {
         Addon.Author(
-            id = authorJson.getSafeString("id"),
             name = authorJson.getSafeString("name"),
-            username = authorJson.getSafeString("username"),
             url = authorJson.getSafeString("url"),
         )
+    } else {
+        null
     }
 }
 

--- a/android-components/components/feature/addons/src/main/res/values/strings.xml
+++ b/android-components/components/feature/addons/src/main/res/values/strings.xml
@@ -75,8 +75,10 @@
     <string name="mozac_feature_addons_permissions_devtools_description">Extend developer tools to access your data in open tabs</string>
     <!-- The version on of add-on. -->
     <string name="mozac_feature_addons_version">Version</string>
+    <!-- The author of an add-on. -->
+    <string name="mozac_feature_addons_author">Author</string>
     <!-- The authors of an add-on. -->
-    <string name="mozac_feature_addons_authors">Authors</string>
+    <string name="mozac_feature_addons_authors" moz:removedIn="120" tools:ignore="UnusedResources">Authors</string>
     <!-- The last date that the add-on was updated. -->
     <string name="mozac_feature_addons_last_updated">Last updated</string>
     <!-- The developer website (Homepage) of the add-on. -->

--- a/android-components/components/feature/addons/src/test/java/AddonTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonTest.kt
@@ -24,7 +24,6 @@ class AddonTest {
     fun `translatePermissions - must return the expected string ids per permission category`() {
         val addon = Addon(
             id = "id",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -94,7 +93,6 @@ class AddonTest {
     fun `isInstalled - true if installed state present and otherwise false`() {
         val addon = Addon(
             id = "id",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -112,7 +110,6 @@ class AddonTest {
     fun `isEnabled - true if installed state enabled and otherwise false`() {
         val addon = Addon(
             id = "id",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -133,7 +130,6 @@ class AddonTest {
     fun `filterTranslations - only keeps specified translations`() {
         val addon = Addon(
             id = "id",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -374,6 +370,8 @@ class AddonTest {
         whenever(metadata.description).thenReturn(description)
         whenever(metadata.disabledFlags).thenReturn(DisabledFlags.select(0))
         whenever(metadata.baseUrl).thenReturn("some-base-url")
+        whenever(metadata.developerName).thenReturn("developer-name")
+        whenever(metadata.developerUrl).thenReturn("developer-url")
 
         val addon = Addon.newFromWebExtension(extension)
 
@@ -385,6 +383,8 @@ class AddonTest {
         assertEquals("some name", addon.translatableName[Addon.DEFAULT_LOCALE])
         assertEquals("some description", addon.translatableDescription[Addon.DEFAULT_LOCALE])
         assertEquals("some description", addon.translatableSummary[Addon.DEFAULT_LOCALE])
+        assertEquals("developer-name", addon.author?.name)
+        assertEquals("developer-url", addon.author?.url)
     }
 
     @Test

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AMOAddonsProviderTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AMOAddonsProviderTest.kt
@@ -74,8 +74,8 @@ class AMOAddonsProviderTest {
         assertEquals("", addon.translatableDescription.getValue("ca"))
         assertEquals(Addon.DEFAULT_LOCALE, addon.defaultLocale)
 
-        // Authors
-        assertTrue(addon.authors.isEmpty())
+        // Author
+        assertNull(addon.author)
         verify(client).fetch(
             Request(
                 url = "https://services.addons.mozilla.org/api/v4/accounts/account/mozilla/collections/" +
@@ -136,13 +136,11 @@ class AMOAddonsProviderTest {
         assertEquals("1.33.2", addon.version)
         assertEquals("en", addon.defaultLocale)
 
-        // Authors
-        assertEquals("11423598", addon.authors.first().id)
-        assertEquals("Raymond Hill", addon.authors.first().name)
-        assertEquals("gorhill", addon.authors.first().username)
+        // Author
+        assertEquals("Raymond Hill", addon.author?.name)
         assertEquals(
             "https://addons.mozilla.org/en-US/firefox/user/11423598/",
-            addon.authors.first().url,
+            addon.author?.url,
         )
 
         // Ratings
@@ -380,7 +378,6 @@ class AMOAddonsProviderTest {
         val provider = AMOAddonsProvider(testContext, client = mockedClient)
         val addon = Addon(
             id = "id",
-            authors = mock(),
             categories = mock(),
             downloadUrl = "https://example.com",
             version = "version",
@@ -399,7 +396,6 @@ class AMOAddonsProviderTest {
         val provider = AMOAddonsProvider(testContext, client = mockedClient)
         val addon = Addon(
             id = "id",
-            authors = mock(),
             categories = mock(),
             downloadUrl = "https://example.com",
             version = "version",
@@ -703,13 +699,11 @@ class AMOAddonsProviderTest {
         assertTrue(addon.translatableDescription.getValue(language).isNotBlank())
         assertEquals("1.51.0", addon.version)
         assertEquals("ca", addon.defaultLocale)
-        // Authors
-        assertEquals("11423598", addon.authors.first().id)
-        assertEquals("Raymond Hill", addon.authors.first().name)
-        assertEquals("gorhill", addon.authors.first().username)
+        // Author
+        assertEquals("Raymond Hill", addon.author?.name)
         assertEquals(
             "https://addons.mozilla.org/ca/firefox/user/11423598/",
-            addon.authors.first().url,
+            addon.author?.url,
         )
         // Ratings
         assertEquals(4.7825F, addon.rating!!.average, 0.7825F)
@@ -777,20 +771,11 @@ class AMOAddonsProviderTest {
         assertEquals("1.6", addon.version)
         assertEquals("en-us", addon.defaultLocale)
 
-        // Authors
-        assertEquals("13394925", addon.authors.first().id)
-        assertEquals("Thomas Wisniewski", addon.authors.first().name)
-        assertEquals("wisniewskit", addon.authors.first().username)
+        // Author
+        assertEquals("Thomas Wisniewski", addon.author?.name)
         assertEquals(
             "https://addons.mozilla.org/en-US/firefox/user/13394925/",
-            addon.authors.first().url,
-        )
-        assertEquals("6084813", addon.authors.last().id)
-        assertEquals("Rob W", addon.authors.last().name)
-        assertEquals("RobW", addon.authors.last().username)
-        assertEquals(
-            "https://addons.mozilla.org/en-US/firefox/user/6084813/",
-            addon.authors.last().url,
+            addon.author?.url,
         )
         // Ratings
         assertEquals(4.4096F, addon.rating!!.average, 0.4096F)
@@ -964,13 +949,11 @@ class AMOAddonsProviderTest {
         assertTrue(addon.translatableDescription.getValue("ca").isNotBlank())
         assertEquals("1.51.0", addon.version)
         assertEquals("en-us", addon.defaultLocale)
-        // Authors
-        assertEquals("11423598", addon.authors.first().id)
-        assertEquals("Raymond Hill", addon.authors.first().name)
-        assertEquals("gorhill", addon.authors.first().username)
+        // Author
+        assertEquals("Raymond Hill", addon.author?.name)
         assertEquals(
             "https://addons.mozilla.org/en-US/firefox/user/11423598/",
-            addon.authors.first().url,
+            addon.author?.url,
         )
         // Ratings
         assertEquals(4.7825F, addon.rating!!.average, 0.7825F)

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt
@@ -219,7 +219,6 @@ class AddonsManagerAdapterTest {
         )
         val addon = Addon(
             id = "id",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -393,7 +392,6 @@ class AddonsManagerAdapterTest {
         )
         val addon = Addon(
             id = "id",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -412,7 +410,6 @@ class AddonsManagerAdapterTest {
     fun updateAddon() {
         var addon = Addon(
             id = "id",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -435,7 +432,6 @@ class AddonsManagerAdapterTest {
     fun updateAddons() {
         var addon1 = Addon(
             id = "addon1",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -446,7 +442,6 @@ class AddonsManagerAdapterTest {
 
         val addon2 = Addon(
             id = "addon2",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -472,7 +467,6 @@ class AddonsManagerAdapterTest {
     fun differCallback() {
         var addon1 = Addon(
             id = "addon1",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",
@@ -483,7 +477,6 @@ class AddonsManagerAdapterTest {
 
         var addon2 = Addon(
             id = "addon1",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/ExtensionsTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/ExtensionsTest.kt
@@ -30,7 +30,6 @@ class ExtensionsTest {
     fun `add-on translateName`() {
         val addon = Addon(
             id = "id",
-            authors = emptyList(),
             categories = emptyList(),
             downloadUrl = "downloadUrl",
             version = "version",

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonDetailsActivity.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonDetailsActivity.kt
@@ -50,7 +50,7 @@ class AddonDetailsActivity : AppCompatActivity() {
 
         bindDetails(addon)
 
-        bindAuthors(addon)
+        bindAuthor(addon)
 
         bindVersion(addon)
 
@@ -114,14 +114,9 @@ class AddonDetailsActivity : AppCompatActivity() {
         }
     }
 
-    private fun bindAuthors(addon: Addon) {
+    private fun bindAuthor(addon: Addon) {
         val authorsView = findViewById<TextView>(R.id.author_text)
-
-        val authorText = addon.authors.joinToString { author ->
-            author.name + " \n"
-        }
-
-        authorsView.text = authorText
+        authorsView.text = addon.author?.name.orEmpty()
     }
 
     private fun bindDetails(addon: Addon) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonDetailsBindingDelegate.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonDetailsBindingDelegate.kt
@@ -17,6 +17,7 @@ import androidx.core.view.isVisible
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.ui.translateDescription
 import mozilla.components.feature.addons.ui.updatedAtDate
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.FragmentAddOnDetailsBinding
 import java.text.DateFormat
@@ -26,9 +27,9 @@ import java.util.Locale
 interface AddonDetailsInteractor {
 
     /**
-     * Open the given addon siteUrl in the browser.
+     * Open the givne URL in the browser.
      */
-    fun openWebsite(addonSiteUrl: Uri)
+    fun openWebsite(url: Uri)
 
     /**
      * Display the updater dialog.
@@ -49,7 +50,7 @@ class AddonDetailsBindingDelegate(
 
     fun bind(addon: Addon) {
         bindDetails(addon)
-        bindAuthors(addon)
+        bindAuthor(addon)
         bindVersion(addon)
         bindLastUpdated(addon)
         bindWebsite(addon)
@@ -108,15 +109,23 @@ class AddonDetailsBindingDelegate(
         }
     }
 
-    private fun bindAuthors(addon: Addon) {
-        if (addon.authors.isEmpty()) {
+    private fun bindAuthor(addon: Addon) {
+        val author = addon.author
+        if (author == null || author.name.isBlank()) {
             binding.authorLabel.isVisible = false
             binding.authorText.isVisible = false
             binding.authorDivider.isVisible = false
             return
         }
 
-        binding.authorText.text = addon.authors.joinToString { author -> author.name }.trim()
+        binding.authorText.text = author.name
+
+        if (author.url.isNotBlank()) {
+            binding.authorText.setTextColor(binding.root.context.getColorFromAttr(R.attr.textAccent))
+            binding.authorText.setOnClickListener {
+                interactor.openWebsite(author.url.toUri())
+            }
+        }
     }
 
     private fun bindDetails(addon: Addon) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonDetailsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonDetailsFragment.kt
@@ -45,9 +45,9 @@ class AddonDetailsFragment : Fragment(R.layout.fragment_add_on_details), AddonDe
         }
     }
 
-    override fun openWebsite(addonSiteUrl: Uri) {
+    override fun openWebsite(url: Uri) {
         (activity as HomeActivity).openToBrowserAndLoad(
-            searchTermOrURL = addonSiteUrl.toString(),
+            searchTermOrURL = url.toString(),
             newTab = true,
             from = BrowserDirection.FromAddonDetailsFragment,
         )

--- a/fenix/app/src/main/res/layout/fragment_add_on_details.xml
+++ b/fenix/app/src/main/res/layout/fragment_add_on_details.xml
@@ -33,7 +33,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
-            android:text="@string/mozac_feature_addons_authors"
+            android:text="@string/mozac_feature_addons_author"
             app:layout_constraintEnd_toStartOf="@+id/author_text"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toStartOf="parent"

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonDetailsBindingDelegateTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/AddonDetailsBindingDelegateTest.kt
@@ -12,13 +12,16 @@ import androidx.core.view.isVisible
 import io.mockk.mockk
 import io.mockk.verify
 import mozilla.components.feature.addons.Addon
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.FragmentAddOnDetailsBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
@@ -115,18 +118,27 @@ class AddonDetailsBindingDelegateTest {
     }
 
     @Test
-    fun `bind addons authors`() {
-        val baseAuthor = Addon.Author("", "", "", "")
+    fun `bind addons author`() {
         detailsBindingDelegate.bind(
-            baseAddon.copy(
-                authors = listOf(
-                    baseAuthor.copy(name = " Sarah Jane"),
-                    baseAuthor.copy(name = "John Smith "),
-                ),
-            ),
+            baseAddon.copy(author = Addon.Author(name = "Sarah Jane", url = "")),
         )
 
-        assertEquals("Sarah Jane, John Smith", binding.authorText.text)
+        assertEquals("Sarah Jane", binding.authorText.text)
+        assertNotEquals(testContext.getColorFromAttr(R.attr.textAccent), binding.authorText.currentTextColor)
+    }
+
+    @Test
+    fun `bind addons author with url`() {
+        detailsBindingDelegate.bind(
+            baseAddon.copy(author = Addon.Author(name = "Sarah Jane", url = "https://example.org/")),
+        )
+
+        assertEquals("Sarah Jane", binding.authorText.text)
+        assertEquals(testContext.getColorFromAttr(R.attr.textAccent), binding.authorText.currentTextColor)
+
+        binding.authorText.performClick()
+
+        verify { interactor.openWebsite(Uri.parse("https://example.org/")) }
     }
 
     @Test
@@ -150,8 +162,8 @@ class AddonDetailsBindingDelegateTest {
     }
 
     @Test
-    fun `bind without authors`() {
-        detailsBindingDelegate.bind(baseAddon.copy(authors = emptyList()))
+    fun `bind without author`() {
+        detailsBindingDelegate.bind(baseAddon.copy(author = null))
 
         assertFalse(binding.authorLabel.isVisible)
         assertFalse(binding.authorText.isVisible)


### PR DESCRIPTION
~~Depends on #3950~~

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1857232