### PR TITLE
Bug 1854501 - Add telemetry to count Fakespot exposures

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -10773,6 +10773,26 @@ shopping:
     metadata:
       tags:
         - Shopping
+  product_page_visits:
+    type: counter
+    description: |
+      Counts number of visits to a supported retailer product page
+      while enrolled in either the control or treatment branches
+      of the shopping experiment.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1854501
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/4120#issuecomment-1768423370
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - Shopping
 
 shopping.settings:
   component_opted_out:

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -288,7 +288,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 shoppingExperienceFeature = DefaultShoppingExperienceFeature(
                     settings = requireContext().settings(),
                 ),
-                onAvailabilityChange = {
+                onIconVisibilityChange = {
                     if (!reviewQualityCheckAvailable && it) {
                         Shopping.addressBarIconDisplayed.record()
                     }
@@ -297,6 +297,9 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 },
                 onBottomSheetStateChange = {
                     reviewQualityCheck.setSelected(selected = it, notifyListener = false)
+                },
+                onProductPageDetected = {
+                    Shopping.productPageVisits.add()
                 },
             ),
             owner = this,


### PR DESCRIPTION
Added a new probe `product_page_visits` which counts the number of visits to a supported retailer product page.

Tested ping can be found [here](https://debug-ping-preview.firebaseapp.com/pings/drevla/c5fc61dd-72de-481f-a1c8-8986cd90cbdd) and looks like this:
```
"counter": {
      "shopping.product_page_visits": 9,
    },
```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1854501