### PR TITLE
Bug 1859408 - Instrument the awesomebar to report visible suggestions.

### DIFF
--- a/android-components/components/compose/awesomebar/build.gradle
+++ b/android-components/components/compose/awesomebar/build.gradle
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-parcelize'
 
 android {
     defaultConfig {

--- a/android-components/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
+++ b/android-components/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/AwesomeBar.kt
@@ -28,6 +28,7 @@ import mozilla.components.concept.base.profiler.Profiler
  * @param orientation Whether the AwesomeBar is oriented to the top or the bottom of the screen.
  * @param onSuggestionClicked Gets invoked whenever the user clicks on a suggestion in the AwesomeBar.
  * @param onAutoComplete Gets invoked when the user clicks on the "autocomplete" icon of a suggestion.
+ * @param onVisibilityStateUpdated Gets invoked when the list of currently displayed suggestions changes.
  * @param onScroll Gets invoked at the beginning of the user performing a scroll gesture.
  */
 @Composable
@@ -38,6 +39,7 @@ fun AwesomeBar(
     orientation: AwesomeBarOrientation = AwesomeBarOrientation.TOP,
     onSuggestionClicked: (AwesomeBar.Suggestion) -> Unit,
     onAutoComplete: (AwesomeBar.Suggestion) -> Unit,
+    onVisibilityStateUpdated: (AwesomeBar.VisibilityState) -> Unit = {},
     onScroll: () -> Unit = {},
     profiler: Profiler? = null,
 ) {
@@ -59,6 +61,7 @@ fun AwesomeBar(
         orientation = orientation,
         onSuggestionClicked = { _, suggestion -> onSuggestionClicked(suggestion) },
         onAutoComplete = { _, suggestion -> onAutoComplete(suggestion) },
+        onVisibilityStateUpdated = onVisibilityStateUpdated,
         onScroll = onScroll,
         profiler = profiler,
     )
@@ -73,6 +76,7 @@ fun AwesomeBar(
  * @param orientation Whether the AwesomeBar is oriented to the top or the bottom of the screen.
  * @param onSuggestionClicked Gets invoked whenever the user clicks on a suggestion in the AwesomeBar.
  * @param onAutoComplete Gets invoked when the user clicks on the "autocomplete" icon of a suggestion.
+ * @param onVisibilityStateUpdated Gets invoked when the list of currently displayed suggestions changes.
  * @param onScroll Gets invoked at the beginning of the user performing a scroll gesture.
  */
 @Composable
@@ -83,6 +87,7 @@ fun AwesomeBar(
     orientation: AwesomeBarOrientation = AwesomeBarOrientation.TOP,
     onSuggestionClicked: (AwesomeBar.SuggestionProviderGroup, AwesomeBar.Suggestion) -> Unit,
     onAutoComplete: (AwesomeBar.SuggestionProviderGroup, AwesomeBar.Suggestion) -> Unit,
+    onVisibilityStateUpdated: (AwesomeBar.VisibilityState) -> Unit = {},
     onScroll: () -> Unit = {},
     profiler: Profiler? = null,
 ) {
@@ -109,6 +114,7 @@ fun AwesomeBar(
             orientation,
             onSuggestionClicked,
             onAutoComplete,
+            onVisibilityStateUpdated,
             onScroll,
         )
     }

--- a/android-components/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestions.kt
+++ b/android-components/components/compose/awesomebar/src/main/java/mozilla/components/compose/browser/awesomebar/internal/Suggestions.kt
@@ -4,15 +4,23 @@
 
 package mozilla.components.compose.browser.awesomebar.internal
 
+import android.os.Parcelable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.parcelize.Parcelize
 import mozilla.components.compose.browser.awesomebar.AwesomeBarColors
 import mozilla.components.compose.browser.awesomebar.AwesomeBarOrientation
 import mozilla.components.concept.awesomebar.AwesomeBar
@@ -25,6 +33,7 @@ internal fun Suggestions(
     orientation: AwesomeBarOrientation,
     onSuggestionClicked: (AwesomeBar.SuggestionProviderGroup, AwesomeBar.Suggestion) -> Unit,
     onAutoComplete: (AwesomeBar.SuggestionProviderGroup, AwesomeBar.Suggestion) -> Unit,
+    onVisibilityStateUpdated: (AwesomeBar.VisibilityState) -> Unit,
     onScroll: () -> Unit,
 ) {
     val state = rememberLazyListState()
@@ -38,14 +47,14 @@ internal fun Suggestions(
         suggestions.forEach { (group, suggestions) ->
             val title = group.title
             if (suggestions.isNotEmpty() && !title.isNullOrEmpty()) {
-                item(group.id) {
+                item(ItemKey.SuggestionGroup(group.id)) {
                     SuggestionGroup(title, colors)
                 }
             }
 
             items(
                 items = suggestions.take(group.limit),
-                key = { suggestion -> "${group.id}:${suggestion.provider.id}:${suggestion.id}" },
+                key = { suggestion -> ItemKey.Suggestion(group.id, suggestion.provider.id, suggestion.id) },
             ) { suggestion ->
                 Suggestion(
                     suggestion,
@@ -56,6 +65,24 @@ internal fun Suggestions(
                 )
             }
         }
+    }
+
+    val currentSuggestions by rememberUpdatedState(suggestions)
+    val currentOnVisibilityStateUpdated by rememberUpdatedState(onVisibilityStateUpdated)
+
+    LaunchedEffect(Unit) {
+        // This effect is launched on the initial composition, and cancelled when `Suggestions` leaves the Composition.
+        // The flow below emits new values when either the latest list of suggestions changes, or the visibility or
+        // position of any suggestion in that list changes.
+        snapshotFlow { currentSuggestions }
+            .combine(snapshotFlow { state.layoutInfo.visibleItemsInfo }) { suggestions, visibleItemsInfo ->
+                VisibleItems(
+                    suggestions = suggestions,
+                    visibleItemKeys = visibleItemsInfo.map { it.key as ItemKey },
+                )
+            }
+            .distinctUntilChangedBy { it.visibleItemKeys }
+            .collect { currentOnVisibilityStateUpdated(it.toVisibilityState()) }
     }
 }
 
@@ -90,4 +117,53 @@ private class ScrollHandlerImpl(
             onScroll()
         }
     }
+}
+
+/**
+ * A stable, unique key for an item in the [Suggestions] list.
+ */
+internal sealed interface ItemKey {
+    @Parcelize
+    data class SuggestionGroup(val id: String) : ItemKey, Parcelable
+
+    @Parcelize
+    data class Suggestion(
+        val groupId: String,
+        val providerId: String,
+        val suggestionId: String,
+    ) : ItemKey, Parcelable
+}
+
+/**
+ * A snapshot of all the fetched suggestions to show in the [Suggestions] list, and the keys of the visible items
+ * in that list, ordered top to bottom. The intersection of the two is the current [AwesomeBar.VisibilityState].
+ */
+internal data class VisibleItems(
+    val suggestions: Map<AwesomeBar.SuggestionProviderGroup, List<AwesomeBar.Suggestion>>,
+    val visibleItemKeys: List<ItemKey>,
+) {
+    fun toVisibilityState(): AwesomeBar.VisibilityState =
+        if (visibleItemKeys.isEmpty()) {
+            AwesomeBar.VisibilityState()
+        } else {
+            AwesomeBar.VisibilityState(
+                // `suggestions` is insertion-ordered, and `toMap()` preserves that order, so the groups in
+                // `visibleProviderGroups` are in the same order as they're shown in the awesomebar.
+                visibleProviderGroups = suggestions.mapNotNull { (group, suggestions) ->
+                    val visibleSuggestions = suggestions.filter { suggestion ->
+                        val suggestionItemKey = ItemKey.Suggestion(
+                            groupId = group.id,
+                            providerId = suggestion.provider.id,
+                            suggestionId = suggestion.id,
+                        )
+                        visibleItemKeys.contains(suggestionItemKey)
+                    }
+                    if (visibleSuggestions.isNotEmpty()) {
+                        group to visibleSuggestions
+                    } else {
+                        null
+                    }
+                }.toMap(),
+            )
+        }
 }

--- a/android-components/components/compose/awesomebar/src/test/java/mozilla/components/compose/browser/awesomebar/internal/SuggestionsTest.kt
+++ b/android-components/components/compose/awesomebar/src/test/java/mozilla/components/compose/browser/awesomebar/internal/SuggestionsTest.kt
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.compose.browser.awesomebar.internal
+
+import mozilla.components.concept.awesomebar.AwesomeBar.Suggestion
+import mozilla.components.concept.awesomebar.AwesomeBar.SuggestionProvider
+import mozilla.components.concept.awesomebar.AwesomeBar.SuggestionProviderGroup
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SuggestionsTest {
+    @Test
+    fun `GIVEN 1 suggestion in 1 group WHEN neither are visible THEN return an empty visibility state`() {
+        val provider: SuggestionProvider = mock()
+
+        val visibleItems = VisibleItems(
+            suggestions = mapOf(SuggestionProviderGroup(listOf(provider)) to listOf(Suggestion(provider))),
+            visibleItemKeys = emptyList(),
+        )
+
+        val visibilityState = visibleItems.toVisibilityState()
+        assertTrue(visibilityState.visibleProviderGroups.isEmpty())
+    }
+
+    @Test
+    fun `GIVEN 1 suggestion in 1 group WHEN both are visible THEN return a visibility state containing the suggestion`() {
+        val provider: SuggestionProvider = mock()
+        whenever(provider.id).thenReturn("provider")
+        val providerGroup = SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(Suggestion(provider))
+
+        val visibleItems = VisibleItems(
+            suggestions = mapOf(providerGroup to providerGroupSuggestions),
+            visibleItemKeys = listOf(
+                ItemKey.SuggestionGroup(providerGroup.id),
+                ItemKey.Suggestion(providerGroup.id, provider.id, providerGroupSuggestions[0].id),
+            ),
+        )
+
+        val visibilityState = visibleItems.toVisibilityState()
+        assertEquals(
+            visibilityState.visibleProviderGroups,
+            mapOf(
+                providerGroup to providerGroupSuggestions,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN 1 suggestion in 1 group WHEN only the suggestion is visible THEN return a visibility state containing the suggestion`() {
+        val provider: SuggestionProvider = mock()
+        whenever(provider.id).thenReturn("provider")
+        val providerGroup = SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(Suggestion(provider))
+
+        val visibleItems = VisibleItems(
+            suggestions = mapOf(providerGroup to providerGroupSuggestions),
+            visibleItemKeys = listOf(
+                ItemKey.Suggestion(providerGroup.id, provider.id, providerGroupSuggestions[0].id),
+            ),
+        )
+
+        val visibilityState = visibleItems.toVisibilityState()
+        assertEquals(
+            visibilityState.visibleProviderGroups,
+            mapOf(
+                providerGroup to providerGroupSuggestions,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN 2 suggestions in 1 group WHEN all are visible THEN return a visibility state containing the suggestions`() {
+        val provider: SuggestionProvider = mock()
+        whenever(provider.id).thenReturn("provider")
+        val providerGroup = SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(Suggestion(provider), Suggestion(provider))
+
+        val visibleItems = VisibleItems(
+            suggestions = mapOf(providerGroup to providerGroupSuggestions),
+            visibleItemKeys = listOf(
+                ItemKey.SuggestionGroup(providerGroup.id),
+                ItemKey.Suggestion(providerGroup.id, provider.id, providerGroupSuggestions[0].id),
+                ItemKey.Suggestion(providerGroup.id, provider.id, providerGroupSuggestions[1].id),
+            ),
+        )
+
+        val visibilityState = visibleItems.toVisibilityState()
+        assertEquals(
+            visibilityState.visibleProviderGroups,
+            mapOf(
+                providerGroup to providerGroupSuggestions,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN 2 suggestions in 2 groups WHEN 1 suggestion is visible in 1 group THEN return a visibility state containing the suggestion`() {
+        val firstProvider: SuggestionProvider = mock()
+        whenever(firstProvider.id).thenReturn("firstProvider")
+        val secondProvider: SuggestionProvider = mock()
+        whenever(secondProvider.id).thenReturn("secondProvider")
+        val thirdProvider: SuggestionProvider = mock()
+        whenever(thirdProvider.id).thenReturn("thirdProvider")
+        val firstProviderGroup = SuggestionProviderGroup(listOf(firstProvider, secondProvider))
+        val firstProviderGroupSuggestions = listOf(Suggestion(firstProvider), Suggestion(secondProvider))
+        val secondProviderGroup = SuggestionProviderGroup(listOf(secondProvider, thirdProvider))
+        val secondProviderGroupSuggestions = listOf(Suggestion(secondProvider), Suggestion(thirdProvider))
+
+        val visibleItems = VisibleItems(
+            suggestions = mapOf(
+                firstProviderGroup to firstProviderGroupSuggestions,
+                secondProviderGroup to secondProviderGroupSuggestions,
+            ),
+            visibleItemKeys = listOf(
+                ItemKey.SuggestionGroup(firstProviderGroup.id),
+                ItemKey.Suggestion(firstProviderGroup.id, secondProvider.id, firstProviderGroupSuggestions[1].id),
+            ),
+        )
+
+        val visibilityState = visibleItems.toVisibilityState()
+        assertEquals(
+            visibilityState.visibleProviderGroups,
+            mapOf(
+                firstProviderGroup to listOf(firstProviderGroupSuggestions[1]),
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN 2 suggestions in 2 groups WHEN 1 suggestion is visible in each group THEN return a visibility state containing the suggestions`() {
+        val firstProvider: SuggestionProvider = mock()
+        whenever(firstProvider.id).thenReturn("firstProvider")
+
+        val secondProvider: SuggestionProvider = mock()
+        whenever(secondProvider.id).thenReturn("secondProvider")
+
+        val thirdProvider: SuggestionProvider = mock()
+        whenever(thirdProvider.id).thenReturn("thirdProvider")
+
+        val firstProviderGroup = SuggestionProviderGroup(listOf(firstProvider, secondProvider))
+        val firstProviderGroupSuggestions = listOf(Suggestion(firstProvider), Suggestion(secondProvider))
+
+        val secondProviderGroup = SuggestionProviderGroup(listOf(secondProvider, thirdProvider))
+        val secondProviderGroupSuggestions = listOf(Suggestion(secondProvider), Suggestion(thirdProvider))
+
+        val visibleItems = VisibleItems(
+            suggestions = mapOf(
+                firstProviderGroup to firstProviderGroupSuggestions,
+                secondProviderGroup to secondProviderGroupSuggestions,
+            ),
+            visibleItemKeys = listOf(
+                ItemKey.SuggestionGroup(firstProviderGroup.id),
+                ItemKey.Suggestion(firstProviderGroup.id, firstProvider.id, firstProviderGroupSuggestions[0].id),
+                ItemKey.SuggestionGroup(secondProviderGroup.id),
+                ItemKey.Suggestion(secondProviderGroup.id, thirdProvider.id, secondProviderGroupSuggestions[1].id),
+            ),
+        )
+        val visibilityState = visibleItems.toVisibilityState()
+        assertEquals(
+            visibilityState.visibleProviderGroups,
+            mapOf(
+                firstProviderGroup to listOf(firstProviderGroupSuggestions[0]),
+                secondProviderGroup to listOf(secondProviderGroupSuggestions[1]),
+            ),
+        )
+    }
+}

--- a/android-components/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/android-components/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -73,6 +73,17 @@ interface AwesomeBar {
     fun setOnEditSuggestionListener(listener: (String) -> Unit)
 
     /**
+     * Information about the [Suggestion]s that are currently displayed by the [AwesomeBar].
+     */
+    data class VisibilityState(
+        /**
+         * An ordered map of the currently visible [SuggestionProviderGroup]s, and the visible [Suggestion]s in each
+         * group. The groups and their suggestions are ordered top to bottom.
+         */
+        val visibleProviderGroups: Map<SuggestionProviderGroup, List<Suggestion>> = emptyMap(),
+    )
+
+    /**
      * A [Suggestion] to be displayed by an [AwesomeBar] implementation.
      *
      * @property provider The provider this suggestion came from.


### PR DESCRIPTION
This commit adds an `onVisibilityStateUpdated` callback to the `AwesomeBar` composable. The new callback is invoked with the current `AwesomeBar.VisibilityState` whenever the list of visible suggestions changes.

I split this out of #4050 to make it a little easier to review, and so that we could land the instrumentation earlier, in case we need to uplift telemetry, or if there are any performance pitfalls.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1859408