### PR TITLE
Bug 1866506 - Update padding in Web Extension menu items to match other menu items

### DIFF
--- a/android-components/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
+++ b/android-components/components/browser/menu/src/main/res/layout/mozac_browser_menu_web_extension.xml
@@ -28,8 +28,8 @@
         android:layout_height="@dimen/mozac_browser_menu_item_container_layout_height"
         android:gravity="center_vertical"
         android:textAlignment="viewStart"
-        android:paddingEnd="16dp"
-        android:paddingStart="16dp"
+        android:paddingStart="@dimen/mozac_browser_menu_item_image_text_label_padding_start"
+        android:paddingEnd="@dimen/mozac_browser_menu_item_image_text_label_padding_start"
         android:clickable="false"
         tools:ignore="RtlCompat"
         tools:text="uBlock Origin" />


### PR DESCRIPTION
Before (off to left side by 4 pixels):
<img src="https://github.com/mozilla-mobile/firefox-android/assets/4525736/f53d46bd-b24d-4fe8-8cc3-cfcf32dd093d" width="300">

After:
<img src="https://github.com/mozilla-mobile/firefox-android/assets/4525736/74a1202a-f13f-4d30-a4a7-c198a8a7aaee" width="300">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1866506