### PR TITLE
Bug 1858439 - Refactor how addons icons are loaded

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -11,7 +11,6 @@ import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import kotlinx.parcelize.Parcelize
-import mozilla.components.concept.engine.webextension.Metadata
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.support.base.log.logger.Logger
 import java.text.ParseException
@@ -41,6 +40,7 @@ val logger = Logger("Addon")
  * @property rating The rating information of this add-on.
  * @property createdAt The date the add-on was created.
  * @property updatedAt The date of the last time the add-on was updated by its developer(s).
+ * @property icon the icon of the this [Addon], available when the icon is loaded.
  * @property installedState Holds the state of the installed web extension for this add-on. Null, if
  * the [Addon] is not installed.
  * @property defaultLocale Indicates which locale will be always available to display translatable fields.
@@ -63,11 +63,20 @@ data class Addon(
     val rating: Rating? = null,
     val createdAt: String = "",
     val updatedAt: String = "",
+    val icon: Bitmap? = null,
     val installedState: InstalledState? = null,
     val defaultLocale: String = DEFAULT_LOCALE,
     val ratingUrl: String = "",
     val detailUrl: String = "",
 ) : Parcelable {
+
+    /**
+     * Returns an icon for this [Addon], either from the [Addon] or [installedState].
+     */
+    fun provideIcon(): Bitmap? {
+        return icon ?: installedState?.icon
+    }
+
     /**
      * Represents an add-on author.
      *
@@ -109,8 +118,7 @@ data class Addon(
      * options page (options_ui in the extension's manifest).
      * @property allowedInPrivateBrowsing true if this addon should be allowed to run in private
      * browsing pages, false otherwise.
-     * @property icon the icon of the installed extension, only used for temporary extensions
-     * as we get the icon from AMO otherwise, see [iconUrl].
+     * @property icon the icon of the installed extension.
      */
     @SuppressLint("ParcelCreator")
     @Parcelize

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonsProvider.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonsProvider.kt
@@ -4,8 +4,6 @@
 
 package mozilla.components.feature.addons
 
-import android.graphics.Bitmap
-
 /**
  * A contract that indicate how an add-on provider must behave.
  */
@@ -27,11 +25,4 @@ interface AddonsProvider {
         readTimeoutInSeconds: Long? = null,
         language: String? = null,
     ): List<Addon>
-
-    /**
-     * Provides the decoded bitmap of an add-on's icon.
-     *
-     * @param addon the add-on for which we want to retrieve its icon as a decoded bitmap
-     */
-    suspend fun getAddonIconBitmap(addon: Addon): Bitmap?
 }

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonDialogFragment.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonDialogFragment.kt
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.addons.ui
+
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.os.Bundle
+import androidx.annotation.ColorRes
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.appcompat.widget.AppCompatImageView
+import mozilla.components.feature.addons.Addon
+import mozilla.components.support.utils.ext.getParcelableCompat
+
+@VisibleForTesting
+internal const val KEY_ICON = "KEY_ICON"
+
+/**
+ * A generic [Addon] dialog which has an [Addon]'s icon.
+ */
+open class AddonDialogFragment : AppCompatDialogFragment() {
+    init {
+        arguments = arguments ?: Bundle()
+    }
+
+    @VisibleForTesting
+    internal val safeArguments get() = requireNotNull(arguments)
+
+    internal fun loadIcon(addon: Addon, iconView: AppCompatImageView) {
+        val icon =
+            safeArguments.getParcelableCompat(KEY_ICON, Bitmap::class.java)
+        if (icon != null) {
+            iconView.setImageDrawable(BitmapDrawable(iconView.resources, addon.icon))
+        } else {
+            safeArguments.putParcelable(KEY_ICON, addon.provideIcon())
+            iconView.setIcon(addon)
+        }
+    }
+
+    /**
+     * Styling for the addon installation dialog.
+     */
+    data class PromptsStyling(
+        val gravity: Int,
+        val shouldWidthMatchParent: Boolean = false,
+        @ColorRes
+        val confirmButtonBackgroundColor: Int? = null,
+        @ColorRes
+        val confirmButtonTextColor: Int? = null,
+        val confirmButtonRadius: Float? = null,
+    )
+}

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/Extensions.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/Extensions.kt
@@ -5,13 +5,17 @@
 package mozilla.components.feature.addons.ui
 
 import android.content.Context
+import android.graphics.drawable.BitmapDrawable
+import android.widget.ImageView
 import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
 import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.feature.addons.update.AddonUpdater.Status.Error
 import mozilla.components.feature.addons.update.AddonUpdater.Status.NoUpdateAvailable
 import mozilla.components.feature.addons.update.AddonUpdater.Status.SuccessfullyUpdated
+import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.ui.widgets.withCenterAlignedButtons
 import java.text.DateFormat
 import java.text.NumberFormat
@@ -109,4 +113,31 @@ private fun AddonUpdater.UpdateAttempt.getDialogMessage(context: Context): Strin
     val lastAttemptLabel = context.getString(R.string.mozac_feature_addons_updater_dialog_last_attempt)
     val statusLabel = context.getString(R.string.mozac_feature_addons_updater_dialog_status)
     return "$lastAttemptLabel $dateString \n $statusLabel $statusString ".trimMargin()
+}
+
+/**
+ * Set icon to this [ImageView] with from the provided [Addon]'s icon.
+ */
+fun ImageView.setIcon(addon: Addon) {
+    val icon = addon.provideIcon()
+    if (icon != null) {
+        setImageDrawable(BitmapDrawable(resources, icon))
+    } else {
+        setDefaultAddonIcon()
+    }
+}
+
+/**
+ * Set the default addon's icon to this [ImageView].
+ */
+fun ImageView.setDefaultAddonIcon() {
+    val safeContext = context ?: return
+    val att = safeContext.theme.resolveAttribute(android.R.attr.textColorPrimary)
+    setColorFilter(ContextCompat.getColor(safeContext, att))
+    setImageDrawable(
+        ContextCompat.getDrawable(
+            safeContext,
+            mozilla.components.ui.icons.R.drawable.mozac_ic_extension_24,
+        ),
+    )
 }

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/PermissionsDialogFragment.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/PermissionsDialogFragment.kt
@@ -19,9 +19,7 @@ import android.view.Window
 import android.widget.Button
 import android.widget.LinearLayout.LayoutParams
 import android.widget.TextView
-import androidx.annotation.ColorRes
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.core.content.ContextCompat
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
@@ -40,7 +38,7 @@ private const val DEFAULT_VALUE = Int.MAX_VALUE
 /**
  * A dialog that shows a set of permission required by an [Addon].
  */
-class PermissionsDialogFragment : AppCompatDialogFragment() {
+class PermissionsDialogFragment : AddonDialogFragment() {
 
     /**
      * A lambda called when the allow button is clicked.
@@ -51,8 +49,6 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
      * A lambda called when the deny button is clicked.
      */
     var onNegativeButtonClicked: (() -> Unit)? = null
-
-    private val safeArguments get() = requireNotNull(arguments)
 
     internal val addon get() = requireNotNull(safeArguments.getParcelableCompat(KEY_ADDON, Addon::class.java))
 
@@ -144,6 +140,8 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
             null,
             false,
         )
+
+        loadIcon(addon = addon, iconView = rootView.findViewById(R.id.icon))
 
         rootView.findViewById<TextView>(R.id.title).text = requireContext().getString(
             if (forOptionalPermissions) {
@@ -263,11 +261,11 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
                 promptsStyling?.shouldWidthMatchParent?.apply {
                     putBoolean(KEY_DIALOG_WIDTH_MATCH_PARENT, this)
                 }
-                promptsStyling?.positiveButtonBackgroundColor?.apply {
+                promptsStyling?.confirmButtonBackgroundColor?.apply {
                     putInt(KEY_POSITIVE_BUTTON_BACKGROUND_COLOR, this)
                 }
 
-                promptsStyling?.positiveButtonTextColor?.apply {
+                promptsStyling?.confirmButtonTextColor?.apply {
                     putInt(KEY_POSITIVE_BUTTON_TEXT_COLOR, this)
                 }
             }
@@ -277,17 +275,4 @@ class PermissionsDialogFragment : AppCompatDialogFragment() {
             return fragment
         }
     }
-
-    /**
-     * Styling for the permissions dialog.
-     */
-    data class PromptsStyling(
-        val gravity: Int,
-        val shouldWidthMatchParent: Boolean = false,
-        @ColorRes
-        val positiveButtonBackgroundColor: Int? = null,
-        @ColorRes
-        val positiveButtonTextColor: Int? = null,
-        val positiveButtonRadius: Float? = null,
-    )
 }

--- a/android-components/components/feature/addons/src/main/res/layout/mozac_feature_addons_fragment_dialog_addon_permissions.xml
+++ b/android-components/components/feature/addons/src/main/res/layout/mozac_feature_addons_fragment_dialog_addon_permissions.xml
@@ -19,7 +19,6 @@
         android:layout_marginTop="16dp"
         android:importantForAccessibility="no"
         android:scaleType="center"
-        app:tint="?android:attr/textColorPrimary"
         app:srcCompat="@drawable/mozac_ic_extension_24" />
 
     <TextView

--- a/android-components/components/feature/addons/src/test/java/AddonTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonTest.kt
@@ -13,6 +13,8 @@ import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -470,5 +472,28 @@ class AddonTest {
 
         assertFalse(addon.isDisabledAsIncompatible())
         assertTrue(blockListedAddon.isDisabledAsIncompatible())
+    }
+
+    @Test
+    fun `provideIcon - should provide the icon from either addon or installedState`() {
+        val addonWithoutIcon = Addon(id = "id")
+
+        assertNull(addonWithoutIcon.icon)
+        assertNull(addonWithoutIcon.installedState?.icon)
+        assertNull(addonWithoutIcon.provideIcon())
+
+        val addonWithIcon = addonWithoutIcon.copy(icon = mock())
+
+        assertNotNull(addonWithIcon.icon)
+        assertNull(addonWithIcon.installedState?.icon)
+        assertNotNull(addonWithIcon.provideIcon())
+
+        val addonWithInstalledStateIcon = addonWithoutIcon.copy(
+            installedState = Addon.InstalledState("id", "1.0", "", icon = mock()),
+        )
+
+        assertNull(addonWithInstalledStateIcon.icon)
+        assertNotNull(addonWithInstalledStateIcon.installedState?.icon)
+        assertNotNull(addonWithInstalledStateIcon.provideIcon())
     }
 }

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AMOAddonsProviderTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AMOAddonsProviderTest.kt
@@ -26,6 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import java.io.File
 import java.io.IOException
@@ -237,7 +238,8 @@ class AMOAddonsProviderTest {
         whenever(provider.getCacheLastUpdated(testContext, null, useFallbackFile = false)).thenReturn(Date().time)
         whenever(provider.cacheExpired(testContext, null, useFallbackFile = false)).thenReturn(false)
         whenever(provider.readFromDiskCache(null, useFallbackFile = false)).thenReturn(cachedAddons)
-        assertSame(cachedAddons, provider.getFeaturedAddons(allowCache = true))
+        whenever(provider.readFromDiskCache(null, useFallbackFile = false)).thenReturn(cachedAddons)
+        assertEquals(cachedAddons, provider.getFeaturedAddons(allowCache = true))
     }
 
     @Test
@@ -359,7 +361,7 @@ class AMOAddonsProviderTest {
     }
 
     @Test
-    fun `getAddonIconBitmap - with a successful status will return a bitmap`() = runTest {
+    fun `loadIconAsync - with a successful status will return a bitmap`() = runTest {
         val mockedClient = mock<Client>()
         val mockedResponse = mock<Response>()
         val stream: InputStream = javaClass.getResourceAsStream("/png/mozac.png")!!.buffered()
@@ -370,33 +372,33 @@ class AMOAddonsProviderTest {
         whenever(mockedClient.fetch(any())).thenReturn(mockedResponse)
 
         val provider = AMOAddonsProvider(testContext, client = mockedClient)
-        val addon = Addon(
-            id = "id",
-            downloadUrl = "https://example.com",
-            version = "version",
-            iconUrl = "https://example.com/image.png",
-            createdAt = "0",
-            updatedAt = "0",
-        )
 
-        val bitmap = provider.getAddonIconBitmap(addon)
+        val bitmap = provider.loadIconAsync("id", "https://example.com/image.png").await()
         assertTrue(bitmap is Bitmap)
     }
 
     @Test
-    fun `getAddonIconBitmap - with an unsuccessful status will return null`() = runTest {
+    fun `loadIconAsync - will return bitmap from the cache when available`() = runTest {
+        val mockedClient = mock<Client>()
+        val expectedIcon = mock<Bitmap>()
+
+        val provider = AMOAddonsProvider(testContext, client = mockedClient)
+
+        provider.iconsCache["id"] = expectedIcon
+
+        val bitmap = provider.loadIconAsync("id", "https://example.com/image.png").await()
+
+        verify(mockedClient, times(0)).fetch(any())
+        assertEquals(expectedIcon, bitmap)
+        assertTrue(bitmap is Bitmap)
+    }
+
+    @Test
+    fun `loadIconAsync - with an unsuccessful status will return null`() = runTest {
         val mockedClient = prepareClient(status = 500)
         val provider = AMOAddonsProvider(testContext, client = mockedClient)
-        val addon = Addon(
-            id = "id",
-            downloadUrl = "https://example.com",
-            version = "version",
-            iconUrl = "https://example.com/image.png",
-            createdAt = "0",
-            updatedAt = "0",
-        )
 
-        val bitmap = provider.getAddonIconBitmap(addon)
+        val bitmap = provider.loadIconAsync("id", "https://example.com/image.png").await()
         assertNull(bitmap)
     }
 

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonDialogFragmentTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonDialogFragmentTest.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.addons.mozilla.components.feature.addons.ui
+
+import android.graphics.Bitmap
+import androidx.appcompat.widget.AppCompatImageView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.ui.AddonDialogFragment
+import mozilla.components.feature.addons.ui.KEY_ICON
+import mozilla.components.feature.addons.ui.setIcon
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.whenever
+import mozilla.components.support.utils.ext.getParcelableCompat
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class AddonDialogFragmentTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val scope = coroutinesTestRule.scope
+
+    @Test
+    fun `loadIcon the add-on icon successfully`() {
+        val addon = mock<Addon>()
+        val bitmap = mock<Bitmap>()
+        val iconView = mock<AppCompatImageView>()
+        val fragment = createAddonDialogFragment()
+
+        fragment.safeArguments.putParcelable(KEY_ICON, bitmap)
+
+        fragment.loadIcon(addon, iconView)
+
+        verify(iconView).setImageDrawable(Mockito.any())
+    }
+
+    @Test
+    fun `loadIcon the add-on icon with a null result`() {
+        val addon = mock<Addon>()
+        val bitmap = mock<Bitmap>()
+        val iconView = mock<AppCompatImageView>()
+        val fragment = createAddonDialogFragment()
+
+        whenever(addon.provideIcon()).thenReturn(bitmap)
+
+        assertNull(fragment.arguments?.getParcelableCompat(KEY_ICON, Bitmap::class.java))
+
+        fragment.loadIcon(addon, iconView)
+
+        assertNotNull(fragment.arguments?.getParcelableCompat(KEY_ICON, Bitmap::class.java))
+        verify(iconView).setIcon(addon)
+    }
+
+    private fun createAddonDialogFragment(): AddonDialogFragment {
+        val dialog = AddonDialogFragment()
+        return spy(dialog).apply {
+            doNothing().`when`(this).dismiss()
+        }
+    }
+}

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/ExtensionsTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/ExtensionsTest.kt
@@ -4,6 +4,8 @@
 
 package mozilla.components.feature.addons.ui
 
+import android.graphics.Bitmap
+import android.widget.ImageView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
@@ -12,11 +14,15 @@ import mozilla.components.feature.addons.update.AddonUpdater.Status.Error
 import mozilla.components.feature.addons.update.AddonUpdater.Status.NoUpdateAvailable
 import mozilla.components.feature.addons.update.AddonUpdater.Status.NotInstalled
 import mozilla.components.feature.addons.update.AddonUpdater.Status.SuccessfullyUpdated
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.any
+import org.mockito.Mockito.verify
 import java.util.Calendar.MILLISECOND
 import java.util.Date
 import java.util.GregorianCalendar
@@ -140,5 +146,17 @@ class ExtensionsTest {
 
         request = request.copy(status = NotInstalled)
         assertEquals("", request.status.toLocalizedString(testContext))
+    }
+
+    @Test
+    fun setIcon() {
+        val iconView = mock<ImageView>()
+        val icon = mock<Bitmap>()
+        val addon = mock<Addon>()
+        whenever(addon.provideIcon()).thenReturn(icon)
+
+        iconView.setIcon(addon)
+
+        verify(iconView).setImageDrawable(any())
     }
 }

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/PermissionsDialogFragmentTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/PermissionsDialogFragmentTest.kt
@@ -13,7 +13,7 @@ import androidx.fragment.app.FragmentTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.R
-import mozilla.components.feature.addons.ui.PermissionsDialogFragment.PromptsStyling
+import mozilla.components.feature.addons.ui.AddonDialogFragment.PromptsStyling
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
@@ -71,7 +71,6 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
 
         findPreviousInstallationDialogFragment()?.let { dialog ->
             dialog.onConfirmButtonClicked = onConfirmInstallationButtonClicked
-            dialog.addonsProvider = requireContext().components.addonsProvider
         }
     }
 
@@ -81,7 +80,6 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
         scope.launch {
             try {
                 val context = requireContext()
-                val addonsProvider = context.components.addonsProvider
                 val addons = context.components.addonManager.getAddons()
 
                 val style = AddonsManagerAdapter.Style(
@@ -92,7 +90,6 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
                 scope.launch(Dispatchers.Main) {
                     if (adapter == null) {
                         adapter = AddonsManagerAdapter(
-                            addonsProvider = addonsProvider,
                             addonsManagerDelegate = this@AddonsFragment,
                             addons = addons,
                             style = style,
@@ -174,10 +171,8 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
         if (isInstallationInProgress) {
             return
         }
-        val addonsProvider = requireContext().components.addonsProvider
         val dialog = AddonInstallationDialogFragment.newInstance(
             addon = addon,
-            addonsProvider = addonsProvider,
             onConfirmButtonClicked = onConfirmInstallationButtonClicked,
         )
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -103,7 +103,6 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
                     runIfFragmentIsAttached {
                         if (!shouldRefresh) {
                             adapter = AddonsManagerAdapter(
-                                addonsProvider = requireContext().components.addonsProvider,
                                 addonsManagerDelegate = managementView,
                                 addons = addons,
                                 style = createAddonStyle(requireContext()),

--- a/fenix/app/src/test/java/org/mozilla/fenix/extension/WebExtensionPromptFeatureTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/extension/WebExtensionPromptFeatureTest.kt
@@ -16,7 +16,6 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.webextension.WebExtensionInstallException
 import mozilla.components.feature.addons.Addon
 import mozilla.components.support.ktx.android.content.appVersionName
-import mozilla.components.support.test.any
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
@@ -44,6 +43,7 @@ class WebExtensionPromptFeatureTest {
                 store = store,
                 context = testContext,
                 fragmentManager = mockk(relaxed = true),
+                addonManager = mockk(relaxed = true),
             ),
         )
     }
@@ -220,10 +220,10 @@ class WebExtensionPromptFeatureTest {
     }
 
     @Test
-    fun `WHEN PermissionsOptional is dispatched THEN handleOptionalPermissionsRequest is called`() {
+    fun `WHEN AfterInstallation is dispatched THEN handleAfterInstallationRequest is called`() {
         webExtensionPromptFeature.start()
 
-        every { webExtensionPromptFeature.handleOptionalPermissionsRequest(any(), any()) } just runs
+        every { webExtensionPromptFeature.handleAfterInstallationRequest(any()) } returns mockk()
 
         store.dispatch(
             UpdatePromptRequestWebExtensionAction(
@@ -234,6 +234,16 @@ class WebExtensionPromptFeatureTest {
                 ),
             ),
         ).joinBlocking()
+
+        verify { webExtensionPromptFeature.handleAfterInstallationRequest(any()) }
+    }
+
+    @Test
+    fun `GIVEN Optional Permissions WHEN handleAfterInstallationRequest is called THEN handleOptionalPermissionsRequest is called`() {
+        webExtensionPromptFeature.start()
+        val request = mockk<WebExtensionPromptRequest.AfterInstallation.Permissions.Optional>(relaxed = true)
+
+        webExtensionPromptFeature.handleAfterInstallationRequest(request)
 
         verify { webExtensionPromptFeature.handleOptionalPermissionsRequest(any(), any()) }
     }


### PR DESCRIPTION


https://github.com/mozilla-mobile/firefox-android/assets/773158/080e4642-61de-4410-a6bd-2d3a063b4773

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.
























### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1858439