### PR TITLE
Bug 1862038 - Update release_checklist.md to swap two steps

### DIFF
--- a/docs/contribute/release_checklist.md
+++ b/docs/contribute/release_checklist.md
@@ -21,21 +21,6 @@ These are instructions for preparing a release branch for Firefox Android and st
         -109.0a1
         +109.0b1
         ```
-    - In [Gecko.kt](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt), set the `channel` to `GeckoChannel.BETA`. Create a commit named `Switch to GeckoView Beta` for this change. This change can either be directly committed to the `releases_v[beta_version]` branch or a pull request can be created against it and then merged. Once landed, it is expected that this change will temporarily break builds on the branch. Step #4 will fix them.
-        ```diff
-        diff --git a/android-components/plugins/dependencies/src/main/java/Gecko.kt b/android-components/plugins/dependencies/src/main/java/Gecko.kt
-        --- a/android-components/plugins/dependencies/src/main/java/Gecko.kt
-        +++ b/android-components/plugins/dependencies/src/main/java/Gecko.kt
-        @@ -14,7 +14,7 @@ object Gecko {
-            /**
-              * GeckoView channel
-              */
-        -    val channel = GeckoChannel.NIGHTLY
-        +    val channel = GeckoChannel.BETA
-        }
-
-        /**
-        ```
     - In [ApplicationServices.kt](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/ApplicationServices.kt):
       - Set `CHANNEL` to `ApplicationServicesChannel.RELEASE`
       - Set `VERSION` to `[major-version].0`
@@ -55,6 +40,21 @@ These are instructions for preparing a release branch for Firefox Android and st
       +val CHANNEL = ApplicationServicesChannel.RELEASE
       ```
       - Create a commit named `Switch to Application Services Release`. (Note: application-services releases directly after the nightly cycle, there's no beta cycle).
+    - In [Gecko.kt](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt), set the `channel` to `GeckoChannel.BETA`. Create a commit named `Switch to GeckoView Beta` for this change. This change can either be directly committed to the `releases_v[beta_version]` branch or a pull request can be created against it and then merged. Once landed, it is expected that this change will temporarily break builds on the branch. Step #4 will fix them.
+        ```diff
+        diff --git a/android-components/plugins/dependencies/src/main/java/Gecko.kt b/android-components/plugins/dependencies/src/main/java/Gecko.kt
+        --- a/android-components/plugins/dependencies/src/main/java/Gecko.kt
+        +++ b/android-components/plugins/dependencies/src/main/java/Gecko.kt
+        @@ -14,7 +14,7 @@ object Gecko {
+            /**
+              * GeckoView channel
+              */
+        -    val channel = GeckoChannel.NIGHTLY
+        +    val channel = GeckoChannel.BETA
+        }
+
+        /**
+        ```
 2. In `main` [version.txt](https://github.com/mozilla-mobile/firefox-android/blob/main/version.txt), update the version from `[previous_nightly_version].0a1` to `[nightly_version].0a1`. Create a commit named `Set version to [nightly_version].0a1` for this change. This change can either be directly committed to the `main` branch or a pull request can be created against it and then merged.
     ```diff
     diff --git a/version.txt b/version.txt


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1862038