### PR TITLE
Bug 1857920 - Focus shouldn't crashes with java.lang.IllegalStateException: Trying to start session but it is already started.

### DIFF
--- a/focus-android/service-telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
+++ b/focus-android/service-telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
@@ -161,9 +161,12 @@ public class Telemetry {
         }
 
         final TelemetryCorePingBuilder builder = (TelemetryCorePingBuilder) pingBuilders.get(TelemetryCorePingBuilder.TYPE);
-
-        builder.getSessionDurationMeasurement().recordSessionStart();
-        builder.getSessionCountMeasurement().countSession();
+        if (builder != null) {
+            boolean sessionAlreadyStarted = builder.getSessionDurationMeasurement().recordSessionStart();
+            if (!sessionAlreadyStarted) {
+                builder.getSessionCountMeasurement().countSession();
+            }
+        }
     }
 
     public Telemetry recordSessionEnd(Function0<Unit> onFailure) {

--- a/focus-android/service-telemetry/src/main/java/org/mozilla/telemetry/measurement/SessionDurationMeasurement.java
+++ b/focus-android/service-telemetry/src/main/java/org/mozilla/telemetry/measurement/SessionDurationMeasurement.java
@@ -6,9 +6,8 @@ package org.mozilla.telemetry.measurement;
 
 import android.content.SharedPreferences;
 import androidx.annotation.VisibleForTesting;
-
+import mozilla.components.support.base.log.logger.Logger;
 import org.mozilla.telemetry.config.TelemetryConfiguration;
-
 import java.util.concurrent.TimeUnit;
 
 public class SessionDurationMeasurement extends TelemetryMeasurement {
@@ -20,6 +19,7 @@ public class SessionDurationMeasurement extends TelemetryMeasurement {
 
     private boolean sessionStarted = false;
     private long timeAtSessionStartNano = -1;
+    private final Logger logger = new Logger("telemetry/measurement");
 
     public SessionDurationMeasurement(TelemetryConfiguration configuration) {
         super(FIELD_NAME);
@@ -27,13 +27,15 @@ public class SessionDurationMeasurement extends TelemetryMeasurement {
         this.configuration = configuration;
     }
 
-    public synchronized void recordSessionStart() {
+    public synchronized Boolean recordSessionStart() {
         if (sessionStarted) {
-            throw new IllegalStateException("Trying to start session but it is already started");
+            logger.error("Trying to start session but it is already started",null);
+            return true;
         }
 
         sessionStarted = true;
         timeAtSessionStartNano = getSystemTimeNano();
+        return false;
     }
 
     public synchronized boolean recordSessionEnd() {


### PR DESCRIPTION
I didn't find a scenario to crash the app. This is a possible fix.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1857920