### PR TITLE
Bug 1861219 - Resolve breaking changes to the Rust fxa-client

### DIFF
--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Config.kt
@@ -6,8 +6,8 @@ package mozilla.components.service.fxa
 
 import mozilla.components.service.fxa.sync.GlobalSyncableStoreProvider
 
-typealias ServerConfig = mozilla.appservices.fxaclient.Config
-typealias Server = mozilla.appservices.fxaclient.Config.Server
+typealias ServerConfig = mozilla.appservices.fxaclient.FxaConfig
+typealias Server = mozilla.appservices.fxaclient.FxaServer
 
 /**
  * @property periodMinutes How frequently periodic sync should happen.

--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -10,6 +10,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
+import mozilla.appservices.fxaclient.FxaClient
 import mozilla.appservices.fxaclient.FxaException
 import mozilla.appservices.syncmanager.SyncTelemetry
 import mozilla.components.concept.base.crash.CrashReporting
@@ -27,7 +28,6 @@ import mozilla.components.concept.sync.ServiceResult
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
-import mozilla.appservices.fxaclient.PersistedFirefoxAccount as FirefoxAccount
 
 internal sealed class FxaDeviceConstellationException : Exception() {
     /**
@@ -37,10 +37,10 @@ internal sealed class FxaDeviceConstellationException : Exception() {
 }
 
 /**
- * Provides an implementation of [DeviceConstellation] backed by a [FirefoxAccount].
+ * Provides an implementation of [DeviceConstellation] backed by a [FxaClient
  */
 class FxaDeviceConstellation(
-    private val account: FirefoxAccount,
+    private val account: FxaClient,
     private val scope: CoroutineScope,
     @get:VisibleForTesting
     internal val crashReporter: CrashReporting? = null,

--- a/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/AccountStorageTest.kt
+++ b/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/AccountStorageTest.kt
@@ -5,6 +5,8 @@
 package mozilla.components.service.fxa
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.appservices.fxaclient.FxaConfig
+import mozilla.appservices.fxaclient.FxaServer
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.support.test.argumentCaptor
@@ -31,7 +33,7 @@ class SharedPrefAccountStorageTest {
     fun `plain storage crud`() {
         val storage = SharedPrefAccountStorage(testContext)
         val account = FirefoxAccount(
-            mozilla.appservices.fxaclient.Config(Server.RELEASE, "someId", "http://www.firefox.com"),
+            FxaConfig(FxaServer.Release, "someId", "http://www.firefox.com"),
         )
         assertNull(storage.read())
         storage.write(account.toJSONString())
@@ -45,7 +47,7 @@ class SharedPrefAccountStorageTest {
     fun `migration from SecureAbove22AccountStorage`() {
         val secureStorage = SecureAbove22AccountStorage(testContext)
         val account = FirefoxAccount(
-            mozilla.appservices.fxaclient.Config(Server.RELEASE, "someId", "http://www.firefox.com"),
+            FxaConfig(FxaServer.Release, "someId", "http://www.firefox.com"),
         )
 
         assertNull(secureStorage.read())
@@ -64,7 +66,7 @@ class SharedPrefAccountStorageTest {
     fun `missing state is reported during a migration`() {
         val secureStorage = SecureAbove22AccountStorage(testContext)
         val account = FirefoxAccount(
-            mozilla.appservices.fxaclient.Config(Server.RELEASE, "someId", "http://www.firefox.com"),
+            FxaConfig(FxaServer.Release, "someId", "http://www.firefox.com"),
         )
         secureStorage.write(account.toJSONString())
 
@@ -91,7 +93,7 @@ class SecureAbove22AccountStorageTest {
         val crashReporter: CrashReporting = mock()
         val storage = SecureAbove22AccountStorage(testContext, crashReporter)
         val account = FirefoxAccount(
-            mozilla.appservices.fxaclient.Config(Server.RELEASE, "someId", "http://www.firefox.com"),
+            FxaConfig(FxaServer.Release, "someId", "http://www.firefox.com"),
         )
         assertNull(storage.read())
         storage.write(account.toJSONString())
@@ -106,7 +108,7 @@ class SecureAbove22AccountStorageTest {
     fun `migration from SharedPrefAccountStorage`() {
         val plainStorage = SharedPrefAccountStorage(testContext)
         val account = FirefoxAccount(
-            mozilla.appservices.fxaclient.Config(Server.RELEASE, "someId", "http://www.firefox.com"),
+            FxaConfig(FxaServer.Release, "someId", "http://www.firefox.com"),
         )
 
         assertNull(plainStorage.read())
@@ -128,7 +130,7 @@ class SecureAbove22AccountStorageTest {
         val crashReporter: CrashReporting = mock()
         val storage = SecureAbove22AccountStorage(testContext, crashReporter)
         val account = FirefoxAccount(
-            mozilla.appservices.fxaclient.Config(Server.RELEASE, "someId", "http://www.firefox.com"),
+            FxaConfig(FxaServer.Release, "someId", "http://www.firefox.com"),
         )
         storage.write(account.toJSONString())
 
@@ -147,7 +149,7 @@ class SecureAbove22AccountStorageTest {
     fun `missing state is ignored without a configured crash reporter`() {
         val storage = SecureAbove22AccountStorage(testContext)
         val account = FirefoxAccount(
-            mozilla.appservices.fxaclient.Config(Server.RELEASE, "someId", "http://www.firefox.com"),
+            FxaConfig(FxaServer.Release, "someId", "http://www.firefox.com"),
         )
         storage.write(account.toJSONString())
 

--- a/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
+++ b/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import mozilla.appservices.fxaclient.FxaConfig
+import mozilla.appservices.fxaclient.FxaServer
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.concept.sync.AccessTokenInfo
 import mozilla.components.concept.sync.AccountEventsObserver
@@ -68,7 +70,7 @@ import kotlin.coroutines.CoroutineContext
 internal class TestableStorageWrapper(
     manager: FxaAccountManager,
     accountEventObserverRegistry: ObserverRegistry<AccountEventsObserver>,
-    serverConfig: ServerConfig,
+    serverConfig: FxaConfig,
     private val block: () -> OAuthAccount = {
         val account: OAuthAccount = mock()
         `when`(account.deviceConstellation()).thenReturn(mock())
@@ -84,7 +86,7 @@ internal class TestableStorageWrapper(
 // Instead, we express all of our account-related operations over an interface.
 internal open class TestableFxaAccountManager(
     context: Context,
-    config: ServerConfig,
+    config: FxaConfig,
     private val storage: AccountStorage,
     capabilities: Set<DeviceCapability> = emptySet(),
     syncConfig: SyncConfig? = null,
@@ -200,7 +202,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            FxaConfig(FxaServer.Release, "dummyId", "http://auth-url/redirect"),
             accountStorage,
             setOf(DeviceCapability.SEND_TAB),
             null,
@@ -236,7 +238,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            FxaConfig(FxaServer.Release, "dummyId", "http://auth-url/redirect"),
             accountStorage,
             setOf(DeviceCapability.SEND_TAB),
             null,
@@ -276,7 +278,7 @@ class FxaAccountManagerTest {
         val accountObserver: AccountObserver = mock()
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            FxaConfig(FxaServer.Release, "dummyId", "http://auth-url/redirect"),
             accountStorage,
             setOf(DeviceCapability.SEND_TAB),
             null,
@@ -315,7 +317,7 @@ class FxaAccountManagerTest {
         val accountObserver: AccountObserver = mock()
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "http://auth-url/redirect"),
+            FxaConfig(FxaServer.Release, "dummyId", "http://auth-url/redirect"),
             accountStorage,
             setOf(DeviceCapability.SEND_TAB),
             null,
@@ -353,7 +355,7 @@ class FxaAccountManagerTest {
         // but an actual implementation of the interface.
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             setOf(DeviceCapability.SEND_TAB),
             null,
@@ -397,7 +399,7 @@ class FxaAccountManagerTest {
         // but an actual implementation of the interface.
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             setOf(DeviceCapability.SEND_TAB),
             null,
@@ -531,7 +533,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             coroutineContext = this.coroutineContext,
         )
@@ -566,7 +568,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             coroutineContext = this.coroutineContext,
         )
@@ -608,7 +610,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             emptySet(),
             null,
@@ -748,7 +750,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             coroutineContext = coroutineContext,
         ) {
@@ -1162,7 +1164,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             coroutineContext = this.coroutineContext,
         ) {
@@ -1233,7 +1235,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             coroutineContext = this.coroutineContext,
         ) {
@@ -1293,7 +1295,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             coroutineContext = this.coroutineContext,
         ) {
@@ -1361,7 +1363,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             coroutineContext = this.coroutineContext,
         ) {
@@ -1435,7 +1437,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             coroutineContext = this.coroutineContext,
         ) {
@@ -1572,7 +1574,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             capabilities,
             SyncConfig(setOf(SyncEngine.History, SyncEngine.Bookmarks), PeriodicSyncConfig()),
@@ -1605,7 +1607,7 @@ class FxaAccountManagerTest {
 
         val manager = TestableFxaAccountManager(
             testContext,
-            ServerConfig(Server.RELEASE, "dummyId", "bad://url"),
+            FxaConfig(FxaServer.Release, "dummyId", "bad://url"),
             accountStorage,
             coroutineContext = coroutineContext,
         ) {

--- a/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaDeviceConstellationTest.kt
+++ b/android-components/components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaDeviceConstellationTest.kt
@@ -54,7 +54,7 @@ import org.mockito.Mockito.`when`
 import mozilla.appservices.fxaclient.AccountEvent as ASAccountEvent
 import mozilla.appservices.fxaclient.Device as NativeDevice
 import mozilla.appservices.fxaclient.DevicePushSubscription as NativeDevicePushSubscription
-import mozilla.appservices.fxaclient.PersistedFirefoxAccount as NativeFirefoxAccount
+import mozilla.appservices.fxaclient.FxaClient as NativeFirefoxAccount
 import mozilla.appservices.sync15.DeviceType as RustDeviceType
 
 @ExperimentalCoroutinesApi

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/FxaServer.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/FxaServer.kt
@@ -5,8 +5,8 @@
 package org.mozilla.fenix.components
 
 import android.content.Context
+import mozilla.appservices.fxaclient.FxaServer
 import mozilla.components.service.fxa.ServerConfig
-import mozilla.components.service.fxa.ServerConfig.Server
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.ext.settings
 
@@ -20,18 +20,19 @@ object FxaServer {
 
     fun config(context: Context): ServerConfig {
         // If a server override is configured, use that. Otherwise:
-        // - for all channels other than Mozilla Online, use Server.Release.
-        // - for Mozilla Online channel, if domestic server is allowed, use Server.CHINA; otherwise, use Server.RELEASE
+        // - for all channels other than Mozilla Online, use FxaServer.Release.
+        // - for Mozilla Online channel, if domestic server is allowed, use FxaServer.China; otherwise,
+        //   use FxaServer.Release
         val serverOverride = context.settings().overrideFxAServer
         val tokenServerOverride = context.settings().overrideSyncTokenServer.ifEmpty { null }
         if (serverOverride.isEmpty()) {
             val releaseServer = if (Config.channel.isMozillaOnline && context.settings().allowDomesticChinaFxaServer) {
-                Server.CHINA
+                FxaServer.China
             } else {
-                Server.RELEASE
+                FxaServer.Release
             }
             return ServerConfig(releaseServer, CLIENT_ID, REDIRECT_URL, tokenServerOverride)
         }
-        return ServerConfig(serverOverride, CLIENT_ID, REDIRECT_URL, tokenServerOverride)
+        return ServerConfig(FxaServer.Custom(serverOverride), CLIENT_ID, REDIRECT_URL, tokenServerOverride)
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
@@ -12,6 +12,8 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
+import mozilla.appservices.fxaclient.FxaServer
+import mozilla.appservices.fxaclient.contentUrl
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.menu.view.MenuButton
 import mozilla.components.concept.sync.FxAEntryPoint
@@ -127,9 +129,9 @@ class HomeMenuView(
                 homeActivity.openToBrowserAndLoad(
                     searchTermOrURL =
                     if (context.settings().allowDomesticChinaFxaServer) {
-                        mozilla.appservices.fxaclient.Config.Server.CHINA.contentUrl + "/settings"
+                        FxaServer.China.contentUrl() + "/settings"
                     } else {
-                        mozilla.appservices.fxaclient.Config.Server.RELEASE.contentUrl + "/settings"
+                        FxaServer.Release.contentUrl() + "/settings"
                     },
                     newTab = true,
                     from = BrowserDirection.FromHome,


### PR DESCRIPTION
This is mostly just renames.

We need to land the app-services PR before merging this: https://github.com/mozilla/application-services/pull/5887

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1861219