### PR TITLE
Bug 1858607 - Top sites TestRail matching

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTopSitesTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTopSitesTest.kt
@@ -62,7 +62,7 @@ class ComposeTopSitesTest {
 
     @SmokeTest
     @Test
-    fun verifyAddToFirefoxHome() {
+    fun addAWebsiteAsATopSiteTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -79,7 +79,7 @@ class ComposeTopSitesTest {
     }
 
     @Test
-    fun verifyOpenTopSiteNormalTab() {
+    fun openTopSiteInANewTabTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -106,7 +106,7 @@ class ComposeTopSitesTest {
     }
 
     @Test
-    fun verifyOpenTopSitePrivateTab() {
+    fun openTopSiteInANewPrivateTabTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -127,7 +127,7 @@ class ComposeTopSitesTest {
     }
 
     @Test
-    fun verifyRenameTopSite() {
+    fun renameATopSiteTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
         val newPageTitle = generateRandomString(5)
 
@@ -151,28 +151,7 @@ class ComposeTopSitesTest {
     }
 
     @Test
-    fun verifyRemoveTopSite() {
-        val defaultWebPage = getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-        }.openThreeDotMenu {
-            expandMenu()
-            verifyAddToShortcutsButton(true)
-        }.addToFirefoxHome {
-            verifySnackBarText(getStringResource(R.string.snackbar_added_to_shortcuts))
-        }.goToHomescreenWithComposeTopSites(composeTestRule) {
-            verifyExistingTopSitesList()
-            verifyExistingTopSiteItem(defaultWebPage.title)
-        }.openContextMenuOnTopSitesWithTitle(defaultWebPage.title) {
-            verifyTopSiteContextMenuItems()
-        }.removeTopSite {
-            verifyNotExistingTopSiteItem(defaultWebPage.title)
-        }
-    }
-
-    @Test
-    fun verifyUndoRemoveTopSite() {
+    fun removeTopSiteUsingMenuButtonTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -190,11 +169,15 @@ class ComposeTopSitesTest {
         }.removeTopSite {
             clickSnackbarButton("UNDO")
             verifyExistingTopSiteItem(defaultWebPage.title)
+        }.openContextMenuOnTopSitesWithTitle(defaultWebPage.title) {
+            verifyTopSiteContextMenuItems()
+        }.removeTopSite {
+            verifyNotExistingTopSiteItem(defaultWebPage.title)
         }
     }
 
     @Test
-    fun verifyRemoveTopSiteFromMainMenu() {
+    fun removeTopSiteFromMainMenuTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -218,7 +201,7 @@ class ComposeTopSitesTest {
 
     // Expected for en-us defaults
     @Test
-    fun verifyDefaultTopSitesList() {
+    fun verifyENLocalesDefaultTopSitesListTest() {
         homeScreenWithComposeTopSites(composeTestRule) {
             verifyExistingTopSitesList()
             val topSitesTitles = arrayListOf("Google", "Top Articles", "Wikipedia")

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PDFViewerTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PDFViewerTest.kt
@@ -67,7 +67,7 @@ class PDFViewerTest {
         }
     }
 
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/edit/2159718/1
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2159718
     @Test
     fun verifyPDFViewerOpenInAppButtonTest() {
         val genericURL = getGenericAsset(mockWebServer, 3)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -55,9 +55,10 @@ class TopSitesTest {
         mockWebServer.shutdown()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/532598
     @SmokeTest
     @Test
-    fun verifyAddToFirefoxHome() {
+    fun addAWebsiteAsATopSiteTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -73,8 +74,9 @@ class TopSitesTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/532599
     @Test
-    fun verifyOpenTopSiteNormalTab() {
+    fun openTopSiteInANewTabTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -100,8 +102,9 @@ class TopSitesTest {
         mDevice.pressBack()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/532600
     @Test
-    fun verifyOpenTopSitePrivateTab() {
+    fun openTopSiteInANewPrivateTabTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -121,8 +124,9 @@ class TopSitesTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1110321
     @Test
-    fun verifyRenameTopSite() {
+    fun renameATopSiteTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
         val newPageTitle = generateRandomString(5)
 
@@ -145,29 +149,9 @@ class TopSitesTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/532601
     @Test
-    fun verifyRemoveTopSite() {
-        val defaultWebPage = getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-        }.openThreeDotMenu {
-            expandMenu()
-            verifyAddToShortcutsButton(shouldExist = true)
-        }.addToFirefoxHome {
-            verifySnackBarText(getStringResource(R.string.snackbar_added_to_shortcuts))
-        }.goToHomescreen {
-            verifyExistingTopSitesList()
-            verifyExistingTopSitesTabs(defaultWebPage.title)
-        }.openContextMenuOnTopSitesWithTitle(defaultWebPage.title) {
-            verifyTopSiteContextMenuItems()
-        }.removeTopSite {
-            verifyNotExistingTopSitesList(defaultWebPage.title)
-        }
-    }
-
-    @Test
-    fun verifyUndoRemoveTopSite() {
+    fun removeTopSiteUsingMenuButtonTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -185,11 +169,16 @@ class TopSitesTest {
         }.removeTopSite {
             clickSnackbarButton("UNDO")
             verifyExistingTopSitesTabs(defaultWebPage.title)
+        }.openContextMenuOnTopSitesWithTitle(defaultWebPage.title) {
+            verifyTopSiteContextMenuItems()
+        }.removeTopSite {
+            verifyNotExistingTopSitesList(defaultWebPage.title)
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2323641
     @Test
-    fun verifyRemoveTopSiteFromMainMenu() {
+    fun removeTopSiteFromMainMenuTest() {
         val defaultWebPage = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -211,9 +200,10 @@ class TopSitesTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/561582
     // Expected for en-us defaults
     @Test
-    fun verifyDefaultTopSitesList() {
+    fun verifyENLocalesDefaultTopSitesListTest() {
         homeScreen {
             verifyExistingTopSitesList()
             defaultTopSitesList.values.forEach { value ->
@@ -222,6 +212,7 @@ class TopSitesTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1050642
     @SmokeTest
     @Test
     fun addAndRemoveMostViewedTopSiteTest() {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTopSitesRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTopSitesRobot.kt
@@ -17,12 +17,14 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
+import androidx.test.uiautomator.UiSelector
 import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
+import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.home.topsites.TopSitesTestTag
 
@@ -37,7 +39,7 @@ class ComposeTopSitesRobot(private val composeTestRule: HomeActivityComposeTestR
     @OptIn(ExperimentalTestApi::class)
     fun verifyExistingTopSiteItem(vararg titles: String) {
         titles.forEach { title ->
-            composeTestRule.waitUntilAtLeastOneExists(hasText(title), waitingTime)
+            mDevice.findObject(UiSelector().textContains(title)).waitForExists(waitingTimeShort)
             composeTestRule.topSiteItem(title).assertExists()
         }
     }

--- a/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -31,7 +31,7 @@ gcloud:
     - class org.mozilla.fenix.ui.HistoryTest#noHistoryInPrivateBrowsingTest
     - class org.mozilla.fenix.ui.TabbedBrowsingTest#openNewTabTest
     - class org.mozilla.fenix.ui.TabbedBrowsingTest#openNewPrivateTabTest
-    - class org.mozilla.fenix.ui.TopSitesTest#verifyOpenTopSiteNormalTab
+    - class org.mozilla.fenix.ui.TopSitesTest#openTopSiteInANewTabTest
     - class org.mozilla.fenix.ui.BookmarksTest#addBookmarkTest
 
   device:


### PR DESCRIPTION
These changes are part of our data alignment between testRail and our automated UI tests.

For more information please see this [document](https://docs.google.com/document/d/1lfcr8MCYBYTYbI55MNiP1LT9un3jzyYvhNUlZJi9IQU/edit?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1858607