### PR TITLE
Bug 1858018 - Persist review checker reanalysis state

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -268,7 +268,9 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 context.getString(R.string.review_quality_check_close_handle_content_description),
                 visible = { reviewQualityCheckAvailable },
                 listener = { _ ->
-                    requireComponents.appStore.dispatch(AppAction.ShoppingSheetStateUpdated(expanded = true))
+                    requireComponents.appStore.dispatch(
+                        AppAction.ShoppingAction.ShoppingSheetStateUpdated(expanded = true),
+                    )
 
                     findNavController().navigate(
                         BrowserFragmentDirections.actionBrowserFragmentToReviewQualityCheckDialogFragment(),

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -218,7 +218,24 @@ sealed class AppAction : Action {
     ) : AppAction()
 
     /**
-     * [AppAction] used to update the expansion state of the shopping sheet.
+     * [AppAction]s related to shopping sheet state.
      */
-    data class ShoppingSheetStateUpdated(val expanded: Boolean) : AppAction()
+    sealed class ShoppingAction : AppAction() {
+
+        /**
+         * [ShoppingAction] used to update the expansion state of the shopping sheet.
+         */
+        data class ShoppingSheetStateUpdated(val expanded: Boolean) : ShoppingAction()
+
+        /**
+         * [ShoppingAction] used to add a product to a set of products that are being analysed.
+         */
+        data class AddToProductAnalysed(val productPageUrl: String) : ShoppingAction()
+
+        /**
+         * [ShoppingAction] used to remove a product from the set of products that are being
+         * analysed.
+         */
+        data class RemoveFromProductAnalysed(val productPageUrl: String) : ShoppingAction()
+    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
@@ -13,6 +13,7 @@ import mozilla.components.service.pocket.PocketStory
 import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
 import org.mozilla.fenix.browser.StandardSnackbarError
+import org.mozilla.fenix.components.appstate.shopping.ShoppingState
 import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.home.Mode
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
@@ -53,7 +54,7 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  * Also serves as an in memory cache of all stories mapped by category allowing for quick stories filtering.
  * @property wallpaperState The [WallpaperState] to display in the [HomeFragment].
  * @property standardSnackbarError A snackbar error message to display.
- * @property shoppingSheetExpanded Boolean indicating if the shopping sheet is expanded and visible.
+ * @property shoppingState Holds state for shopping feature that's required to live the lifetime of a session.
  */
 data class AppState(
     val isForeground: Boolean = true,
@@ -77,5 +78,5 @@ data class AppState(
     val pendingDeletionHistoryItems: Set<PendingDeletionHistory> = emptySet(),
     val wallpaperState: WallpaperState = WallpaperState.default,
     val standardSnackbarError: StandardSnackbarError? = null,
-    val shoppingSheetExpanded: Boolean? = null,
+    val shoppingState: ShoppingState = ShoppingState(),
 ) : State

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -9,6 +9,7 @@ import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
 import mozilla.components.service.pocket.ext.recordNewImpression
 import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.shopping.ShoppingStateReducer
 import org.mozilla.fenix.ext.filterOutTab
 import org.mozilla.fenix.ext.getFilteredStories
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesSelectedCategory
@@ -232,7 +233,7 @@ internal object AppStoreReducer {
             standardSnackbarError = action.standardSnackbarError,
         )
 
-        is AppAction.ShoppingSheetStateUpdated -> state.copy(shoppingSheetExpanded = action.expanded)
+        is AppAction.ShoppingAction -> ShoppingStateReducer.reduce(state, action)
     }
 }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/shopping/ShoppingState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/shopping/ShoppingState.kt
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.appstate.shopping
+
+/**
+ * State for shopping feature that's required to live the lifetime of a session.
+ *
+ * @property productsInAnalysis Set of product ids that are currently being analysed or were being
+ * analysed when the sheet was closed.
+ * @property shoppingSheetExpanded Boolean indicating if the shopping sheet is expanded and visible.
+ */
+data class ShoppingState(
+    val productsInAnalysis: Set<String> = emptySet(),
+    val shoppingSheetExpanded: Boolean? = null,
+)

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/shopping/ShoppingStateReducer.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/shopping/ShoppingStateReducer.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.appstate.shopping
+
+import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.fenix.components.appstate.AppAction.ShoppingAction
+import org.mozilla.fenix.components.appstate.AppState
+
+/**
+ * Reducer for the shopping state that handles [ShoppingAction]s.
+ */
+internal object ShoppingStateReducer {
+
+    private val logger = Logger("ReviewQualityCheckShoppingStateReducer")
+
+    /**
+     * Reduces the given [ShoppingAction] into a new [AppState].
+     */
+    fun reduce(state: AppState, action: ShoppingAction): AppState =
+        when (action) {
+            is ShoppingAction.ShoppingSheetStateUpdated -> state.copy(
+                shoppingState = state.shoppingState.copy(
+                    shoppingSheetExpanded = action.expanded,
+                ),
+            )
+
+            is ShoppingAction.AddToProductAnalysed -> state.copy(
+                shoppingState = state.shoppingState.copy(
+                    productsInAnalysis = state.shoppingState.productsInAnalysis + action.productPageUrl,
+                ),
+            )
+
+            is ShoppingAction.RemoveFromProductAnalysed -> state.copy(
+                shoppingState = state.shoppingState.copy(
+                    productsInAnalysis = state.shoppingState.productsInAnalysis - action.productPageUrl,
+                ),
+            )
+        }.also {
+            logger.debug("Action processed: $action, updated shopping state: ${it.shoppingState}")
+        }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeature.kt
@@ -50,7 +50,7 @@ class ReviewQualityCheckFeature(
         }
 
         appStoreScope = appStore.flowScoped { flow ->
-            flow.mapNotNull { it.shoppingSheetExpanded }
+            flow.mapNotNull { it.shoppingState.shoppingSheetExpanded }
                 .distinctUntilChanged()
                 .collect(onBottomSheetStateChange)
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ReviewQualityCheckFragment.kt
@@ -40,6 +40,7 @@ class ReviewQualityCheckFragment : BottomSheetDialogFragment() {
             middleware = ReviewQualityCheckMiddlewareProvider.provideMiddleware(
                 settings = requireComponents.settings,
                 browserStore = requireComponents.core.store,
+                appStore = requireComponents.appStore,
                 context = requireContext().applicationContext,
                 scope = lifecycleScope,
             ),
@@ -96,7 +97,7 @@ class ReviewQualityCheckFragment : BottomSheetDialogFragment() {
 
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
-        requireComponents.appStore.dispatch(AppAction.ShoppingSheetStateUpdated(expanded = false))
+        requireComponents.appStore.dispatch(AppAction.ShoppingAction.ShoppingSheetStateUpdated(expanded = false))
     }
 
     private fun BottomSheetBehavior<View>.setPeekHeightToHalfScreenHeight() {

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/di/ReviewQualityCheckMiddlewareProvider.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/di/ReviewQualityCheckMiddlewareProvider.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.tabs.TabsUseCases
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.shopping.middleware.DefaultNetworkChecker
 import org.mozilla.fenix.shopping.middleware.DefaultReviewQualityCheckPreferences
 import org.mozilla.fenix.shopping.middleware.DefaultReviewQualityCheckService
@@ -30,18 +31,20 @@ object ReviewQualityCheckMiddlewareProvider {
      *
      * @param settings The [Settings] instance to use.
      * @param browserStore The [BrowserStore] instance to access state.
+     * @param appStore The [AppStore] instance to access state.
      * @param context The [Context] instance to use.
      * @param scope The [CoroutineScope] to use for launching coroutines.
      */
     fun provideMiddleware(
         settings: Settings,
         browserStore: BrowserStore,
+        appStore: AppStore,
         context: Context,
         scope: CoroutineScope,
     ): List<ReviewQualityCheckMiddleware> =
         listOf(
             providePreferencesMiddleware(settings, browserStore, scope),
-            provideNetworkMiddleware(browserStore, context, scope),
+            provideNetworkMiddleware(browserStore, appStore, context, scope),
             provideNavigationMiddleware(TabsUseCases.SelectOrAddUseCase(browserStore), context),
             provideTelemetryMiddleware(),
         )
@@ -58,11 +61,13 @@ object ReviewQualityCheckMiddlewareProvider {
 
     private fun provideNetworkMiddleware(
         browserStore: BrowserStore,
+        appStore: AppStore,
         context: Context,
         scope: CoroutineScope,
     ) = ReviewQualityCheckNetworkMiddleware(
         reviewQualityCheckService = DefaultReviewQualityCheckService(browserStore),
         networkChecker = DefaultNetworkChecker(context),
+        appStore = appStore,
         scope = scope,
     )
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapper.kt
@@ -15,15 +15,8 @@ import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductR
 /**
  * Maps [ProductAnalysis] to [ProductReviewState].
  */
-fun ProductAnalysis?.toProductReviewState(): ProductReviewState =
-    if (this == null) {
-        ProductReviewState.Error.GenericError
-    } else {
-        when (this) {
-            is GeckoProductAnalysis -> toProductReview()
-            else -> ProductReviewState.Error.GenericError
-        }
-    }
+fun GeckoProductAnalysis?.toProductReviewState(): ProductReviewState =
+    this?.toProductReview() ?: ProductReviewState.Error.GenericError
 
 private fun GeckoProductAnalysis.toProductReview(): ProductReviewState =
     if (productId == null) {

--- a/fenix/app/src/test/java/org/mozilla/fenix/components/appstate/ShoppingActionTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/appstate/ShoppingActionTest.kt
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.appstate
+
+import mozilla.components.support.test.ext.joinBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.shopping.ShoppingState
+
+class ShoppingActionTest {
+
+    @Test
+    fun `WHEN shopping sheet is collapsed THEN state should reflect that`() {
+        val store = AppStore(
+            initialState = AppState(
+                shoppingState = ShoppingState(
+                    shoppingSheetExpanded = true,
+                ),
+            ),
+        )
+
+        store.dispatch(AppAction.ShoppingAction.ShoppingSheetStateUpdated(false)).joinBlocking()
+
+        val expected = ShoppingState(
+            shoppingSheetExpanded = false,
+        )
+
+        assertEquals(expected, store.state.shoppingState)
+    }
+
+    @Test
+    fun `WHEN shopping sheet is expanded THEN state should reflect that`() {
+        val store = AppStore()
+
+        store.dispatch(AppAction.ShoppingAction.ShoppingSheetStateUpdated(true)).joinBlocking()
+
+        val expected = ShoppingState(
+            shoppingSheetExpanded = true,
+        )
+
+        assertEquals(expected, store.state.shoppingState)
+    }
+
+    @Test
+    fun `WHEN product analysed is added THEN state should reflect that`() {
+        val store = AppStore()
+
+        store.dispatch(AppAction.ShoppingAction.AddToProductAnalysed("pdp")).joinBlocking()
+
+        val expected = ShoppingState(
+            productsInAnalysis = setOf("pdp"),
+        )
+
+        assertEquals(expected, store.state.shoppingState)
+    }
+
+    @Test
+    fun `WHEN product analysed is removed THEN state should reflect that`() {
+        val store = AppStore(
+            initialState = AppState(
+                shoppingState = ShoppingState(
+                    productsInAnalysis = setOf("pdp"),
+                ),
+            ),
+        )
+
+        store.dispatch(AppAction.ShoppingAction.RemoveFromProductAnalysed("pdp")).joinBlocking()
+
+        val expected = ShoppingState(
+            productsInAnalysis = emptySet(),
+        )
+
+        assertEquals(expected, store.state.shoppingState)
+    }
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeatureTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeatureTest.kt
@@ -17,8 +17,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.components.AppStore
-import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.appstate.AppAction.ShoppingAction
 import org.mozilla.fenix.components.appstate.AppState
+import org.mozilla.fenix.components.appstate.shopping.ShoppingState
 import org.mozilla.fenix.shopping.fake.FakeShoppingExperienceFeature
 
 class ReviewQualityCheckFeatureTest {
@@ -226,7 +227,7 @@ class ReviewQualityCheckFeatureTest {
     fun `WHEN the shopping sheet is collapsed THEN the callback is called with false`() {
         val appStore = AppStore(
             initialState = AppState(
-                shoppingSheetExpanded = true,
+                shoppingState = ShoppingState(shoppingSheetExpanded = true),
             ),
         )
         var isExpanded: Boolean? = null
@@ -242,7 +243,7 @@ class ReviewQualityCheckFeatureTest {
 
         tested.start()
 
-        appStore.dispatch(AppAction.ShoppingSheetStateUpdated(expanded = false)).joinBlocking()
+        appStore.dispatch(ShoppingAction.ShoppingSheetStateUpdated(expanded = false)).joinBlocking()
 
         assertFalse(isExpanded!!)
     }
@@ -251,7 +252,7 @@ class ReviewQualityCheckFeatureTest {
     fun `WHEN the shopping sheet is expanded THEN the collapsed callback is called with true`() {
         val appStore = AppStore(
             initialState = AppState(
-                shoppingSheetExpanded = false,
+                shoppingState = ShoppingState(shoppingSheetExpanded = false),
             ),
         )
         var isExpanded: Boolean? = null
@@ -267,7 +268,7 @@ class ReviewQualityCheckFeatureTest {
 
         tested.start()
 
-        appStore.dispatch(AppAction.ShoppingSheetStateUpdated(expanded = true)).joinBlocking()
+        appStore.dispatch(ShoppingAction.ShoppingSheetStateUpdated(expanded = true)).joinBlocking()
 
         assertTrue(isExpanded!!)
     }
@@ -276,7 +277,7 @@ class ReviewQualityCheckFeatureTest {
     fun `WHEN the feature is restarted THEN first emission is collected to set the tint`() {
         val appStore = AppStore(
             initialState = AppState(
-                shoppingSheetExpanded = false,
+                shoppingState = ShoppingState(shoppingSheetExpanded = false),
             ),
         )
         var isExpanded: Boolean? = null
@@ -294,7 +295,7 @@ class ReviewQualityCheckFeatureTest {
         tested.stop()
 
         // emulate emission
-        appStore.dispatch(AppAction.ShoppingSheetStateUpdated(expanded = false)).joinBlocking()
+        appStore.dispatch(ShoppingAction.ShoppingSheetStateUpdated(expanded = false)).joinBlocking()
 
         tested.start()
         assertFalse(isExpanded!!)

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckService.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckService.kt
@@ -4,19 +4,20 @@
 
 package org.mozilla.fenix.shopping.fake
 
-import mozilla.components.concept.engine.shopping.ProductAnalysis
+import mozilla.components.browser.engine.gecko.shopping.GeckoProductAnalysis
 import org.mozilla.fenix.shopping.middleware.AnalysisStatusDto
 import org.mozilla.fenix.shopping.middleware.ReviewQualityCheckService
 
 class FakeReviewQualityCheckService(
-    private val productAnalysis: (Int) -> ProductAnalysis? = { null },
+    private val productAnalysis: (Int) -> GeckoProductAnalysis? = { null },
     private val reanalysis: AnalysisStatusDto? = null,
     private val status: AnalysisStatusDto? = null,
+    private val selectedTabUrl: String? = null,
 ) : ReviewQualityCheckService {
 
     private var analysisCount = 0
 
-    override suspend fun fetchProductReview(): ProductAnalysis? {
+    override suspend fun fetchProductReview(): GeckoProductAnalysis? {
         return productAnalysis(analysisCount).also {
             analysisCount++
         }
@@ -25,4 +26,6 @@ class FakeReviewQualityCheckService(
     override suspend fun reanalyzeProduct(): AnalysisStatusDto? = reanalysis
 
     override suspend fun analysisStatus(): AnalysisStatusDto? = status
+
+    override fun selectedTabUrl(): String? = selectedTabUrl
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapperTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapperTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.shopping.middleware
 
 import mozilla.components.browser.engine.gecko.shopping.Highlight
-import mozilla.components.concept.engine.shopping.ProductAnalysis
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mozilla.fenix.shopping.ProductAnalysisTestData
@@ -145,18 +144,6 @@ class ProductAnalysisMapperTest {
                 highlights = null,
             ).toProductReviewState()
         val expected = ReviewQualityCheckState.OptedIn.ProductReviewState.NoAnalysisPresent()
-
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `WHEN ProductAnalysis is not GeckoProductAnalysis THEN it is mapped to Error`() {
-        val randomAnalysis = object : ProductAnalysis {
-            override val productId: String = "id1"
-        }
-
-        val actual = randomAnalysis.toProductReviewState()
-        val expected = ReviewQualityCheckState.OptedIn.ProductReviewState.Error.GenericError
 
         assertEquals(expected, actual)
     }


### PR DESCRIPTION
### What
Restore reanalysis state if the product was in the process of reanalyzing when the sheet was closed, i.e. hold state of `productsAnalysed` for a session (no need for persistence).

### How
– Create `ShoppingState` to be held in `AppState`. Migrate existing shopping related state inside so it's all in one place.
– Create `ShoppingReducer` that actions on `ShoppingAction`s, this is a similar pattern to `BrowserStateReducer`.
– Add tests for the above, note that the tests don't just test the reducer but the logic from action dispatch, again similar to `BrowserAction`s, making refactoring of reducer state easier without updating tests.
– Use `AppStore` in `ReviewQualityCheckNetworkMiddleware` to dispatch `AddToProductAnalysed` when reanalysis has started and `RemoveFromProductAnalysed` once reanalysis is finished.
– On `FetchProductAnalysis` action, `ShoppingState` is used to restore the reanalysis state based on the productAnalysis response when `needsAnalysis` is true, that means that analysis wasn't completed, that starts polling again. Note that polling is stopped when sheet is closed, we merely display the progress that's happening on the backend.
– To use `ProductAnalysis.needsAnalysis`, `ReviewQualityCheckService.fetchProductReview` now returns `GeckoProductAnalysis`, moving the object check and tests from the mapper. Ideally, `ProductAnalysis` should have all the fields, something to update in AC as a future improvement.

### Note
Logs in middleware and `ShoppingStateReducer` are left to make reviews easier, will be removed before landing.

### Preview
https://github.com/mozilla-mobile/firefox-android/assets/38040960/85d6dc25-4d59-487d-a120-665cb6b1a6c7



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1858018