### PR TITLE
Bug 1567912 - Add build-bundle as a dependency for the complete task

### DIFF
--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -6,6 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 kind-dependencies:
     - build-apk
+    - build-bundle
     - build-components
     - build-samples-browser
     - docker-image


### PR DESCRIPTION
Drive-by fix for an issue I noticed today.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1567912