### PR TITLE
Bug 1861084 - Add cookie banner global-rules/ sub-frames to default settings and toContentBlockingSetting

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -879,6 +879,8 @@ class GeckoEngine(
             this.cookieBannerHandlingMode = it.cookieBannerHandlingMode
             this.cookieBannerHandlingModePrivateBrowsing = it.cookieBannerHandlingModePrivateBrowsing
             this.cookieBannerHandlingDetectOnlyMode = it.cookieBannerHandlingDetectOnlyMode
+            this.cookieBannerHandlingGlobalRules = it.cookieBannerHandlingGlobalRules
+            this.cookieBannerHandlingGlobalRulesSubFrames = it.cookieBannerHandlingGlobalRulesSubFrames
         }
     }
 

--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
@@ -20,6 +20,8 @@ fun TrackingProtectionPolicy.toContentBlockingSetting(
     cookieBannerHandlingModePrivateBrowsing: EngineSession.CookieBannerHandlingMode =
         EngineSession.CookieBannerHandlingMode.REJECT_ALL,
     cookieBannerHandlingDetectOnlyMode: Boolean = false,
+    cookieBannerGlobalRulesEnabled: Boolean = false,
+    cookieBannerGlobalRulesSubFramesEnabled: Boolean = false,
 ) = ContentBlocking.Settings.Builder().apply {
     enhancedTrackingProtectionLevel(getEtpLevel())
     antiTracking(getAntiTrackingPolicy())
@@ -31,6 +33,8 @@ fun TrackingProtectionPolicy.toContentBlockingSetting(
     cookieBannerHandlingMode(cookieBannerHandlingMode.mode)
     cookieBannerHandlingModePrivateBrowsing(cookieBannerHandlingModePrivateBrowsing.mode)
     cookieBannerHandlingDetectOnlyMode(cookieBannerHandlingDetectOnlyMode)
+    cookieBannerGlobalRulesEnabled(cookieBannerGlobalRulesEnabled)
+    cookieBannerGlobalRulesSubFramesEnabled(cookieBannerGlobalRulesSubFramesEnabled)
 }.build()
 
 /**

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
@@ -40,11 +40,15 @@ class TrackingProtectionPolicyKtTest {
                 cookieBannerHandlingMode = cookieBannerSetting,
                 cookieBannerHandlingModePrivateBrowsing = cookieBannerSettingPrivateBrowsing,
                 cookieBannerHandlingDetectOnlyMode = true,
+                cookieBannerGlobalRulesEnabled = true,
+                cookieBannerGlobalRulesSubFramesEnabled = true,
             )
         assertEquals(0, policyWithSafeBrowsing.safeBrowsingCategories)
         assertEquals(cookieBannerSetting.mode, policyWithSafeBrowsing.cookieBannerMode)
         assertEquals(cookieBannerSettingPrivateBrowsing.mode, policyWithSafeBrowsing.cookieBannerModePrivateBrowsing)
         assertTrue(policyWithSafeBrowsing.cookieBannerDetectOnlyMode)
+        assertTrue(policyWithSafeBrowsing.cookieBannerGlobalRulesEnabled)
+        assertTrue(policyWithSafeBrowsing.cookieBannerGlobalRulesSubFramesEnabled)
     }
 
     @Test

--- a/fenix/app/src/main/java/org/mozilla/fenix/gecko/GeckoProvider.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/gecko/GeckoProvider.kt
@@ -110,7 +110,19 @@ object GeckoProvider {
             .crashHandler(CrashHandlerService::class.java)
             .telemetryDelegate(GeckoAdapter())
             .experimentDelegate(NimbusExperimentDelegate())
-            .contentBlocking(policy.toContentBlockingSetting())
+            .contentBlocking(
+                policy.toContentBlockingSetting(
+                    cookieBannerHandlingMode = context.settings().getCookieBannerHandling(),
+                    cookieBannerHandlingModePrivateBrowsing = context.settings()
+                        .getCookieBannerHandlingPrivateMode(),
+                    cookieBannerHandlingDetectOnlyMode =
+                    context.settings().shouldEnableCookieBannerDetectOnly,
+                    cookieBannerGlobalRulesEnabled =
+                    context.settings().shouldEnableCookieBannerGlobalRules,
+                    cookieBannerGlobalRulesSubFramesEnabled =
+                    context.settings().shouldEnableCookieBannerGlobalRulesSubFrame,
+                ),
+            )
             .consoleOutput(context.components.settings.enableGeckoLogs)
             .debugLogging(Config.channel.isDebug || context.components.settings.enableGeckoLogs)
             .aboutConfigEnabled(Config.channel.isBeta || Config.channel.isNightlyOrDebug)


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1861084