### PR TITLE
Revert "Bug 1849368 - Remove data path and data authorities requirement for open links in apps"

### DIFF
--- a/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
+++ b/android-components/components/feature/app-links/src/main/java/mozilla/components/feature/app/links/AppLinksUseCases.kt
@@ -183,9 +183,10 @@ class AppLinksUseCases(
                     // no default app found but Android resolver shows there are multiple applications
                     // that can open this app link
                     ANDROID_RESOLVER_PACKAGE_NAME, null -> {
-                        findActivities(appIntent).firstOrNull {
-                            it.filter != null
-                        }
+                        findActivities(appIntent).filter {
+                            it.filter != null &&
+                                !(it.filter.countDataPaths() == 0 && it.filter.countDataAuthorities() == 0)
+                        }.getOrNull(0)
                     }
                     // use default app
                     else -> {


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-android#3739
https://bugzilla.mozilla.org/show_bug.cgi?id=1849368
https://bugzilla.mozilla.org/show_bug.cgi?id=1849368
https://bugzilla.mozilla.org/show_bug.cgi?id=1849368