### PR TITLE
Bug 1857487 - Kill the app when backgrounded and extensions process s…

### DIFF
--- a/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/ExtensionsProcessDisabledPromptObserver.kt
+++ b/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/ExtensionsProcessDisabledPromptObserver.kt
@@ -5,41 +5,43 @@
 package mozilla.components.support.webextensions
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 
 /**
- * Feature implementation that shows a prompt when the extensions process spawning has been
- * disabled due to the restart threshold being met.
+ * Observes the [BrowserStore] state for when the extensions process spawning has been disabled and
+ * the user should be prompted. This requires running in both the foreground and background.
  *
  * @property store the application's [BrowserStore].
- * @property onShowExtensionsProcessDisabledPrompt a callback invoked when the application should open a
- * prompt.
+ * @property onShowExtensionsProcessDisabledPrompt a callback invoked when the application should
+ * open a prompt.
  */
 open class ExtensionsProcessDisabledPromptObserver(
     private val store: BrowserStore,
     private val onShowExtensionsProcessDisabledPrompt: () -> Unit = { },
 ) : LifecycleAwareFeature {
-    private var promptScope: CoroutineScope? = null
+    private var scope: CoroutineScope? = null
 
     override fun start() {
-        promptScope = store.flowScoped { flow ->
-            flow.distinctUntilChangedBy { it.showExtensionsProcessDisabledPrompt }
-                .collect { state ->
-                    if (state.showExtensionsProcessDisabledPrompt) {
-                        // There should only be one active dialog to the user when the extensions
-                        // process spawning is disabled.
-                        onShowExtensionsProcessDisabledPrompt()
+        if (scope == null) {
+            scope = store.flowScoped { flow ->
+                flow.distinctUntilChangedBy { it.showExtensionsProcessDisabledPrompt }
+                    .collect { state ->
+                        if (state.showExtensionsProcessDisabledPrompt) {
+                            onShowExtensionsProcessDisabledPrompt()
+                        }
                     }
-                }
+            }
         }
     }
 
+    /**
+     * This observer needs to run indefinitely because we need to react to state changes when the
+     * app is either in the foreground or in the background.
+     */
     override fun stop() {
-        promptScope?.cancel()
-        promptScope = null
+        /** NO-OP */
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -204,7 +204,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     }
 
     private val extensionsProcessDisabledPromptObserver by lazy {
-        ExtensionsProcessDisabledController(this@HomeActivity, components.core.store)
+        ExtensionsProcessDisabledController(this@HomeActivity)
     }
 
     private val serviceWorkerSupport by lazy {

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionsProcessDisabledController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/ExtensionsProcessDisabledController.kt
@@ -5,6 +5,8 @@
 package org.mozilla.fenix.addons
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.widget.Button
 import android.widget.TextView
@@ -16,23 +18,39 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.ktx.android.content.appName
 import mozilla.components.support.webextensions.ExtensionsProcessDisabledPromptObserver
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.ext.components
+import kotlin.system.exitProcess
 
 /**
- * Controller for showing the user a dialog when the the extensions process spawning has been disabled.
+ * Controller for handling extensions process spawning disabled events. When the app is in
+ * foreground this will call for a dialog to decide on correct action to take (retry enabling
+ * process spawning or disable extensions). When in background, we kill the app to prevent
+ * extensions from being disabled and network requests continuing.
  *
  * @param context to show the AlertDialog
- * @param store The [BrowserStore] which holds the state for showing the dialog
+ * @param browserStore The [BrowserStore] which holds the state for showing the dialog
+ * @param appStore The [AppStore] containing the application state
  * @param builder to use for creating the dialog which can be styled as needed
  * @param appName to be added to the message. Optional and mainly relevant for testing
+ * @param onKillApp called when the app is backgrounded and extensions process is disabled
  */
 class ExtensionsProcessDisabledController(
     @UiContext context: Context,
-    store: BrowserStore,
+    browserStore: BrowserStore = context.components.core.store,
+    appStore: AppStore = context.components.appStore,
     builder: AlertDialog.Builder = AlertDialog.Builder(context),
     appName: String = context.appName,
+    onKillApp: () -> Unit = { killApp() },
 ) : ExtensionsProcessDisabledPromptObserver(
-    store,
-    { presentDialog(context, store, builder, appName) },
+    browserStore,
+    {
+        if (appStore.state.isForeground) {
+            presentDialog(context, browserStore, builder, appName)
+        } else {
+            onKillApp.invoke()
+        }
+    },
 ) {
     override fun onDestroy(owner: LifecycleOwner) {
         super.onDestroy(owner)
@@ -42,6 +60,16 @@ class ExtensionsProcessDisabledController(
 
     companion object {
         private var shouldCreateDialog: Boolean = true
+
+        /**
+         * When a dialog can't be shown because the app is in the background, instead the app will
+         * be killed to prevent leaking network data without extensions enabled.
+         */
+        private fun killApp() {
+            Handler(Looper.getMainLooper()).post {
+                exitProcess(0)
+            }
+        }
 
         /**
          * Present a dialog to the user notifying of extensions process spawning disabled and also asking

--- a/fenix/app/src/test/java/org/mozilla/fenix/addons/ExtensionsProcessDisabledControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/addons/ExtensionsProcessDisabledControllerTest.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.widget.Button
 import androidx.appcompat.app.AlertDialog
 import mozilla.components.browser.state.action.ExtensionsProcessAction
+import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
@@ -23,6 +24,8 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @RunWith(FenixRobolectricTestRunner::class)
@@ -34,83 +37,98 @@ class ExtensionsProcessDisabledControllerTest {
 
     @Test
     fun `WHEN showExtensionsProcessDisabledPrompt is true AND positive button clicked then enable extension process spawning`() {
-        val store = BrowserStore()
+        val browserStore = BrowserStore()
         val dialog: AlertDialog = mock()
-        val appName = "TestApp"
         val builder: AlertDialog.Builder = mock()
-        val controller = ExtensionsProcessDisabledController(testContext, store, builder, appName)
+        val controller = ExtensionsProcessDisabledController(
+            context = testContext,
+            appStore = AppStore(AppState(isForeground = true)),
+            browserStore = browserStore,
+            builder = builder,
+            appName = "TestApp",
+        )
         val buttonsContainerCaptor = argumentCaptor<View>()
 
         controller.start()
 
         whenever(builder.show()).thenReturn(dialog)
 
-        assertFalse(store.state.showExtensionsProcessDisabledPrompt)
-        assertFalse(store.state.extensionsProcessDisabled)
+        assertFalse(browserStore.state.showExtensionsProcessDisabledPrompt)
+        assertFalse(browserStore.state.extensionsProcessDisabled)
 
         // Pretend the process has been disabled and we show the dialog.
-        store.dispatch(ExtensionsProcessAction.DisabledAction)
-        store.dispatch(ExtensionsProcessAction.ShowPromptAction(show = true))
+        browserStore.dispatch(ExtensionsProcessAction.DisabledAction)
+        browserStore.dispatch(ExtensionsProcessAction.ShowPromptAction(show = true))
         dispatcher.scheduler.advanceUntilIdle()
-        store.waitUntilIdle()
-        assertTrue(store.state.showExtensionsProcessDisabledPrompt)
-        assertTrue(store.state.extensionsProcessDisabled)
+        browserStore.waitUntilIdle()
+        assertTrue(browserStore.state.showExtensionsProcessDisabledPrompt)
+        assertTrue(browserStore.state.extensionsProcessDisabled)
 
         verify(builder).setView(buttonsContainerCaptor.capture())
         verify(builder).show()
 
         buttonsContainerCaptor.value.findViewById<Button>(R.id.positive).performClick()
 
-        store.waitUntilIdle()
+        browserStore.waitUntilIdle()
 
-        assertFalse(store.state.showExtensionsProcessDisabledPrompt)
-        assertFalse(store.state.extensionsProcessDisabled)
+        assertFalse(browserStore.state.showExtensionsProcessDisabledPrompt)
+        assertFalse(browserStore.state.extensionsProcessDisabled)
         verify(dialog).dismiss()
     }
 
     @Test
     fun `WHEN showExtensionsProcessDisabledPrompt is true AND negative button clicked then dismiss without enabling extension process spawning`() {
-        val store = BrowserStore()
-        val appName = "TestApp"
+        val browserStore = BrowserStore()
         val dialog: AlertDialog = mock()
         val builder: AlertDialog.Builder = mock()
-        val controller = ExtensionsProcessDisabledController(testContext, store, builder, appName)
+        val controller = ExtensionsProcessDisabledController(
+            context = testContext,
+            appStore = AppStore(AppState(isForeground = true)),
+            browserStore = browserStore,
+            builder = builder,
+            appName = "TestApp",
+        )
         val buttonsContainerCaptor = argumentCaptor<View>()
 
         controller.start()
 
         whenever(builder.show()).thenReturn(dialog)
 
-        assertFalse(store.state.showExtensionsProcessDisabledPrompt)
-        assertFalse(store.state.extensionsProcessDisabled)
+        assertFalse(browserStore.state.showExtensionsProcessDisabledPrompt)
+        assertFalse(browserStore.state.extensionsProcessDisabled)
 
         // Pretend the process has been disabled and we show the dialog.
-        store.dispatch(ExtensionsProcessAction.DisabledAction)
-        store.dispatch(ExtensionsProcessAction.ShowPromptAction(show = true))
+        browserStore.dispatch(ExtensionsProcessAction.DisabledAction)
+        browserStore.dispatch(ExtensionsProcessAction.ShowPromptAction(show = true))
         dispatcher.scheduler.advanceUntilIdle()
-        store.waitUntilIdle()
-        assertTrue(store.state.showExtensionsProcessDisabledPrompt)
-        assertTrue(store.state.extensionsProcessDisabled)
+        browserStore.waitUntilIdle()
+        assertTrue(browserStore.state.showExtensionsProcessDisabledPrompt)
+        assertTrue(browserStore.state.extensionsProcessDisabled)
 
         verify(builder).setView(buttonsContainerCaptor.capture())
         verify(builder).show()
 
         buttonsContainerCaptor.value.findViewById<Button>(R.id.negative).performClick()
 
-        store.waitUntilIdle()
+        browserStore.waitUntilIdle()
 
-        assertFalse(store.state.showExtensionsProcessDisabledPrompt)
-        assertTrue(store.state.extensionsProcessDisabled)
+        assertFalse(browserStore.state.showExtensionsProcessDisabledPrompt)
+        assertTrue(browserStore.state.extensionsProcessDisabled)
         verify(dialog).dismiss()
     }
 
     @Test
     fun `WHEN dispatching the same event twice THEN the dialog should only be created once`() {
-        val store = BrowserStore()
-        val appName = "TestApp"
+        val browserStore = BrowserStore()
         val dialog: AlertDialog = mock()
         val builder: AlertDialog.Builder = mock()
-        val controller = ExtensionsProcessDisabledController(testContext, store, builder, appName)
+        val controller = ExtensionsProcessDisabledController(
+            context = testContext,
+            appStore = AppStore(AppState(isForeground = true)),
+            browserStore = browserStore,
+            builder = builder,
+            appName = "TestApp",
+        )
         val buttonsContainerCaptor = argumentCaptor<View>()
 
         controller.start()
@@ -118,20 +136,39 @@ class ExtensionsProcessDisabledControllerTest {
         whenever(builder.show()).thenReturn(dialog)
 
         // First dispatch...
-        store.dispatch(ExtensionsProcessAction.ShowPromptAction(show = true))
+        browserStore.dispatch(ExtensionsProcessAction.ShowPromptAction(show = true))
         dispatcher.scheduler.advanceUntilIdle()
-        store.waitUntilIdle()
+        browserStore.waitUntilIdle()
 
         // Second dispatch... without having dismissed the dialog before!
-        store.dispatch(ExtensionsProcessAction.ShowPromptAction(show = true))
+        browserStore.dispatch(ExtensionsProcessAction.ShowPromptAction(show = true))
         dispatcher.scheduler.advanceUntilIdle()
-        store.waitUntilIdle()
+        browserStore.waitUntilIdle()
 
         verify(builder).setView(buttonsContainerCaptor.capture())
         verify(builder, times(1)).show()
 
         // Click a button to dismiss the dialog.
         buttonsContainerCaptor.value.findViewById<Button>(R.id.negative).performClick()
-        store.waitUntilIdle()
+        browserStore.waitUntilIdle()
+    }
+
+    @Test
+    fun `WHEN app is backgrounded AND extension process spawning threshold is exceeded THEN kill the app`() {
+        val browserStore = BrowserStore(BrowserState())
+        val appStore = AppStore(AppState(isForeground = false))
+        val builder: AlertDialog.Builder = mock()
+        val appName = "TestApp"
+        val onKillApp: () -> Unit = mock()
+
+        val controller = ExtensionsProcessDisabledController(testContext, browserStore, appStore, builder, appName, onKillApp)
+
+        controller.start()
+
+        browserStore.dispatch(ExtensionsProcessAction.ShowPromptAction(show = true))
+        dispatcher.scheduler.advanceUntilIdle()
+        browserStore.waitUntilIdle()
+
+        verify(onKillApp).invoke()
     }
 }


### PR DESCRIPTION
…pawning threshold is exceeded


Because we need this in 119 the code is the most minimal change I could make for the functionality needed. 

There will be a separate larger PR for refactoring this code that primarily focuses on:

+ Removing the static call for the `presentDialog`
+ Removing the lifecycle aware "feature" and instead move to a HomeActivity dependency for the controller and observer
+ Moving the `killApp()` to the `HomeActivity`
+ Changing the switch from being whether to present a dialog to when the threshold has been exceeded.

https://bugzilla.mozilla.org/show_bug.cgi?id=1859678

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1857487