### PR TITLE
Bug 1858438 - Tabs Tray TestRail matching

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHomeScreenTest.kt
@@ -88,7 +88,7 @@ class ComposeHomeScreenTest {
         homeScreen { }.togglePrivateBrowsingMode()
 
         homeScreen {
-            verifyPrivateBrowsingHomeScreen()
+            verifyPrivateBrowsingHomeScreenItems()
         }.openCommonMythsLink {
             verifyUrl("common-myths-about-private-browsing")
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeMediaNotificationTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeMediaNotificationTest.kt
@@ -69,6 +69,7 @@ class ComposeMediaNotificationTest {
         mockWebServer.shutdown()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1347033
     @SmokeTest
     @Test
     fun verifyVideoPlaybackSystemNotificationTest() {
@@ -103,6 +104,7 @@ class ComposeMediaNotificationTest {
         mDevice.pressBack()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2316010
     @SmokeTest
     @Test
     fun verifyAudioPlaybackSystemNotificationTest() {
@@ -137,6 +139,7 @@ class ComposeMediaNotificationTest {
         mDevice.pressBack()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/903595
     @Test
     fun mediaSystemNotificationInPrivateModeTest() {
         val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSmokeTest.kt
@@ -12,8 +12,6 @@ import androidx.core.net.toUri
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice
-import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.concept.engine.mediasession.MediaSession
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -22,17 +20,13 @@ import org.junit.Test
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
-import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.ui.robots.browserScreen
-import org.mozilla.fenix.ui.robots.clickPageObject
-import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
 /**
@@ -46,8 +40,6 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class ComposeSmokeTest {
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
-    private val customMenuItem = "TestMenuItem"
-    private lateinit var browserStore: BrowserStore
 
     @get:Rule(order = 0)
     val activityTestRule = AndroidComposeTestRule(
@@ -69,10 +61,6 @@ class ComposeSmokeTest {
 
     @Before
     fun setUp() {
-        // Initializing this as part of class construction, below the rule would throw a NPE
-        // So we are initializing this here instead of in all related tests.
-        browserStore = activityTestRule.activity.components.core.store
-
         mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
@@ -83,62 +71,6 @@ class ComposeSmokeTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-    }
-
-    @Test
-    fun shareTabsFromTabsTrayTest() {
-        val firstWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        val secondWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 2)
-        val firstWebsiteTitle = firstWebsite.title
-        val secondWebsiteTitle = secondWebsite.title
-        val sharingApp = "Gmail"
-        val sharedUrlsString = "${firstWebsite.url}\n\n${secondWebsite.url}"
-
-        homeScreen {
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(firstWebsite.url) {
-            verifyPageContent(firstWebsite.content)
-        }.openComposeTabDrawer(activityTestRule) {
-        }.openNewTab {
-        }.submitQuery(secondWebsite.url.toString()) {
-            verifyPageContent(secondWebsite.content)
-        }.openComposeTabDrawer(activityTestRule) {
-            verifyExistingOpenTabs("Test_Page_1")
-            verifyExistingOpenTabs("Test_Page_2")
-        }.openThreeDotMenu {
-            verifyShareAllTabsButton()
-        }.clickShareAllTabsButton {
-            verifyShareTabsOverlay(firstWebsiteTitle, secondWebsiteTitle)
-            verifySharingWithSelectedApp(
-                sharingApp,
-                sharedUrlsString,
-                "$firstWebsiteTitle, $secondWebsiteTitle",
-            )
-        }
-    }
-
-    @Test
-    fun privateTabsTrayWithOpenedTabTest() {
-        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen {
-        }.togglePrivateBrowsingMode()
-
-        homeScreen {
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(website.url) {
-        }.openComposeTabDrawer(activityTestRule) {
-            verifyNormalBrowsingButtonIsSelected(false)
-            verifyPrivateBrowsingButtonIsSelected(true)
-            verifySyncedTabsButtonIsSelected(false)
-            verifyThreeDotButton()
-            verifyNormalTabCounter()
-            verifyPrivateTabsList()
-            verifyExistingOpenTabs(website.title)
-            verifyTabCloseButton()
-            verifyTabThumbnail()
-            verifyFab()
-        }
     }
 
     @Test
@@ -196,24 +128,6 @@ class ComposeSmokeTest {
             verifyAppearanceColorDark(true)
             verifyAppearanceColorLight(true)
             verifyAppearanceColorSepia(true)
-        }
-    }
-
-    @Test
-    fun tabMediaControlButtonTest() {
-        val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            mDevice.waitForIdle()
-            clickPageObject(itemWithText("Play"))
-            assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
-        }.openComposeTabDrawer(activityTestRule) {
-            verifyTabMediaControlButtonState("Pause")
-            clickTabMediaControlButton("Pause")
-            verifyTabMediaControlButtonState("Play")
-        }.openTab(audioTestPage.title) {
-            assertPlaybackState(browserStore, MediaSession.PlaybackState.PAUSED)
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -86,7 +86,7 @@ class HomeScreenTest {
         homeScreen { }.togglePrivateBrowsingMode()
 
         homeScreen {
-            verifyPrivateBrowsingHomeScreen()
+            verifyPrivateBrowsingHomeScreenItems()
         }.openCommonMythsLink {
             verifyUrl("common-myths-about-private-browsing")
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
@@ -132,6 +132,7 @@ class MediaNotificationTest {
         mDevice.pressBack()
     }
 
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903595
     @Test
     fun mediaSystemNotificationInPrivateModeTest() {
         val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -12,8 +12,6 @@ import androidx.core.net.toUri
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice
-import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.concept.engine.mediasession.MediaSession
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -22,16 +20,13 @@ import org.junit.Test
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
-import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.ui.robots.browserScreen
-import org.mozilla.fenix.ui.robots.clickPageObject
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -46,7 +41,6 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class SmokeTest {
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
-    private lateinit var browserStore: BrowserStore
 
     @get:Rule(order = 0)
     val activityTestRule = AndroidComposeTestRule(
@@ -67,10 +61,6 @@ class SmokeTest {
 
     @Before
     fun setUp() {
-        // Initializing this as part of class construction, below the rule would throw a NPE
-        // So we are initializing this here instead of in all related tests.
-        browserStore = activityTestRule.activity.components.core.store
-
         mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
@@ -112,30 +102,6 @@ class SmokeTest {
                 sharedUrlsString,
                 "$firstWebsiteTitle, $secondWebsiteTitle",
             )
-        }
-    }
-
-    @Test
-    fun privateTabsTrayWithOpenedTabTest() {
-        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen {
-        }.togglePrivateBrowsingMode()
-
-        homeScreen {
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(website.url) {
-        }.openTabDrawer {
-            verifyNormalBrowsingButtonIsSelected(false)
-            verifyPrivateBrowsingButtonIsSelected(true)
-            verifySyncedTabsButtonIsSelected(false)
-            verifyTabTrayOverflowMenu(true)
-            verifyTabsTrayCounter()
-            verifyExistingTabList()
-            verifyExistingOpenTabs(website.title)
-            verifyCloseTabsButton(website.title)
-            verifyOpenedTabThumbnail()
-            verifyPrivateBrowsingNewTabButton()
         }
     }
 
@@ -194,24 +160,6 @@ class SmokeTest {
             verifyAppearanceColorDark(true)
             verifyAppearanceColorLight(true)
             verifyAppearanceColorSepia(true)
-        }
-    }
-
-    @Test
-    fun tabMediaControlButtonTest() {
-        val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            mDevice.waitForIdle()
-            clickPageObject(itemWithText("Play"))
-            assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
-        }.openTabDrawer {
-            verifyTabMediaControlButtonState("Pause")
-            clickTabMediaControlButton("Pause")
-            verifyTabMediaControlButtonState("Play")
-        }.openTab(audioTestPage.title) {
-            assertPlaybackState(browserStore, MediaSession.PlaybackState.PAUSED)
         }
     }
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -7,20 +7,25 @@ package org.mozilla.fenix.ui
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.mediasession.MediaSession
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.MatcherHelper
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.closeApp
 import org.mozilla.fenix.helpers.TestHelper.restartApp
 import org.mozilla.fenix.helpers.TestHelper.verifyKeyboardVisibility
 import org.mozilla.fenix.ui.robots.browserScreen
+import org.mozilla.fenix.ui.robots.clickPageObject
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 import org.mozilla.fenix.ui.robots.notificationShade
@@ -45,6 +50,7 @@ import org.mozilla.fenix.ui.robots.notificationShade
 class TabbedBrowsingTest {
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
+    private lateinit var browserStore: BrowserStore
 
     @get:Rule
     val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
@@ -55,6 +61,10 @@ class TabbedBrowsingTest {
 
     @Before
     fun setUp() {
+        // Initializing this as part of class construction, below the rule would throw a NPE
+        // So we are initializing this here instead of in all related tests.
+        browserStore = activityTestRule.activity.components.core.store
+
         mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
@@ -67,51 +77,7 @@ class TabbedBrowsingTest {
         mockWebServer.shutdown()
     }
 
-    @Test
-    fun openNewTabTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            mDevice.waitForIdle()
-            verifyTabCounter("1")
-        }.openTabDrawer {
-            verifyNormalModeSelected()
-            verifyExistingOpenTabs("Test_Page_1")
-            closeTab()
-        }.openTabDrawer {
-            verifyNoOpenTabsInNormalBrowsing()
-        }.openNewTab {
-        }.submitQuery(defaultWebPage.url.toString()) {
-            mDevice.waitForIdle()
-            verifyTabCounter("1")
-        }.openTabDrawer {
-            verifyNormalModeSelected()
-            verifyExistingOpenTabs("Test_Page_1")
-        }
-    }
-
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/233629
-    @Test
-    fun openNewPrivateTabTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen {}.togglePrivateBrowsingMode()
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            mDevice.waitForIdle()
-            verifyTabCounter("1")
-        }.openTabDrawer {
-            verifyExistingTabList()
-            verifyPrivateModeSelected()
-        }.toggleToNormalTabs {
-            verifyNoOpenTabsInNormalBrowsing()
-        }.toggleToPrivateTabs {
-            verifyExistingTabList()
-        }
-    }
-
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903599
     @Test
     fun closeAllTabsTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -144,45 +110,9 @@ class TabbedBrowsingTest {
         }
     }
 
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903604
     @Test
-    fun closeTabTest() {
-        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-            closeTab()
-        }
-        homeScreen {
-            verifyTabCounter("0")
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-            swipeTabRight("Test_Page_1")
-        }
-        homeScreen {
-            verifyTabCounter("0")
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-            swipeTabLeft("Test_Page_1")
-        }
-        homeScreen {
-            verifyTabCounter("0")
-        }
-    }
-
-    @Test
-    fun verifyUndoSnackBarTest() {
-        // disabling these features because they interfere with the snackbar visibility
-        activityTestRule.applySettingsExceptions {
-            it.isPocketEnabled = false
-            it.isRecentTabsFeatureEnabled = false
-        }
-
+    fun closingTabsMethodsTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -193,24 +123,9 @@ class TabbedBrowsingTest {
             verifySnackBarText("Tab closed")
             snackBarButtonClick("UNDO")
         }
-
         browserScreen {
             verifyTabCounter("1")
         }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-        }
-    }
-
-    @Test
-    fun closePrivateTabTest() {
-        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen { }.togglePrivateBrowsingMode()
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-            verifyCloseTabsButton("Test_Page_1")
             closeTab()
         }
         homeScreen {
@@ -220,6 +135,7 @@ class TabbedBrowsingTest {
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
             swipeTabRight("Test_Page_1")
+            verifySnackBarText("Tab closed")
         }
         homeScreen {
             verifyTabCounter("0")
@@ -228,14 +144,16 @@ class TabbedBrowsingTest {
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
             swipeTabLeft("Test_Page_1")
+            verifySnackBarText("Tab closed")
         }
         homeScreen {
             verifyTabCounter("0")
         }
     }
 
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903591
     @Test
-    fun verifyPrivateTabUndoSnackBarTest() {
+    fun closingPrivateTabsMethodsTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         homeScreen { }.togglePrivateBrowsingMode()
@@ -248,12 +166,51 @@ class TabbedBrowsingTest {
             verifySnackBarText("Private tab closed")
             snackBarButtonClick("UNDO")
         }
-
         browserScreen {
             verifyTabCounter("1")
         }.openTabDrawer {
+            closeTab()
+        }
+        homeScreen {
+            verifyTabCounter("0")
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
-            verifyPrivateModeSelected()
+            swipeTabRight("Test_Page_1")
+            verifySnackBarText("Private tab closed")
+        }
+        homeScreen {
+            verifyTabCounter("0")
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openTabDrawer {
+            verifyExistingOpenTabs("Test_Page_1")
+            swipeTabLeft("Test_Page_1")
+            verifySnackBarText("Private tab closed")
+        }
+        homeScreen {
+            verifyTabCounter("0")
+        }
+    }
+
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903606
+    @SmokeTest
+    @Test
+    fun tabMediaControlButtonTest() {
+        val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(audioTestPage.url) {
+            mDevice.waitForIdle()
+            clickPageObject(MatcherHelper.itemWithText("Play"))
+            assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
+        }.openTabDrawer {
+            verifyTabMediaControlButtonState("Pause")
+            clickTabMediaControlButton("Pause")
+            verifyTabMediaControlButtonState("Play")
+        }.openTab(audioTestPage.title) {
+            assertPlaybackState(browserStore, MediaSession.PlaybackState.PAUSED)
         }
     }
 
@@ -275,6 +232,40 @@ class TabbedBrowsingTest {
             verifyPrivateTabsNotification()
         }.clickClosePrivateTabsNotification {
             verifyHomeScreen()
+        }
+    }
+
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903598
+    @SmokeTest
+    @Test
+    fun shareTabsFromTabsTrayTest() {
+        val firstWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 2)
+        val firstWebsiteTitle = firstWebsite.title
+        val secondWebsiteTitle = secondWebsite.title
+        val sharingApp = "Gmail"
+        val sharedUrlsString = "${firstWebsite.url}\n\n${secondWebsite.url}"
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebsite.url) {
+            verifyPageContent(firstWebsite.content)
+        }.openTabDrawer {
+        }.openNewTab {
+        }.submitQuery(secondWebsite.url.toString()) {
+            verifyPageContent(secondWebsite.content)
+        }.openTabDrawer {
+            verifyExistingOpenTabs("Test_Page_1")
+            verifyExistingOpenTabs("Test_Page_2")
+        }.openTabsListThreeDotMenu {
+            verifyShareAllTabsButton()
+        }.clickShareAllTabsButton {
+            verifyShareTabsOverlay(firstWebsiteTitle, secondWebsiteTitle)
+            verifySharingWithSelectedApp(
+                sharingApp,
+                sharedUrlsString,
+                "$firstWebsiteTitle, $secondWebsiteTitle",
+            )
         }
     }
 
@@ -301,6 +292,7 @@ class TabbedBrowsingTest {
         }
     }
 
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903600
     @Test
     fun verifyEmptyTabTray() {
         navigationToolbar {
@@ -315,8 +307,9 @@ class TabbedBrowsingTest {
         }
     }
 
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903585
     @Test
-    fun emptyTabsTrayViewPrivateBrowsingTest() {
+    fun verifyEmptyPrivateTabsTrayTest() {
         navigationToolbar {
         }.openTabTray {
         }.toggleToPrivateTabs {
@@ -330,12 +323,15 @@ class TabbedBrowsingTest {
         }
     }
 
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903601
     @Test
-    fun verifyOpenTabDetails() {
+    fun verifyTabsTrayWithOpenTabTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        homeScreen {
+        }.openTabDrawer {
+        }.openNewTab {
+        }.submitQuery(defaultWebPage.url.toString()) {
         }.openTabDrawer {
             verifyNormalBrowsingButtonIsSelected(true)
             verifyPrivateBrowsingButtonIsSelected(false)
@@ -353,29 +349,57 @@ class TabbedBrowsingTest {
         }
     }
 
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/903587
+    @SmokeTest
     @Test
-    fun verifyContextMenuShortcuts() {
+    fun verifyPrivateTabsTrayWithOpenTabTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openTabDrawer {
+        }.toggleToPrivateTabs {
+        }.openNewTab {
+        }.submitQuery(website.url.toString()) {
+        }.openTabDrawer {
+            verifyNormalBrowsingButtonIsSelected(false)
+            verifyPrivateBrowsingButtonIsSelected(true)
+            verifySyncedTabsButtonIsSelected(false)
+            verifyTabTrayOverflowMenu(true)
+            verifyTabsTrayCounter()
+            verifyExistingTabList()
+            verifyExistingOpenTabs(website.title)
+            verifyCloseTabsButton(website.title)
+            verifyOpenedTabThumbnail()
+            verifyPrivateBrowsingNewTabButton()
+        }
+    }
+
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/927315
+    @Test
+    fun tabsCounterShortcutMenuTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
+        navigationToolbar {
         }.openTabButtonShortcutsMenu {
             verifyTabButtonShortcutMenuItems()
         }.closeTabFromShortcutsMenu {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
+        navigationToolbar {
         }.openTabButtonShortcutsMenu {
         }.openNewPrivateTabFromShortcutsMenu {
             verifyKeyboardVisibility()
             verifySearchBarPlaceholder("Search or enter address")
             // dismiss search dialog
         }.dismissSearchBar {
-            verifyCommonMythsLink()
-            verifyNavigationToolbar()
+            verifyPrivateBrowsingHomeScreenItems()
         }
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
+        navigationToolbar {
         }.openTabButtonShortcutsMenu {
-        }.openTabFromShortcutsMenu {
+        }.openNewTabFromShortcutsMenu {
             verifyKeyboardVisibility()
             verifySearchBarPlaceholder("Search or enter address")
             // dismiss search dialog
@@ -385,6 +409,45 @@ class TabbedBrowsingTest {
         }
     }
 
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/927314
+    @Test
+    fun privateTabsCounterShortcutMenuTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {}.togglePrivateBrowsingMode()
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+            waitForPageToLoad()
+        }
+        navigationToolbar {
+        }.openTabButtonShortcutsMenu {
+            verifyTabButtonShortcutMenuItems()
+        }.closeTabFromShortcutsMenu {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
+        navigationToolbar {
+        }.openTabButtonShortcutsMenu {
+        }.openNewPrivateTabFromShortcutsMenu {
+            verifyKeyboardVisibility()
+            verifySearchBarPlaceholder("Search or enter address")
+            // dismiss search dialog
+        }.dismissSearchBar {
+            verifyCommonMythsLink()
+        }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
+        navigationToolbar {
+        }.openTabButtonShortcutsMenu {
+        }.openNewTabFromShortcutsMenu {
+            verifyKeyboardVisibility()
+            verifySearchBarPlaceholder("Search or enter address")
+            // dismiss search dialog
+        }.dismissSearchBar {
+            // Verify normal browsing homescreen
+            verifyExistingTopSitesList()
+        }
+    }
+
+    // TestRail: https://testrail.stage.mozaws.net/index.php?/cases/view/1046683
     @Test
     fun verifySyncedTabsWhenUserIsNotSignedInTest() {
         navigationToolbar {
@@ -411,7 +474,7 @@ class TabbedBrowsingTest {
         closeApp(activityTestRule)
         restartApp(activityTestRule)
         homeScreen {
-            verifyPrivateBrowsingHomeScreen()
+            verifyPrivateBrowsingHomeScreenItems()
         }.openTabDrawer {
         }.toggleToNormalTabs {
             verifyExistingOpenTabs(defaultWebPage.title)
@@ -439,7 +502,7 @@ class TabbedBrowsingTest {
         restartApp(activityTestRule)
 
         homeScreen {
-            verifyPrivateBrowsingHomeScreen()
+            verifyPrivateBrowsingHomeScreenItems()
         }.openTabDrawer {
             verifyNoOpenTabsInPrivateBrowsing()
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -1105,14 +1105,6 @@ class BrowserRobot {
             return ComposeTabDrawerRobot.Transition(composeTestRule)
         }
 
-        fun openTabButtonShortcutsMenu(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
-            mDevice.waitNotNull(Until.findObject(By.desc("Tabs")))
-            tabsCounter().click(LONG_CLICK_DURATION)
-
-            NavigationToolbarRobot().interact()
-            return NavigationToolbarRobot.Transition()
-        }
-
         fun openNotificationShade(interact: NotificationRobot.() -> Unit): NotificationRobot.Transition {
             mDevice.openNotification()
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -87,11 +87,10 @@ class HomeScreenRobot {
 
     fun verifyHomeScreen() = assertItemWithResIdExists(homeScreen)
 
-    fun verifyPrivateBrowsingHomeScreen() {
+    fun verifyPrivateBrowsingHomeScreenItems() {
         verifyHomeScreenAppBarItems()
         assertItemContainingTextExists(itemContainingText(privateSessionMessage))
         verifyCommonMythsLink()
-        verifyNavigationToolbarItems()
     }
 
     fun verifyHomeScreenAppBarItems() =

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -305,7 +305,15 @@ class NavigationToolbarRobot {
             return HomeScreenRobot.Transition()
         }
 
-        fun closeTabFromShortcutsMenu(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
+        fun openTabButtonShortcutsMenu(interact: NavigationToolbarRobot.() -> Unit): Transition {
+            mDevice.waitNotNull(Until.findObject(By.desc("Tabs")))
+            tabsCounter().click(LONG_CLICK_DURATION)
+
+            NavigationToolbarRobot().interact()
+            return Transition()
+        }
+
+        fun closeTabFromShortcutsMenu(interact: NavigationToolbarRobot.() -> Unit): Transition {
             mDevice.waitForIdle(waitingTime)
 
             onView(withId(R.id.mozac_browser_menu_recyclerView))
@@ -319,10 +327,10 @@ class NavigationToolbarRobot {
                 )
 
             NavigationToolbarRobot().interact()
-            return NavigationToolbarRobot.Transition()
+            return Transition()
         }
 
-        fun openTabFromShortcutsMenu(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
+        fun openNewTabFromShortcutsMenu(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
             mDevice.waitForIdle(waitingTime)
 
             onView(withId(R.id.mozac_browser_menu_recyclerView))
@@ -413,6 +421,8 @@ private fun awesomeBar() =
     mDevice.findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_edit_url_view"))
 private fun threeDotButton() = onView(withId(R.id.mozac_browser_toolbar_menu))
 private fun tabTrayButton() = onView(withId(R.id.tab_button))
+private fun tabsCounter() =
+    mDevice.findObject(By.res("$packageName:id/counter_root"))
 private fun fillLinkButton() = onView(withId(R.id.fill_link_from_clipboard))
 private fun clearAddressBarButton() = itemWithResId("$packageName:id/mozac_browser_toolbar_clear_view")
 private fun goBackButton() = mDevice.pressBack()


### PR DESCRIPTION
Tabs tray tests data alignment. See doc for reference: https://docs.google.com/document/d/1_VTY18OWluKes4pmENisJqqugaOpwBGGHOwEWiNJJD4/edit

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1858438