### PR TITLE
Bug 1861234 — Add SharedPreferences to NimbusBuilder

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -64,6 +64,7 @@ fun createNimbus(context: Context, urlString: String?): NimbusApi {
         initialExperiments = R.raw.initial_experiments
         timeoutLoadingExperiment = TIME_OUT_LOADING_EXPERIMENT_FROM_DISK_MS
         usePreviewCollection = context.settings().nimbusUsePreview
+        sharedPreferences = context.settings().preferences
         isFirstRun = isAppFirstRun
         featureManifest = FxNimbus
         onFetchCallback = {

--- a/focus-android/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/experiments/NimbusSetup.kt
@@ -69,6 +69,7 @@ fun createNimbus(context: Context, urlString: String?): NimbusApi {
         initialExperiments = R.raw.initial_experiments
         timeoutLoadingExperiment = TIME_OUT_LOADING_EXPERIMENT_FROM_DISK_MS
         usePreviewCollection = context.settings.shouldUseNimbusPreview
+        sharedPreferences = context.settings.preferences
         isFirstRun = isAppFirstRun
         featureManifest = FocusNimbus
     }.build(appInfo)


### PR DESCRIPTION
Fixes [EXP-2822](https://mozilla-hub.atlassian.net/browse/EXP-2822).

This PR tells the `NimbusBuilder` in both Focus and Firefox about SharedPrefernece. The first place this is [exposed to is the Nimbus FML file](https://experimenter.info/fml/using-prefs/).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1861234