### PR TITLE
WIP Bug 1821701 - Updated IconDiskCache to use consistent keys for storing and retrieving values

### DIFF
--- a/android-components/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconDiskCache.kt
+++ b/android-components/components/browser/icons/src/main/java/mozilla/components/browser/icons/utils/IconDiskCache.kt
@@ -6,6 +6,7 @@ package mozilla.components.browser.icons.utils
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.jakewharton.disklrucache.DiskLruCache
@@ -182,4 +183,7 @@ class IconDiskCache :
     }
 }
 
-private fun createKey(rawKey: String): String = rawKey.sha1()
+/**
+ * Attempts to create a consistent key for the host with the given [url].
+ */
+private fun createKey(url: String): String = Uri.parse(url).host?.sha1() ?: url.sha1()

--- a/android-components/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/IconDiskCacheTest.kt
+++ b/android-components/components/browser/icons/src/test/java/mozilla/components/browser/icons/utils/IconDiskCacheTest.kt
@@ -26,7 +26,7 @@ import java.io.OutputStream
 class IconDiskCacheTest {
 
     @Test
-    fun `GIVEN read & write request URLs are the same THEN getResources returns the written resource`() {
+    fun `GIVEN read & write Request URLs are the same THEN getResources returns the Request Resources`() {
         val cache = IconDiskCache()
 
         val resources = listOf(
@@ -58,7 +58,7 @@ class IconDiskCacheTest {
     }
 
     @Test
-    fun `GIVEN read & write request URLs are different with same host THEN getResources returns the written resource`() {
+    fun `GIVEN read & write Request URLs are different with same host THEN getResources returns the Request Resources`() {
         val cache = IconDiskCache()
 
         val resources = listOf(
@@ -93,7 +93,7 @@ class IconDiskCacheTest {
     }
 
     @Test
-    fun `GIVEN read & write request URLs are different THEN getResources returns an empty list`() {
+    fun `GIVEN read & write Request URLs are different THEN getResources returns an empty list`() {
         val cache = IconDiskCache()
 
         val resources = listOf(
@@ -125,7 +125,7 @@ class IconDiskCacheTest {
     }
 
     @Test
-    fun `GIVEN read & write request URLs are the same & no host THEN getResources returns the written resource`() {
+    fun `GIVEN read & write Request URLs are the same & no host THEN getResources returns the Request Resources`() {
         val cache = IconDiskCache()
 
         val resources = listOf(
@@ -187,7 +187,7 @@ class IconDiskCacheTest {
     }
 
     @Test
-    fun `GIVEN read & write request URLs are the same THEN getIconData returns the written resource`() {
+    fun `GIVEN read & write Resource URLs are the same THEN getIconData returns the Resource`() {
         val cache = IconDiskCache()
 
         val resource = IconRequest.Resource(
@@ -217,7 +217,7 @@ class IconDiskCacheTest {
     }
 
     @Test
-    fun `GIVEN read & write request URLs are different with same host THEN getIconData returns the written resource`() {
+    fun `GIVEN read & write Resource URLs are different with same host THEN getIconData returns null`() {
         val cache = IconDiskCache()
 
         val resource = IconRequest.Resource(
@@ -245,12 +245,11 @@ class IconDiskCacheTest {
             testContext,
             resource.copy(url = "https://www.mozilla.org/extra/icon128.png"),
         )
-        assertNotNull(data!!)
-        assertEquals("Hello World", String(data))
+        assertNull(data)
     }
 
     @Test
-    fun `GIVEN read & write request URLs are different THEN putIconBitmap returns null`() {
+    fun `GIVEN read & write Resource URLs are different THEN putIconBitmap returns null`() {
         val cache = IconDiskCache()
 
         val resource = IconRequest.Resource(


### PR DESCRIPTION
The issue we are seeing was due to the different request URLs for the same _host_ being used to create the key used to store and retrieve the icon resources.

Original 
The favicon for the added shortcut are inconsistent - notice the top site favicon is replaced by the placeholder icon on restart

https://github.com/mozilla-mobile/firefox-android/assets/1833156/1039d501-7a1b-4190-a77d-ded999f95dfa

Fix

https://github.com/mozilla-mobile/firefox-android/assets/1833156/8fa7262e-fe52-4bdc-870e-d6edd44c6b25



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1821701