### PR TITLE
Bug 1861680 - Use link instead of src for 'Download Link'

### DIFF
--- a/android-components/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
+++ b/android-components/components/feature/contextmenu/src/main/java/mozilla/components/feature/contextmenu/ContextMenuCandidate.kt
@@ -446,7 +446,7 @@ data class ContextMenuCandidate(
             action = { tab, hitResult ->
                 contextMenuUseCases.injectDownload(
                     tab.id,
-                    DownloadState(hitResult.src, skipConfirmation = true, private = tab.content.private),
+                    DownloadState(hitResult.getLink(), skipConfirmation = true, private = tab.content.private),
                 )
             },
         )

--- a/android-components/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
+++ b/android-components/components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt
@@ -963,7 +963,7 @@ class ContextMenuCandidateTest {
             store.state.tabs.first(),
             HitResult.IMAGE_SRC(
                 "https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png",
-                "https://firefox.com",
+                "https://www.mozilla.org/en-US/privacy-policy.pdf",
             ),
         )
 
@@ -971,7 +971,7 @@ class ContextMenuCandidateTest {
 
         assertNotNull(store.state.tabs.first().content.download)
         assertEquals(
-            "https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png",
+            "https://www.mozilla.org/en-US/privacy-policy.pdf",
             store.state.tabs.first().content.download!!.url,
         )
         assertTrue(


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
