### PR TITLE
Bug 1855291 - Handle FxA exceptions in getManageAccountURL

### DIFF
--- a/android-components/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
+++ b/android-components/components/concept/sync/src/main/java/mozilla/components/concept/sync/OAuthAccount.kt
@@ -162,7 +162,7 @@ interface OAuthAccount : AutoCloseable {
      * @param entryPoint A string which will be included as a query param in the URL for metrics.
      * @return The URL which should be opened in a browser tab.
      */
-    suspend fun getManageAccountURL(entryPoint: FxAEntryPoint): String
+    suspend fun getManageAccountURL(entryPoint: FxAEntryPoint): String?
 
     /**
      * Get the pairing URL to navigate to on the Authority side (typically a computer).

--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -156,8 +156,10 @@ class FirefoxAccount internal constructor(
         }
     }
 
-    override suspend fun getManageAccountURL(entryPoint: FxAEntryPoint): String {
-        return inner.getManageAccountURL(entryPoint.entryName)
+    override suspend fun getManageAccountURL(entryPoint: FxAEntryPoint): String? {
+        return handleFxaExceptions(logger, "getManageAccountURL", { null }) {
+            inner.getManageAccountURL(entryPoint.entryName)
+        }
     }
 
     override fun getPairingAuthorityURL(): String {

--- a/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -490,7 +490,7 @@ class FxaAccountManagerTest {
             return ""
         }
 
-        override suspend fun getManageAccountURL(entryPoint: FxAEntryPoint): String {
+        override suspend fun getManageAccountURL(entryPoint: FxAEntryPoint): String? {
             return "https://firefox.com/settings"
         }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1855291