### PR TITLE
Bug 1861415 - Filter sponsored suggestion URLs from other providers when the "show sponsored suggestions" setting is enabled

### DIFF
--- a/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
+++ b/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
@@ -20,7 +20,6 @@ import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.feature.awesomebar.R
 import mozilla.components.feature.awesomebar.facts.emitOpenTabSuggestionClickedFact
 import mozilla.components.feature.tabs.TabsUseCases
-import mozilla.components.support.ktx.android.net.sameHostWithoutMobileSubdomainAs
 import java.util.UUID
 
 /**
@@ -36,7 +35,7 @@ class SessionSuggestionProvider(
     private val indicatorIcon: Drawable? = null,
     private val excludeSelectedSession: Boolean = false,
     private val suggestionsHeader: String? = null,
-    @get:VisibleForTesting val resultsUriFilter: Uri? = null,
+    @get:VisibleForTesting val resultsUriFilter: ((Uri) -> Boolean)? = null,
 ) : AwesomeBar.SuggestionProvider {
     override val id: String = UUID.randomUUID().toString()
 
@@ -62,7 +61,7 @@ class SessionSuggestionProvider(
         val searchWords = searchText.split(" ")
         tabs.zip(iconRequests) { result, icon ->
             if (
-                resultsUriFilter?.sameHostWithoutMobileSubdomainAs(result.content.url.toUri()) != false &&
+                resultsUriFilter?.invoke(result.content.url.toUri()) != false &&
                 searchWords.all { result.contains(it) } &&
                 !result.content.private &&
                 shouldIncludeSelectedTab(state, result)

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.concept.storage.BookmarkInfo
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.concept.storage.BookmarksStorage
+import mozilla.components.support.ktx.android.net.sameHostWithoutMobileSubdomainAs
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.utils.StorageUtils.levenshteinDistance
@@ -179,7 +180,9 @@ class BookmarksStorageSuggestionProviderTest {
         val provider = BookmarksStorageSuggestionProvider(
             bookmarksStorage = bookmarksSpy,
             loadUrlUseCase = mock(),
-            resultsUriFilter = "https://www.test.com".toUri(),
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs("https://www.test.com".toUri())
+            },
         )
 
         provider.onInputChanged("moz")
@@ -196,7 +199,9 @@ class BookmarksStorageSuggestionProviderTest {
         val provider = BookmarksStorageSuggestionProvider(
             bookmarksStorage = bookmarksSpy,
             loadUrlUseCase = mock(),
-            resultsUriFilter = "https://mozilla.com".toUri(),
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs("https://mozilla.com".toUri())
+            },
         )
 
         bookmarks.addItem("Other", "https://mozilla.com/firefox", newItem.title!!, null)

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProviderTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.concept.storage.HistoryMetadataKey
 import mozilla.components.concept.storage.HistoryMetadataStorage
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.storage.SearchResult
+import mozilla.components.support.ktx.android.net.sameHostWithoutMobileSubdomainAs
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -298,7 +299,9 @@ class CombinedHistorySuggestionProviderTest {
             historyMetadataStorage = metadata,
             loadUrlUseCase = mock(),
             showEditSuggestion = false,
-            resultsUriFilter = "test".toUri(),
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs("test".toUri())
+            },
         )
 
         provider.onInputChanged("moz")
@@ -327,7 +330,9 @@ class CombinedHistorySuggestionProviderTest {
             historyMetadataStorage = metadata,
             loadUrlUseCase = mock(),
             showEditSuggestion = false,
-            resultsUriFilter = "https://mozilla.com".toUri(),
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs("https://mozilla.com".toUri())
+            },
         )
 
         val suggestions = provider.onInputChanged("moz")
@@ -358,7 +363,9 @@ class CombinedHistorySuggestionProviderTest {
             historyMetadataStorage = metadata,
             loadUrlUseCase = mock(),
             showEditSuggestion = false,
-            resultsUriFilter = "https://mozilla.com".toUri(),
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs("https://mozilla.com".toUri())
+            },
         )
 
         val suggestions = provider.onInputChanged("moz")

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt
@@ -17,6 +17,7 @@ import mozilla.components.support.base.facts.Action
 import mozilla.components.support.base.facts.Fact
 import mozilla.components.support.base.facts.FactProcessor
 import mozilla.components.support.base.facts.Facts
+import mozilla.components.support.ktx.android.net.sameHostWithoutMobileSubdomainAs
 import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
@@ -326,7 +327,9 @@ class HistoryStorageSuggestionProviderTest {
             historyStorage = history,
             loadUrlUseCase = mock(),
             maxNumberOfSuggestions = 13,
-            resultsUriFilter = "test".toUri(),
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs("test".toUri())
+            },
         )
         val expectedQueryCount = 13 * HISTORY_RESULTS_TO_FILTER_SCALE_FACTOR
 
@@ -351,7 +354,9 @@ class HistoryStorageSuggestionProviderTest {
         val provider = HistoryStorageSuggestionProvider(
             historyStorage = history,
             loadUrlUseCase = mock(),
-            resultsUriFilter = "https://mozilla.com".toUri(),
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs("https://mozilla.com".toUri())
+            },
         )
 
         val suggestions = provider.onInputChanged("moz")
@@ -376,7 +381,9 @@ class HistoryStorageSuggestionProviderTest {
         val provider = HistoryStorageSuggestionProvider(
             historyStorage = history,
             loadUrlUseCase = mock(),
-            resultsUriFilter = "https://mozilla.com".toUri(),
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs("https://mozilla.com".toUri())
+            },
         )
 
         val suggestions = provider.onInputChanged("moz")

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.support.ktx.android.net.sameHostWithoutMobileSubdomainAs
 import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -366,7 +367,9 @@ class SessionSuggestionProviderTest {
             resources = resources,
             store = store,
             selectTabUseCase = mock(),
-            resultsUriFilter = "https://mozilla.org".toUri(),
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs("https://mozilla.org".toUri())
+            },
         )
 
         val suggestions = provider.onInputChanged("moz")
@@ -399,7 +402,9 @@ class SessionSuggestionProviderTest {
             resources = resources,
             store = store,
             selectTabUseCase = mock(),
-            resultsUriFilter = uriFilter,
+            resultsUriFilter = {
+                it.sameHostWithoutMobileSubdomainAs(uriFilter)
+            },
         )
 
         val suggestions = provider.onInputChanged("moz")

--- a/android-components/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProvider.kt
+++ b/android-components/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProvider.kt
@@ -14,7 +14,6 @@ import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.syncedtabs.ext.getActiveDeviceTabs
 import mozilla.components.feature.syncedtabs.facts.emitSyncedTabSuggestionClickedFact
 import mozilla.components.feature.syncedtabs.storage.SyncedTabsStorage
-import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import java.util.UUID
 
 /**
@@ -27,7 +26,7 @@ class SyncedTabsStorageSuggestionProvider(
     private val icons: BrowserIcons? = null,
     private val deviceIndicators: DeviceIndicators = DeviceIndicators(),
     private val suggestionsHeader: String? = null,
-    @get:VisibleForTesting val resultsHostFilter: String? = null,
+    @get:VisibleForTesting val resultsUrlFilter: ((String) -> Boolean)? = null,
 ) : AwesomeBar.SuggestionProvider {
     override val id: String = UUID.randomUUID().toString()
 
@@ -43,7 +42,7 @@ class SyncedTabsStorageSuggestionProvider(
         val results = syncedTabs.getActiveDeviceTabs { tab ->
             // This is a fairly naive match implementation, but this is what we do on Desktop 🤷.
             (tab.url.contains(text, ignoreCase = true) || tab.title.contains(text, ignoreCase = true)) &&
-                resultsHostFilter?.equals(tab.url.tryGetHostFromUrl()) != false
+                resultsUrlFilter?.invoke(tab.url) != false
         }
 
         return results.sortedByDescending { it.lastUsed }.into()

--- a/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
+++ b/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt
@@ -73,7 +73,9 @@ class SyncedTabsStorageSuggestionProviderTest {
             loadUrlUseCase = mock(),
             icons = mock(),
             deviceIndicators = indicatorIcon,
-            resultsHostFilter = "https://foo.bar".tryGetHostFromUrl(),
+            resultsUrlFilter = {
+                it.tryGetHostFromUrl() == "https://foo.bar".tryGetHostFromUrl()
+            },
         )
 
         val suggestions = provider.onInputChanged("foo")

--- a/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
+++ b/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/kotlin/String.kt
@@ -235,6 +235,15 @@ fun String.tryGetHostFromUrl(): String = try {
 }
 
 /**
+ * Returns `true` if this string is a valid URL that contains [searchParameters] in its query parameters.
+ */
+fun String.urlContainsQueryParameters(searchParameters: String): Boolean = try {
+    URL(this).query?.split("&")?.any { it == searchParameters } ?: false
+} catch (e: MalformedURLException) {
+    false
+}
+
+/**
  * Compares 2 URLs and returns true if they have the same origin,
  * which means: same protocol, same host, same port.
  * It will return false if either this or [other] is not a valid URL.

--- a/android-components/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
+++ b/android-components/components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt
@@ -568,6 +568,25 @@ class StringTest {
         assertNull(invalidBase64String2.extractBase6RawString())
     }
 
+    @Test
+    fun `GIVEN a URL with matching parameters WHEN testing if a URL contains query parameters THEN the result is true`() {
+        assertTrue("http://example.com?a".urlContainsQueryParameters("a"))
+        assertTrue("http://example.com?a&b&c".urlContainsQueryParameters("b"))
+        assertTrue("http://example.com?a=b".urlContainsQueryParameters("a=b"))
+        assertTrue("http://example.com?a=b&c=d&e=f".urlContainsQueryParameters("c=d"))
+        assertTrue("http://example.com?a=b&c=d&e=f#g=h".urlContainsQueryParameters("e=f"))
+    }
+
+    @Test
+    fun `GIVEN a URL without matching parameters WHEN testing if a URL contains query parameters THEN the result is false`() {
+        assertFalse("".urlContainsQueryParameters("a"))
+        assertFalse("!@#$%^&*()-+".urlContainsQueryParameters("a"))
+        assertFalse("http://example.com".urlContainsQueryParameters("a"))
+        assertFalse("http://example.com?a&b".urlContainsQueryParameters("c"))
+        assertFalse("http://example.com?a=b".urlContainsQueryParameters("a"))
+        assertFalse("http://example.com?a=b&c=d&e=f#g=h".urlContainsQueryParameters("g=h"))
+    }
+
     private infix fun String.shortenedShouldBecome(expect: String) {
         assertEquals(expect, this.shortened())
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -32,6 +32,8 @@ import mozilla.components.feature.syncedtabs.DeviceIndicators
 import mozilla.components.feature.syncedtabs.SyncedTabsStorageSuggestionProvider
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.ktx.android.content.getColorFromAttr
+import mozilla.components.support.ktx.android.net.sameHostWithoutMobileSubdomainAs
+import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
@@ -363,7 +365,7 @@ class AwesomeBarView(
                 maxNumberOfSuggestions = METADATA_SUGGESTION_LIMIT,
                 showEditSuggestion = false,
                 suggestionsHeader = activity.getString(R.string.firefox_suggest_header),
-                resultsUriFilter = searchEngineUriFilter,
+                resultsUriFilter = { it.sameHostWithoutMobileSubdomainAs(searchEngineUriFilter) },
             )
         } else {
             HistoryStorageSuggestionProvider(
@@ -374,7 +376,7 @@ class AwesomeBarView(
                 maxNumberOfSuggestions = METADATA_SUGGESTION_LIMIT,
                 showEditSuggestion = false,
                 suggestionsHeader = activity.getString(R.string.firefox_suggest_header),
-                resultsUriFilter = searchEngineUriFilter,
+                resultsUriFilter = { it.sameHostWithoutMobileSubdomainAs(searchEngineUriFilter) },
             )
         }
     }
@@ -483,7 +485,9 @@ class AwesomeBarView(
                 getDrawable(activity, R.drawable.ic_search_results_device_tablet),
             ),
             suggestionsHeader = activity.getString(R.string.firefox_suggest_header),
-            resultsHostFilter = searchEngineHostFilter,
+            resultsUrlFilter = searchEngineHostFilter?.let {
+                { url -> url.tryGetHostFromUrl() == searchEngineHostFilter }
+            },
         )
     }
 
@@ -514,7 +518,9 @@ class AwesomeBarView(
             getDrawable(activity, R.drawable.ic_search_results_tab),
             excludeSelectedSession = !fromHomeFragment,
             suggestionsHeader = activity.getString(R.string.firefox_suggest_header),
-            resultsUriFilter = searchEngineUriFilter,
+            resultsUriFilter = searchEngineUriFilter?.let {
+                { uri -> uri.sameHostWithoutMobileSubdomainAs(it) }
+            },
         )
     }
 
@@ -545,7 +551,9 @@ class AwesomeBarView(
             engine = engineForSpeculativeConnects,
             showEditSuggestion = false,
             suggestionsHeader = activity.getString(R.string.firefox_suggest_header),
-            resultsUriFilter = searchEngineHostFilter,
+            resultsUriFilter = searchEngineHostFilter?.let {
+                { uri -> uri.sameHostWithoutMobileSubdomainAs(it) }
+            },
         )
     }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/awesomebar/AwesomeBarViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/awesomebar/AwesomeBarViewTest.kt
@@ -87,13 +87,35 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN a search from history and history metadata enabled WHEN setting the providers THEN set more suggestions to be shown`() {
+    fun `GIVEN a search from history and history metadata is enabled and sponsored suggestions are enabled WHEN setting the providers THEN set less suggestions to be shown`() {
         val settings: Settings = mockk(relaxed = true) {
             every { historyMetadataUIFeature } returns true
         }
         every { activity.settings() } returns settings
         val state = getSearchProviderState(
             searchEngineSource = SearchEngineSource.History(mockk(relaxed = true)),
+            showSponsoredSuggestions = true,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val historyProvider = result.firstOrNull { it is CombinedHistorySuggestionProvider }
+        assertNotNull(historyProvider)
+        assertEquals(
+            AwesomeBarView.METADATA_SUGGESTION_LIMIT,
+            (historyProvider as CombinedHistorySuggestionProvider).getMaxNumberOfSuggestions(),
+        )
+    }
+
+    @Test
+    fun `GIVEN a search from history and history metadata is enabled and sponsored suggestions are disabled WHEN setting the providers THEN set more suggestions to be shown`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { historyMetadataUIFeature } returns true
+        }
+        every { activity.settings() } returns settings
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.History(mockk(relaxed = true)),
+            showSponsoredSuggestions = false,
         )
 
         val result = awesomeBarView.getProvidersToAdd(state)
@@ -107,33 +129,98 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN a search from history and history metadata disabled WHEN setting the providers THEN set more suggestions to be shown`() {
+    fun `GIVEN a search from history and history metadata is disabled and sponsored suggestions are enabled WHEN setting the providers THEN set less suggestions to be shown`() {
         val settings: Settings = mockk(relaxed = true) {
-            every { historyMetadataUIFeature } returns true
+            every { historyMetadataUIFeature } returns false
         }
         every { activity.settings() } returns settings
         val state = getSearchProviderState(
             searchEngineSource = SearchEngineSource.History(mockk(relaxed = true)),
+            showSponsoredSuggestions = true,
         )
 
         val result = awesomeBarView.getProvidersToAdd(state)
 
-        val historyProvider = result.firstOrNull { it is CombinedHistorySuggestionProvider }
+        val historyProvider = result.firstOrNull { it is HistoryStorageSuggestionProvider }
         assertNotNull(historyProvider)
         assertEquals(
-            Companion.METADATA_HISTORY_SUGGESTION_LIMIT,
-            (historyProvider as CombinedHistorySuggestionProvider).getMaxNumberOfSuggestions(),
+            AwesomeBarView.METADATA_SUGGESTION_LIMIT,
+            (historyProvider as HistoryStorageSuggestionProvider).getMaxNumberOfSuggestions(),
         )
     }
 
     @Test
-    fun `GIVEN a search not from history and history metadata enabled WHEN setting the providers THEN set less suggestions to be shown`() {
+    fun `GIVEN a search from history and history metadata is disabled and sponsored suggestions are disabled WHEN setting the providers THEN set more suggestions to be shown`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { historyMetadataUIFeature } returns false
+        }
+        every { activity.settings() } returns settings
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.History(mockk(relaxed = true)),
+            showSponsoredSuggestions = false,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val historyProvider = result.firstOrNull { it is HistoryStorageSuggestionProvider }
+        assertNotNull(historyProvider)
+        assertEquals(
+            Companion.METADATA_HISTORY_SUGGESTION_LIMIT,
+            (historyProvider as HistoryStorageSuggestionProvider).getMaxNumberOfSuggestions(),
+        )
+    }
+
+    @Test
+    fun `GIVEN a search not from history and history metadata is enabled and sponsored suggestions are enabled WHEN setting the providers THEN set less suggestions to be shown`() {
         val settings: Settings = mockk(relaxed = true) {
             every { historyMetadataUIFeature } returns true
         }
         every { activity.settings() } returns settings
         val state = getSearchProviderState(
             searchEngineSource = SearchEngineSource.Shortcut(mockk(relaxed = true)),
+            showSponsoredSuggestions = true,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val historyProvider = result.firstOrNull { it is CombinedHistorySuggestionProvider }
+        assertNotNull(historyProvider)
+        assertEquals(
+            AwesomeBarView.METADATA_SUGGESTION_LIMIT,
+            (historyProvider as CombinedHistorySuggestionProvider).getMaxNumberOfSuggestions(),
+        )
+    }
+
+    @Test
+    fun `GIVEN a search not from history and history metadata is enabled and sponsored suggestions are disabled WHEN setting the providers THEN set less suggestions to be shown`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { historyMetadataUIFeature } returns true
+        }
+        every { activity.settings() } returns settings
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.Shortcut(mockk(relaxed = true)),
+            showSponsoredSuggestions = false,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val historyProvider = result.firstOrNull { it is CombinedHistorySuggestionProvider }
+        assertNotNull(historyProvider)
+        assertEquals(
+            AwesomeBarView.METADATA_SUGGESTION_LIMIT,
+            (historyProvider as CombinedHistorySuggestionProvider).getMaxNumberOfSuggestions(),
+        )
+    }
+
+    @Test
+    fun `GIVEN a search not from history and history metadata is disabled and sponsored suggestions are enabled WHEN setting the providers THEN set less suggestions to be shown`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { historyMetadataUIFeature } returns true
+        }
+        every { activity.settings() } returns settings
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.Bookmarks(mockk(relaxed = true)),
+            showSponsoredSuggestions = true,
         )
 
         val result = awesomeBarView.getProvidersToAdd(state)
@@ -167,7 +254,7 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN a search that should show filtered history WHEN history metadata is enabled THEN return a history metadata provider with an engine filter`() {
+    fun `GIVEN a search that should show filtered history WHEN history metadata is enabled and sponsored suggestions are enabled THEN return a history metadata provider with an engine filter`() {
         val settings: Settings = mockk(relaxed = true) {
             every { historyMetadataUIFeature } returns true
         }
@@ -180,6 +267,7 @@ class AwesomeBarViewTest {
                     every { resultsUrl } returns url
                 },
             ),
+            showSponsoredSuggestions = true,
         )
 
         val result = awesomeBarView.getProvidersToAdd(state)
@@ -188,6 +276,34 @@ class AwesomeBarViewTest {
         assertNotNull(historyProvider)
         assertNotNull((historyProvider as CombinedHistorySuggestionProvider).resultsUriFilter)
         assertEquals(AwesomeBarView.METADATA_SUGGESTION_LIMIT, historyProvider.getMaxNumberOfSuggestions())
+    }
+
+    @Test
+    fun `GIVEN a search that should show filtered history WHEN history metadata is enabled and sponsored suggestions are disabled THEN return a history metadata provider with an engine filter`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { historyMetadataUIFeature } returns true
+        }
+        val url = Uri.parse("test.com")
+        every { activity.settings() } returns settings
+        val state = getSearchProviderState(
+            showAllHistorySuggestions = false,
+            searchEngineSource = SearchEngineSource.Shortcut(
+                mockk(relaxed = true) {
+                    every { resultsUrl } returns url
+                },
+            ),
+            showSponsoredSuggestions = false,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val historyProvider = result.firstOrNull { it is CombinedHistorySuggestionProvider }
+        assertNotNull(historyProvider)
+        assertNotNull((historyProvider as CombinedHistorySuggestionProvider).resultsUriFilter)
+        assertEquals(
+            AwesomeBarView.METADATA_SUGGESTION_LIMIT,
+            historyProvider.getMaxNumberOfSuggestions(),
+        )
     }
 
     @Test
@@ -543,7 +659,7 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN a search that should show filtered history WHEN history metadata is disabled THEN return a history provider with an engine filter`() {
+    fun `GIVEN a search that should show filtered history WHEN history metadata is disabled and sponsored suggestions are enabled THEN return a history provider with an engine filter`() {
         val settings: Settings = mockk(relaxed = true) {
             every { historyMetadataUIFeature } returns false
         }
@@ -556,6 +672,32 @@ class AwesomeBarViewTest {
                     every { resultsUrl } returns url
                 },
             ),
+            showSponsoredSuggestions = true,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val historyProvider = result.firstOrNull { it is HistoryStorageSuggestionProvider }
+        assertNotNull(historyProvider)
+        assertNotNull((historyProvider as HistoryStorageSuggestionProvider).resultsUriFilter)
+        assertEquals(AwesomeBarView.METADATA_SUGGESTION_LIMIT, historyProvider.getMaxNumberOfSuggestions())
+    }
+
+    @Test
+    fun `GIVEN a search that should show filtered history WHEN history metadata is disabled and sponsored suggestions are disabled THEN return a history provider with an engine filter`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { historyMetadataUIFeature } returns false
+        }
+        val url = Uri.parse("test.com")
+        every { activity.settings() } returns settings
+        val state = getSearchProviderState(
+            showAllHistorySuggestions = false,
+            searchEngineSource = SearchEngineSource.Shortcut(
+                mockk(relaxed = true) {
+                    every { resultsUrl } returns url
+                },
+            ),
+            showSponsoredSuggestions = false,
         )
 
         val result = awesomeBarView.getProvidersToAdd(state)
@@ -623,17 +765,42 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN normal browsing mode and needing to show all local tabs suggestions WHEN configuring providers THEN add the tabs provider`() {
+    fun `GIVEN normal browsing mode and needing to show all local tabs suggestions and sponsored suggestions are enabled WHEN configuring providers THEN add the tabs provider`() {
         val settings: Settings = mockk(relaxed = true)
+        val url = Uri.parse("https://www.test.com")
         every { activity.settings() } returns settings
         every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
         val state = getSearchProviderState(
             showSessionSuggestionsForCurrentEngine = false,
             searchEngineSource = SearchEngineSource.Shortcut(
                 mockk(relaxed = true) {
-                    every { resultsUrl.host } returns "test"
+                    every { resultsUrl } returns url
                 },
             ),
+            showSponsoredSuggestions = true,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val localSessionsProviders = result.filterIsInstance<SessionSuggestionProvider>()
+        assertEquals(1, localSessionsProviders.size)
+        assertNull(localSessionsProviders[0].resultsUriFilter)
+    }
+
+    @Test
+    fun `GIVEN normal browsing mode and needing to show all local tabs suggestions and sponsored suggestions are disabled WHEN configuring providers THEN add the tabs provider`() {
+        val settings: Settings = mockk(relaxed = true)
+        val url = Uri.parse("https://www.test.com")
+        every { activity.settings() } returns settings
+        every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
+        val state = getSearchProviderState(
+            showSessionSuggestionsForCurrentEngine = false,
+            searchEngineSource = SearchEngineSource.Shortcut(
+                mockk(relaxed = true) {
+                    every { resultsUrl } returns url
+                },
+            ),
+            showSponsoredSuggestions = false,
         )
 
         val result = awesomeBarView.getProvidersToAdd(state)
@@ -680,38 +847,19 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN needing to show all synced tabs suggestions WHEN configuring providers THEN add the synced tabs provider`() {
+    fun `GIVEN needing to show all synced tabs suggestions and sponsored suggestions are enabled WHEN configuring providers THEN add the synced tabs provider with a sponsored filter`() {
         val settings: Settings = mockk(relaxed = true)
+        val url = Uri.parse("https://www.test.com")
         every { activity.settings() } returns settings
         every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
         val state = getSearchProviderState(
             showSyncedTabsSuggestionsForCurrentEngine = false,
             searchEngineSource = SearchEngineSource.Shortcut(
                 mockk(relaxed = true) {
-                    every { resultsUrl.host } returns "test"
+                    every { resultsUrl } returns url
                 },
             ),
-        )
-
-        val result = awesomeBarView.getProvidersToAdd(state)
-
-        val localSessionsProviders = result.filterIsInstance<SyncedTabsStorageSuggestionProvider>()
-        assertEquals(1, localSessionsProviders.size)
-        assertNull(localSessionsProviders[0].resultsUrlFilter)
-    }
-
-    @Test
-    fun `GIVEN needing to show filtered synced tabs suggestions WHEN configuring providers THEN add the synced tabs provider with an engine filter`() {
-        val settings: Settings = mockk(relaxed = true)
-        every { activity.settings() } returns settings
-        every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
-        val state = getSearchProviderState(
-            showAllSyncedTabsSuggestions = false,
-            searchEngineSource = SearchEngineSource.Shortcut(
-                mockk(relaxed = true) {
-                    every { resultsUrl.host } returns "test"
-                },
-            ),
+            showSponsoredSuggestions = true,
         )
 
         val result = awesomeBarView.getProvidersToAdd(state)
@@ -722,17 +870,88 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN needing to show all bookmarks suggestions WHEN configuring providers THEN add the bookmarks provider`() {
+    fun `GIVEN needing to show filtered synced tabs suggestions and sponsored suggestions are enabled WHEN configuring providers THEN add the synced tabs provider with an engine filter`() {
         val settings: Settings = mockk(relaxed = true)
+        val url = Uri.parse("https://www.test.com")
+        every { activity.settings() } returns settings
+        every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
+        val state = getSearchProviderState(
+            showAllSyncedTabsSuggestions = false,
+            searchEngineSource = SearchEngineSource.Shortcut(
+                mockk(relaxed = true) {
+                    every { resultsUrl } returns url
+                },
+            ),
+            showSponsoredSuggestions = true,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val localSessionsProviders = result.filterIsInstance<SyncedTabsStorageSuggestionProvider>()
+        assertEquals(1, localSessionsProviders.size)
+        assertNotNull(localSessionsProviders[0].resultsUrlFilter)
+    }
+
+    @Test
+    fun `GIVEN needing to show all synced tabs suggestions and sponsored suggestions are disabled WHEN configuring providers THEN add the synced tabs provider`() {
+        val settings: Settings = mockk(relaxed = true)
+        val url = Uri.parse("https://www.test.com")
+        every { activity.settings() } returns settings
+        every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
+        val state = getSearchProviderState(
+            showSyncedTabsSuggestionsForCurrentEngine = false,
+            searchEngineSource = SearchEngineSource.Shortcut(
+                mockk(relaxed = true) {
+                    every { resultsUrl } returns url
+                },
+            ),
+            showSponsoredSuggestions = false,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val localSessionsProviders = result.filterIsInstance<SyncedTabsStorageSuggestionProvider>()
+        assertEquals(1, localSessionsProviders.size)
+        assertNull(localSessionsProviders[0].resultsUrlFilter)
+    }
+
+    @Test
+    fun `GIVEN needing to show all bookmarks suggestions and sponsored suggestions are enabled WHEN configuring providers THEN add the bookmarks provider with a sponsored filter`() {
+        val settings: Settings = mockk(relaxed = true)
+        val url = Uri.parse("https://www.test.com")
         every { activity.settings() } returns settings
         every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
         val state = getSearchProviderState(
             showBookmarksSuggestionsForCurrentEngine = false,
             searchEngineSource = SearchEngineSource.Shortcut(
                 mockk(relaxed = true) {
-                    every { resultsUrl.host } returns "test"
+                    every { resultsUrl } returns url
                 },
             ),
+            showSponsoredSuggestions = true,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val localSessionsProviders = result.filterIsInstance<BookmarksStorageSuggestionProvider>()
+        assertEquals(1, localSessionsProviders.size)
+        assertNotNull(localSessionsProviders[0].resultsUriFilter)
+    }
+
+    @Test
+    fun `GIVEN needing to show all bookmarks suggestions and sponsored suggestions are disabled WHEN configuring providers THEN add the bookmarks provider`() {
+        val settings: Settings = mockk(relaxed = true)
+        val url = Uri.parse("https://www.test.com")
+        every { activity.settings() } returns settings
+        every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
+        val state = getSearchProviderState(
+            showBookmarksSuggestionsForCurrentEngine = false,
+            searchEngineSource = SearchEngineSource.Shortcut(
+                mockk(relaxed = true) {
+                    every { resultsUrl } returns url
+                },
+            ),
+            showSponsoredSuggestions = false,
         )
 
         val result = awesomeBarView.getProvidersToAdd(state)
@@ -778,7 +997,7 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN a search from the default engine with all suggestions asked WHEN configuring providers THEN add them all`() {
+    fun `GIVEN a search from the default engine with all suggestions asked and sponsored suggestions are enabled WHEN configuring providers THEN add them all`() {
         val settings: Settings = mockk(relaxed = true)
         val url = Uri.parse("https://www.test.com")
         every { activity.settings() } returns settings
@@ -789,6 +1008,45 @@ class AwesomeBarViewTest {
                     every { resultsUrl } returns url
                 },
             ),
+            showSponsoredSuggestions = true,
+        )
+
+        val result = awesomeBarView.getProvidersToAdd(state)
+
+        val historyProviders: List<HistoryStorageSuggestionProvider> = result.filterIsInstance<HistoryStorageSuggestionProvider>()
+        assertEquals(2, historyProviders.size)
+        assertNotNull(historyProviders[0].resultsUriFilter) // the general history provider
+        assertNotNull(historyProviders[1].resultsUriFilter) // the filtered history provider
+        val bookmarksProviders: List<BookmarksStorageSuggestionProvider> = result.filterIsInstance<BookmarksStorageSuggestionProvider>()
+        assertEquals(2, bookmarksProviders.size)
+        assertNotNull(bookmarksProviders[0].resultsUriFilter) // the general bookmarks provider
+        assertNotNull(bookmarksProviders[1].resultsUriFilter) // the filtered bookmarks provider
+        assertEquals(1, result.filterIsInstance<SearchActionProvider>().size)
+        assertEquals(1, result.filterIsInstance<SearchSuggestionProvider>().size)
+        val syncedTabsProviders: List<SyncedTabsStorageSuggestionProvider> = result.filterIsInstance<SyncedTabsStorageSuggestionProvider>()
+        assertEquals(2, syncedTabsProviders.size)
+        assertNotNull(syncedTabsProviders[0].resultsUrlFilter) // the general synced tabs provider
+        assertNotNull(syncedTabsProviders[1].resultsUrlFilter) // the filtered synced tabs provider
+        val localTabsProviders: List<SessionSuggestionProvider> = result.filterIsInstance<SessionSuggestionProvider>()
+        assertEquals(2, localTabsProviders.size)
+        assertNull(localTabsProviders[0].resultsUriFilter) // the general tabs provider
+        assertNotNull(localTabsProviders[1].resultsUriFilter) // the filtered tabs provider
+        assertEquals(1, result.filterIsInstance<SearchEngineSuggestionProvider>().size)
+    }
+
+    @Test
+    fun `GIVEN a search from the default engine with all suggestions asked and sponsored suggestions are disabled WHEN configuring providers THEN add them all`() {
+        val settings: Settings = mockk(relaxed = true)
+        val url = Uri.parse("https://www.test.com")
+        every { activity.settings() } returns settings
+        every { activity.browsingModeManager.mode } returns BrowsingMode.Normal
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.Default(
+                mockk(relaxed = true) {
+                    every { resultsUrl } returns url
+                },
+            ),
+            showSponsoredSuggestions = false,
         )
 
         val result = awesomeBarView.getProvidersToAdd(state)
@@ -929,23 +1187,17 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN the current search engine's url is not known WHEN creating a history provider for that engine THEN return null`() {
-        val engineSource = SearchEngineSource.None
-
-        val result = awesomeBarView.getHistoryProvidersForSearchEngine(engineSource)
-
-        assertNull(result)
-    }
-
-    @Test
     fun `GIVEN a valid search engine and history metadata enabled WHEN creating a history provider for that engine THEN return a history metadata provider with engine filter`() {
         val settings: Settings = mockk {
             every { historyMetadataUIFeature } returns true
         }
         every { activity.settings() } returns settings
         val searchEngineSource = SearchEngineSource.Shortcut(mockk(relaxed = true))
+        val state = getSearchProviderState(searchEngineSource = searchEngineSource)
 
-        val result = awesomeBarView.getHistoryProvidersForSearchEngine(searchEngineSource)
+        val result = awesomeBarView.getHistoryProvider(
+            filter = awesomeBarView.getFilterForCurrentEngineResults(state),
+        )
 
         assertNotNull(result)
         assertTrue(result is CombinedHistorySuggestionProvider)
@@ -954,67 +1206,24 @@ class AwesomeBarViewTest {
     }
 
     @Test
-    fun `GIVEN a valid search engine and history metadata disabled WHEN creating a history provider for that engine THEN return a history metadata provider with engine filter`() {
+    fun `GIVEN a valid search engine and history metadata disabled WHEN creating a history provider for that engine THEN return a history metadata provider with an engine filter`() {
         val settings: Settings = mockk {
             every { historyMetadataUIFeature } returns false
         }
         every { activity.settings() } returns settings
         val searchEngineSource = SearchEngineSource.Shortcut(mockk(relaxed = true))
+        val state = getSearchProviderState(
+            searchEngineSource = searchEngineSource,
+        )
 
-        val result = awesomeBarView.getHistoryProvidersForSearchEngine(searchEngineSource)
+        val result = awesomeBarView.getHistoryProvider(
+            filter = awesomeBarView.getFilterForCurrentEngineResults(state),
+        )
 
         assertNotNull(result)
         assertTrue(result is HistoryStorageSuggestionProvider)
         assertNotNull((result as HistoryStorageSuggestionProvider).resultsUriFilter)
         assertEquals(AwesomeBarView.METADATA_SUGGESTION_LIMIT, result.getMaxNumberOfSuggestions())
-    }
-
-    @Test
-    fun `GIVEN a filter is required WHEN configuring a bookmarks provider THEN include a url filter`() {
-        assertNotNull(
-            awesomeBarView.getBookmarksProvider(
-                searchEngineSource = mockk(relaxed = true),
-            ),
-        )
-
-        assertNotNull(
-            awesomeBarView.getBookmarksProvider(
-                searchEngineSource = mockk(relaxed = true),
-                filterByCurrentEngine = true,
-            ),
-        )
-    }
-
-    @Test
-    fun `GIVEN a filter is required WHEN configuring a synced tabs provider THEN include a url filter`() {
-        assertNotNull(
-            awesomeBarView.getSyncedTabsProvider(
-                searchEngineSource = mockk(relaxed = true),
-            ),
-        )
-
-        assertNotNull(
-            awesomeBarView.getSyncedTabsProvider(
-                searchEngineSource = mockk(relaxed = true),
-                filterByCurrentEngine = true,
-            ),
-        )
-    }
-
-    @Test
-    fun `GIVEN a filter is required WHEN configuring a local tabs provider THEN include a url filter`() {
-        assertNotNull(
-            awesomeBarView.getLocalTabsProvider(
-                searchEngineSource = mockk(relaxed = true),
-            ),
-        )
-
-        assertNotNull(
-            awesomeBarView.getLocalTabsProvider(
-                searchEngineSource = mockk(relaxed = true),
-                filterByCurrentEngine = true,
-            ),
-        )
     }
 
     @Test
@@ -1121,6 +1330,121 @@ class AwesomeBarViewTest {
         val result = awesomeBarView.getProvidersToAdd(state)
 
         assertEquals(1, result.filterIsInstance<SearchTermSuggestionsProvider>().size)
+    }
+
+    @Test
+    fun `GIVEN sponsored suggestions are enabled WHEN getting a filter to exclude sponsored suggestions THEN return the filter`() {
+        every { activity.settings() } returns mockk(relaxed = true) {
+            every { frecencyFilterQuery } returns "query=value"
+        }
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.Default(mockk(relaxed = true)),
+            showSponsoredSuggestions = true,
+        )
+        val filter = awesomeBarView.getFilterToExcludeSponsoredResults(state)
+
+        assertEquals(AwesomeBarView.SearchResultFilter.ExcludeSponsored("query=value"), filter)
+    }
+
+    @Test
+    fun `GIVEN sponsored suggestions are disabled WHEN getting a filter to exclude sponsored suggestions THEN return null`() {
+        every { activity.settings() } returns mockk(relaxed = true) {
+            every { frecencyFilterQuery } returns "query=value"
+        }
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.Default(mockk(relaxed = true)),
+            showSponsoredSuggestions = false,
+        )
+        val filter = awesomeBarView.getFilterToExcludeSponsoredResults(state)
+
+        assertNull(filter)
+    }
+
+    @Test
+    fun `GIVEN a sponsored query parameter and a sponsored filter WHEN a URL contains the sponsored query parameter THEN that URL should be excluded`() {
+        every { activity.settings() } returns mockk(relaxed = true) {
+            every { frecencyFilterQuery } returns "query=value"
+        }
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.Default(mockk(relaxed = true)),
+            showSponsoredSuggestions = true,
+        )
+        val filter = requireNotNull(awesomeBarView.getFilterToExcludeSponsoredResults(state))
+
+        assertFalse(filter.shouldIncludeUri(Uri.parse("http://example.com?query=value")))
+        assertFalse(filter.shouldIncludeUri(Uri.parse("http://example.com/a?query=value")))
+        assertFalse(filter.shouldIncludeUri(Uri.parse("http://example.com/a?b=c&query=value")))
+        assertFalse(filter.shouldIncludeUri(Uri.parse("http://example.com/a?b=c&query=value&d=e")))
+
+        assertFalse(filter.shouldIncludeUrl("http://example.com?query=value"))
+        assertFalse(filter.shouldIncludeUrl("http://example.com/a?query=value"))
+        assertFalse(filter.shouldIncludeUrl("http://example.com/a?b=c&query=value"))
+        assertFalse(filter.shouldIncludeUrl("http://example.com/a?b=c&query=value&d=e"))
+    }
+
+    @Test
+    fun `GIVEN a sponsored query parameter and a sponsored filter WHEN a URL does not contain the sponsored query parameter THEN that URL should be included`() {
+        every { activity.settings() } returns mockk(relaxed = true) {
+            every { frecencyFilterQuery } returns "query=value"
+        }
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.Default(mockk(relaxed = true)),
+            showSponsoredSuggestions = true,
+        )
+        val filter = requireNotNull(awesomeBarView.getFilterToExcludeSponsoredResults(state))
+
+        assertTrue(filter.shouldIncludeUri(Uri.parse("http://example.com")))
+        assertTrue(filter.shouldIncludeUri(Uri.parse("http://example.com?query")))
+        assertTrue(filter.shouldIncludeUri(Uri.parse("http://example.com/a")))
+        assertTrue(filter.shouldIncludeUri(Uri.parse("http://example.com/a?b")))
+        assertTrue(filter.shouldIncludeUri(Uri.parse("http://example.com/a?b&c=d")))
+
+        assertTrue(filter.shouldIncludeUrl("http://example.com"))
+        assertTrue(filter.shouldIncludeUrl("http://example.com?query"))
+        assertTrue(filter.shouldIncludeUrl("http://example.com/a"))
+        assertTrue(filter.shouldIncludeUrl("http://example.com/a?b"))
+        assertTrue(filter.shouldIncludeUrl("http://example.com/a?b&c=d"))
+    }
+
+    @Test
+    fun `GIVEN an engine with a results URL and an engine filter WHEN a URL matches the results URL THEN that URL should be included`() {
+        val url = Uri.parse("http://test.com")
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.Shortcut(
+                mockk(relaxed = true) {
+                    every { resultsUrl } returns url
+                },
+            ),
+        )
+
+        val filter = requireNotNull(awesomeBarView.getFilterForCurrentEngineResults(state))
+
+        assertTrue(filter.shouldIncludeUri(Uri.parse("http://test.com")))
+        assertTrue(filter.shouldIncludeUri(Uri.parse("http://test.com/a")))
+        assertTrue(filter.shouldIncludeUri(Uri.parse("http://mobile.test.com")))
+        assertTrue(filter.shouldIncludeUri(Uri.parse("http://mobile.test.com/a")))
+
+        assertTrue(filter.shouldIncludeUrl("http://test.com"))
+        assertTrue(filter.shouldIncludeUrl("http://test.com/a"))
+    }
+
+    @Test
+    fun `GIVEN an engine with a results URL and an engine filter WHEN a URL does not match the results URL THEN that URL should be excluded`() {
+        val url = Uri.parse("http://test.com")
+        val state = getSearchProviderState(
+            searchEngineSource = SearchEngineSource.Shortcut(
+                mockk(relaxed = true) {
+                    every { resultsUrl } returns url
+                },
+            ),
+        )
+
+        val filter = requireNotNull(awesomeBarView.getFilterForCurrentEngineResults(state))
+
+        assertFalse(filter.shouldIncludeUri(Uri.parse("http://other.com")))
+        assertFalse(filter.shouldIncludeUri(Uri.parse("http://subdomain.test.com")))
+
+        assertFalse(filter.shouldIncludeUrl("http://mobile.test.com"))
     }
 }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/awesomebar/AwesomeBarViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/awesomebar/AwesomeBarViewTest.kt
@@ -186,7 +186,7 @@ class AwesomeBarViewTest {
 
         val historyProvider = result.firstOrNull { it is CombinedHistorySuggestionProvider }
         assertNotNull(historyProvider)
-        assertEquals(url, (historyProvider as CombinedHistorySuggestionProvider).resultsUriFilter)
+        assertNotNull((historyProvider as CombinedHistorySuggestionProvider).resultsUriFilter)
         assertEquals(AwesomeBarView.METADATA_SUGGESTION_LIMIT, historyProvider.getMaxNumberOfSuggestions())
     }
 
@@ -562,7 +562,7 @@ class AwesomeBarViewTest {
 
         val historyProvider = result.firstOrNull { it is HistoryStorageSuggestionProvider }
         assertNotNull(historyProvider)
-        assertEquals(url, (historyProvider as HistoryStorageSuggestionProvider).resultsUriFilter)
+        assertNotNull((historyProvider as HistoryStorageSuggestionProvider).resultsUriFilter)
         assertEquals(AwesomeBarView.METADATA_SUGGESTION_LIMIT, historyProvider.getMaxNumberOfSuggestions())
     }
 
@@ -662,7 +662,7 @@ class AwesomeBarViewTest {
 
         val localSessionsProviders = result.filterIsInstance<SessionSuggestionProvider>()
         assertEquals(1, localSessionsProviders.size)
-        assertEquals(url, localSessionsProviders[0].resultsUriFilter)
+        assertNotNull(localSessionsProviders[0].resultsUriFilter)
     }
 
     @Test
@@ -697,7 +697,7 @@ class AwesomeBarViewTest {
 
         val localSessionsProviders = result.filterIsInstance<SyncedTabsStorageSuggestionProvider>()
         assertEquals(1, localSessionsProviders.size)
-        assertNull(localSessionsProviders[0].resultsHostFilter)
+        assertNull(localSessionsProviders[0].resultsUrlFilter)
     }
 
     @Test
@@ -718,7 +718,7 @@ class AwesomeBarViewTest {
 
         val localSessionsProviders = result.filterIsInstance<SyncedTabsStorageSuggestionProvider>()
         assertEquals(1, localSessionsProviders.size)
-        assertEquals("test", localSessionsProviders[0].resultsHostFilter)
+        assertNotNull(localSessionsProviders[0].resultsUrlFilter)
     }
 
     @Test
@@ -761,7 +761,7 @@ class AwesomeBarViewTest {
 
         val localSessionsProviders = result.filterIsInstance<BookmarksStorageSuggestionProvider>()
         assertEquals(1, localSessionsProviders.size)
-        assertEquals(url, localSessionsProviders[0].resultsUriFilter)
+        assertNotNull(localSessionsProviders[0].resultsUriFilter)
     }
 
     @Test
@@ -800,17 +800,17 @@ class AwesomeBarViewTest {
         val bookmarksProviders: List<BookmarksStorageSuggestionProvider> = result.filterIsInstance<BookmarksStorageSuggestionProvider>()
         assertEquals(2, bookmarksProviders.size)
         assertNull(bookmarksProviders[0].resultsUriFilter) // the general bookmarks provider
-        assertEquals(url, bookmarksProviders[1].resultsUriFilter) // the filtered bookmarks provider
+        assertNotNull(bookmarksProviders[1].resultsUriFilter) // the filtered bookmarks provider
         assertEquals(1, result.filterIsInstance<SearchActionProvider>().size)
         assertEquals(1, result.filterIsInstance<SearchSuggestionProvider>().size)
         val syncedTabsProviders: List<SyncedTabsStorageSuggestionProvider> = result.filterIsInstance<SyncedTabsStorageSuggestionProvider>()
         assertEquals(2, syncedTabsProviders.size)
-        assertNull(syncedTabsProviders[0].resultsHostFilter) // the general synced tabs provider
-        assertEquals("www.test.com", syncedTabsProviders[1].resultsHostFilter) // the filtered synced tabs provider
+        assertNull(syncedTabsProviders[0].resultsUrlFilter) // the general synced tabs provider
+        assertNotNull(syncedTabsProviders[1].resultsUrlFilter) // the filtered synced tabs provider
         val localTabsProviders: List<SessionSuggestionProvider> = result.filterIsInstance<SessionSuggestionProvider>()
         assertEquals(2, localTabsProviders.size)
         assertNull(localTabsProviders[0].resultsUriFilter) // the general tabs provider
-        assertEquals(url, localTabsProviders[1].resultsUriFilter) // the filtered tabs provider
+        assertNotNull(localTabsProviders[1].resultsUriFilter) // the filtered tabs provider
         assertEquals(1, result.filterIsInstance<SearchEngineSuggestionProvider>().size)
     }
 


### PR DESCRIPTION
Hi @jonalmeida and @MatthewTighe! 👋🏼 This turned into a bit of a refactor, so I wanted to put this up as a draft for your initial thoughts, in case you'd like to approach it differently!

The big idea is that, if the "show sponsored suggestions" setting is switched on, we want to hide suggestions whose URLs have `mfadid=adm` in their query params.

I saw we already do that for Top Sites via `frecencyFilterQuery`, and set about extending that to suggestions. I also noticed that we already have logic for filtering suggestions to only show URLs for the current search engine when a shortcut engine is selected, which got me thinking about ways to combine these filters.

So I did an exploratory refactor that:

1. Changed the providers to take a predicate function, instead of a URL or a host, for filtering results. The synced tabs provider is the only interesting case here: all our other providers give us an `android.net.Uri` to work with, but the synced tabs provider works with `String`s. I kept that behavior, instead of trying to turn it into a `Uri`, in case it's intentional.
2. Moved the filters into a new `SearchResultFilter` type, to capture the two types of filtering that we want to do.
3. Changed `AwesomeBarView.getProvidersToAdd` to build a list of `SearchResultFilter`s.
4. Changed the `AwesomeBarView.get*Providers` methods to take that list of filters, and turn them into a predicate to pass down to the providers.

Please let me know what you think about this direction, and if you like it, or if you have a better / easier way to approach it! I updated the tests in the first commit, but held off on updating the tests in the second commit for now.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
8. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
9. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
10. Click on `View task in Taskcluster` in the new `DETAILS` section.
11. The APK links should be on the right side of the screen, named for each CPU architecture.


















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1861415