### PR TITLE
Bug 1858771 - New Help button telemetry in home menu

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -9211,6 +9211,22 @@ android_autofill:
     expires: never
 
 home_menu:
+  help_tapped:
+    type: event
+    description: The user clicked the help button in home menu.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1858771
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/4066
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - Settings
+        - MainMenu
   settings_item_clicked:
     type: event
     description: The user clicked the settings option in home menu.

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
@@ -154,6 +154,7 @@ class HomeMenuView(
                 )
             }
             HomeMenu.Item.Help -> {
+                HomeMenuMetrics.helpTapped.record(NoExtras())
                 homeActivity.openToBrowserAndLoad(
                     searchTermOrURL = SupportUtils.getSumoURLForTopic(
                         context = context,

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/HomeMenuViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/HomeMenuViewTest.kt
@@ -180,8 +180,12 @@ class HomeMenuViewTest {
     }
 
     @Test
-    fun `WHEN Help menu item is tapped THEN open the browser to the SUMO help page`() {
+    fun `WHEN Help menu item is tapped THEN open the browser to the SUMO help page  and record metrics`() {
+        assertNull(HomeMenuMetrics.helpTapped.testGetValue())
+
         homeMenuView.onItemTapped(HomeMenu.Item.Help)
+
+        assertNotNull(HomeMenuMetrics.helpTapped.testGetValue())
 
         verify {
             homeActivity.openToBrowserAndLoad(


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1858771