### PR TITLE
Bug 1807307 - Disable LeakCanary in ui-test-apk build task

### DIFF
--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -42,6 +42,12 @@ task-defaults:
         dummy-secrets:
             - content: "faketoken"
               path: .adjust_token
+            - content: |
+                <?xml version="1.0" encoding="utf-8"?>
+                <resources>
+                  <string name="leak_canary_test_class_name">org.mozilla.fenix.DebugFenixApplication</string>
+                </resources>
+              path: app/src/main/res/values/leakcanary.xml
     routes:
         - notify.slack-channel.G016BC5FUHJ.on-failed
     scopes:


### PR DESCRIPTION
From the previous attempts, I didn't realize that I was adding the XML file in the wrong task. I should have been adding it to the fenix app build task instead of the _test_ app build task.

~~I'd like to land this ASAP early in the day and see if it fails so we can back it out and try [the alternative solution](https://github.com/mozilla-mobile/firefox-android/pull/3968).~~

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807307