### PR TITLE
Bug 1855286 - Fix Talk Back with link texts with multiple embedded links

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckNavigationMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckNavigationMiddleware.kt
@@ -10,12 +10,6 @@ import org.mozilla.fenix.shopping.store.ReviewQualityCheckAction
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckMiddleware
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 
-private const val POWERED_BY_URL =
-    "https://www.fakespot.com/our-mission?utm_source=review-checker" +
-        "&utm_campaign=fakespot-by-mozilla&utm_medium=inproduct&utm_term=core-sheet"
-private const val PRIVACY_POLICY_URL = "https://www.fakespot.com/privacy-policy"
-private const val TERMS_OF_USE_URL = "https://www.fakespot.com/terms"
-
 /**
  * Middleware that handles navigation events for the review quality check feature.
  *
@@ -64,5 +58,13 @@ class ReviewQualityCheckNavigationMiddleware(
         is ReviewQualityCheckAction.OpenOnboardingPrivacyPolicyLink -> PRIVACY_POLICY_URL
 
         is ReviewQualityCheckAction.OpenPoweredByLink -> POWERED_BY_URL
+    }
+
+    companion object {
+        private const val POWERED_BY_URL =
+            "https://www.fakespot.com/our-mission?utm_source=review-checker" +
+                "&utm_campaign=fakespot-by-mozilla&utm_medium=inproduct&utm_term=core-sheet"
+        const val PRIVACY_POLICY_URL = "https://www.fakespot.com/privacy-policy"
+        const val TERMS_OF_USE_URL = "https://www.fakespot.com/terms"
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContextualOnboarding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContextualOnboarding.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -26,12 +27,12 @@ import org.mozilla.fenix.compose.LinkText
 import org.mozilla.fenix.compose.LinkTextState
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.compose.button.PrimaryButton
+import org.mozilla.fenix.shopping.middleware.GetReviewQualityCheckSumoUrl
+import org.mozilla.fenix.shopping.middleware.ReviewQualityCheckNavigationMiddleware
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.ProductVendor
 import org.mozilla.fenix.shopping.ui.ext.displayName
 import org.mozilla.fenix.theme.FirefoxTheme
-
-const val PLACEHOLDER_URL = "www.fakespot.com"
 
 /**
  * A placeholder UI for review quality check contextual onboarding. The actual UI will be
@@ -87,7 +88,7 @@ fun ReviewQualityCheckContextualOnboarding(
             linkTextStates = listOf(
                 LinkTextState(
                     text = learnMoreText,
-                    url = PLACEHOLDER_URL,
+                    url = GetReviewQualityCheckSumoUrl(LocalContext.current).invoke(),
                     onClick = {
                         onLearnMoreClick()
                     },
@@ -111,14 +112,14 @@ fun ReviewQualityCheckContextualOnboarding(
             linkTextStates = listOf(
                 LinkTextState(
                     text = privacyPolicyText,
-                    url = PLACEHOLDER_URL,
+                    url = ReviewQualityCheckNavigationMiddleware.PRIVACY_POLICY_URL,
                     onClick = {
                         onPrivacyPolicyClick()
                     },
                 ),
                 LinkTextState(
                     text = termsOfUseText,
-                    url = PLACEHOLDER_URL,
+                    url = ReviewQualityCheckNavigationMiddleware.TERMS_OF_USE_URL,
                     onClick = {
                         onTermsOfUseClick()
                     },


### PR DESCRIPTION
Talkback was only discovering one of the two links in Shopping onboarding. After doing some adjacent pairing with Jeff, I discovered we could add `addUrlAnnotation` when constructing the annotated string to allow TalkBack to properly get two links inside its context menu but also do the link chime sound effect when reading off the blurb. The proper links also had to be plugged-in for `LinkText` to function properly.

This should also fix [Bug 1857850](https://bugzilla.mozilla.org/show_bug.cgi?id=1857850).


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1855286