### PR TITLE
Bug 1859318 - Text selection TestRail matching

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TextSelectionTest.kt
@@ -53,9 +53,10 @@ class TextSelectionTest {
         mockWebServer.shutdown()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326832
     @SmokeTest
     @Test
-    fun selectAllAndCopyTextTest() {
+    fun verifySelectAllTextOptionTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -77,9 +78,9 @@ class TextSelectionTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326828
     @Test
-    fun copyTextTest() {
+    fun verifyCopyTextOptionTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -98,9 +99,9 @@ class TextSelectionTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326829
     @Test
-    fun shareSelectedTextTest() {
+    fun verifyShareSelectedTextOptionTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -111,9 +112,9 @@ class TextSelectionTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326830
     @Test
-    fun selectAndSearchTextTest() {
+    fun verifySearchTextOptionTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -126,9 +127,10 @@ class TextSelectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326831
     @SmokeTest
     @Test
-    fun privateSelectAndSearchTextTest() {
+    fun verifyPrivateSearchTextTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         homeScreen {
@@ -144,9 +146,9 @@ class TextSelectionTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326834
     @Test
-    fun selectAllAndCopyPDFTextTest() {
+    fun verifySelectAllPDFTextOptionTest() {
         val genericURL =
             TestAssetHelper.getGenericAsset(mockWebServer, 3)
 
@@ -168,9 +170,10 @@ class TextSelectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/243839
     @SmokeTest
     @Test
-    fun copyPDFTextTest() {
+    fun verifyCopyPDFTextOptionTest() {
         val genericURL =
             TestAssetHelper.getGenericAsset(mockWebServer, 3)
 
@@ -191,9 +194,9 @@ class TextSelectionTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326835
     @Test
-    fun shareSelectedPDFTextTest() {
+    fun verifyShareSelectedPDFTextOptionTest() {
         val genericURL =
             TestAssetHelper.getGenericAsset(mockWebServer, 3)
 
@@ -206,9 +209,10 @@ class TextSelectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326836
     @SmokeTest
     @Test
-    fun selectAndSearchPDFTextTest() {
+    fun verifySearchPDFTextOptionTest() {
         val genericURL =
             TestAssetHelper.getGenericAsset(mockWebServer, 3)
 
@@ -222,9 +226,9 @@ class TextSelectionTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326837
     @Test
-    fun privateSelectAndSearchPDFTextTest() {
+    fun verifyPrivateSearchPDFTextOptionTest() {
         val genericURL =
             TestAssetHelper.getGenericAsset(mockWebServer, 3)
 
@@ -241,6 +245,7 @@ class TextSelectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326813
     @Test
     fun verifyUrlBarTextSelectionOptionsTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -253,8 +258,9 @@ class TextSelectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326814
     @Test
-    fun copyUrlBarTextTest() {
+    fun verifyCopyUrlBarTextSelectionOptionTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -270,8 +276,9 @@ class TextSelectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2326815
     @Test
-    fun cutUrlBarTextTest() {
+    fun verifyCutUrlBarTextSelectionOptionTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -286,8 +293,10 @@ class TextSelectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/243845
+    @SmokeTest
     @Test
-    fun shareUrlBarTextTest() {
+    fun verifyShareUrlBarTextSelectionOptionTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -301,6 +310,7 @@ class TextSelectionTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/414316
     @Test
     fun urlBarQuickActionsTest() {
         val firstWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 1)


### PR DESCRIPTION
These changes are part of our data alignment between testRail and our automated UI tests.

For more information please see this [document](https://docs.google.com/document/d/17zd189M_uzClDtmxZIOuANeEuvkscDXj2TJe3as_8uk/edit?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1859318