### PR TITLE
Bug 1857215 - Part 2:Integrate review checker recommendations

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductRecommendationMapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductRecommendationMapper.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.middleware
+
+import mozilla.components.concept.engine.shopping.ProductRecommendation
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.RecommendedProductState
+import java.text.NumberFormat
+import java.util.Currency
+import java.util.Locale
+
+private const val MINIMUM_FRACTION_DIGITS = 0
+private const val MAXIMUM_FRACTION_DIGITS = 2
+
+/**
+ * Maps [ProductRecommendation] to [RecommendedProductState].
+ */
+fun ProductRecommendation?.toRecommendedProductState(): RecommendedProductState =
+    this?.toRecommendedProduct() ?: RecommendedProductState.Error
+
+private fun ProductRecommendation.toRecommendedProduct(): RecommendedProductState.Product =
+    RecommendedProductState.Product(
+        aid = aid,
+        name = name,
+        productUrl = url,
+        imageUrl = imageUrl,
+        formattedPrice = price.toDouble().toFormattedAmount(currency),
+        reviewGrade = grade.asEnumOrDefault<ReviewQualityCheckState.Grade>()!!,
+        adjustedRating = adjustedRating.toFloat(),
+        isSponsored = sponsored,
+        analysisUrl = analysisUrl,
+    )
+
+private fun Double.toFormattedAmount(currencyCode: String): String =
+    mapCurrencyCodeToNumberFormat(currencyCode).apply {
+        minimumFractionDigits = MINIMUM_FRACTION_DIGITS
+        maximumFractionDigits = MAXIMUM_FRACTION_DIGITS
+    }.format(this)
+
+private fun mapCurrencyCodeToNumberFormat(currencyCode: String): NumberFormat =
+    try {
+        val currency = Currency.getInstance(currencyCode)
+        NumberFormat.getCurrencyInstance(Locale.getDefault()).apply {
+            this.currency = currency
+        }
+    } catch (e: IllegalArgumentException) {
+        NumberFormat.getNumberInstance()
+    }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckNetworkMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckNetworkMiddleware.kt
@@ -14,10 +14,12 @@ import org.mozilla.fenix.components.appstate.AppAction.ShoppingAction
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckAction
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckAction.FetchProductAnalysis
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckAction.RetryProductAnalysis
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckAction.UpdateRecommendedProduct
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckMiddleware
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent.AnalysisStatus
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.RecommendedProductState
 
 /**
  * Middleware that handles network requests for the review quality check feature.
@@ -71,6 +73,10 @@ class ReviewQualityCheckNetworkMiddleware(
                             productReviewState = productReviewState,
                             productAnalysis = productAnalysis,
                         )
+                    }
+
+                    if (productReviewState is ProductReviewState.AnalysisPresent) {
+                        store.updateRecommendedProductState()
                     }
                 }
 
@@ -150,4 +156,16 @@ class ReviewQualityCheckNetworkMiddleware(
 
     private fun ProductReviewState.isAnalysisPresentOrNoAnalysisPresent() =
         this is ProductReviewState.AnalysisPresent || this is ProductReviewState.NoAnalysisPresent
+
+    private suspend fun Store<ReviewQualityCheckState, ReviewQualityCheckAction>.updateRecommendedProductState() {
+        val currentState = state
+        if (currentState is ReviewQualityCheckState.OptedIn &&
+            currentState.productRecommendationsPreference == true
+        ) {
+            dispatch(UpdateRecommendedProduct(RecommendedProductState.Loading))
+            reviewQualityCheckService.productRecommendation().toRecommendedProductState().also {
+                dispatch(UpdateRecommendedProduct(it))
+            }
+        }
+    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.shopping.store
 
 import mozilla.components.lib.state.Action
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.RecommendedProductState
 
 /**
  * Actions for review quality check feature.
@@ -79,9 +80,16 @@ sealed interface ReviewQualityCheckAction : Action {
     ) : UpdateAction, TelemetryAction
 
     /**
-     * Triggered as a result of a [NetworkAction] to update the state.
+     * Triggered as a result of a [NetworkAction] to update the [ProductReviewState].
      */
     data class UpdateProductReview(val productReviewState: ProductReviewState) : UpdateAction
+
+    /**
+     * Triggered as a result of a [NetworkAction] to update the [RecommendedProductState].
+     */
+    data class UpdateRecommendedProduct(
+        val recommendedProductState: RecommendedProductState,
+    ) : UpdateAction
 
     /**
      * Triggered when the user has opted in to the review quality check feature and the UI is opened.

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
@@ -171,6 +171,7 @@ sealed interface ReviewQualityCheckState : State {
         /**
          * The state when the recommended product is available.
          *
+         * @property aid The unique identifier of the product.
          * @property name The name of the product.
          * @property productUrl The url of the product.
          * @property imageUrl The url of the image of the product.
@@ -181,6 +182,7 @@ sealed interface ReviewQualityCheckState : State {
          * @property analysisUrl The url of the analysis of the product.
          */
         data class Product(
+            val aid: String,
             val name: String,
             val productUrl: String,
             val imageUrl: String,

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
@@ -564,6 +564,7 @@ private class ProductAnalysisPreviewModelParameterProvider :
             ProductAnalysisPreviewModel(
                 productRecommendationsEnabled = true,
                 recommendedProductState = RecommendedProductState.Product(
+                    aid = "aid",
                     name = "The best desk ever with a really really really long product name that " +
                         "forces the preview to wrap its text to at least 4 lines.",
                     productUrl = "www.mozilla.com",

--- a/fenix/app/src/test/java/org/mozilla/fenix/helpers/LocaleTestRule.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/helpers/LocaleTestRule.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.helpers
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.util.Locale
+
+/**
+ * A JUnit [TestRule] that sets the default locale to a given [localeToSet] for the duration of
+ * the test and then resets it to the original locale.
+ *
+ * @param localeToSet The locale to set for the duration of the test.
+ */
+class LocaleTestRule(private val localeToSet: Locale) : TestRule {
+
+    private var originalLocale: Locale? = null
+
+    override fun apply(base: Statement, description: Description): Statement =
+        object : Statement() {
+
+            override fun evaluate() {
+                originalLocale = Locale.getDefault()
+                Locale.setDefault(localeToSet)
+
+                try {
+                    base.evaluate() // Run the tests
+                } finally {
+                    // Reset to the original locale after tests
+                    Locale.setDefault(originalLocale!!)
+                }
+            }
+        }
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/ProductAnalysisTestData.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/ProductAnalysisTestData.kt
@@ -8,6 +8,7 @@ import mozilla.components.concept.engine.shopping.Highlight
 import mozilla.components.concept.engine.shopping.ProductAnalysis
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent.AnalysisStatus
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.RecommendedProductState
 import java.util.SortedMap
 
 object ProductAnalysisTestData {
@@ -43,6 +44,7 @@ object ProductAnalysisTestData {
         adjustedRating: Float? = 4.5f,
         analysisStatus: AnalysisStatus = AnalysisStatus.UP_TO_DATE,
         highlights: SortedMap<ReviewQualityCheckState.HighlightType, List<String>>? = null,
+        recommendedProductState: RecommendedProductState = RecommendedProductState.Initial,
     ): ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent =
         ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent(
             productId = productId,
@@ -51,5 +53,6 @@ object ProductAnalysisTestData {
             adjustedRating = adjustedRating,
             analysisStatus = analysisStatus,
             highlights = highlights,
+            recommendedProductState = recommendedProductState,
         )
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/ProductRecommendationTestData.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/ProductRecommendationTestData.kt
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping
+
+import mozilla.components.concept.engine.shopping.ProductRecommendation
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
+
+object ProductRecommendationTestData {
+
+    fun productRecommendation(
+        aid: String = "aid",
+        url: String = "https://test.com",
+        grade: String = "A",
+        adjustedRating: Double = 4.7,
+        sponsored: Boolean = true,
+        analysisUrl: String = "analysisUrl",
+        imageUrl: String = "https://imageurl.com",
+        name: String = "Test Product",
+        price: String = "100",
+        currency: String = "USD",
+    ): ProductRecommendation = ProductRecommendation(
+        aid = aid,
+        url = url,
+        grade = grade,
+        adjustedRating = adjustedRating,
+        sponsored = sponsored,
+        analysisUrl = analysisUrl,
+        imageUrl = imageUrl,
+        name = name,
+        price = price,
+        currency = currency,
+    )
+
+    fun product(
+        aid: String = "aid",
+        url: String = "https://test.com",
+        reviewGrade: ReviewQualityCheckState.Grade = ReviewQualityCheckState.Grade.A,
+        adjustedRating: Double = 4.7,
+        sponsored: Boolean = true,
+        analysisUrl: String = "analysisUrl",
+        imageUrl: String = "https://imageurl.com",
+        name: String = "Test Product",
+        formattedPrice: String = "$100",
+    ): ReviewQualityCheckState.RecommendedProductState.Product =
+        ReviewQualityCheckState.RecommendedProductState.Product(
+            aid = aid,
+            productUrl = url,
+            reviewGrade = reviewGrade,
+            adjustedRating = adjustedRating.toFloat(),
+            isSponsored = sponsored,
+            analysisUrl = analysisUrl,
+            imageUrl = imageUrl,
+            name = name,
+            formattedPrice = formattedPrice,
+        )
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductRecommendationMapperTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductRecommendationMapperTest.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shopping.middleware
+
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.helpers.LocaleTestRule
+import org.mozilla.fenix.shopping.ProductRecommendationTestData
+import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
+import java.util.Locale
+
+class ProductRecommendationMapperTest {
+
+    @get:Rule
+    val localeTestRule = LocaleTestRule(Locale.US)
+
+    @Test
+    fun `WHEN ProductRecommendation is null THEN it is mapped to Error`() {
+        val actual = null.toRecommendedProductState()
+        val expected = ReviewQualityCheckState.RecommendedProductState.Error
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN ProductRecommendation has data THEN it is mapped to product`() {
+        val productRecommendation = ProductRecommendationTestData.productRecommendation()
+        val actual = productRecommendation.toRecommendedProductState()
+        val expected = ProductRecommendationTestData.product()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN ProductRecommendation has data with invalid currency code THEN it is mapped to product`() {
+        val productRecommendation = ProductRecommendationTestData.productRecommendation(
+            price = "100",
+            currency = "invalid",
+        )
+        val actual = productRecommendation.toRecommendedProductState()
+        val expected = ProductRecommendationTestData.product(
+            formattedPrice = "100",
+        )
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
– Uses `ReviewQualityCheckService` in middleware to fetch product recommendations and update the state
– Add `ProductRecommendationsMapper`
– Update RecommendedProductState.Product to include `aid`.
– Add LocaleTestRule to make Locale based testing easier

Note: Since this is a [bug](https://mozilla-hub.atlassian.net/jira/software/c/projects/FAK/boards/669?selectedIssue=FAK-665) on backend, make `price` nullable in `mozilla.components.concept.engine.shopping.ProductRecommendation` to use this to display the UI.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1857215