### PR TITLE
Bug 1859644 - Don't show full keyword in FxSuggest Suggesions

### DIFF
--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
@@ -81,7 +81,7 @@ class FxSuggestSuggestionProvider(
                 icon = details.icon?.let {
                     it.toUByteArray().asByteArray().toBitmap()
                 },
-                title = "${details.fullKeyword} — ${details.title}",
+                title = details.title,
                 description = if (details.isSponsored) {
                     resources.getString(R.string.sponsored_suggestion_description)
                 } else {

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProviderTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProviderTest.kt
@@ -118,10 +118,10 @@ class FxSuggestSuggestionProviderTest {
             ),
         )
         assertEquals(2, suggestions.size)
-        assertEquals("lasagna — Lasagna Come Out Tomorrow", suggestions[0].title)
+        assertEquals("Lasagna Come Out Tomorrow", suggestions[0].title)
         assertEquals(testContext.resources.getString(R.string.sponsored_suggestion_description), suggestions[0].description)
         assertNotNull(suggestions[0].icon)
-        assertEquals("las — Las Vegas", suggestions[1].title)
+        assertEquals("Las Vegas", suggestions[1].title)
         assertNull(suggestions[1].description)
         assertNull(suggestions[1].icon)
     }
@@ -173,7 +173,7 @@ class FxSuggestSuggestionProviderTest {
             ),
         )
         assertEquals(1, suggestions.size)
-        assertEquals("las — Las Vegas", suggestions.first().title)
+        assertEquals("Las Vegas", suggestions.first().title)
         assertNull(suggestions.first().description)
         assertNull(suggestions.first().icon)
     }
@@ -216,7 +216,7 @@ class FxSuggestSuggestionProviderTest {
             ),
         )
         assertEquals(1, suggestions.size)
-        assertEquals("lasagna — Lasagna Come Out Tomorrow", suggestions.first().title)
+        assertEquals("Lasagna Come Out Tomorrow", suggestions.first().title)
         assertEquals(testContext.resources.getString(R.string.sponsored_suggestion_description), suggestions.first().description)
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1859644