### PR TITLE
Bug 1859755 - Read text count from AMO API response to get the number of reviews

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AMOAddonsProvider.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/amo/AMOAddonsProvider.kt
@@ -374,7 +374,7 @@ internal fun JSONObject.getRating(): Addon.Rating? {
     val jsonRating = optJSONObject("ratings")
     return if (jsonRating != null) {
         Addon.Rating(
-            reviews = jsonRating.optInt("count"),
+            reviews = jsonRating.optInt("text_count"),
             average = jsonRating.optDouble("average").toFloat(),
         )
     } else {

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AMOAddonsProviderTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AMOAddonsProviderTest.kt
@@ -139,7 +139,7 @@ class AMOAddonsProviderTest {
 
         // Ratings
         assertEquals(4.7003F, addon.rating!!.average, 0.7003F)
-        assertEquals(13324, addon.rating!!.reviews)
+        assertEquals(4433, addon.rating!!.reviews)
 
         verify(client).fetch(
             Request(
@@ -643,7 +643,7 @@ class AMOAddonsProviderTest {
         )
         // Ratings
         assertEquals(4.7825F, addon.rating!!.average, 0.7825F)
-        assertEquals(15799, addon.rating!!.reviews)
+        assertEquals(4101, addon.rating!!.reviews)
         assertEquals(
             "https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/reviews/",
             addon.ratingUrl,


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1859755