### PR TITLE
Bug 1861732 - Split-out "terms of use" and "privacy policy" text links

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContextualOnboarding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContextualOnboarding.kt
@@ -57,9 +57,9 @@ fun ReviewQualityCheckContextualOnboarding(
     val learnMoreText =
         stringResource(id = R.string.review_quality_check_contextual_onboarding_learn_more_link)
     val privacyPolicyText =
-        stringResource(id = R.string.review_quality_check_contextual_onboarding_privacy_policy)
+        stringResource(id = R.string.review_quality_check_contextual_onboarding_privacy_policy_2)
     val termsOfUseText =
-        stringResource(id = R.string.review_quality_check_contextual_onboarding_terms_use)
+        stringResource(id = R.string.review_quality_check_contextual_onboarding_terms_use_2)
 
     ReviewQualityCheckCard(modifier = Modifier.fillMaxWidth()) {
         Text(
@@ -76,7 +76,7 @@ fun ReviewQualityCheckContextualOnboarding(
             style = FirefoxTheme.typography.body2,
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         LinkText(
             text = stringResource(
@@ -99,15 +99,21 @@ fun ReviewQualityCheckContextualOnboarding(
             linkTextDecoration = TextDecoration.Underline,
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = stringResource(
+                id = R.string.review_quality_check_contextual_onboarding_caption_3,
+                stringResource(id = R.string.shopping_product_name),
+            ),
+            color = FirefoxTheme.colors.textPrimary,
+            style = FirefoxTheme.typography.caption,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
 
         LinkText(
-            text = stringResource(
-                id = R.string.review_quality_check_contextual_onboarding_caption_2,
-                stringResource(id = R.string.shopping_product_name),
-                privacyPolicyText,
-                termsOfUseText,
-            ),
+            text = privacyPolicyText,
             linkTextStates = listOf(
                 LinkTextState(
                     text = privacyPolicyText,
@@ -116,6 +122,16 @@ fun ReviewQualityCheckContextualOnboarding(
                         onPrivacyPolicyClick()
                     },
                 ),
+            ),
+            style = FirefoxTheme.typography.body2,
+            linkTextDecoration = TextDecoration.Underline,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        LinkText(
+            text = termsOfUseText,
+            linkTextStates = listOf(
                 LinkTextState(
                     text = termsOfUseText,
                     url = PLACEHOLDER_URL,
@@ -124,14 +140,11 @@ fun ReviewQualityCheckContextualOnboarding(
                     },
                 ),
             ),
-            style = FirefoxTheme.typography.caption
-                .copy(
-                    color = FirefoxTheme.colors.textSecondary,
-                ),
+            style = FirefoxTheme.typography.body2,
             linkTextDecoration = TextDecoration.Underline,
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         Image(
             painter = painterResource(id = R.drawable.shopping_onboarding),
@@ -142,7 +155,7 @@ fun ReviewQualityCheckContextualOnboarding(
                 .padding(all = 16.dp),
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         PrimaryButton(
             text = stringResource(R.string.review_quality_check_contextual_onboarding_primary_button_text),

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -2212,11 +2212,17 @@
     <!-- Caption text to be displayed in review quality check contextual onboarding card above the opt-in button. First parameter is the Fakespot product name. Following parameters are for clickable texts defined in review_quality_check_contextual_onboarding_privacy_policy and review_quality_check_contextual_onboarding_terms_use. In the phrase "Fakespot by Mozilla", "by" can be localized. Does not need to stay by. -->
     <string name="review_quality_check_contextual_onboarding_caption" moz:RemovedIn="121" tools:ignore="UnusedResources">By selecting “Yes, try it” you agree to %1$s by Mozilla’s %2$s and %3$s.</string>
     <!-- Caption text to be displayed in review quality check contextual onboarding card above the opt-in button. First parameter is the Fakespot product name. Following parameters are for clickable texts defined in review_quality_check_contextual_onboarding_privacy_policy and review_quality_check_contextual_onboarding_terms_use. -->
-    <string name="review_quality_check_contextual_onboarding_caption_2">By selecting “Yes, try it” you agree to %1$s’s %2$s and %3$s.</string>
+    <string name="review_quality_check_contextual_onboarding_caption_2" moz:RemovedIn="121" tools:ignore="UnusedResources">By selecting “Yes, try it” you agree to %1$s’s %2$s and %3$s.</string>
+    <!-- Caption text to be displayed in review quality check contextual onboarding card above the opt-in button. Parameter is the Fakespot product name. After the colon, what appears are two links, each on their own line. The first link is to a Privacy policy (review_quality_check_contextual_onboarding_privacy_policy_2). The second link is to Terms of use (review_quality_check_contextual_onboarding_terms_use_2). -->
+    <string name="review_quality_check_contextual_onboarding_caption_3">By selecting \"Yes, try it\" you agree to the following from %1$s:</string>
     <!-- Clickable text from the review quality check contextual onboarding card that links to Fakespot privacy policy. -->
-    <string name="review_quality_check_contextual_onboarding_privacy_policy">privacy policy</string>
+    <string name="review_quality_check_contextual_onboarding_privacy_policy" moz:RemovedIn="121" tools:ignore="UnusedResources">privacy policy</string>
+    <!-- Clickable text from the review quality check contextual onboarding card that links to Fakespot privacy policy. -->
+    <string name="review_quality_check_contextual_onboarding_privacy_policy_2">Privacy policy</string>
     <!-- Clickable text from the review quality check contextual onboarding card that links to Fakespot terms of use. -->
-    <string name="review_quality_check_contextual_onboarding_terms_use">terms of use</string>
+    <string name="review_quality_check_contextual_onboarding_terms_use" moz:RemovedIn="121" tools:ignore="UnusedResources">terms of use</string>
+    <!-- Clickable text from the review quality check contextual onboarding card that links to Fakespot terms of use. -->
+    <string name="review_quality_check_contextual_onboarding_terms_use_2">Terms of use</string>
     <!-- Text for opt-in button from the review quality check contextual onboarding card. -->
     <string name="review_quality_check_contextual_onboarding_primary_button_text">Yes, try it</string>
     <!-- Text for opt-out button from the review quality check contextual onboarding card. -->


### PR DESCRIPTION
| Before | After | 
| -- | -- |
| ![image](https://github.com/mozilla-mobile/firefox-android/assets/87384386/e971dbc4-e2ec-4be2-b536-988adef35c56) | ![image](https://github.com/mozilla-mobile/firefox-android/assets/87384386/1e072405-e2a0-4050-a4fb-2a7146542889) |



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1861732