### PR TITLE
Bug 1859650 - Robo Test: Expand Device Coverage and Execution Duration

### DIFF
--- a/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
@@ -3,7 +3,7 @@
 gcloud:
   results-bucket: fenix_test_artifacts
   record-video: false
-  timeout: 10m
+  timeout: 15m
   async: false
 
   app: /app/path
@@ -14,11 +14,11 @@ gcloud:
     clearPackageData: true
 
   device:
-    - model: Pixel2.arm
-      version: 26
+    - model: redfin
+      version: 30
       locale: en_US
-    - model: Pixel2.arm
-      version: 27
+    - model: OnePlus9Pro
+      version: 33
       locale: en_US
     - model: dreamlte
       version: 28
@@ -28,6 +28,27 @@ gcloud:
       locale: en_US
     - model: x1q
       version: 29
+      locale: en_US
+    - model: a51
+      version: 31
+      locale: en_US
+    - model: b0q
+      version: 33
+      locale: en_US
+    - model: b4q
+      version: 33
+      locale: en_US
+    - model: bluejay
+      version: 32
+      locale: en_US
+    - model: cheetah
+      version: 33
+      locale: en_US
+    - model: f2q
+      version: 30
+      locale: en_US
+    - model: q2q
+      version: 31
       locale: en_US
 
   type: robo

--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -329,7 +329,7 @@ tasks:
             shipping-product: fenix
             code-review: false
         description: Run Robo test on ARM devices
-        run-on-tasks-for: [github-push]
+        run-on-tasks-for: [github-pull-request, github-push]
         run-on-git-branches: [main]
         dependencies:
             signed-apk-debug-apk: signing-apk-fenix-debug


### PR DESCRIPTION
This is a temporary draft only test to see if we can unearth some more crashes in Fenix across a wider spectrum of devices on Robo Test.

https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650
https://bugzilla.mozilla.org/show_bug.cgi?id=1859650