### PR TITLE
Bug 1826318 - Fix verifyCreditCardsAutofillToggleTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
@@ -88,7 +88,7 @@ class CreditCardAutofillTest {
         }
         navigationToolbar {
         }.enterURLAndEnterToBrowser(creditCardFormPage.url) {
-            clickPageObject(itemWithResId("cardNumber"))
+            clickCreditCardNumberTextBox()
             clickPageObject(itemWithResId("$packageName:id/select_credit_card_header"))
             clickPageObject(
                 itemWithResIdContainingText(
@@ -200,7 +200,7 @@ class CreditCardAutofillTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(creditCardFormPage.url) {
-            clickPageObject(itemWithResId("cardNumber"))
+            clickCreditCardNumberTextBox()
             clickPageObject(itemWithResId("$packageName:id/select_credit_card_header"))
         }.clickManageCreditCardsButton {
         }.goBackToBrowser {
@@ -231,7 +231,7 @@ class CreditCardAutofillTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(creditCardFormPage.url) {
-            clickPageObject(itemWithResId("cardNumber"))
+            clickCreditCardNumberTextBox()
             verifySelectCreditCardPromptExists(true)
         }.openThreeDotMenu {
         }.openSettings {
@@ -244,7 +244,7 @@ class CreditCardAutofillTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(creditCardFormPage.url) {
-            clickPageObject(itemWithResId("cardNumber"))
+            clickCreditCardNumberTextBox()
             verifySelectCreditCardPromptExists(false)
         }
     }
@@ -321,7 +321,7 @@ class CreditCardAutofillTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(creditCardFormPage.url) {
-            clickPageObject(itemWithResId("cardNumber"))
+            clickCreditCardNumberTextBox()
             clickPageObject(itemWithResId("$packageName:id/select_credit_card_header"))
             clickPageObject(
                 itemWithResIdContainingText(
@@ -408,7 +408,7 @@ class CreditCardAutofillTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(creditCardFormPage.url) {
-            clickPageObject(itemWithResId("cardNumber"))
+            clickCreditCardNumberTextBox()
             clickPageObject(itemWithResId("$packageName:id/select_credit_card_header"))
             verifyCreditCardSuggestion(
                 MockCreditCard1.MOCK_LAST_CARD_DIGITS,
@@ -498,7 +498,7 @@ class CreditCardAutofillTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(creditCardFormPage.url) {
-            clickPageObject(itemWithResId("cardNumber"))
+            clickCreditCardNumberTextBox()
             clickPageObject(itemWithResId("$packageName:id/select_credit_card_header"))
             clickPageObject(
                 itemWithResIdContainingText(
@@ -549,7 +549,7 @@ class CreditCardAutofillTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(creditCardFormPage.url) {
-            clickPageObject(itemWithResId("cardNumber"))
+            clickCreditCardNumberTextBox()
             clickPageObject(itemWithResId("$packageName:id/select_credit_card_header"))
             clickPageObject(
                 itemWithResIdContainingText(

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -55,6 +55,7 @@ import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
+import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
@@ -427,6 +428,12 @@ class BrowserRobot {
 
     fun changeCreditCardExpiryDate(expiryDate: String) =
         itemWithResId("expiryMonthAndYear").setText(expiryDate)
+
+    fun clickCreditCardNumberTextBox() {
+        mDevice.wait(Until.findObject(By.res("cardNumber")), waitingTime)
+        mDevice.findObject(By.res("cardNumber")).click()
+        mDevice.waitForWindowUpdate(appName, waitingTimeShort)
+    }
 
     fun clickCreditCardFormSubmitButton() =
         itemWithResId("submit").clickAndWaitForNewWindow(waitingTime)


### PR DESCRIPTION
Summary:
Sometimes the click on the credit card number text box wasn't properly performed.
Based on the logs the click was performed but in reality it looked like nothing happened. (even after performing the page refresh from the catch block)

I've created `clickCreditCardNumberTextBox()` in which we'll use BySelectors instead of UISelectors, change that seems to be properly working without using any retry loops. (compared to `clickPageObject`)

Both `verifyCreditCardsAutofillToggleTest` and `verifyEditedCardIsSavedTest` successfully passed 100x on Firebase. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1826318