### PR TITLE
Bug 1807545 - Add new "Open in regular tab" feature.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -94,6 +94,7 @@ class DefaultBrowserToolbarMenuController(
     override fun handleToolbarItemInteraction(item: ToolbarMenu.Item) {
         val sessionUseCases = activity.components.useCases.sessionUseCases
         val customTabUseCases = activity.components.useCases.customTabsUseCases
+        val tabsUseCases = activity.components.useCases.tabsUseCases
         trackToolbarItemInteraction(item)
 
         when (item) {
@@ -252,6 +253,13 @@ class DefaultBrowserToolbarMenuController(
                         item.isChecked,
                         it.id,
                     )
+                }
+            }
+            is ToolbarMenu.Item.OpenInRegularTab -> {
+                currentSession?.let { session ->
+                    getProperUrl(session)?.let { url ->
+                        tabsUseCases.migratePrivateTabUseCase.invoke(session.id, url)
+                    }
                 }
             }
             is ToolbarMenu.Item.AddToTopSites -> {
@@ -443,6 +451,8 @@ class DefaultBrowserToolbarMenuController(
                 } else {
                     Events.browserMenuAction.record(Events.BrowserMenuActionExtra("desktop_view_off"))
                 }
+            is ToolbarMenu.Item.OpenInRegularTab ->
+                Events.browserMenuAction.record(Events.BrowserMenuActionExtra("open_in_regular_tab"))
             is ToolbarMenu.Item.FindInPage ->
                 Events.browserMenuAction.record(Events.BrowserMenuActionExtra("find_in_page"))
             is ToolbarMenu.Item.SaveToCollection ->

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
@@ -12,6 +12,11 @@ interface ToolbarMenu {
     sealed class Item {
         object Settings : Item()
         data class RequestDesktop(val isChecked: Boolean) : Item()
+
+        /**
+         * Opens the current private tabs in a regular tab.
+         */
+        object OpenInRegularTab : Item()
         object FindInPage : Item()
         object Share : Item()
         data class Back(val viewHistory: Boolean) : Item()

--- a/fenix/app/src/main/res/drawable/ic_open_in_regular_tab.xml
+++ b/fenix/app/src/main/res/drawable/ic_open_in_regular_tab.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!--
+
+NOTE: This is a copy of ic_open_in_new.xml with the following changes:
+* All widths and heights on the <vector> element are 24 instead of 18.
+* A containing group with "translate" values so the image is centered vertically
+  and horizontally.
+
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group
+        android:translateX="3"
+        android:translateY="3"
+    >
+        <path
+            android:fillColor="?attr/textPrimary"
+            android:fillType="evenOdd"
+            android:pathData="M9,0a1.005,1.005 0,1 1,0 2.012L4.557,2.012a2.55,2.55 0,0 0,-2.547 2.547v8.883a2.55,2.55 0,0 0,2.547 2.547h8.883a2.55,2.55 0,0 0,2.547 -2.547L15.987,8.97a1.006,1.006 0,1 1,2.011 0v4.472A4.564,4.564 0,0 1,13.441 18L4.558,18A4.564,4.564 0,0 1,0 13.442L0,4.559a4.564,4.564 0,0 1,4.56 -4.56zM17,0a1,1 0,0 1,1 1v4a1,1 0,1 1,-2 0L16,3.414l-5.293,5.293a0.999,0.999 0,1 1,-1.414 -1.414L14.586,2L13,2a1,1 0,1 1,0 -2z" />
+    </group>
+</vector>

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -199,6 +199,8 @@
     <string name="browser_menu_library">Library</string>
     <!-- Browser menu toggle that requests a desktop site -->
     <string name="browser_menu_desktop_site">Desktop site</string>
+    <!-- Browser menu button that reopens a private tab as a regular tab -->
+    <string name="browser_menu_open_in_regular_tab">Open in regular tab</string>
     <!-- Browser menu toggle that adds a shortcut to the site on the device home screen. -->
     <string name="browser_menu_add_to_homescreen">Add to Home screen</string>
     <!-- Browser menu toggle that installs a Progressive Web App shortcut to the site on the device home screen. -->


### PR DESCRIPTION
This feature allows a private tab to be reopened as a regular tab. The feature is only enabled for users with the "Open links in a private tab" option enabled - such users who follow links from external applications will always have these tabs opened as private, so may wish to "opt-out" of individual tabs being private.
Users without this option set will not have private tabs opened by default, so have already opted-in to each private tab - thus, those users are unlikely to benefit from this feature.

The feature is added to the main menu - however, as above, it will only be visible when a private tab is open *and* "Open links in a private tab" is enabled, so will only be seen by a minority of users.

The feature is also enabled only for Nightly while it is polished, but the intention is that it eventually ride to release.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807545