### PR TITLE
Bug 1860632 - Add unenrollment telemetry verification tests to integration test suite

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration/GenericExperimentIntegrationTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration/GenericExperimentIntegrationTest.kt
@@ -33,7 +33,8 @@ class GenericExperimentIntegrationTest {
         TestHelper.appContext.settings().showSecretDebugMenuThisSession = false
     }
 
-    private fun disableStudiesViaStudiesToggle() {
+    @Test
+    fun disableStudiesViaStudiesToggle() {
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration/tests/test_generic_scenarios.py
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/experimentintegration/tests/test_generic_scenarios.py
@@ -1,12 +1,17 @@
 import pytest
 
 @pytest.mark.parametrize("load_branches", [("branch")], indirect=True)
-def test_experiment_unenrolls_via_studies_toggle(setup_experiment, gradlewbuild, load_branches):
+def test_experiment_unenrolls_via_studies_toggle(setup_experiment, gradlewbuild, load_branches, check_ping_for_experiment):
     setup_experiment(load_branches)
     gradlewbuild.test("GenericExperimentIntegrationTest#disableStudiesViaStudiesToggle")
-    gradlewbuild.test("GenericExperimentIntegrationTest#testExperimentUnenrolls")
+    assert check_ping_for_experiment(reason="enrollment", branch=load_branches[0])
+    gradlewbuild.test("GenericExperimentIntegrationTest#testExperimentUnenrolled")
+    assert check_ping_for_experiment(reason="unenrollment", branch=load_branches[0])
 
 @pytest.mark.parametrize("load_branches", [("branch")], indirect=True)
-def test_experiment_unenrolls_via_secret_menu(setup_experiment, gradlewbuild, load_branches):
+def test_experiment_unenrolls_via_secret_menu(setup_experiment, gradlewbuild, load_branches, check_ping_for_experiment):
     setup_experiment(load_branches)
-    gradlewbuild.test("GenericExperimentIntegrationTest#testExperimentUnenrollsViaSecretMenu")
+    gradlewbuild.test("GenericExperimentIntegrationTest#testExperimentUnenrolledViaSecretMenu")
+    assert check_ping_for_experiment(reason="enrollment", branch=load_branches[0])
+    gradlewbuild.test("GenericExperimentIntegrationTest#testExperimentUnenrolled")
+    assert check_ping_for_experiment(reason="unenrollment", branch=load_branches[0])

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -428,8 +428,7 @@ class SettingsRobot {
 
         fun openExperimentsMenu(interact: SettingsSubMenuExperimentsRobot.() -> Unit): SettingsSubMenuExperimentsRobot.Transition {
             scrollToElementByText("Nimbus Experiments")
-            fun nimbusExperimentsButton() = mDevice.findObject(textContains("Nimbus Experiments"))
-            nimbusExperimentsButton().click()
+            onView(withText(getStringResource(R.string.preferences_nimbus_experiments))).click()
 
             SettingsSubMenuExperimentsRobot().interact()
             return SettingsSubMenuExperimentsRobot.Transition()


### PR DESCRIPTION
[JIRA TICKET](https://mozilla-hub.atlassian.net/browse/EXP-3955
)
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1860632