### PR TITLE
Bug 1817955 - Increase Tap Area of the Add new collection prompt edittext field.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionsDialog.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/collections/CollectionsDialog.kt
@@ -22,6 +22,7 @@ import mozilla.components.ui.widgets.withCenterAlignedButtons
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.ext.getDefaultCollectionNumber
+import org.mozilla.fenix.ext.increaseTapArea
 
 /**
  * A lambda that is invoked when a confirmation button in a [CollectionsDialog] is clicked.
@@ -113,6 +114,7 @@ internal fun CollectionsDialog.showAddNewDialog(
             collectionsStorage.cachedTabCollections.getDefaultCollectionNumber(),
         ),
     )
+    collectionNameEditText.increaseTapArea(context.resources.getDimension(R.dimen.tap_increase_2).toInt())
 
     val dialog = AlertDialog.Builder(context)
         .setTitle(R.string.tab_tray_add_new_collection)

--- a/fenix/app/src/main/res/values/dimens.xml
+++ b/fenix/app/src/main/res/values/dimens.xml
@@ -185,6 +185,6 @@
 
     <!-- a11y -->
     <dimen name="accessibility_min_height">48dp</dimen>
-
     <dimen name="tap_increase_16">16dp</dimen>
+    <dimen name="tap_increase_2">2dp</dimen>
 </resources>


### PR DESCRIPTION
This is the same as https://github.com/mozilla-mobile/firefox-android/pull/1393 which already has r+ from @boek. Just starting a fresh PR because Mergify was getting confused on the rebase.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1817955