### PR TITLE
Bug 1860263 - Remove onActivityCreated from Focus fragments.

### DIFF
--- a/focus-android/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/searchsuggestions/ui/SearchSuggestionsFragment.kt
@@ -12,7 +12,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -35,10 +35,11 @@ class SearchSuggestionsFragment : Fragment(), CoroutineScope {
 
     private var _binding: FragmentSearchSuggestionsBinding? = null
     private val binding get() = _binding!!
-    lateinit var searchSuggestionsViewModel: SearchSuggestionsViewModel
 
     private val defaultSearchEngineName: String
         get() = requireComponents.store.defaultSearchEngineName()
+
+    private val searchSuggestionsViewModel: SearchSuggestionsViewModel by activityViewModels()
 
     override fun onResume() {
         super.onResume()
@@ -60,12 +61,17 @@ class SearchSuggestionsFragment : Fragment(), CoroutineScope {
         _binding = null
     }
 
-    @Suppress("DEPRECATION") // https://github.com/mozilla-mobile/focus-android/issues/4958
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentSearchSuggestionsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
-        searchSuggestionsViewModel = ViewModelProvider(requireParentFragment())
-            .get(SearchSuggestionsViewModel::class.java)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         searchSuggestionsViewModel.state.observe(
             viewLifecycleOwner,
@@ -82,19 +88,6 @@ class SearchSuggestionsFragment : Fragment(), CoroutineScope {
                     binding.enableSearchSuggestionsContainer.isVisible = state.givePrompt
             }
         }
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?,
-    ): View {
-        _binding = FragmentSearchSuggestionsBinding.inflate(inflater, container, false)
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
 
         val appName = resources.getString(R.string.app_name)
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1860263