### PR TITLE
Bug 1860052 - Custom tabs TestRail matching

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
@@ -21,7 +21,6 @@ import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.FeatureSettingsHelperDelegate
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
-import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper
@@ -33,7 +32,6 @@ import org.mozilla.fenix.ui.robots.clickPageObject
 import org.mozilla.fenix.ui.robots.customTabScreen
 import org.mozilla.fenix.ui.robots.enhancedTrackingProtection
 import org.mozilla.fenix.ui.robots.homeScreen
-import org.mozilla.fenix.ui.robots.longClickPageObject
 import org.mozilla.fenix.ui.robots.navigationToolbar
 import org.mozilla.fenix.ui.robots.notificationShade
 import org.mozilla.fenix.ui.robots.openEditURLView
@@ -78,29 +76,10 @@ class CustomTabsTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/249659
     @SmokeTest
     @Test
-    fun customTabsOpenExternalLinkTest() {
-        val externalLinkURL = "https://mozilla-mobile.github.io/testapp/downloads"
-
-        intentReceiverActivityTestRule.launchActivity(
-            createCustomTabIntent(
-                externalLinksPWAPage.toUri().toString(),
-                customMenuItem,
-            ),
-        )
-
-        customTabScreen {
-            waitForPageToLoad()
-            clickPageObject(itemContainingText("External link"))
-            waitForPageToLoad()
-            verifyCustomTabToolbarTitle(externalLinkURL)
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun customTabsSaveLoginTest() {
+    fun verifyLoginSaveInCustomTabTest() {
         intentReceiverActivityTestRule.launchActivity(
             createCustomTabIntent(
                 loginPage.toUri().toString(),
@@ -131,9 +110,9 @@ class CustomTabsTest {
         }
     }
 
-    @SmokeTest
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2334762
     @Test
-    fun customTabCopyToolbarUrlTest() {
+    fun copyCustomTabToolbarUrlTest() {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         intentReceiverActivityTestRule.launchActivity(
@@ -161,33 +140,11 @@ class CustomTabsTest {
         }
     }
 
-    @SmokeTest
-    @Test
-    fun customTabShareTextTest() {
-        val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        intentReceiverActivityTestRule.launchActivity(
-            createCustomTabIntent(
-                customTabPage.url.toString(),
-                customMenuItem,
-            ),
-        )
-
-        customTabScreen {
-            waitForPageToLoad()
-        }
-
-        browserScreen {
-            longClickPageObject(itemContainingText("content"))
-        }.clickShareSelectedText {
-            verifyAndroidShareLayout()
-        }
-    }
-
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2334761
     @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807289")
     @SmokeTest
     @Test
-    fun customTabDownloadTest() {
+    fun verifyDownloadInACustomTabTest() {
         val customTabPage = "https://storage.googleapis.com/mobile_test_assets/test_app/downloads.html"
         val downloadFile = "web_icon.png"
 
@@ -214,10 +171,11 @@ class CustomTabsTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/249644
     // Verifies the main menu of a custom tab with a custom menu item
     @SmokeTest
     @Test
-    fun customTabMenuItemsTest() {
+    fun verifyCustomTabMenuItemsTest() {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         intentReceiverActivityTestRule.launchActivity(
@@ -241,9 +199,11 @@ class CustomTabsTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/249645
     // The test opens a link in a custom tab then sends it to the browser
+    @SmokeTest
     @Test
-    fun openCustomTabInBrowserTest() {
+    fun openCustomTabInFirefoxTest() {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         intentReceiverActivityTestRule.launchActivity(
@@ -260,8 +220,9 @@ class CustomTabsTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2239548
     @Test
-    fun shareCustomTabTest() {
+    fun shareCustomTabUsingToolbarButtonTest() {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         intentReceiverActivityTestRule.launchActivity(
@@ -276,8 +237,9 @@ class CustomTabsTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/249643
     @Test
-    fun verifyCustomTabViewTest() {
+    fun verifyCustomTabViewItemsTest() {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         intentReceiverActivityTestRule.launchActivity(
@@ -302,8 +264,9 @@ class CustomTabsTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2239544
     @Test
-    fun verifyPdfCustomTabViewTest() {
+    fun verifyPDFViewerInACustomTabTest() {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 3)
         val pdfFormResource = TestAssetHelper.getPdfFormAsset(mockWebServer)
 
@@ -331,8 +294,9 @@ class CustomTabsTest {
         }
     }
 
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2239117
     @Test
-    fun verifyETPSheetAndToggleTest() {
+    fun verifyCustomTabETPSheetAndToggleTest() {
         val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         intentReceiverActivityTestRule.launchActivity(


### PR DESCRIPTION
These changes are part of our data alignment between testRail and our automated UI tests.

For more information please see this [document](https://docs.google.com/document/d/1NMr5xo-vnle5zp95X5rVUSS-TzBKabdjNLt-6SiutJw/edit?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1860052