### PR TITLE
Bug 1855519 - Make resources return correct isTablet value when switching foldable state

### DIFF
--- a/android-components/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleAwareAppCompatActivity.kt
+++ b/android-components/components/support/locale/src/main/java/mozilla/components/support/locale/LocaleAwareAppCompatActivity.kt
@@ -5,6 +5,7 @@
 package mozilla.components.support.locale
 
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.VisibleForTesting
@@ -18,6 +19,7 @@ open class LocaleAwareAppCompatActivity : AppCompatActivity() {
         val newContext = LocaleManager.updateResources(base)
         val contextWrapper = ActivityContextWrapper(newContext, base)
         super.attachBaseContext(contextWrapper)
+        super.applyOverrideConfiguration(Configuration())
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1855519