### PR TITLE
Bug 1858081 - Collections TestRail matching

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
@@ -64,9 +64,10 @@ class CollectionTest {
         mockWebServer.shutdown()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/353823
     @SmokeTest
     @Test
-    fun createFirstCollectionTest() {
+    fun createFirstCollectionUsingHomeScreenButtonTest() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
 
@@ -108,6 +109,7 @@ class CollectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/343422
     @SmokeTest
     @Test
     fun verifyExpandedCollectionItemsTest() {
@@ -158,9 +160,10 @@ class CollectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/343425
     @SmokeTest
     @Test
-    fun openAllTabsInCollectionTest() {
+    fun openAllTabsFromACollectionTest() {
         val firstTestPage = getGenericAsset(mockWebServer, 1)
         val secondTestPage = getGenericAsset(mockWebServer, 2)
 
@@ -191,9 +194,10 @@ class CollectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/343426
     @SmokeTest
     @Test
-    fun shareCollectionTest() {
+    fun shareAllTabsFromACollectionTest() {
         val firstWebsite = getGenericAsset(mockWebServer, 1)
         val secondWebsite = getGenericAsset(mockWebServer, 2)
         val sharingApp = "Gmail"
@@ -218,6 +222,7 @@ class CollectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/343428
     // Test running on beta/release builds in CI:
     // caution when making changes to it, so they don't block the builds
     @SmokeTest
@@ -241,13 +246,27 @@ class CollectionTest {
 
         homeScreen {
             verifySnackBarText("Collection deleted")
+            clickSnackbarButton("UNDO")
+            verifyCollectionIsDisplayed(collectionName, true)
+        }
+
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            clickCollectionThreeDotButton(composeTestRule)
+            selectDeleteCollection(composeTestRule)
+        }
+
+        homeScreen {
+            verifySnackBarText("Collection deleted")
             verifyNoCollectionsText()
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2319453
     // open a webpage, and add currently opened tab to existing collection
     @Test
-    fun mainMenuSaveToExistingCollection() {
+    fun saveTabToExistingCollectionFromMainMenuTest() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
 
@@ -273,8 +292,9 @@ class CollectionTest {
         }
     }
 
+    // Testrail link: https://testrail.stage.mozaws.net/index.php?/cases/view/343423
     @Test
-    fun verifyAddTabButtonOfCollectionMenu() {
+    fun saveTabToExistingCollectionUsingTheAddTabButtonTest() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
 
@@ -300,6 +320,7 @@ class CollectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/343424
     @Test
     fun renameCollectionTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
@@ -322,53 +343,32 @@ class CollectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/991248
     @Test
-    fun createSecondCollectionTest() {
-        val webPage = getGenericAsset(mockWebServer, 1)
+    fun createCollectionUsingSelectTabsButtonTest() {
+        val firstWebPage = getGenericAsset(mockWebServer, 1)
+        val secondWebPage = getGenericAsset(mockWebServer, 2)
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
         }.openTabDrawer {
-            createCollection(webPage.title, collectionName = firstCollectionName)
-            verifySnackBarText("Collection saved!")
+        }.openNewTab {
+        }.submitQuery(secondWebPage.url.toString()) {
+        }.openTabDrawer {
             createCollection(
-                webPage.title,
-                collectionName = secondCollectionName,
-                firstCollection = false,
+                tabTitles = arrayOf(firstWebPage.title, secondWebPage.title),
+                collectionName = firstCollectionName,
             )
             verifySnackBarText("Collection saved!")
         }.closeTabDrawer {
         }.goToHomescreen {
             verifyCollectionIsDisplayed(firstCollectionName)
-            verifyCollectionIsDisplayed(secondCollectionName)
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2319455
     @Test
-    fun removeTabFromCollectionTest() {
-        val webPage = getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(webPage.url) {
-        }.openTabDrawer {
-            createCollection(webPage.title, collectionName = collectionName)
-            closeTab()
-        }
-
-        homeScreen {
-            verifyCollectionIsDisplayed(collectionName)
-        }.expandCollection(collectionName) {
-            verifyTabSavedInCollection(webPage.title, true)
-            removeTabFromCollection(webPage.title)
-            verifyTabSavedInCollection(webPage.title, false)
-        }
-        homeScreen {
-            verifyCollectionIsDisplayed(collectionName, false)
-        }
-    }
-
-    @Test
-    fun undoTabRemovalFromCollectionTest() {
+    fun removeTabFromCollectionUsingTheCloseButtonTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -387,13 +387,20 @@ class CollectionTest {
         homeScreen {
             verifySnackBarText("Collection deleted")
             clickSnackbarButton("UNDO")
-            verifyCollectionIsDisplayed(collectionName, true)
-            verifyCollectionIsDisplayed(collectionName, true)
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            verifyTabSavedInCollection(webPage.title, true)
+            removeTabFromCollection(webPage.title)
+            verifyTabSavedInCollection(webPage.title, false)
+        }
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName, false)
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/343427
     @Test
-    fun swipeLeftToRemoveTabFromCollectionTest() {
+    fun removeTabFromCollectionUsingSwipeLeftActionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -415,13 +422,21 @@ class CollectionTest {
         }
         homeScreen {
             verifySnackBarText("Collection deleted")
-            verifySnackBarText("UNDO")
+            clickSnackbarButton("UNDO")
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            verifyTabSavedInCollection(testPage.title, true)
+            swipeTabLeft(testPage.title, composeTestRule)
+            verifyTabSavedInCollection(testPage.title, false)
+        }
+        homeScreen {
             verifyCollectionIsDisplayed(collectionName, false)
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/991278
     @Test
-    fun swipeRightToRemoveTabFromCollectionTest() {
+    fun removeTabFromCollectionUsingSwipeRightActionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -443,13 +458,21 @@ class CollectionTest {
         }
         homeScreen {
             verifySnackBarText("Collection deleted")
-            verifySnackBarText("UNDO")
+            clickSnackbarButton("UNDO")
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            verifyTabSavedInCollection(testPage.title, true)
+            swipeTabRight(testPage.title, composeTestRule)
+            verifyTabSavedInCollection(testPage.title, false)
+        }
+        homeScreen {
             verifyCollectionIsDisplayed(collectionName, false)
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/991276
     @Test
-    fun selectTabOnLongTapTest() {
+    fun createCollectionByLongPressingOpenTabsTest() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
 
@@ -479,6 +502,7 @@ class CollectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/344897
     @Test
     fun navigateBackInCollectionFlowTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
@@ -508,32 +532,6 @@ class CollectionTest {
         // verify the browser layout is visible
         browserScreen {
             verifyMenuButton()
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun undoDeleteCollectionTest() {
-        val webPage = getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(webPage.url) {
-        }.openTabDrawer {
-            createCollection(webPage.title, collectionName = collectionName)
-            snackBarButtonClick("VIEW")
-        }
-
-        homeScreen {
-            verifyCollectionIsDisplayed(collectionName)
-        }.expandCollection(collectionName) {
-            clickCollectionThreeDotButton(composeTestRule)
-            selectDeleteCollection(composeTestRule)
-        }
-
-        homeScreen {
-            verifySnackBarText("Collection deleted")
-            clickSnackbarButton("UNDO")
-            verifyCollectionIsDisplayed(collectionName, true)
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeCollectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeCollectionTest.kt
@@ -67,7 +67,7 @@ class ComposeCollectionTest {
 
     @SmokeTest
     @Test
-    fun createFirstCollectionTest() {
+    fun createFirstCollectionUsingHomeScreenButtonTest() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
 
@@ -149,7 +149,7 @@ class ComposeCollectionTest {
 
     @SmokeTest
     @Test
-    fun openAllTabsInCollectionTest() {
+    fun openAllTabsFromACollectionTest() {
         val firstTestPage = getGenericAsset(mockWebServer, 1)
         val secondTestPage = getGenericAsset(mockWebServer, 2)
 
@@ -183,7 +183,7 @@ class ComposeCollectionTest {
 
     @SmokeTest
     @Test
-    fun shareCollectionTest() {
+    fun shareAllTabsFromACollectionTest() {
         val firstWebsite = getGenericAsset(mockWebServer, 1)
         val secondWebsite = getGenericAsset(mockWebServer, 2)
         val sharingApp = "Gmail"
@@ -231,13 +231,26 @@ class ComposeCollectionTest {
 
         homeScreen {
             verifySnackBarText("Collection deleted")
+            clickSnackbarButton("UNDO")
+            verifyCollectionIsDisplayed(collectionName, true)
+        }
+
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            clickCollectionThreeDotButton(composeTestRule)
+            selectDeleteCollection(composeTestRule)
+        }
+
+        homeScreen {
+            verifySnackBarText("Collection deleted")
             verifyNoCollectionsText()
         }
     }
 
     // open a webpage, and add currently opened tab to existing collection
     @Test
-    fun mainMenuSaveToExistingCollection() {
+    fun saveTabToExistingCollectionFromMainMenuTest() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
 
@@ -313,52 +326,29 @@ class ComposeCollectionTest {
     }
 
     @Test
-    fun createSecondCollectionTest() {
-        val webPage = getGenericAsset(mockWebServer, 1)
+    fun createCollectionUsingSelectTabsButtonTest() {
+        val firstWebPage = getGenericAsset(mockWebServer, 1)
+        val secondWebPage = getGenericAsset(mockWebServer, 2)
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
         }.openComposeTabDrawer(composeTestRule) {
-            createCollection(webPage.title, collectionName = firstCollectionName)
-            verifySnackBarText("Collection saved!")
+        }.openNewTab {
+        }.submitQuery(secondWebPage.url.toString()) {
+        }.openComposeTabDrawer(composeTestRule) {
             createCollection(
-                webPage.title,
-                collectionName = secondCollectionName,
-                firstCollection = false,
+                tabTitles = arrayOf(firstWebPage.title, secondWebPage.title),
+                collectionName = firstCollectionName,
             )
             verifySnackBarText("Collection saved!")
         }.closeTabDrawer {
         }.goToHomescreen {
             verifyCollectionIsDisplayed(firstCollectionName)
-            verifyCollectionIsDisplayed(secondCollectionName)
         }
     }
 
     @Test
-    fun removeTabFromCollectionTest() {
-        val webPage = getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(webPage.url) {
-        }.openComposeTabDrawer(composeTestRule) {
-            createCollection(webPage.title, collectionName = collectionName)
-            closeTab()
-        }
-
-        homeScreen {
-            verifyCollectionIsDisplayed(collectionName)
-        }.expandCollection(collectionName) {
-            verifyTabSavedInCollection(webPage.title, true)
-            removeTabFromCollection(webPage.title)
-            verifyTabSavedInCollection(webPage.title, false)
-        }
-        homeScreen {
-            verifyCollectionIsDisplayed(collectionName, false)
-        }
-    }
-
-    @Test
-    fun undoTabRemovalFromCollectionTest() {
+    fun removeTabFromCollectionUsingTheCloseButtonTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -377,13 +367,19 @@ class ComposeCollectionTest {
         homeScreen {
             verifySnackBarText("Collection deleted")
             clickSnackbarButton("UNDO")
-            verifyCollectionIsDisplayed(collectionName, true)
-            verifyCollectionIsDisplayed(collectionName, true)
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            verifyTabSavedInCollection(webPage.title, true)
+            removeTabFromCollection(webPage.title)
+            verifyTabSavedInCollection(webPage.title, false)
+        }
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName, false)
         }
     }
 
     @Test
-    fun swipeLeftToRemoveTabFromCollectionTest() {
+    fun removeTabFromCollectionUsingSwipeLeftActionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -405,13 +401,17 @@ class ComposeCollectionTest {
         }
         homeScreen {
             verifySnackBarText("Collection deleted")
-            verifySnackBarText("UNDO")
-            verifyCollectionIsDisplayed(collectionName, false)
+            clickSnackbarButton("UNDO")
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            verifyTabSavedInCollection(testPage.title, true)
+            swipeTabLeft(testPage.title, composeTestRule)
+            verifyTabSavedInCollection(testPage.title, false)
         }
     }
 
     @Test
-    fun swipeRightToRemoveTabFromCollectionTest() {
+    fun removeTabFromCollectionUsingSwipeRightActionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -433,13 +433,17 @@ class ComposeCollectionTest {
         }
         homeScreen {
             verifySnackBarText("Collection deleted")
-            verifySnackBarText("UNDO")
-            verifyCollectionIsDisplayed(collectionName, false)
+            clickSnackbarButton("UNDO")
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName) {
+            verifyTabSavedInCollection(testPage.title, true)
+            swipeTabRight(testPage.title, composeTestRule)
+            verifyTabSavedInCollection(testPage.title, false)
         }
     }
 
     @Test
-    fun selectTabOnLongTapTest() {
+    fun createCollectionByLongPressingOpenTabsTest() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
 
@@ -499,32 +503,6 @@ class ComposeCollectionTest {
         // verify the browser layout is visible
         browserScreen {
             verifyMenuButton()
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun undoDeleteCollectionTest() {
-        val webPage = getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(webPage.url) {
-        }.openComposeTabDrawer(composeTestRule) {
-            createCollection(webPage.title, collectionName = collectionName)
-            clickSnackbarButton("VIEW")
-        }
-
-        homeScreen {
-            verifyCollectionIsDisplayed(collectionName)
-        }.expandCollection(collectionName) {
-            clickCollectionThreeDotButton(composeTestRule)
-            selectDeleteCollection(composeTestRule)
-        }
-
-        homeScreen {
-            verifySnackBarText("Collection deleted")
-            clickSnackbarButton("UNDO")
-            verifyCollectionIsDisplayed(collectionName, true)
         }
     }
 }


### PR DESCRIPTION
These changes are part of our data alignment between testRail and our automated UI tests.

For more information please see this [document](https://docs.google.com/document/d/1_Am_8fF-nXStNcjd9Gltp2KSbZzq1tpFp5lbBRgYNC0/edit?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1858081