### PR TITLE
Nav proto

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/AppNavigationBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/AppNavigationBinding.kt
@@ -1,0 +1,122 @@
+package org.mozilla.fenix
+
+import androidx.annotation.IdRes
+import androidx.navigation.NavController
+import androidx.navigation.NavDirections
+import androidx.navigation.NavHost
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import mozilla.components.lib.state.helpers.AbstractBinding
+import org.mozilla.fenix.addons.AddonDetailsFragmentDirections
+import org.mozilla.fenix.addons.AddonPermissionsDetailsFragmentDirections
+import org.mozilla.fenix.addons.AddonsManagementFragmentDirections
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.AppState
+import org.mozilla.fenix.components.appstate.Screen
+import org.mozilla.fenix.exceptions.trackingprotection.TrackingProtectionExceptionsFragmentDirections
+import org.mozilla.fenix.ext.alreadyOnDestination
+import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.home.HomeFragment
+import org.mozilla.fenix.home.HomeFragmentDirections
+import org.mozilla.fenix.library.bookmarks.BookmarkFragmentDirections
+import org.mozilla.fenix.library.history.HistoryFragmentDirections
+import org.mozilla.fenix.library.historymetadata.HistoryMetadataGroupFragmentDirections
+import org.mozilla.fenix.library.recentlyclosed.RecentlyClosedFragmentDirections
+import org.mozilla.fenix.search.SearchDialogFragmentDirections
+import org.mozilla.fenix.settings.CookieBannersFragmentDirections
+import org.mozilla.fenix.settings.HttpsOnlyFragmentDirections
+import org.mozilla.fenix.settings.SettingsFragmentDirections
+import org.mozilla.fenix.settings.TrackingProtectionFragmentDirections
+import org.mozilla.fenix.settings.about.AboutFragmentDirections
+import org.mozilla.fenix.settings.logins.fragment.LoginDetailFragmentDirections
+import org.mozilla.fenix.settings.logins.fragment.SavedLoginsAuthFragmentDirections
+import org.mozilla.fenix.settings.search.SaveSearchEngineFragmentDirections
+import org.mozilla.fenix.settings.search.SearchEngineFragmentDirections
+import org.mozilla.fenix.settings.studies.StudiesFragmentDirections
+import org.mozilla.fenix.settings.wallpaper.WallpaperSettingsFragmentDirections
+import org.mozilla.fenix.share.AddNewDeviceFragmentDirections
+import org.mozilla.fenix.shopping.ReviewQualityCheckFragmentDirections
+import org.mozilla.fenix.tabstray.TabsTrayFragmentDirections
+import org.mozilla.fenix.trackingprotection.TrackingProtectionPanelDialogFragmentDirections
+
+class AppNavigationBinding(
+    appStore: AppStore,
+    private val navController: NavController,
+) : AbstractBinding<AppState>(appStore) {
+    override suspend fun onState(flow: Flow<AppState>) = flow.distinctUntilChangedBy { it.screen }
+        .collect {
+            when (val screen = it.screen) {
+                is Screen.Home -> {
+                    navController.navigate(R.id.homeFragment)
+                }
+                is Screen.Browser -> {
+                    val from = screen.from
+                    if (navController.alreadyOnDestination(R.id.browserFragment)) return@collect
+                    @IdRes val fragmentId = if (from.fragmentId != 0) from.fragmentId else null
+                    val directions = getNavDirections(from, screen.customTabSessionId)
+                    navController.nav(fragmentId, directions)
+                }
+            }
+        }
+
+    private fun getNavDirections(
+        from: BrowserDirection,
+        customTabSessionId: String?,
+    ): NavDirections = when (from) {
+        BrowserDirection.FromGlobal ->
+            NavGraphDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromHome ->
+            HomeFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromWallpaper ->
+            WallpaperSettingsFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromSearchDialog ->
+            SearchDialogFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromSettings ->
+            SettingsFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromBookmarks ->
+            BookmarkFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromHistory ->
+            HistoryFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromHistoryMetadataGroup ->
+            HistoryMetadataGroupFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromTrackingProtectionExceptions ->
+            TrackingProtectionExceptionsFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromCookieBanner ->
+            CookieBannersFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromHttpsOnlyMode ->
+            HttpsOnlyFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromAbout ->
+            AboutFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromTrackingProtection ->
+            TrackingProtectionFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromTrackingProtectionDialog ->
+            TrackingProtectionPanelDialogFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromSavedLoginsFragment ->
+            SavedLoginsAuthFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromAddNewDeviceFragment ->
+            AddNewDeviceFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromSearchEngineFragment ->
+            SearchEngineFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromSaveSearchEngineFragment ->
+            SaveSearchEngineFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromAddonDetailsFragment ->
+            AddonDetailsFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromAddonPermissionsDetailsFragment ->
+            AddonPermissionsDetailsFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromLoginDetailFragment ->
+            LoginDetailFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromTabsTray ->
+            TabsTrayFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromRecentlyClosed ->
+            RecentlyClosedFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromStudiesFragment -> StudiesFragmentDirections.actionGlobalBrowser(
+            customTabSessionId,
+        )
+        BrowserDirection.FromReviewQualityCheck -> ReviewQualityCheckFragmentDirections.actionGlobalBrowser(
+            customTabSessionId,
+        )
+        BrowserDirection.FromAddonsManagementFragment -> AddonsManagementFragmentDirections.actionGlobalBrowser(
+            customTabSessionId,
+        )
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/AppTabMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/AppTabMiddleware.kt
@@ -1,0 +1,119 @@
+package org.mozilla.fenix
+
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.base.profiler.Profiler
+import mozilla.components.feature.search.SearchUseCases
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+import mozilla.components.support.ktx.kotlin.isUrl
+import mozilla.components.support.ktx.kotlin.toNormalizedUrl
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
+import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.appstate.AppState
+import org.mozilla.fenix.components.appstate.Screen
+import org.mozilla.fenix.utils.Settings
+
+class AppTabMiddleware(
+    private val browserStore: BrowserStore,
+    private val settings: Settings,
+    private val tabsUseCases: TabsUseCases,
+    private val sessionUseCases: SessionUseCases,
+    private val searchUseCases: SearchUseCases,
+    private val profiler: Profiler? = null,
+) : Middleware<AppState, AppAction> {
+    override fun invoke(
+        context: MiddlewareContext<AppState, AppAction>,
+        next: (AppAction) -> Unit,
+        action: AppAction
+    ) {
+        next(action)
+        when (action) {
+            is AppAction.ChangeScreen -> {
+                if (action.screen is Screen.Browser) loadBrowserTab(action.screen)
+            }
+            else -> Unit
+        }
+    }
+
+    private fun loadBrowserTab(screen: Screen.Browser) {
+        val startTime = profiler?.getProfilerTime()
+        val mode = BrowsingMode.Normal
+//        val mode = browsingModeManager.mode
+
+
+//        val private = when (mode) {
+//            BrowsingMode.Private -> true
+//            BrowsingMode.Normal -> false
+//        }
+
+        // In situations where we want to perform a search but have no search engine (e.g. the user
+        // has removed all of them, or we couldn't load any) we will pass searchTermOrURL to Gecko
+        // and let it try to load whatever was entered.
+        if ((!screen.forceSearch && screen.searchTermOrURL.isUrl()) || screen.engine == null) {
+            val tabId = if (screen.newTab) {
+                tabsUseCases.addTab(
+                    url = screen.searchTermOrURL.toNormalizedUrl(),
+                    flags = screen.flags,
+                    private = mode.isPrivate,
+                    historyMetadata = screen.historyMetadata,
+                )
+            } else {
+               sessionUseCases.loadUrl(
+                    url = screen.searchTermOrURL.toNormalizedUrl(),
+                    flags = screen.flags,
+                )
+                browserStore.state.selectedTabId
+            }
+
+            if (screen.requestDesktopMode && tabId != null) {
+                handleRequestDesktopMode(tabId)
+            }
+        } else {
+            if (screen.newTab) {
+                val searchUseCase = if (mode.isPrivate) {
+                    searchUseCases.newPrivateTabSearch
+                } else {
+                    searchUseCases.newTabSearch
+                }
+                searchUseCase.invoke(
+                    searchTerms = screen.searchTermOrURL,
+                    source = SessionState.Source.Internal.UserEntered,
+                    selected = true,
+                    searchEngine = screen.engine,
+                    flags = screen.flags,
+                    additionalHeaders = screen.additionalHeaders,
+                )
+            } else {
+                searchUseCases.defaultSearch.invoke(
+                    searchTerms = screen.searchTermOrURL,
+                    searchEngine = screen.engine,
+                    flags = screen.flags,
+                    additionalHeaders = screen.additionalHeaders,
+                )
+            }
+        }
+
+        if (profiler?.isProfilerActive() == true) {
+            // Wrapping the `addMarker` method with `isProfilerActive` even though it's no-op when
+            // profiler is not active. That way, `text` argument will not create a string builder all the time.
+            profiler.addMarker(
+                "HomeActivity.load",
+                startTime,
+                "newTab: $screen.newTab",
+            )
+        }
+    }
+
+    private fun handleRequestDesktopMode(tabId: String) {
+        sessionUseCases.requestDesktopSite(true, tabId)
+        browserStore.dispatch(ContentAction.UpdateDesktopModeAction(tabId, true))
+
+        // Reset preference value after opening the tab in desktop mode
+        settings.openNextTabInDesktopMode = false
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -1026,7 +1026,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
     @OptIn(DelicateCoroutinesApi::class)
     open fun downloadWallpapers() {
         GlobalScope.launch {
-            components.useCases.wallpaperUseCases.initialize()
+            components.wallpaperUseCases.initialize()
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -568,8 +568,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
                 "finishing" to isFinishing.toString(),
             ),
         )
-
-        navigationBinding.stop()
     }
 
     final override fun onPause() {

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -215,6 +215,10 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         supportFragmentManager.findFragmentById(R.id.container) as NavHostFragment
     }
 
+    private val navigationBinding by lazy {
+        AppNavigationBinding(components.appStore, navHost.navController)
+    }
+
     private val externalSourceIntentProcessors by lazy {
         listOf(
             HomeDeepLinkIntentProcessor(this),
@@ -359,6 +363,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             extensionsProcessDisabledPromptObserver,
             serviceWorkerSupport,
             webExtensionPromptFeature,
+            navigationBinding,
         )
 
         if (shouldAddToRecentsScreen(intent)) {
@@ -563,6 +568,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
                 "finishing" to isFinishing.toString(),
             ),
         )
+
+        navigationBinding.stop()
     }
 
     final override fun onPause() {

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -260,12 +260,6 @@ abstract class BaseBrowserFragment :
         val originalContext = ActivityContextWrapper.getOriginalContext(activity)
         binding.engineView.setActivityContext(originalContext)
 
-        browserFragmentStore = StoreProvider.get(this) {
-            BrowserFragmentStore(
-                BrowserFragmentState(),
-            )
-        }
-
         startForResult = registerForActivityResult { result ->
             listOf(
                 promptsFeature,

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -44,9 +44,6 @@ class UseCases(
     private val topSitesStorage: TopSitesStorage,
     private val bookmarksStorage: BookmarksStorage,
     private val historyStorage: HistoryStorage,
-    appStore: AppStore,
-    client: Client,
-    strictMode: StrictModeManager,
 ) {
     /**
      * Use cases that provide engine interactions for a given browser session.
@@ -107,15 +104,4 @@ class UseCases(
      * Use cases that provide bookmark management.
      */
     val bookmarksUseCases by lazyMonitored { BookmarksUseCase(bookmarksStorage, historyStorage) }
-
-    val wallpaperUseCases by lazyMonitored {
-        // Required to even access context.filesDir property and to retrieve current locale
-        val (rootStorageDirectory, currentLocale) = strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
-            val rootStorageDirectory = context.filesDir
-            val currentLocale = LocaleManager.getCurrentLocale(context)?.toLanguageTag()
-                ?: LocaleManager.getSystemDefault().toLanguageTag()
-            rootStorageDirectory to currentLocale
-        }
-        WallpapersUseCases(context, appStore, client, rootStorageDirectory, currentLocale)
-    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -30,6 +30,7 @@ import org.mozilla.fenix.wallpapers.Wallpaper
  * [Action] implementation related to [AppStore].
  */
 sealed class AppAction : Action {
+    data class ChangeScreen(val screen: Screen) : AppAction()
     data class UpdateInactiveExpanded(val expanded: Boolean) : AppAction()
 
     /**

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
@@ -4,7 +4,10 @@
 
 package org.mozilla.fenix.components.appstate
 
+import mozilla.components.browser.state.search.SearchEngine
+import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.storage.BookmarkNode
+import mozilla.components.concept.storage.HistoryMetadataKey
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.lib.crash.Crash.NativeCodeCrash
@@ -12,6 +15,7 @@ import mozilla.components.lib.state.State
 import mozilla.components.service.pocket.PocketStory
 import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.browser.StandardSnackbarError
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.appstate.shopping.ShoppingState
@@ -79,4 +83,22 @@ data class AppState(
     val wallpaperState: WallpaperState = WallpaperState.default,
     val standardSnackbarError: StandardSnackbarError? = null,
     val shoppingState: ShoppingState = ShoppingState(),
+    val screen: Screen = Screen.Home,
 ) : State
+
+sealed class Screen {
+
+    object Home : Screen()
+    data class Browser(
+        val searchTermOrURL: String,
+        val newTab: Boolean,
+        val from: BrowserDirection,
+        val customTabSessionId: String? = null,
+        val engine: SearchEngine? = null,
+        val forceSearch: Boolean = false,
+        val flags: EngineSession.LoadUrlFlags = EngineSession.LoadUrlFlags.none(),
+        val requestDesktopMode: Boolean = false,
+        val historyMetadata: HistoryMetadataKey? = null,
+        val additionalHeaders: Map<String, String>? = null,
+    ) : Screen()
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -24,6 +24,7 @@ import org.mozilla.fenix.messaging.state.MessagingReducer
 internal object AppStoreReducer {
     @Suppress("LongMethod")
     fun reduce(state: AppState, action: AppAction): AppState = when (action) {
+        is AppAction.ChangeScreen -> state.copy(screen = action.screen)
         is AppAction.UpdateInactiveExpanded ->
             state.copy(inactiveTabsExpanded = action.expanded)
         is AppAction.UpdateFirstFrameDrawn -> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserFragmentStore.kt
@@ -7,13 +7,17 @@
 package org.mozilla.fenix.components.toolbar
 
 import mozilla.components.lib.state.Action
+import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
 
 // The state that used to live in this class was moved into another component in #4281. Keeping
 // the shell of this file because we will need to expand it as we add additional features to
 // the browser.
-class BrowserFragmentStore(initialState: BrowserFragmentState) :
+class BrowserFragmentStore(
+    initialState: BrowserFragmentState,
+    middleware: List<Middleware<BrowserFragmentState, BrowserFragmentAction>>
+) :
     Store<BrowserFragmentState, BrowserFragmentAction>(initialState, ::browserStateReducer)
 
 /**
@@ -21,7 +25,9 @@ class BrowserFragmentStore(initialState: BrowserFragmentState) :
  */
 class BrowserFragmentState : State
 
-sealed class BrowserFragmentAction : Action
+sealed class BrowserFragmentAction : Action {
+    object Init : BrowserFragmentAction()
+}
 
 /**
  * Reducers for [BrowserFragmentStore].

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarCFRPresenter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarCFRPresenter.kt
@@ -395,6 +395,6 @@ class BrowserToolbarCFRPresenter(
 /**
  * The CFR to be shown in the toolbar.
  */
-private enum class ToolbarCFR {
+internal enum class ToolbarCFR {
     TCP, SHOPPING, SHOPPING_OPTED_IN, ERASE, NONE
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -25,6 +25,8 @@ import org.mozilla.fenix.browser.BrowserAnimator.Companion.getToolbarNavOptions
 import org.mozilla.fenix.browser.BrowserFragmentDirections
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.readermode.ReaderModeController
+import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.appstate.Screen
 import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
@@ -195,9 +197,7 @@ class DefaultBrowserToolbarController(
     override fun handleHomeButtonClick() {
         Events.browserToolbarHomeTapped.record(NoExtras())
         browserAnimator.captureEngineViewAndDrawStatically {
-            navController.navigate(
-                BrowserFragmentDirections.actionGlobalHome(),
-            )
+            activity.components.appStore.dispatch(AppAction.ChangeScreen(Screen.Home))
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -28,6 +28,7 @@ import org.mozilla.fenix.customtabs.CustomTabToolbarIntegration
 import org.mozilla.fenix.customtabs.CustomTabToolbarMenu
 import org.mozilla.fenix.ext.bookmarkStorage
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.shopping.DefaultShoppingExperienceFeature
 import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.utils.ToolbarPopupWindow
@@ -58,6 +59,7 @@ class BrowserToolbarView(
         .findViewById(R.id.toolbar)
 
     val toolbarIntegration: ToolbarIntegration
+    private val browserFragmentStore: BrowserFragmentStore
 
     @VisibleForTesting
     internal val isPwaTabOrTwaTab: Boolean
@@ -181,6 +183,20 @@ class BrowserToolbarView(
                     interactor = interactor,
                 )
             }
+
+            browserFragmentStore = BrowserFragmentStore(
+                initialState = BrowserFragmentState(),
+                middleware = listOf(ToolbarCfrMiddleware(
+                    components.core.store,
+                    view,
+                    components.settings,
+                    DefaultShoppingExperienceFeature(),
+                    customTabSession?.id,
+                    {},
+                    {},
+                    {},
+                )),
+            )
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarCfrMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarCfrMiddleware.kt
@@ -1,0 +1,152 @@
+package org.mozilla.fenix.components.toolbar
+
+import android.view.View
+import androidx.annotation.VisibleForTesting
+import androidx.core.view.isVisible
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.transformWhile
+import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
+import mozilla.components.browser.state.selector.selectedTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.compose.cfr.CFRPopup
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+import mozilla.components.lib.state.ext.flowScoped
+import org.mozilla.fenix.R
+import org.mozilla.fenix.shopping.ShoppingExperienceFeature
+import org.mozilla.fenix.utils.Settings
+
+class ToolbarCfrMiddleware(
+    private val browserStore: BrowserStore,
+    private val toolbar: BrowserToolbar,
+    private val settings: Settings,
+    private val shoppingExperienceFeature: ShoppingExperienceFeature,
+    private val customTabId: String?,
+    private val showTcpCfr: () -> Unit,
+    private val showShoppingCFR: (Boolean) -> Unit,
+    private val showEraseCfr: () -> Unit,
+) : Middleware<BrowserFragmentState, BrowserFragmentAction> {
+
+    @VisibleForTesting
+    internal var scope: CoroutineScope? = null
+
+    @VisibleForTesting
+    internal var popup: CFRPopup? = null
+    override fun invoke(
+        context: MiddlewareContext<BrowserFragmentState, BrowserFragmentAction>,
+        next: (BrowserFragmentAction) -> Unit,
+        action: BrowserFragmentAction
+    ) {
+        when (action) {
+            is BrowserFragmentAction.Init -> {
+                val isPrivate = customTabId?.let {
+                    browserStore.state.findCustomTabOrSelectedTab(it)?.content?.private
+                } ?: browserStore.state.selectedTab?.content?.private ?: false
+                val cfr = getCFRToShow(isPrivate)
+                handleCfr(cfr)
+            }
+        }
+    }
+
+    private fun handleCfr(cfr: ToolbarCFR) = when(cfr) {
+        ToolbarCFR.TCP -> {
+            scope = browserStore.flowScoped { flow ->
+                flow.mapNotNull { it.findCustomTabOrSelectedTab(customTabId)?.content?.progress }
+                    // The "transformWhile" below ensures that the 100% progress is only collected once.
+                    .transformWhile { progress ->
+                        emit(progress)
+                        progress != 100
+                    }.filter { popup == null && it == 100 }.collect {
+                        scope?.cancel()
+                        showTcpCfr()
+                    }
+            }
+        }
+
+        ToolbarCFR.SHOPPING, ToolbarCFR.SHOPPING_OPTED_IN -> {
+            scope = browserStore.flowScoped { flow ->
+                val shouldShowCfr: Boolean? = flow.mapNotNull { it.selectedTab }
+                    .filter { it.content.isProductUrl && it.content.progress == 100 && !it.content.loading }
+                    .distinctUntilChanged()
+                    .map { toolbar.findViewById<View>(R.id.mozac_browser_toolbar_page_actions).isVisible }
+                    .filter { popup == null && it }
+                    .firstOrNull()
+
+                if (shouldShowCfr == true) {
+                    showShoppingCFR(cfr == ToolbarCFR.SHOPPING_OPTED_IN)
+                }
+
+                scope?.cancel()
+            }
+        }
+
+        ToolbarCFR.ERASE -> {
+            scope = browserStore.flowScoped { flow ->
+                flow
+                    .mapNotNull { it.findCustomTabOrSelectedTab(customTabId) }
+                    .filter { it.content.private }
+                    .map { it.content.progress }
+                    // The "transformWhile" below ensures that the 100% progress is only collected once.
+                    .transformWhile { progress ->
+                        emit(progress)
+                        progress != 100
+                    }
+                    .filter { popup == null && it == 100 }
+                    .collect {
+                        scope?.cancel()
+                        showEraseCfr()
+                    }
+            }
+        }
+
+        ToolbarCFR.NONE -> {
+            // no-op
+        }
+    }
+
+    private fun getCFRToShow(isPrivate: Boolean): ToolbarCFR = when {
+        settings.shouldShowEraseActionCFR && isPrivate -> {
+            ToolbarCFR.ERASE
+        }
+
+        settings.shouldShowTotalCookieProtectionCFR && (
+                settings.openTabsCount >= CFR_MINIMUM_NUMBER_OPENED_TABS
+                ) -> ToolbarCFR.TCP
+
+        shoppingExperienceFeature.isEnabled &&
+                settings.shouldShowReviewQualityCheckCFR -> whichShoppingCFR()
+
+        else -> ToolbarCFR.NONE
+    }
+
+    private fun whichShoppingCFR(): ToolbarCFR {
+        fun Long.isInitialized(): Boolean = this != 0L
+        fun Long.afterOneDay(): Boolean = this.isInitialized() &&
+                System.currentTimeMillis() - this > Settings.ONE_DAY_MS
+
+        val optInTime = settings.reviewQualityCheckOptInTimeInMillis
+        val firstCfrShownTime = settings.reviewQualityCheckCfrDisplayTimeInMillis
+
+        return when {
+            // First CFR should be displayed on first product page visit
+            !firstCfrShownTime.isInitialized() ->
+                ToolbarCFR.SHOPPING
+            // First CFR should be displayed again 24 hours later only for not opted in users
+            !optInTime.isInitialized() && firstCfrShownTime.afterOneDay() ->
+                ToolbarCFR.SHOPPING
+            // Second CFR should be shown 24 hours after opt in
+            optInTime.afterOneDay() ->
+                ToolbarCFR.SHOPPING_OPTED_IN
+            else -> {
+                ToolbarCFR.NONE
+            }
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/ext/NavController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ext/NavController.kt
@@ -27,9 +27,6 @@ fun NavController.nav(@IdRes id: Int?, directions: NavDirections, navOptions: Na
 }
 
 fun NavController.alreadyOnDestination(@IdRes destId: Int?): Boolean {
-    listOf("").let {
-
-    }
     return destId?.let { currentDestination?.id == it || popBackStack(it, false) } ?: false
 }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/ext/NavController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ext/NavController.kt
@@ -27,6 +27,9 @@ fun NavController.nav(@IdRes id: Int?, directions: NavDirections, navOptions: Na
 }
 
 fun NavController.alreadyOnDestination(@IdRes destId: Int?): Boolean {
+    listOf("").let {
+
+    }
     return destId?.let { currentDestination?.id == it || popBackStack(it, false) } ?: false
 }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -1012,7 +1012,7 @@ class HomeFragment : Fragment() {
                     // qualified type to load the image
                     val wallpaper = Wallpaper.Default.copy(name = wallpaperName)
                     val wallpaperImage =
-                        requireComponents.useCases.wallpaperUseCases.loadBitmap(wallpaper)
+                        requireComponents.wallpaperUseCases.loadBitmap(wallpaper)
                     wallpaperImage?.let {
                         it.scaleToBottomOfView(binding.wallpaperImageView)
                         binding.wallpaperImageView.isVisible = true

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesController.kt
@@ -15,6 +15,7 @@ import org.mozilla.fenix.GleanMetrics.Pocket
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.appstate.Screen
 
 /**
  * Contract for how all user interactions with the Pocket stories feature are to be handled.
@@ -149,7 +150,12 @@ internal class DefaultPocketStoriesController(
         storyClicked: PocketStory,
         storyPosition: Pair<Int, Int>,
     ) {
-        homeActivity.openToBrowserAndLoad(storyClicked.url, true, BrowserDirection.FromHome)
+//        homeActivity.openToBrowserAndLoad(storyClicked.url, true, BrowserDirection.FromHome)
+        appStore.dispatch(AppAction.ChangeScreen(Screen.Browser(
+            searchTermOrURL = storyClicked.url,
+            newTab = true,
+            from = BrowserDirection.FromHome
+        )))
 
         when (storyClicked) {
             is PocketRecommendedStory -> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/WallpaperOnboardingDialogFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/WallpaperOnboardingDialogFragment.kt
@@ -42,7 +42,7 @@ class WallpaperOnboardingDialogFragment : BottomSheetDialogFragment() {
     }
 
     private val wallpaperUseCases by lazy {
-        requireComponents.useCases.wallpaperUseCases
+        requireComponents.wallpaperUseCases
     }
 
     @SuppressLint("SourceLockedOrientationActivity")

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
@@ -35,7 +35,7 @@ class WallpaperSettingsFragment : Fragment() {
     }
 
     private val wallpaperUseCases by lazy {
-        requireComponents.useCases.wallpaperUseCases
+        requireComponents.wallpaperUseCases
     }
 
     override fun onCreateView(


### PR DESCRIPTION
This is a prototype patch to show case the two main proposals from RFC 0010: https://github.com/mozilla-mobile/firefox-android/pull/4126

I've separated them into two commits:
1. Adding a `Screen` property to the `AppState` which will be observed from the `HomeActivity` in order to control app-wide navigation.
2. A small test for creating a middleware to handle "transient" effects in response to `Action`s. This commit is less polished and is meant mostly to try and demonstrate that piece of the proposal.

Due to time constraints, only the 1st item is actually functional. To see it in action, check out the first commit and try clicking pocket stories on the home page or the home button from the browser to see it in action.

I've left comments in-line in the patch to try and explain some outstanding concerns/questions of my own and to address areas that would need more investigation and refinement if we were to adopt them for real.

Much of the code here is copied from where it currently lives. I think there are further improvements that could be made if this work were actually done to fit better into the unidirectional, single-source of truth patterns defined by `lib-state`. 

Used by GitHub Actions.
