### PR TITLE
Bug 1860130 - Fix getSerializedDoc message reply in readerview-background.js

### DIFF
--- a/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
+++ b/android-components/components/feature/readerview/src/main/assets/extensions/readerview/readerview-background.js
@@ -5,16 +5,17 @@
 // This background script is needed to update the current tab
 // and activate reader view.
 
-browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
+browser.runtime.onMessage.addListener(message => {
   switch (message.action) {
      case 'addSerializedDoc':
         browser.storage.session.set({ [message.id]: message.doc });
-        break;
+        return Promise.resolve();
      case 'getSerializedDoc':
-       let doc = await browser.storage.session.get(message.id);
-       browser.storage.session.remove(message.id);
-       sendResponse(doc);
-       break;
+        return (async () => {
+          let doc = await browser.storage.session.get(message.id);
+          browser.storage.session.remove(message.id);
+          return doc[message.id];
+        })();
      default:
        console.error(`Received unsupported action ${message.action}`);
    }

--- a/android-components/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
+++ b/android-components/components/feature/readerview/src/main/java/mozilla/components/feature/readerview/ReaderViewFeature.kt
@@ -30,6 +30,7 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.filterChanged
 import mozilla.components.support.webextensions.WebExtensionController
 import org.json.JSONObject
 import java.lang.ref.WeakReference
+import java.net.URLEncoder
 import java.util.Locale
 import java.util.UUID
 
@@ -294,7 +295,12 @@ class ReaderViewFeature(
 
     private fun WebExtensionController.createReaderUrl(url: String, id: String): String? {
         val colorScheme = config.colorScheme.name.lowercase(Locale.ROOT)
-        return readerBaseUrl?.let { it + "readerview.html?url=$url&id=$id&colorScheme=$colorScheme" }
+        // Encode the original page url, otherwise when the readerview page will try to
+        // parse the url and retrieve the readerview url params (ir and colorScheme)
+        // the parser may get confused because the original webpage url being interpolated
+        // may also include its own search params non-escaped (See Bug 1860490).
+        val encodedUrl = URLEncoder.encode(url, "UTF-8")
+        return readerBaseUrl?.let { it + "readerview.html?url=$encodedUrl&id=$id&colorScheme=$colorScheme" }
     }
 
     @VisibleForTesting

--- a/android-components/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
+++ b/android-components/components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt
@@ -282,7 +282,7 @@ class ReaderViewFeatureTest {
         val readerViewFeature = ReaderViewFeature(testContext, engine, store, mock(), { "bbbbf5ce-3b0f-4f74-8a1f-986d89bffea7" })
         readerViewFeature.readerBaseUrl = "moz-extension://012345/"
         readerViewFeature.showReaderView()
-        verify(store).dispatch(EngineAction.LoadUrlAction(tab.id, "moz-extension://012345/readerview.html?url=https://www.mozilla.org&id=bbbbf5ce-3b0f-4f74-8a1f-986d89bffea7&colorScheme=light"))
+        verify(store).dispatch(EngineAction.LoadUrlAction(tab.id, "moz-extension://012345/readerview.html?url=https%3A%2F%2Fwww.mozilla.org&id=bbbbf5ce-3b0f-4f74-8a1f-986d89bffea7&colorScheme=light"))
         verify(store).dispatch(ReaderAction.UpdateReaderActiveAction(tab.id, true))
     }
 


### PR DESCRIPTION
### Pull Request checklist

- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1860130