### PR TITLE
Bug 1860919 - Send Glean pings for Wikipedia Firefox Suggestion impressions and clicks.

### DIFF
--- a/android-components/components/feature/fxsuggest/README.md
+++ b/android-components/components/feature/fxsuggest/README.md
@@ -18,10 +18,12 @@ implementation "org.mozilla.components:feature-fxsuggest:{latest-version}"
 
 This component emits the following [Facts](../../support/base/README.md#Facts):
 
-| Action        | Item                       | Extras                        | Description                                                                    |
-|---------------|----------------------------|-------------------------------|--------------------------------------------------------------------------------|
-| `INTERACTION` | `amp_suggestion_clicked`   | `suggestion_clicked_extras`   | The user clicked on a Firefox Suggestion.                                      |
-| `DISPLAY`     | `amp_suggestion_impressed` | `suggestion_impressed_extras` | The user saw a Firefox Suggestion just before they navigated to a destination. |
+| Action        | Item                             | Extras                        | Description                                                                                         |
+|---------------|----------------------------------|-------------------------------|-----------------------------------------------------------------------------------------------------|
+| `INTERACTION` | `amp_suggestion_clicked`         | `suggestion_clicked_extras`   | The user clicked on a Firefox Suggestion from adMarketplace.                                        |
+| `DISPLAY`     | `amp_suggestion_impressed`       | `suggestion_impressed_extras` | The user saw a Firefox Suggestion from adMarketplace just before they navigated to a destination.   |
+| `INTERACTION` | `wikipedia_suggestion_clicked`   | `suggestion_clicked_extras`   | The user clicked on a Firefox Suggestion for a Wikipedia page.                                      |
+| `DISPLAY`     | `wikipedia_suggestion_impressed` | `suggestion_impressed_extras` | The user saw a Firefox Suggestion for a Wikipedia page just before they navigated to a destination. |
 
 #### `suggestion_clicked_extras`
 

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
@@ -95,20 +95,25 @@ class FxSuggestSuggestionProvider(
                         )
                     },
                 )
-                is Suggestion.Wikipedia -> SuggestionDetails(
-                    title = suggestion.title,
-                    url = suggestion.url,
-                    fullKeyword = suggestion.fullKeyword,
-                    isSponsored = false,
-                    icon = suggestion.icon,
-                )
+                is Suggestion.Wikipedia -> {
+                    val interactionInfo = contextId?.let {
+                        FxSuggestInteractionInfo.Wikipedia(contextId = it)
+                    }
+                    SuggestionDetails(
+                        title = suggestion.title,
+                        url = suggestion.url,
+                        fullKeyword = suggestion.fullKeyword,
+                        isSponsored = false,
+                        icon = suggestion.icon,
+                        clickInfo = interactionInfo,
+                        impressionInfo = interactionInfo,
+                    )
+                }
                 else -> return@mapNotNull null
             }
             AwesomeBar.Suggestion(
                 provider = this@FxSuggestSuggestionProvider,
-                icon = details.icon?.let {
-                    it.toUByteArray().asByteArray().toBitmap()
-                },
+                icon = details.icon?.toUByteArray()?.asByteArray()?.toBitmap(),
                 title = details.title,
                 description = if (details.isSponsored) {
                     resources.getString(R.string.sponsored_suggestion_description)
@@ -155,6 +160,15 @@ sealed interface FxSuggestInteractionInfo {
         val advertiser: String,
         val reportingUrl: String,
         val iabCategory: String,
+        val contextId: String,
+    ) : FxSuggestInteractionInfo
+
+    /**
+     * Interaction information for a Firefox Suggest search suggestion from Wikipedia.
+     *
+     * @param contextId The contextual services user identifier.
+     */
+    data class Wikipedia(
         val contextId: String,
     ) : FxSuggestInteractionInfo
 }

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/facts/FxSuggestFacts.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/facts/FxSuggestFacts.kt
@@ -20,6 +20,8 @@ class FxSuggestFacts {
     object Items {
         const val AMP_SUGGESTION_CLICKED = "amp_suggestion_clicked"
         const val AMP_SUGGESTION_IMPRESSED = "amp_suggestion_impressed"
+        const val WIKIPEDIA_SUGGESTION_CLICKED = "wikipedia_suggestion_clicked"
+        const val WIKIPEDIA_SUGGESTION_IMPRESSED = "wikipedia_suggestion_impressed"
     }
 
     /**
@@ -50,32 +52,35 @@ private fun emitFxSuggestFact(
 internal fun emitSuggestionClickedFact(
     interactionInfo: FxSuggestInteractionInfo,
     positionInAwesomeBar: Long,
-) = when (interactionInfo) {
-    is FxSuggestInteractionInfo.Amp -> {
-        emitFxSuggestFact(
-            Action.INTERACTION,
-            FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED,
-            metadata = mapOf(
-                FxSuggestFacts.MetadataKeys.INTERACTION_INFO to interactionInfo,
-                FxSuggestFacts.MetadataKeys.POSITION to positionInAwesomeBar,
-            ),
-        )
-    }
+) {
+    emitFxSuggestFact(
+        Action.INTERACTION,
+        when (interactionInfo) {
+            is FxSuggestInteractionInfo.Amp -> FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED
+            is FxSuggestInteractionInfo.Wikipedia -> FxSuggestFacts.Items.WIKIPEDIA_SUGGESTION_CLICKED
+        },
+        metadata = mapOf(
+            FxSuggestFacts.MetadataKeys.INTERACTION_INFO to interactionInfo,
+            FxSuggestFacts.MetadataKeys.POSITION to positionInAwesomeBar,
+        ),
+    )
 }
 
 internal fun emitSuggestionImpressedFact(
     interactionInfo: FxSuggestInteractionInfo,
     positionInAwesomeBar: Long,
     isClicked: Boolean,
-) = when (interactionInfo) {
-    is FxSuggestInteractionInfo.Amp ->
-        emitFxSuggestFact(
-            Action.DISPLAY,
-            FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED,
-            metadata = mapOf(
-                FxSuggestFacts.MetadataKeys.INTERACTION_INFO to interactionInfo,
-                FxSuggestFacts.MetadataKeys.POSITION to positionInAwesomeBar,
-                FxSuggestFacts.MetadataKeys.IS_CLICKED to isClicked,
-            ),
-        )
+) {
+    emitFxSuggestFact(
+        Action.DISPLAY,
+        when (interactionInfo) {
+            is FxSuggestInteractionInfo.Amp -> FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED
+            is FxSuggestInteractionInfo.Wikipedia -> FxSuggestFacts.Items.WIKIPEDIA_SUGGESTION_IMPRESSED
+        },
+        metadata = mapOf(
+            FxSuggestFacts.MetadataKeys.INTERACTION_INFO to interactionInfo,
+            FxSuggestFacts.MetadataKeys.POSITION to positionInAwesomeBar,
+            FxSuggestFacts.MetadataKeys.IS_CLICKED to isClicked,
+        ),
+    )
 }

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsTest.kt
@@ -6,16 +6,18 @@ package mozilla.components.feature.fxsuggest
 
 import mozilla.components.feature.fxsuggest.facts.FxSuggestFacts
 import mozilla.components.feature.fxsuggest.facts.emitSuggestionClickedFact
+import mozilla.components.feature.fxsuggest.facts.emitSuggestionImpressedFact
 import mozilla.components.support.base.Component
 import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.processor.CollectionProcessor
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FxSuggestFactsTest {
 
     @Test
-    fun emitSuggestionClickedFactWithAmpInteractionInfo() {
+    fun `GIVEN interaction information for an AMP suggestion WHEN emitting a click fact THEN 1 click fact is collected`() {
         CollectionProcessor.withFactCollection { facts ->
 
             emitSuggestionClickedFact(
@@ -35,12 +37,143 @@ class FxSuggestFactsTest {
                 assertEquals(Action.INTERACTION, action)
                 assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED, item)
 
+                assertEquals(
+                    setOf(
+                        FxSuggestFacts.MetadataKeys.INTERACTION_INFO,
+                        FxSuggestFacts.MetadataKeys.POSITION,
+                    ),
+                    metadata?.keys,
+                )
+
                 val clickInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
                 assertEquals(clickInfo.blockId, 123)
                 assertEquals(clickInfo.advertiser, "mozilla")
                 assertEquals(clickInfo.reportingUrl, "https://example.com/reporting")
                 assertEquals(clickInfo.iabCategory, "22 - Shopping")
                 assertEquals(clickInfo.contextId, "c303282d-f2e6-46ca-a04a-35d3d873712d")
+
+                val positionInAwesomebar = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+                assertEquals(0, positionInAwesomebar)
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN interaction information for an AMP suggestion WHEN emitting an impression fact THEN 1 impression fact is collected`() {
+        CollectionProcessor.withFactCollection { facts ->
+
+            emitSuggestionImpressedFact(
+                FxSuggestInteractionInfo.Amp(
+                    blockId = 123,
+                    advertiser = "mozilla",
+                    reportingUrl = "https://example.com/reporting",
+                    iabCategory = "22 - Shopping",
+                    contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                ),
+                positionInAwesomeBar = 0,
+                isClicked = true,
+            )
+
+            assertEquals(1, facts.size)
+            facts[0].apply {
+                assertEquals(Component.FEATURE_FXSUGGEST, component)
+                assertEquals(Action.DISPLAY, action)
+                assertEquals(FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED, item)
+
+                assertEquals(
+                    setOf(
+                        FxSuggestFacts.MetadataKeys.INTERACTION_INFO,
+                        FxSuggestFacts.MetadataKeys.POSITION,
+                        FxSuggestFacts.MetadataKeys.IS_CLICKED,
+                    ),
+                    metadata?.keys,
+                )
+
+                val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)
+                assertEquals(impressionInfo.blockId, 123)
+                assertEquals(impressionInfo.advertiser, "mozilla")
+                assertEquals(impressionInfo.reportingUrl, "https://example.com/reporting")
+                assertEquals(impressionInfo.iabCategory, "22 - Shopping")
+                assertEquals(impressionInfo.contextId, "c303282d-f2e6-46ca-a04a-35d3d873712d")
+
+                val positionInAwesomebar = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+                assertEquals(0, positionInAwesomebar)
+
+                val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+                assertTrue(isClicked)
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN interaction information for a Wikipedia suggestion WHEN emitting a click fact THEN 1 click fact is collected`() {
+        CollectionProcessor.withFactCollection { facts ->
+
+            emitSuggestionClickedFact(
+                FxSuggestInteractionInfo.Wikipedia(
+                    contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                ),
+                positionInAwesomeBar = 0,
+            )
+
+            assertEquals(1, facts.size)
+            facts[0].apply {
+                assertEquals(Component.FEATURE_FXSUGGEST, component)
+                assertEquals(Action.INTERACTION, action)
+                assertEquals(FxSuggestFacts.Items.WIKIPEDIA_SUGGESTION_CLICKED, item)
+
+                assertEquals(
+                    setOf(
+                        FxSuggestFacts.MetadataKeys.INTERACTION_INFO,
+                        FxSuggestFacts.MetadataKeys.POSITION,
+                    ),
+                    metadata?.keys,
+                )
+
+                val clickInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Wikipedia)
+                assertEquals(clickInfo.contextId, "c303282d-f2e6-46ca-a04a-35d3d873712d")
+
+                val positionInAwesomebar = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+                assertEquals(0, positionInAwesomebar)
+            }
+        }
+    }
+
+    @Test
+    fun `GIVEN interaction information for a Wikipedia suggestion WHEN emitting an impression fact THEN 1 impression fact is collected`() {
+        CollectionProcessor.withFactCollection { facts ->
+
+            emitSuggestionImpressedFact(
+                FxSuggestInteractionInfo.Wikipedia(
+                    contextId = "c303282d-f2e6-46ca-a04a-35d3d873712d",
+                ),
+                positionInAwesomeBar = 0,
+                isClicked = true,
+            )
+
+            assertEquals(1, facts.size)
+            facts[0].apply {
+                assertEquals(Component.FEATURE_FXSUGGEST, component)
+                assertEquals(Action.DISPLAY, action)
+                assertEquals(FxSuggestFacts.Items.WIKIPEDIA_SUGGESTION_IMPRESSED, item)
+
+                assertEquals(
+                    setOf(
+                        FxSuggestFacts.MetadataKeys.INTERACTION_INFO,
+                        FxSuggestFacts.MetadataKeys.POSITION,
+                        FxSuggestFacts.MetadataKeys.IS_CLICKED,
+                    ),
+                    metadata?.keys,
+                )
+
+                val impressionInfo = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Wikipedia)
+                assertEquals(impressionInfo.contextId, "c303282d-f2e6-46ca-a04a-35d3d873712d")
+
+                val positionInAwesomebar = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)
+                assertEquals(0, positionInAwesomebar)
+
+                val isClicked = requireNotNull(metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)
+                assertTrue(isClicked)
             }
         }
     }

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProviderTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProviderTest.kt
@@ -179,7 +179,15 @@ class FxSuggestSuggestionProviderTest {
         assertEquals("Las Vegas", suggestions.first().title)
         assertNull(suggestions.first().description)
         assertNull(suggestions.first().icon)
-        assertTrue(suggestions.first().metadata.isNullOrEmpty())
+        suggestions.first().metadata?.let {
+            assertEquals(setOf(FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO, FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO), it.keys)
+
+            val clickInfo = requireNotNull(it[FxSuggestSuggestionProvider.MetadataKeys.CLICK_INFO] as? FxSuggestInteractionInfo.Wikipedia)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", clickInfo.contextId)
+
+            val impressionInfo = requireNotNull(it[FxSuggestSuggestionProvider.MetadataKeys.IMPRESSION_INFO] as? FxSuggestInteractionInfo.Wikipedia)
+            assertEquals("c303282d-f2e6-46ca-a04a-35d3d873712d", impressionInfo.contextId)
+        }
     }
 
     @Test

--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -10969,7 +10969,7 @@ fx_suggest:
   block_id:
     type: quantity
     description: |
-      A unique identifier for the suggestion (a.k.a. a keywords block).
+      A unique identifier for a sponsored suggestion. Not set for non-sponsored suggestions.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
@@ -11025,7 +11025,8 @@ fx_suggest:
   reporting_url:
     type: url
     description: |
-      The url to report this interaction to.
+      If this ping is for a sponsored suggestion, the partner URL for reporting this interaction.
+      Not set for non-sponsored suggestions.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:
@@ -11061,7 +11062,8 @@ fx_suggest:
   iab_category:
     type: string
     description: |
-      The suggestion's category. Either "22 - Shopping" or "5 - Educational".
+      The suggestion's advertising category. "22 - Shopping" for sponsored suggestions.
+      Not set for non-sponsored suggestions.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1857092
     data_reviews:

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -280,23 +280,33 @@ internal class ReleaseMetricController(
             }
         }
 
-        Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED -> {
+        Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.AMP_SUGGESTION_CLICKED,
+        Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.WIKIPEDIA_SUGGESTION_CLICKED,
+        -> {
             FxSuggest.pingType.set("fxsuggest-click")
             FxSuggest.isClicked.set(true)
             (metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)?.let {
                 FxSuggest.position.set(it)
             }
-            (metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)?.let {
-                FxSuggest.blockId.set(it.blockId)
-                FxSuggest.advertiser.set(it.advertiser)
-                FxSuggest.reportingUrl.set(it.reportingUrl)
-                FxSuggest.iabCategory.set(it.iabCategory)
-                FxSuggest.contextId.set(UUID.fromString(it.contextId))
+            when (val clickInfo = metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO)) {
+                is FxSuggestInteractionInfo.Amp -> {
+                    FxSuggest.blockId.set(clickInfo.blockId)
+                    FxSuggest.advertiser.set(clickInfo.advertiser)
+                    FxSuggest.reportingUrl.set(clickInfo.reportingUrl)
+                    FxSuggest.iabCategory.set(clickInfo.iabCategory)
+                    FxSuggest.contextId.set(UUID.fromString(clickInfo.contextId))
+                }
+                is FxSuggestInteractionInfo.Wikipedia -> {
+                    FxSuggest.advertiser.set("wikipedia")
+                    FxSuggest.contextId.set(UUID.fromString(clickInfo.contextId))
+                }
             }
             Pings.fxSuggest.submit()
         }
 
-        Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED -> {
+        Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.AMP_SUGGESTION_IMPRESSED,
+        Component.FEATURE_FXSUGGEST to FxSuggestFacts.Items.WIKIPEDIA_SUGGESTION_IMPRESSED,
+        -> {
             FxSuggest.pingType.set("fxsuggest-impression")
             (metadata?.get(FxSuggestFacts.MetadataKeys.IS_CLICKED) as? Boolean)?.let {
                 FxSuggest.isClicked.set(it)
@@ -304,12 +314,18 @@ internal class ReleaseMetricController(
             (metadata?.get(FxSuggestFacts.MetadataKeys.POSITION) as? Long)?.let {
                 FxSuggest.position.set(it)
             }
-            (metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO) as? FxSuggestInteractionInfo.Amp)?.let {
-                FxSuggest.blockId.set(it.blockId)
-                FxSuggest.advertiser.set(it.advertiser)
-                FxSuggest.reportingUrl.set(it.reportingUrl)
-                FxSuggest.iabCategory.set(it.iabCategory)
-                FxSuggest.contextId.set(UUID.fromString(it.contextId))
+            when (val impressionInfo = metadata?.get(FxSuggestFacts.MetadataKeys.INTERACTION_INFO)) {
+                is FxSuggestInteractionInfo.Amp -> {
+                    FxSuggest.blockId.set(impressionInfo.blockId)
+                    FxSuggest.advertiser.set(impressionInfo.advertiser)
+                    FxSuggest.reportingUrl.set(impressionInfo.reportingUrl)
+                    FxSuggest.iabCategory.set(impressionInfo.iabCategory)
+                    FxSuggest.contextId.set(UUID.fromString(impressionInfo.contextId))
+                }
+                is FxSuggestInteractionInfo.Wikipedia -> {
+                    FxSuggest.advertiser.set("wikipedia")
+                    FxSuggest.contextId.set(UUID.fromString(impressionInfo.contextId))
+                }
             }
             Pings.fxSuggest.submit()
         }


### PR DESCRIPTION
This PR:

* Adds new facts, `wikipedia_suggestion_clicked` and `wikipedia_suggestion_impressed`, to the `feature-fxsuggest` component.
* Emits `fx-suggest` Glean pings for those facts in Fenix's `MetricController`.

This PR doesn't add any new probes, but expands the existing `fx_suggest` metrics added for AMP suggestions in https://bugzilla.mozilla.org/show_bug.cgi?id=1857092 and https://bugzilla.mozilla.org/show_bug.cgi?id=1858542 to also be emitted for Wikipedia suggestions. Would you still like a data review form, @HarrisonOg?

@ncloudioj I can't tag you for review—I think you might need to [join the `mozilla-mobile` GitHub organization first](https://bugzilla.mozilla.org/show_bug.cgi?id=1851706), and then I can add you to the `ast` team—but could you take a look also, please?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1860919