### PR TITLE
Bug 1858542 - Add Glean metrics for sponsored Firefox Suggest impressions.

### DIFF
--- a/android-components/.buildconfig.yml
+++ b/android-components/.buildconfig.yml
@@ -19,6 +19,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -72,6 +73,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -94,6 +96,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -133,6 +136,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -165,6 +169,7 @@ projects:
     publish: true
     upstream_dependencies:
     - browser-errorpages
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -200,6 +205,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -222,6 +228,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -245,6 +252,7 @@ projects:
     - browser-menu
     - browser-menu2
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -289,6 +297,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -325,6 +334,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -348,6 +358,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -491,6 +502,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -541,6 +553,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -565,6 +578,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -648,6 +662,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -673,6 +688,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -712,6 +728,7 @@ projects:
     - browser-tabstray
     - browser-thumbnails
     - browser-toolbar
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -747,6 +764,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -771,6 +789,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -816,6 +835,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -851,6 +871,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -881,6 +902,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -901,6 +923,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -926,6 +949,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -974,6 +998,7 @@ projects:
     - browser-tabstray
     - browser-thumbnails
     - browser-toolbar
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1022,6 +1047,7 @@ projects:
     - browser-errorpages
     - browser-menu
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1045,6 +1071,7 @@ projects:
     - browser-errorpages
     - browser-session-storage
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1073,6 +1100,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1109,6 +1137,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1139,6 +1168,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1179,6 +1209,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1240,6 +1271,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1275,6 +1307,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1304,6 +1337,7 @@ projects:
     - browser-domains
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1360,6 +1394,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1381,6 +1416,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1406,6 +1442,7 @@ projects:
     - browser-state
     - browser-tabstray
     - browser-thumbnails
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1713,6 +1750,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1804,6 +1842,7 @@ projects:
     - browser-menu2
     - browser-state
     - browser-toolbar
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -1907,6 +1946,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -2024,6 +2064,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch
@@ -2138,6 +2179,7 @@ projects:
     upstream_dependencies:
     - browser-errorpages
     - browser-state
+    - concept-awesomebar
     - concept-base
     - concept-engine
     - concept-fetch

--- a/android-components/components/browser/state/build.gradle
+++ b/android-components/components/browser/state/build.gradle
@@ -50,6 +50,7 @@ tasks.withType(KotlinCompile).configureEach {
 dependencies {
     api project(':lib-state')
 
+    implementation project(':concept-awesomebar')
     implementation project(':concept-engine')
     implementation project(':concept-storage')
     implementation project(':support-utils')

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/AwesomeBarAction.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/AwesomeBarAction.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.action
+
+import mozilla.components.concept.awesomebar.AwesomeBar
+
+/**
+ * [BrowserAction]s related to interactions with the [AwesomeBar].
+ */
+sealed class AwesomeBarAction : BrowserAction() {
+    /**
+     * Indicates that the suggestions displayed in the [AwesomeBar] have changed.
+     */
+    data class VisibilityStateUpdated(val visibilityState: AwesomeBar.VisibilityState) : AwesomeBarAction()
+
+    /**
+     * Indicates that the user clicked a [suggestion] in the [AwesomeBar].
+     */
+    data class SuggestionClicked(val suggestion: AwesomeBar.Suggestion) : AwesomeBarAction()
+
+    /**
+     * Indicates that the user has finished engaging with the [AwesomeBar].
+     *
+     * An [abandoned] engagement means that the user dismissed the [AwesomeBar] without either clicking on a
+     * suggestion, or entering a search term or URL.
+     */
+    data class EngagementFinished(val abandoned: Boolean) : AwesomeBarAction()
+}

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/AwesomeBarStateReducer.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/AwesomeBarStateReducer.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.reducer
+
+import mozilla.components.browser.state.action.AwesomeBarAction
+import mozilla.components.browser.state.state.AwesomeBarState
+import mozilla.components.browser.state.state.BrowserState
+
+/**
+ * An [AwesomeBarAction] reducer that updates [BrowserState.awesomeBarState].
+ */
+internal object AwesomeBarStateReducer {
+    fun reduce(state: BrowserState, action: AwesomeBarAction): BrowserState {
+        return when (action) {
+            is AwesomeBarAction.VisibilityStateUpdated -> {
+                val awesomeBarState = state.awesomeBarState.copy(visibilityState = action.visibilityState)
+                state.copy(awesomeBarState = awesomeBarState)
+            }
+            is AwesomeBarAction.SuggestionClicked -> {
+                val awesomeBarState = state.awesomeBarState.copy(clickedSuggestion = action.suggestion)
+                state.copy(awesomeBarState = awesomeBarState)
+            }
+            is AwesomeBarAction.EngagementFinished -> {
+                state.copy(awesomeBarState = AwesomeBarState())
+            }
+        }
+    }
+}

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/BrowserStateReducer.kt
@@ -5,6 +5,7 @@
 package mozilla.components.browser.state.reducer
 
 import mozilla.components.browser.state.action.AppLifecycleAction
+import mozilla.components.browser.state.action.AwesomeBarAction
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContainerAction
 import mozilla.components.browser.state.action.ContentAction
@@ -75,6 +76,7 @@ internal object BrowserStateReducer {
             is HistoryMetadataAction -> HistoryMetadataReducer.reduce(state, action)
             is DebugAction -> DebugReducer.reduce(state, action)
             is ExtensionsProcessAction -> ExtensionsProcessStateReducer.reduce(state, action)
+            is AwesomeBarAction -> AwesomeBarStateReducer.reduce(state, action)
         }
     }
 }

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/AwesomeBarState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/AwesomeBarState.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.state
+
+import mozilla.components.concept.awesomebar.AwesomeBar
+
+/**
+ * State for interactions with the [AwesomeBar].
+ *
+ * @property visibilityState The suggestions and groups that are currently displayed in the [AwesomeBar].
+ * @property clickedSuggestion The [AwesomeBar.Suggestion] that the user clicked. This is `null` if the user is still
+ * interacting with the [AwesomeBar], or entered a search term or URL instead of clicking on a suggestion.
+ */
+data class AwesomeBarState(
+    val visibilityState: AwesomeBar.VisibilityState = AwesomeBar.VisibilityState(),
+    val clickedSuggestion: AwesomeBar.Suggestion? = null,
+)

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/BrowserState.kt
@@ -7,6 +7,7 @@ package mozilla.components.browser.state.state
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.state.extension.WebExtensionPromptRequest
 import mozilla.components.browser.state.state.recover.TabState
+import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.lib.state.State
 import java.util.Locale
 
@@ -33,6 +34,7 @@ import java.util.Locale
  * @property restoreComplete Whether or not restoring [BrowserState] has completed. This can be used
  * on application startup e.g. as an indicator that tabs have been restored.
  * @property locale The current locale of the app. Will be null when following the system default.
+ * @property awesomeBarState Holds state for interactions with the [AwesomeBar].
  */
 data class BrowserState(
     val tabs: List<TabSessionState> = emptyList(),
@@ -51,4 +53,5 @@ data class BrowserState(
     val locale: Locale? = null,
     val showExtensionsProcessDisabledPrompt: Boolean = false,
     val extensionsProcessDisabled: Boolean = false,
+    val awesomeBarState: AwesomeBarState = AwesomeBarState(),
 ) : State

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/AwesomeBarActionTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/AwesomeBarActionTest.kt
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.action
+
+import mozilla.components.browser.state.state.AwesomeBarState
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AwesomeBarActionTest {
+    @Test
+    fun `VisibilityStateUpdated - Stores updated visibility state`() {
+        val store = BrowserStore()
+
+        assertTrue(store.state.awesomeBarState.visibilityState.visibleProviderGroups.isEmpty())
+        assertNull(store.state.awesomeBarState.clickedSuggestion)
+
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(AwesomeBar.Suggestion(provider))
+
+        store.dispatch(
+            AwesomeBarAction.VisibilityStateUpdated(
+                AwesomeBar.VisibilityState(
+                    visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                ),
+            ),
+        ).joinBlocking()
+
+        assertEquals(1, store.state.awesomeBarState.visibilityState.visibleProviderGroups.size)
+        assertEquals(providerGroupSuggestions, store.state.awesomeBarState.visibilityState.visibleProviderGroups[providerGroup])
+        assertNull(store.state.awesomeBarState.clickedSuggestion)
+    }
+
+    @Test
+    fun `SuggestionClicked - Stores clicked suggestion`() {
+        val store = BrowserStore()
+
+        assertTrue(store.state.awesomeBarState.visibilityState.visibleProviderGroups.isEmpty())
+        assertNull(store.state.awesomeBarState.clickedSuggestion)
+
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val suggestion = AwesomeBar.Suggestion(provider)
+
+        store.dispatch(AwesomeBarAction.SuggestionClicked(suggestion)).joinBlocking()
+
+        assertTrue(store.state.awesomeBarState.visibilityState.visibleProviderGroups.isEmpty())
+        assertEquals(suggestion, store.state.awesomeBarState.clickedSuggestion)
+    }
+
+    @Test
+    fun `EngagementFinished - Completed engagement resets state`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val suggestion = AwesomeBar.Suggestion(provider)
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(suggestion)
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                    clickedSuggestion = suggestion,
+                ),
+            ),
+        )
+
+        assertTrue(store.state.awesomeBarState.visibilityState.visibleProviderGroups.isNotEmpty())
+        assertNotNull(store.state.awesomeBarState.clickedSuggestion)
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false)).joinBlocking()
+
+        assertTrue(store.state.awesomeBarState.visibilityState.visibleProviderGroups.isEmpty())
+        assertNull(store.state.awesomeBarState.clickedSuggestion)
+    }
+
+    @Test
+    fun `EngagementFinished - Abandoned engagement resets state`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val suggestion = AwesomeBar.Suggestion(provider)
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(suggestion)
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                    clickedSuggestion = suggestion,
+                ),
+            ),
+        )
+
+        assertTrue(store.state.awesomeBarState.visibilityState.visibleProviderGroups.isNotEmpty())
+        assertNotNull(store.state.awesomeBarState.clickedSuggestion)
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = true)).joinBlocking()
+
+        assertTrue(store.state.awesomeBarState.visibilityState.visibleProviderGroups.isEmpty())
+        assertNull(store.state.awesomeBarState.clickedSuggestion)
+    }
+}

--- a/android-components/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
+++ b/android-components/components/concept/awesomebar/src/main/java/mozilla/components/concept/awesomebar/AwesomeBar.kt
@@ -102,6 +102,8 @@ interface AwesomeBar {
      * @property onChipClicked A callback to be executed when a [Chip] was clicked by the user.
      * @property score A score used to rank suggestions of this provider against each other. A suggestion with a higher
      * score will be shown on top of suggestions with a lower score.
+     * @property metadata Opaque metadata associated with this [Suggestion]. A [SuggestionProvider] can use this field
+     * to pass additional information about this suggestion.
      */
     data class Suggestion(
         val provider: SuggestionProvider,
@@ -116,6 +118,7 @@ interface AwesomeBar {
         val onSuggestionClicked: (() -> Unit)? = null,
         val onChipClicked: ((Chip) -> Unit)? = null,
         val score: Int = 0,
+        val metadata: Map<String, Any>? = null,
     ) {
         /**
          * Chips are compact actions that are shown as part of a suggestion. For example a [Suggestion] from a search

--- a/android-components/components/feature/fxsuggest/README.md
+++ b/android-components/components/feature/fxsuggest/README.md
@@ -18,9 +18,26 @@ implementation "org.mozilla.components:feature-fxsuggest:{latest-version}"
 
 This component emits the following [Facts](../../support/base/README.md#Facts):
 
-| Action      | Item                       | Extras            | Description                     |
-|-------------|----------------------------|-------------------|---------------------------------|
-| Click | amp_suggestion_clicked |  | a Firefox Suggestion has been clicked |
+| Action        | Item                       | Extras                        | Description                                                                    |
+|---------------|----------------------------|-------------------------------|--------------------------------------------------------------------------------|
+| `INTERACTION` | `amp_suggestion_clicked`   | `suggestion_clicked_extras`   | The user clicked on a Firefox Suggestion.                                      |
+| `DISPLAY`     | `amp_suggestion_impressed` | `suggestion_impressed_extras` | The user saw a Firefox Suggestion just before they navigated to a destination. |
+
+#### `suggestion_clicked_extras`
+
+| Key                | Type                       | Value                                                      |
+|--------------------|----------------------------|------------------------------------------------------------|
+| `interaction_info` | `FxSuggestInteractionInfo` | Type-specific information to record for this suggestion.   |
+| `position`         | `Long`                     | The 1-based position of this suggestion in the awesomebar. |
+
+
+#### `suggestion_impressed_extras`
+
+| Key                | Type                       | Value                                                      |
+|--------------------|----------------------------|------------------------------------------------------------|
+| `interaction_info` | `FxSuggestInteractionInfo` | Type-specific information to record for this suggestion.   |
+| `position`         | `Long`                     | The 1-based position of this suggestion in the awesomebar. |
+| `is_clicked`       | `Boolean`                  | Whether the user clicked on this suggestion.               |
 
 ## License
 

--- a/android-components/components/feature/fxsuggest/build.gradle
+++ b/android-components/components/feature/fxsuggest/build.gradle
@@ -32,6 +32,7 @@ tasks.withType(KotlinCompile).configureEach {
 dependencies {
     api ComponentsDependencies.mozilla_appservices_suggest
 
+    implementation project(':browser-state')
     implementation project(':concept-awesomebar')
     implementation project(':concept-engine')
     implementation project(':feature-session')

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/facts/FxSuggestFacts.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/facts/FxSuggestFacts.kt
@@ -4,7 +4,7 @@
 
 package mozilla.components.feature.fxsuggest.facts
 
-import mozilla.components.feature.fxsuggest.FxSuggestClickInfo
+import mozilla.components.feature.fxsuggest.FxSuggestInteractionInfo
 import mozilla.components.support.base.Component
 import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.Fact
@@ -19,13 +19,16 @@ class FxSuggestFacts {
      */
     object Items {
         const val AMP_SUGGESTION_CLICKED = "amp_suggestion_clicked"
+        const val AMP_SUGGESTION_IMPRESSED = "amp_suggestion_impressed"
     }
 
     /**
      * Keys used in the metadata map.
      */
     object MetadataKeys {
-        const val CLICK_INFO = "click_info"
+        const val INTERACTION_INFO = "interaction_info"
+        const val POSITION = "position"
+        const val IS_CLICKED = "is_clicked"
     }
 }
 
@@ -44,10 +47,35 @@ private fun emitFxSuggestFact(
     ).collect()
 }
 
-internal fun emitSponsoredSuggestionClickedFact(clickInfo: FxSuggestClickInfo) {
-    emitFxSuggestFact(
-        Action.INTERACTION,
-        FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED,
-        metadata = mapOf(FxSuggestFacts.MetadataKeys.CLICK_INFO to clickInfo),
-    )
+internal fun emitSuggestionClickedFact(
+    interactionInfo: FxSuggestInteractionInfo,
+    positionInAwesomeBar: Long,
+) = when (interactionInfo) {
+    is FxSuggestInteractionInfo.Amp -> {
+        emitFxSuggestFact(
+            Action.INTERACTION,
+            FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED,
+            metadata = mapOf(
+                FxSuggestFacts.MetadataKeys.INTERACTION_INFO to interactionInfo,
+                FxSuggestFacts.MetadataKeys.POSITION to positionInAwesomeBar,
+            ),
+        )
+    }
+}
+
+internal fun emitSuggestionImpressedFact(
+    interactionInfo: FxSuggestInteractionInfo,
+    positionInAwesomeBar: Long,
+    isClicked: Boolean,
+) = when (interactionInfo) {
+    is FxSuggestInteractionInfo.Amp ->
+        emitFxSuggestFact(
+            Action.DISPLAY,
+            FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED,
+            metadata = mapOf(
+                FxSuggestFacts.MetadataKeys.INTERACTION_INFO to interactionInfo,
+                FxSuggestFacts.MetadataKeys.POSITION to positionInAwesomeBar,
+                FxSuggestFacts.MetadataKeys.IS_CLICKED to isClicked,
+            ),
+        )
 }

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/facts/FxSuggestFactsMiddleware.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/facts/FxSuggestFactsMiddleware.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.fxsuggest.facts
+
+import mozilla.components.browser.state.action.AwesomeBarAction
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.state.AwesomeBarState
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.feature.fxsuggest.FxSuggestInteractionInfo
+import mozilla.components.feature.fxsuggest.FxSuggestSuggestionProvider
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+import mozilla.components.support.base.facts.Fact
+
+/**
+ * Reports [Fact]s for interactions with Firefox Suggest [AwesomeBar.Suggestion]s.
+ *
+ * We report two kinds of interactions: impressions and clicks. We report impressions for any Firefox Suggest
+ * search suggestions that are still visible just before the user navigates to a destination: either a URL, a
+ * search results page, or a suggestion. If the user navigates to one of those Firefox Suggest suggestions,
+ * we also report a click.
+ *
+ * We _don't_ report impressions for any suggestions that the user sees as they're still typing, or
+ * if they dismiss the [AwesomeBar] without navigating to a destination.
+ */
+class FxSuggestFactsMiddleware : Middleware<BrowserState, BrowserAction> {
+    override fun invoke(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        next: (BrowserAction) -> Unit,
+        action: BrowserAction,
+    ) {
+        handleAction(context, action)
+        next(action)
+    }
+
+    private fun handleAction(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        action: BrowserAction,
+    ) = when (action) {
+        is AwesomeBarAction.EngagementFinished ->
+            if (action.abandoned) Unit else emitSuggestionFacts(context.state.awesomeBarState)
+        else -> Unit
+    }
+
+    private fun emitSuggestionFacts(awesomeBarState: AwesomeBarState) {
+        val visibilityState = awesomeBarState.visibilityState
+        val clickedSuggestion = awesomeBarState.clickedSuggestion
+        visibilityState.visibleProviderGroups.entries.forEachIndexed { groupIndex, (_, suggestions) ->
+            suggestions.forEachIndexed { suggestionIndex, suggestion ->
+                val positionInGroup = suggestionIndex.toLong() + 1
+                val positionInAwesomeBar = groupIndex.toLong() + positionInGroup
+                val isClicked = clickedSuggestion == suggestion
+
+                val impressionInfo = suggestion.metadata?.get(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO,
+                ) as? FxSuggestInteractionInfo
+                impressionInfo?.let {
+                    emitSuggestionImpressedFact(it, positionInGroup, isClicked = isClicked)
+                }
+
+                if (isClicked) {
+                    val clickInfo = suggestion.metadata?.get(
+                        FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO,
+                    ) as? FxSuggestInteractionInfo
+                    clickInfo?.let {
+                        emitSuggestionClickedFact(it, positionInAwesomeBar)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsMiddlewareTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsMiddlewareTest.kt
@@ -1,0 +1,649 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.fxsuggest
+
+import mozilla.components.browser.state.action.AwesomeBarAction
+import mozilla.components.browser.state.state.AwesomeBarState
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.feature.fxsuggest.facts.FxSuggestFacts
+import mozilla.components.feature.fxsuggest.facts.FxSuggestFactsMiddleware
+import mozilla.components.support.base.Component
+import mozilla.components.support.base.facts.Action
+import mozilla.components.support.base.facts.Facts
+import mozilla.components.support.base.facts.processor.CollectionProcessor
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.mock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class FxSuggestFactsMiddlewareTest {
+    private lateinit var processor: CollectionProcessor
+
+    @Before
+    fun setUp() {
+        processor = CollectionProcessor()
+        Facts.registerProcessor(processor)
+    }
+
+    @After
+    fun tearDown() {
+        Facts.clearProcessors()
+    }
+
+    @Test
+    fun `GIVEN no suggestions are visible WHEN the engagement is completed THEN no facts are collected`() {
+        val store = BrowserStore(
+            middleware = listOf(FxSuggestFactsMiddleware()),
+        )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false)).joinBlocking()
+
+        assertTrue(processor.facts.isEmpty())
+    }
+
+    @Test
+    fun `GIVEN 2 non-AMP suggestions are visible WHEN the engagement is completed THEN no facts are collected`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(provider),
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                    clickedSuggestion = providerGroupSuggestions[1],
+                ),
+            ),
+            middleware = listOf(FxSuggestFactsMiddleware()),
+        )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false)).joinBlocking()
+
+        assertTrue(processor.facts.isEmpty())
+    }
+
+    @Test
+    fun `GIVEN 1 AMP suggestion is visible WHEN the engagement is abandoned THEN no facts are collected`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/impression",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/click",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                    clickedSuggestion = providerGroupSuggestions[1],
+                ),
+            ),
+            middleware = listOf(FxSuggestFactsMiddleware()),
+        )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = true)).joinBlocking()
+
+        assertTrue(processor.facts.isEmpty())
+    }
+
+    @Test
+    fun `GIVEN 1 AMP suggestion is visible WHEN the engagement is completed THEN 1 impression fact is collected`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/impression",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/click",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                ),
+            ),
+            middleware = listOf(FxSuggestFactsMiddleware()),
+        )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false)).joinBlocking()
+
+        assertEquals(1, processor.facts.size)
+        processor.facts[0].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.DISPLAY, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION, FxSuggestFacts.MetadataKeys.IS_CLICKED), metadata?.keys)
+
+            val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(123, impressionInfo.blockId)
+            assertEquals("mozilla", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression", impressionInfo.reportingUrl)
+            assertEquals("22 - Shopping", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(2, position)
+
+            val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+            assertFalse(isClicked)
+        }
+    }
+
+    @Test
+    fun `GIVEN 1 AMP suggestion is visible and a non-AMP suggestion is clicked WHEN the engagement is completed THEN 1 impression fact is collected`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/impression",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/click",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                    clickedSuggestion = providerGroupSuggestions[0],
+                ),
+            ),
+            middleware = listOf(FxSuggestFactsMiddleware()),
+        )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false)).joinBlocking()
+
+        assertEquals(1, processor.facts.size)
+        processor.facts[0].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.DISPLAY, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION, FxSuggestFacts.MetadataKeys.IS_CLICKED), metadata?.keys)
+
+            val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(123, impressionInfo.blockId)
+            assertEquals("mozilla", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression", impressionInfo.reportingUrl)
+            assertEquals("22 - Shopping", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(2, position)
+
+            val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+            assertFalse(isClicked)
+        }
+    }
+
+    @Test
+    fun `GIVEN 1 AMP suggestion is visible and clicked WHEN the engagement is completed THEN 1 impression fact and 1 click fact are collected`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/impression",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/click",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                    clickedSuggestion = providerGroupSuggestions[1],
+                ),
+            ),
+            middleware = listOf(FxSuggestFactsMiddleware()),
+        )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false)).joinBlocking()
+
+        assertEquals(2, processor.facts.size)
+        processor.facts[0].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.DISPLAY, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION, FxSuggestFacts.MetadataKeys.IS_CLICKED), metadata?.keys)
+
+            val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(123, impressionInfo.blockId)
+            assertEquals("mozilla", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression", impressionInfo.reportingUrl)
+            assertEquals("22 - Shopping", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(2, position)
+
+            val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+            assertTrue(isClicked)
+        }
+        processor.facts[1].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.INTERACTION, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION), metadata?.keys)
+
+            val clickInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(123, clickInfo.blockId)
+            assertEquals("mozilla", clickInfo.advertiser)
+            assertEquals("https://example.com/click", clickInfo.reportingUrl)
+            assertEquals("22 - Shopping", clickInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", clickInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(2, position)
+        }
+    }
+
+    @Test
+    fun `GIVEN 2 AMP suggestions are visible WHEN the engagement is completed THEN 2 impression facts are collected`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/impression-1",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/click-1",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 456,
+                        advertiser = "good place eats",
+                        reportingUrl = "https://example.com/impression-2",
+                        iabCategory = "8 - Food & Drink",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 456,
+                        advertiser = "good place eats",
+                        reportingUrl = "https://example.com/click-2",
+                        iabCategory = "8 - Food & Drink",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                ),
+            ),
+            middleware = listOf(FxSuggestFactsMiddleware()),
+        )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false)).joinBlocking()
+
+        assertEquals(2, processor.facts.size)
+        processor.facts[0].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.DISPLAY, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION, FxSuggestFacts.MetadataKeys.IS_CLICKED), metadata?.keys)
+
+            val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(123, impressionInfo.blockId)
+            assertEquals("mozilla", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression-1", impressionInfo.reportingUrl)
+            assertEquals("22 - Shopping", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(2, position)
+
+            val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+            assertFalse(isClicked)
+        }
+        processor.facts[1].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.DISPLAY, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION, FxSuggestFacts.MetadataKeys.IS_CLICKED), metadata?.keys)
+
+            val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(456, impressionInfo.blockId)
+            assertEquals("good place eats", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression-2", impressionInfo.reportingUrl)
+            assertEquals("8 - Food & Drink", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(4, position)
+
+            val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+            assertFalse(isClicked)
+        }
+    }
+
+    @Test
+    fun `GIVEN 2 AMP suggestions are visible and a non-AMP suggestion is clicked WHEN the engagement is completed THEN 2 impression facts are collected`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/impression-1",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/click-1",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 456,
+                        advertiser = "good place eats",
+                        reportingUrl = "https://example.com/impression-2",
+                        iabCategory = "8 - Food & Drink",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 456,
+                        advertiser = "good place eats",
+                        reportingUrl = "https://example.com/click-2",
+                        iabCategory = "8 - Food & Drink",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                    clickedSuggestion = providerGroupSuggestions[2],
+                ),
+            ),
+            middleware = listOf(FxSuggestFactsMiddleware()),
+        )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false)).joinBlocking()
+
+        assertEquals(2, processor.facts.size)
+        processor.facts[0].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.DISPLAY, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION, FxSuggestFacts.MetadataKeys.IS_CLICKED), metadata?.keys)
+
+            val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(123, impressionInfo.blockId)
+            assertEquals("mozilla", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression-1", impressionInfo.reportingUrl)
+            assertEquals("22 - Shopping", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(2, position)
+
+            val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+            assertFalse(isClicked)
+        }
+        processor.facts[1].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.DISPLAY, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION, FxSuggestFacts.MetadataKeys.IS_CLICKED), metadata?.keys)
+
+            val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(456, impressionInfo.blockId)
+            assertEquals("good place eats", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression-2", impressionInfo.reportingUrl)
+            assertEquals("8 - Food & Drink", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(4, position)
+
+            val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+            assertFalse(isClicked)
+        }
+    }
+
+    @Test
+    fun `GIVEN 2 AMP suggestions are visible and an AMP suggestion is clicked WHEN the engagement is completed THEN 2 impression facts and 1 click fact are collected`() {
+        val provider: AwesomeBar.SuggestionProvider = mock()
+        val providerGroup = AwesomeBar.SuggestionProviderGroup(listOf(provider))
+        val providerGroupSuggestions = listOf(
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/impression-1",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 123,
+                        advertiser = "mozilla",
+                        reportingUrl = "https://example.com/click-1",
+                        iabCategory = "22 - Shopping",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+            AwesomeBar.Suggestion(provider),
+            AwesomeBar.Suggestion(
+                provider = provider,
+                metadata = mapOf(
+                    FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 456,
+                        advertiser = "good place eats",
+                        reportingUrl = "https://example.com/impression-2",
+                        iabCategory = "8 - Food & Drink",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                    FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO to FxSuggestInteractionInfo.Amp(
+                        blockId = 456,
+                        advertiser = "good place eats",
+                        reportingUrl = "https://example.com/click-2",
+                        iabCategory = "8 - Food & Drink",
+                        contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                    ),
+                ),
+            ),
+        )
+        val store = BrowserStore(
+            initialState = BrowserState(
+                awesomeBarState = AwesomeBarState(
+                    visibilityState = AwesomeBar.VisibilityState(
+                        visibleProviderGroups = mapOf(providerGroup to providerGroupSuggestions),
+                    ),
+                    clickedSuggestion = providerGroupSuggestions[3],
+                ),
+            ),
+            middleware = listOf(FxSuggestFactsMiddleware()),
+        )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false)).joinBlocking()
+
+        assertEquals(3, processor.facts.size)
+        processor.facts[0].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.DISPLAY, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION, FxSuggestFacts.MetadataKeys.IS_CLICKED), metadata?.keys)
+
+            val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(123, impressionInfo.blockId)
+            assertEquals("mozilla", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression-1", impressionInfo.reportingUrl)
+            assertEquals("22 - Shopping", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(2, position)
+
+            val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+            assertFalse(isClicked)
+        }
+        processor.facts[1].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.DISPLAY, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION, FxSuggestFacts.MetadataKeys.IS_CLICKED), metadata?.keys)
+
+            val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(456, impressionInfo.blockId)
+            assertEquals("good place eats", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression-2", impressionInfo.reportingUrl)
+            assertEquals("8 - Food & Drink", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(4, position)
+
+            val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+            assertTrue(isClicked)
+        }
+        processor.facts[2].apply {
+            assertEquals(Component.FEATURE_FXSUGGEST, component)
+            assertEquals(Action.INTERACTION, action)
+            assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED, item)
+
+            assertEquals(setOf(FxSuggestFacts.MetadataKeys.INTERACTION_INFO, FxSuggestFacts.MetadataKeys.POSITION), metadata?.keys)
+
+            val clickInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+            assertEquals(456, clickInfo.blockId)
+            assertEquals("good place eats", clickInfo.advertiser)
+            assertEquals("https://example.com/click-2", clickInfo.reportingUrl)
+            assertEquals("8 - Food & Drink", clickInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", clickInfo.contextId)
+
+            val position = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+            assertEquals(4, position)
+        }
+    }
+}

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsTest.kt
@@ -5,7 +5,7 @@
 package mozilla.components.feature.fxsuggest
 
 import mozilla.components.feature.fxsuggest.facts.FxSuggestFacts
-import mozilla.components.feature.fxsuggest.facts.emitSponsoredSuggestionClickedFact
+import mozilla.components.feature.fxsuggest.facts.emitSuggestionClickedFact
 import mozilla.components.support.base.Component
 import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.processor.CollectionProcessor
@@ -15,17 +15,18 @@ import org.junit.Test
 class FxSuggestFactsTest {
 
     @Test
-    fun testEmitSponsoredSuggestionClickedFact() {
+    fun emitSuggestionClickedFactWithAmpInteractionInfo() {
         CollectionProcessor.withFactCollection { facts ->
 
-            emitSponsoredSuggestionClickedFact(
-                FxSuggestClickInfo.Amp(
+            emitSuggestionClickedFact(
+                FxSuggestInteractionInfo.Amp(
                     blockId = 123,
                     advertiser = "mozilla",
-                    clickUrl = "https://example.com/reporting",
+                    reportingUrl = "https://example.com/reporting",
                     iabCategory = "22 - Shopping",
                     contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
                 ),
+                positionInAwesomeBar = 0,
             )
 
             assertEquals(1, facts.size)
@@ -34,10 +35,10 @@ class FxSuggestFactsTest {
                 assertEquals(Action.INTERACTION, action)
                 assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED, item)
 
-                val clickInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.CLICK_INFO) as? FxSuggestClickInfo.Amp)
+                val clickInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
                 assertEquals(clickInfo.blockId, 123)
                 assertEquals(clickInfo.advertiser, "mozilla")
-                assertEquals(clickInfo.clickUrl, "https://example.com/reporting")
+                assertEquals(clickInfo.reportingUrl, "https://example.com/reporting")
                 assertEquals(clickInfo.iabCategory, "22 - Shopping")
                 assertEquals(clickInfo.contextId, "c303282d-f2e6-46ca-a04a-35d3d873712d")
             }

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProviderTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProviderTest.kt
@@ -121,9 +121,11 @@ class FxSuggestSuggestionProviderTest {
         assertEquals("Lasagna Come Out Tomorrow", suggestions[0].title)
         assertEquals(testContext.resources.getString(R.string.sponsored_suggestion_description), suggestions[0].description)
         assertNotNull(suggestions[0].icon)
+        assertTrue(suggestions[0].metadata.isNullOrEmpty())
         assertEquals("Las Vegas", suggestions[1].title)
         assertNull(suggestions[1].description)
         assertNull(suggestions[1].icon)
+        assertTrue(suggestions[1].metadata.isNullOrEmpty())
     }
 
     @Test
@@ -160,6 +162,7 @@ class FxSuggestSuggestionProviderTest {
             loadUrlUseCase = mock(),
             includeNonSponsoredSuggestions = true,
             includeSponsoredSuggestions = false,
+            contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
         )
 
         val suggestions = provider.onInputChanged("la")
@@ -176,6 +179,7 @@ class FxSuggestSuggestionProviderTest {
         assertEquals("Las Vegas", suggestions.first().title)
         assertNull(suggestions.first().description)
         assertNull(suggestions.first().icon)
+        assertTrue(suggestions.first().metadata.isNullOrEmpty())
     }
 
     @Test
@@ -203,6 +207,7 @@ class FxSuggestSuggestionProviderTest {
             loadUrlUseCase = mock(),
             includeNonSponsoredSuggestions = false,
             includeSponsoredSuggestions = true,
+            contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
         )
 
         val suggestions = provider.onInputChanged("la")
@@ -218,5 +223,22 @@ class FxSuggestSuggestionProviderTest {
         assertEquals(1, suggestions.size)
         assertEquals("Lasagna Come Out Tomorrow", suggestions.first().title)
         assertEquals(testContext.resources.getString(R.string.sponsored_suggestion_description), suggestions.first().description)
+        suggestions.first().metadata?.let {
+            assertEquals(setOf(FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO, FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO), it.keys)
+
+            val clickInfo = requireNotNull(it[FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO] as? FxSuggestInteractionInfo.Amp)
+            assertEquals(0, clickInfo.blockId)
+            assertEquals("good place eats", clickInfo.advertiser)
+            assertEquals("https://example.com/click_url", clickInfo.reportingUrl)
+            assertEquals("8 - Food & Drink", clickInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", clickInfo.contextId)
+
+            val impressionInfo = requireNotNull(it[FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO] as? FxSuggestInteractionInfo.Amp)
+            assertEquals(0, impressionInfo.blockId)
+            assertEquals("good place eats", impressionInfo.advertiser)
+            assertEquals("https://example.com/impression_url", impressionInfo.reportingUrl)
+            assertEquals("8 - Food & Drink", impressionInfo.iabCategory)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+        }
     }
 }

--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -10836,14 +10836,36 @@ fx_suggest:
   ping_type:
     type: string
     description: >
-      The ping's type. Currently always "fxsuggest-click".
+      The ping's type. Either "fxsuggest-click" or "fxsuggest-impression".
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1768996728
+      - https://github.com/mozilla-mobile/firefox-android/pull/4146#issuecomment-1775955811
     data_sensitivity:
       - interaction
     notification_emails:
+      - android-probes@mozilla.com
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  position:
+    type: quantity
+    unit: non-negative integer
+    description: >
+      The position (1-based) of this suggestion in the full list of suggestions, relative to the
+      top of the awesomebar.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1858542
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/4146#issuecomment-1775955811
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
       - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
@@ -10857,10 +10879,11 @@ fx_suggest:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1768996728
     data_sensitivity:
       - interaction
     notification_emails:
+      - android-probes@mozilla.com
       - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
@@ -10875,10 +10898,30 @@ fx_suggest:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1768996728
     data_sensitivity:
       - interaction
     notification_emails:
+      - android-probes@mozilla.com
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    send_in_pings:
+      - fx-suggest
+  is_clicked:
+    type: boolean
+    description: >
+      If `ping_type` is "fxsuggest-impression", indicates whether this impression is for a clicked
+      suggestion. If `ping_type` is "fxsuggest-click", always `true`.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1858542
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/4146#issuecomment-1775955811
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
       - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
@@ -10892,10 +10935,11 @@ fx_suggest:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1768996728
     data_sensitivity:
       - interaction
     notification_emails:
+      - android-probes@mozilla.com
       - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
@@ -10909,10 +10953,11 @@ fx_suggest:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1768996728
     data_sensitivity:
       - interaction
     notification_emails:
+      - android-probes@mozilla.com
       - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com
@@ -10926,10 +10971,11 @@ fx_suggest:
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
-      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1758607927
+      - https://github.com/mozilla-mobile/firefox-android/pull/3958#issuecomment-1768996728
     data_sensitivity:
       - interaction
     notification_emails:
+      - android-probes@mozilla.com
       - lina@mozilla.com
       - ttran@mozilla.com
       - najiang@mozilla.com

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -40,6 +40,7 @@ import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.awesomebar.provider.SessionAutocompleteProvider
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import mozilla.components.feature.downloads.DownloadMiddleware
+import mozilla.components.feature.fxsuggest.facts.FxSuggestFactsMiddleware
 import mozilla.components.feature.logins.exceptions.LoginExceptionStorage
 import mozilla.components.feature.media.MediaSessionFeature
 import mozilla.components.feature.media.middleware.LastMediaAccessMiddleware
@@ -281,6 +282,7 @@ class Core(
                 HistoryMetadataMiddleware(historyMetadataService),
                 SessionPrioritizationMiddleware(),
                 SaveToPDFMiddleware(context),
+                FxSuggestFactsMiddleware(),
             )
 
         BrowserStore(

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -281,16 +281,37 @@ internal class ReleaseMetricController(
         }
 
         Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED -> {
+            FxSuggest.pingType.set("fxsuggest-click")
+            FxSuggest.isClicked.set(true)
+            (metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)?.let {
+                FxSuggest.position.set(it)
+            }
             (metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)?.let {
-                FxSuggest.pingType.set("fxsuggest-click")
                 FxSuggest.blockId.set(it.blockId)
                 FxSuggest.advertiser.set(it.advertiser)
                 FxSuggest.reportingUrl.set(it.reportingUrl)
                 FxSuggest.iabCategory.set(it.iabCategory)
                 FxSuggest.contextId.set(UUID.fromString(it.contextId))
-                Pings.fxSuggest.submit()
             }
-            Unit
+            Pings.fxSuggest.submit()
+        }
+
+        Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED -> {
+            FxSuggest.pingType.set("fxsuggest-impression")
+            (metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)?.let {
+                FxSuggest.isClicked.set(it)
+            }
+            (metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)?.let {
+                FxSuggest.position.set(it)
+            }
+            (metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)?.let {
+                FxSuggest.blockId.set(it.blockId)
+                FxSuggest.advertiser.set(it.advertiser)
+                FxSuggest.reportingUrl.set(it.reportingUrl)
+                FxSuggest.iabCategory.set(it.iabCategory)
+                FxSuggest.contextId.set(UUID.fromString(it.contextId))
+            }
+            Pings.fxSuggest.submit()
         }
 
         Component.FEATURE_PWA to ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP -> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -16,7 +16,7 @@ import mozilla.components.feature.awesomebar.provider.HistoryStorageSuggestionPr
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.SessionSuggestionProvider
 import mozilla.components.feature.contextmenu.facts.ContextMenuFacts
-import mozilla.components.feature.fxsuggest.FxSuggestClickInfo
+import mozilla.components.feature.fxsuggest.FxSuggestInteractionInfo
 import mozilla.components.feature.fxsuggest.facts.FxSuggestFacts
 import mozilla.components.feature.media.facts.MediaFacts
 import mozilla.components.feature.prompts.dialog.LoginDialogFacts
@@ -281,11 +281,11 @@ internal class ReleaseMetricController(
         }
 
         Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED -> {
-            (metadata?.get(FxSuggestFacts.MetadataKeys.CLICK_INFO) as? FxSuggestClickInfo.Amp)?.let {
+            (metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)?.let {
                 FxSuggest.pingType.set("fxsuggest-click")
                 FxSuggest.blockId.set(it.blockId)
                 FxSuggest.advertiser.set(it.advertiser)
-                FxSuggest.reportingUrl.set(it.clickUrl)
+                FxSuggest.reportingUrl.set(it.reportingUrl)
                 FxSuggest.iabCategory.set(it.iabCategory)
                 FxSuggest.contextId.set(UUID.fromString(it.contextId))
                 Pings.fxSuggest.submit()

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -12,6 +12,7 @@ import android.text.SpannableString
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.navigation.NavController
+import mozilla.components.browser.state.action.AwesomeBarAction
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
 import mozilla.components.browser.state.store.BrowserStore
@@ -88,11 +89,13 @@ class SearchDialogController(
                 // fennec users may be used to navigating to "about:crashes". So we intercept this here
                 // and open the crash list activity instead.
                 activity.startActivity(Intent(activity, CrashListActivity::class.java))
+                store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false))
             }
             "about:addons" -> {
                 val directions =
                     SearchDialogFragmentDirections.actionGlobalAddonsManagementFragment()
                 navController.navigateSafe(R.id.searchDialogFragment, directions)
+                store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false))
             }
             "moz://a" -> openSearchOrUrl(
                 SupportUtils.getMozillaPageUrl(SupportUtils.MozillaPage.MANIFESTO),
@@ -101,6 +104,8 @@ class SearchDialogController(
             else ->
                 if (url.isNotBlank()) {
                     openSearchOrUrl(url, fromHomeScreen)
+                } else {
+                    store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = true))
                 }
         }
         dismissDialog()
@@ -143,6 +148,8 @@ class SearchDialogController(
                 searchAccessPoint,
             )
         }
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false))
     }
 
     override fun handleEditingCancelled() {
@@ -193,6 +200,8 @@ class SearchDialogController(
         )
 
         Events.enteredUrl.record(Events.EnteredUrlExtra(autocomplete = false))
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false))
     }
 
     override fun handleSearchTermsTapped(searchTerms: String) {
@@ -228,6 +237,8 @@ class SearchDialogController(
                 searchAccessPoint,
             )
         }
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false))
     }
 
     override fun handleSearchShortcutEngineSelected(searchEngine: SearchEngine) {
@@ -280,6 +291,7 @@ class SearchDialogController(
         clearToolbarFocus()
         val directions = SearchDialogFragmentDirections.actionGlobalSearchEngineFragment()
         navController.navigateSafe(R.id.searchDialogFragment, directions)
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = true))
     }
 
     override fun handleExistingSessionSelected(tabId: String) {
@@ -290,6 +302,8 @@ class SearchDialogController(
         activity.openToBrowser(
             from = BrowserDirection.FromSearchDialog,
         )
+
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = false))
     }
 
     /**
@@ -345,6 +359,9 @@ class SearchDialogController(
                 intent.data = uri
                 dialog.cancel()
                 activity.startActivity(intent)
+            }
+            setOnDismissListener {
+                store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = true))
             }
             create().withCenterAlignedButtons()
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -46,6 +46,7 @@ import androidx.navigation.fragment.navArgs
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import mozilla.components.browser.state.action.AwesomeBarAction
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.state.searchEngines
 import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
@@ -634,6 +635,9 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
     override fun onDismiss(dialog: DialogInterface) {
         super.onDismiss(dialog)
         hideDeviceKeyboard()
+        if (!dialogHandledAction) {
+            requireComponents.core.store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = true))
+        }
     }
 
     override fun onBackPressed(): Boolean {

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarWrapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarWrapper.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.AbstractComposeView
+import mozilla.components.browser.state.action.AwesomeBarAction
 import mozilla.components.compose.browser.awesomebar.AwesomeBar
 import mozilla.components.compose.browser.awesomebar.AwesomeBarDefaults
 import mozilla.components.compose.browser.awesomebar.AwesomeBarOrientation
@@ -64,6 +65,7 @@ class AwesomeBarWrapper @JvmOverloads constructor(
                     groupTitle = ThemeManager.resolveAttributeColor(R.attr.textSecondary),
                 ),
                 onSuggestionClicked = { suggestion ->
+                    context.components.core.store.dispatch(AwesomeBarAction.SuggestionClicked(suggestion))
                     suggestion.onSuggestionClicked?.invoke()
                     when {
                         suggestion.flags.contains(AwesomeBar.Suggestion.Flag.HISTORY) -> {
@@ -77,6 +79,9 @@ class AwesomeBarWrapper @JvmOverloads constructor(
                 },
                 onAutoComplete = { suggestion ->
                     onEditSuggestionListener?.invoke(suggestion.editSuggestion!!)
+                },
+                onVisibilityStateUpdated = {
+                    context.components.core.store.dispatch(AwesomeBarAction.VisibilityStateUpdated(it))
                 },
                 onScroll = { hideKeyboard() },
                 profiler = context.components.core.engine.profiler,

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -18,6 +18,7 @@ import io.mockk.spyk
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
+import mozilla.components.browser.state.action.AwesomeBarAction
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.search.SearchEngine
@@ -112,6 +113,8 @@ class SearchDialogControllerTest {
 
         createController().handleUrlCommitted(url)
 
+        browserStore.waitUntilIdle()
+
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = url,
@@ -122,6 +125,10 @@ class SearchDialogControllerTest {
                 flags = EngineSession.LoadUrlFlags.none(),
                 additionalHeaders = null,
             )
+        }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
         }
 
         assertNotNull(Events.enteredUrl.testGetValue())
@@ -139,6 +146,8 @@ class SearchDialogControllerTest {
 
         createController().handleUrlCommitted(url)
 
+        browserStore.waitUntilIdle()
+
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = url,
@@ -149,6 +158,10 @@ class SearchDialogControllerTest {
                 flags = EngineSession.LoadUrlFlags.none(),
                 additionalHeaders = null,
             )
+        }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
         }
 
         assertNotNull(Events.enteredUrl.testGetValue())
@@ -168,6 +181,8 @@ class SearchDialogControllerTest {
 
         createController().handleUrlCommitted(searchTerm)
 
+        browserStore.waitUntilIdle()
+
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = searchTerm,
@@ -180,6 +195,10 @@ class SearchDialogControllerTest {
                     "X-Search-Subdivision" to "1",
                 ),
             )
+        }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
         }
     }
 
@@ -194,6 +213,8 @@ class SearchDialogControllerTest {
 
         createController().handleUrlCommitted(searchTerm)
 
+        browserStore.waitUntilIdle()
+
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = searchTerm,
@@ -206,6 +227,10 @@ class SearchDialogControllerTest {
                     "X-Search-Subdivision" to "0",
                 ),
             )
+        }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
         }
     }
 
@@ -220,7 +245,13 @@ class SearchDialogControllerTest {
             },
         ).handleUrlCommitted(url)
 
+        browserStore.waitUntilIdle()
+
         assertTrue(dismissDialogInvoked)
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertTrue(action.abandoned)
+        }
     }
 
     @Test
@@ -228,6 +259,8 @@ class SearchDialogControllerTest {
         val searchTerm = "Firefox"
 
         createController().handleUrlCommitted(searchTerm)
+
+        browserStore.waitUntilIdle()
 
         verify {
             activity.openToBrowserAndLoad(
@@ -239,6 +272,10 @@ class SearchDialogControllerTest {
                 flags = EngineSession.LoadUrlFlags.none(),
                 additionalHeaders = null,
             )
+        }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
         }
     }
 
@@ -255,6 +292,8 @@ class SearchDialogControllerTest {
             },
         ).handleUrlCommitted(searchTerm)
 
+        browserStore.waitUntilIdle()
+
         verify(exactly = 0) {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = any(),
@@ -265,6 +304,8 @@ class SearchDialogControllerTest {
         }
 
         assertFalse(dismissDialogInvoked)
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -274,8 +315,14 @@ class SearchDialogControllerTest {
 
         createController().handleUrlCommitted(url)
 
+        browserStore.waitUntilIdle()
+
         verify {
             activity.startActivity(any())
+        }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
         }
     }
 
@@ -286,7 +333,13 @@ class SearchDialogControllerTest {
 
         createController().handleUrlCommitted(url)
 
+        browserStore.waitUntilIdle()
+
         verify { navController.navigate(directions) }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
+        }
     }
 
     @Test
@@ -298,6 +351,8 @@ class SearchDialogControllerTest {
 
         createController().handleUrlCommitted(url)
 
+        browserStore.waitUntilIdle()
+
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = SupportUtils.getMozillaPageUrl(SupportUtils.MozillaPage.MANIFESTO),
@@ -307,6 +362,10 @@ class SearchDialogControllerTest {
                 flags = EngineSession.LoadUrlFlags.none(),
                 additionalHeaders = null,
             )
+        }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
         }
 
         assertNotNull(Events.enteredUrl.testGetValue())
@@ -338,7 +397,11 @@ class SearchDialogControllerTest {
 
         createController().handleTextChanged(text)
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.UpdateQuery(text)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -347,7 +410,11 @@ class SearchDialogControllerTest {
 
         createController().handleTextChanged(text)
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.UpdateQuery(text)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -357,7 +424,11 @@ class SearchDialogControllerTest {
 
         createController().handleTextChanged(text)
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(true)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -368,7 +439,11 @@ class SearchDialogControllerTest {
 
         createController().handleTextChanged(text)
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(true)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -379,7 +454,11 @@ class SearchDialogControllerTest {
 
         createController().handleTextChanged(text)
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(false)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -391,7 +470,11 @@ class SearchDialogControllerTest {
 
         createController().handleTextChanged(text)
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(false)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -400,7 +483,11 @@ class SearchDialogControllerTest {
 
         createController().handleTextChanged(text)
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(false)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -411,7 +498,11 @@ class SearchDialogControllerTest {
 
         createController().handleTextChanged(text)
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(false)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -422,7 +513,11 @@ class SearchDialogControllerTest {
 
         createController().handleTextChanged(text)
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(false)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -432,9 +527,14 @@ class SearchDialogControllerTest {
         val text = "mozilla"
 
         createController().handleTextChanged(text)
+
+        browserStore.waitUntilIdle()
+
         val actionSlot = mutableListOf<SearchFragmentAction>()
         verify { store.dispatch(capture(actionSlot)) }
         assertFalse(actionSlot.any { it is SearchFragmentAction.AllowSearchSuggestionsInPrivateModePrompt })
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -444,9 +544,14 @@ class SearchDialogControllerTest {
         val text = "mozilla"
 
         createController().handleTextChanged(text)
+
+        browserStore.waitUntilIdle()
+
         val actionSlot = mutableListOf<SearchFragmentAction>()
         verify { store.dispatch(capture(actionSlot)) }
         assertTrue(actionSlot.any { it is SearchFragmentAction.AllowSearchSuggestionsInPrivateModePrompt })
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -457,6 +562,8 @@ class SearchDialogControllerTest {
 
         createController().handleUrlTapped(url, flags)
         createController().handleUrlTapped(url)
+
+        browserStore.waitUntilIdle()
 
         verify {
             activity.openToBrowserAndLoad(
@@ -472,6 +579,10 @@ class SearchDialogControllerTest {
         assertEquals(2, snapshot.size)
         assertEquals("false", snapshot.first().extra?.getValue("autocomplete"))
         assertEquals("false", snapshot[1].extra?.getValue("autocomplete"))
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
+        }
     }
 
     @Test
@@ -479,6 +590,8 @@ class SearchDialogControllerTest {
         val searchTerms = "fenix"
 
         createController().handleSearchTermsTapped(searchTerms)
+
+        browserStore.waitUntilIdle()
 
         verify {
             activity.openToBrowserAndLoad(
@@ -490,6 +603,10 @@ class SearchDialogControllerTest {
                 flags = EngineSession.LoadUrlFlags.none(),
                 additionalHeaders = null,
             )
+        }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
         }
     }
 
@@ -506,8 +623,12 @@ class SearchDialogControllerTest {
             },
         ).handleSearchShortcutEngineSelected(searchEngine)
 
+        browserStore.waitUntilIdle()
+
         assertTrue(focusToolbarInvoked)
         verify { store.dispatch(SearchFragmentAction.SearchShortcutEngineSelected(searchEngine, browsingMode, settings)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
 
         assertNotNull(SearchShortcuts.selected.testGetValue())
         val recordedEvents = SearchShortcuts.selected.testGetValue()!!
@@ -534,8 +655,12 @@ class SearchDialogControllerTest {
             },
         ).handleSearchShortcutEngineSelected(searchEngine)
 
+        browserStore.waitUntilIdle()
+
         assertTrue(focusToolbarInvoked)
         verify { store.dispatch(SearchFragmentAction.SearchHistoryEngineSelected(searchEngine)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
 
         assertNotNull(UnifiedSearch.engineSelected.testGetValue())
         val recordedEvents = UnifiedSearch.engineSelected.testGetValue()!!
@@ -562,8 +687,12 @@ class SearchDialogControllerTest {
             },
         ).handleSearchShortcutEngineSelected(searchEngine)
 
+        browserStore.waitUntilIdle()
+
         assertTrue(focusToolbarInvoked)
         verify { store.dispatch(SearchFragmentAction.SearchBookmarksEngineSelected(searchEngine)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
 
         assertNotNull(UnifiedSearch.engineSelected.testGetValue())
         val recordedEvents = UnifiedSearch.engineSelected.testGetValue()!!
@@ -590,8 +719,12 @@ class SearchDialogControllerTest {
             },
         ).handleSearchShortcutEngineSelected(searchEngine)
 
+        browserStore.waitUntilIdle()
+
         assertTrue(focusToolbarInvoked)
         verify { store.dispatch(SearchFragmentAction.SearchTabsEngineSelected(searchEngine)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
 
         assertNotNull(UnifiedSearch.engineSelected.testGetValue())
         val recordedEvents = UnifiedSearch.engineSelected.testGetValue()!!
@@ -608,7 +741,13 @@ class SearchDialogControllerTest {
 
         createController().handleClickSearchEngineSettings()
 
+        browserStore.waitUntilIdle()
+
         verify { navController.navigate(directions) }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertTrue(action.abandoned)
+        }
     }
 
     @Test
@@ -617,7 +756,11 @@ class SearchDialogControllerTest {
 
         createController().handleSearchShortcutsButtonClicked()
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(false)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -626,7 +769,11 @@ class SearchDialogControllerTest {
 
         createController().handleSearchShortcutsButtonClicked()
 
+        browserStore.waitUntilIdle()
+
         verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(true)) }
+
+        middleware.assertNotDispatched(AwesomeBarAction.EngagementFinished::class)
     }
 
     @Test
@@ -640,6 +787,10 @@ class SearchDialogControllerTest {
         }
 
         verify { activity.openToBrowser(from = BrowserDirection.FromSearchDialog) }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
+        }
     }
 
     @Test
@@ -652,6 +803,10 @@ class SearchDialogControllerTest {
             assertEquals("tab-id", action.tabId)
         }
         verify { activity.openToBrowser(from = BrowserDirection.FromSearchDialog) }
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertFalse(action.abandoned)
+        }
     }
 
     @Test


### PR DESCRIPTION
This is a three-part change that builds on bug 1857092 to record impressions for sponsored Firefox Suggest suggestions.

It's probably easiest to review commit-by-commit—the messages for each commit have a bit more context about how the changes fit together! But here's a quick overview:

* The first part adds new actions (`AwesomeBarAction`) and state (`AwesomeBarState`) to `browser-state` that remembers the currently visible suggestions and the last clicked suggestion.
* The second part adds middleware to `feature-fxsuggest` that emits facts for impressions and clicks based on the `AwesomeBarState`.
* The third part is the Fenix integration: dispatching the new `AwesomeBarAction`s, mounting the new middleware, and collecting the emitted facts in Glean.

/cc @ncloudioj

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1858542