### PR TITLE
WIP Bug 1859981 

### DIFF
--- a/fenix/app/src/test/java/org/mozilla/fenix/utils/ClipboardHandlerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/utils/ClipboardHandlerTest.kt
@@ -7,101 +7,183 @@ package org.mozilla.fenix.utils
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import io.mockk.every
-import io.mockk.mockkObject
-import io.mockk.spyk
-import io.mockk.unmockkObject
-import io.mockk.verify
+import android.content.Intent
+import android.os.PersistableBundle
+import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.utils.SafeUrl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.`when`
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+private const val CLIPBOARD_URL = "https://www.mozilla.org"
+private const val CLIPBOARD_TEXT = "Mozilla"
 
 @RunWith(FenixRobolectricTestRunner::class)
 class ClipboardHandlerTest {
+    private val safeUrl = mock<SafeUrl>()
+    private val bestWebUrlFunc = mock<((String) -> String?)>()
+    private val isWebUrlFunc = mock<((String) -> Boolean)>()
 
-    private val clipboardUrl = "https://www.mozilla.org"
-    private val clipboardText = "Mozilla"
     private lateinit var clipboard: ClipboardManager
     private lateinit var clipboardHandler: ClipboardHandler
 
     @Before
     fun setup() {
         clipboard = testContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        clipboardHandler = ClipboardHandler(testContext)
+        clipboardHandler =
+            ClipboardHandler(testContext, clipboard, safeUrl, bestWebUrlFunc, isWebUrlFunc)
     }
 
     @Test
-    fun getText() {
+    fun `WHEN text is set THEN the bundle and text is set for the clipboard`() {
+        `when`(isWebUrlFunc(CLIPBOARD_TEXT)).thenReturn(false)
         assertEquals(null, clipboardHandler.text)
 
-        clipboard.setPrimaryClip(ClipData.newPlainText("Text", clipboardText))
-        assertEquals(clipboardText, clipboardHandler.text)
+        clipboardHandler.text = CLIPBOARD_TEXT
+        val persistableBundle = PersistableBundle().apply {
+            putBoolean("android.content.extra.IS_SENSITIVE", false)
+        }
+        assertEquals(
+            persistableBundle.toString(),
+            clipboard.primaryClipDescription?.extras.toString(),
+        )
+        assertEquals(CLIPBOARD_TEXT, clipboardHandler.text)
     }
 
     @Test
-    fun setText() {
+    fun `WHEN sensitive text is set THEN the bundle and text is set for the clipboard`() {
+        `when`(isWebUrlFunc(CLIPBOARD_TEXT)).thenReturn(false)
+        assertEquals(null, clipboardHandler.sensitiveText)
+
+        clipboardHandler.sensitiveText = CLIPBOARD_TEXT
+        val persistableBundle = PersistableBundle().apply {
+            putBoolean("android.content.extra.IS_SENSITIVE", true)
+        }
+        assertEquals(
+            persistableBundle.toString(),
+            clipboard.primaryClipDescription?.extras.toString(),
+        )
+        assertEquals(CLIPBOARD_TEXT, clipboardHandler.sensitiveText)
+    }
+
+    @Test
+    fun `WHEN clipboard item is null THEN text returns null`() {
+        assertEquals(null, clipboardHandler.text)
+    }
+
+    @Test
+    fun `WHEN clipboard item MimeType is TEXT_PLAIN and text is a URL THEN text returned as safe URL`() {
         assertEquals(null, clipboardHandler.text)
 
-        clipboardHandler.text = clipboardText
-        assertEquals(clipboardText, clipboardHandler.text)
+        clipboard.setPrimaryClip(ClipData.newPlainText("Text", CLIPBOARD_URL))
+
+        `when`(isWebUrlFunc(CLIPBOARD_URL)).thenReturn(true)
+        val expected = CLIPBOARD_URL.plus("1")
+        `when`(safeUrl.stripUnsafeUrlSchemes(testContext, CLIPBOARD_URL)).thenReturn(expected)
+        assertEquals(expected, clipboardHandler.text)
     }
 
     @Test
-    fun `extract url from plaintext mime clipboard clip`() {
-        assertEquals(null, clipboardHandler.extractURL())
+    fun `WHEN clipboard item MimeType is TEXT_PLAIN and text is not a URL THEN text is returned unmodified`() {
+        assertEquals(null, clipboardHandler.text)
 
-        clipboard.setPrimaryClip(ClipData.newPlainText("Text", clipboardUrl))
-        assertEquals(clipboardUrl, clipboardHandler.extractURL())
+        clipboard.setPrimaryClip(ClipData.newPlainText("Text", CLIPBOARD_TEXT))
+
+        `when`(isWebUrlFunc(CLIPBOARD_TEXT)).thenReturn(false)
+        assertEquals(CLIPBOARD_TEXT, clipboardHandler.text)
     }
 
     @Test
-    fun `extract url from html mime clipboard clip`() {
-        assertEquals(null, clipboardHandler.extractURL())
+    fun `WHEN clipboard item MimeType is TEXT_HTML and text is a URL THEN text is returned as safe URL`() {
+        assertEquals(null, clipboardHandler.text)
 
-        clipboard.setPrimaryClip(ClipData.newHtmlText("Html", clipboardUrl, clipboardUrl))
-        assertEquals(clipboardUrl, clipboardHandler.extractURL())
+        clipboard.setPrimaryClip(ClipData.newHtmlText("Html", CLIPBOARD_URL, CLIPBOARD_URL))
+
+        `when`(isWebUrlFunc(CLIPBOARD_URL)).thenReturn(true)
+        val expected = CLIPBOARD_URL.plus("1")
+        `when`(safeUrl.stripUnsafeUrlSchemes(testContext, CLIPBOARD_URL)).thenReturn(expected)
+        assertEquals(expected, clipboardHandler.text)
     }
 
     @Test
-    fun `extract url from url mime clipboard clip`() {
-        assertEquals(null, clipboardHandler.extractURL())
+    fun `WHEN clipboard item MimeType is TEXT_HTML and text is not a URL THEN text is returned unmodified`() {
+        assertEquals(null, clipboardHandler.text)
+
+        clipboard.setPrimaryClip(ClipData.newHtmlText("Html", CLIPBOARD_TEXT, CLIPBOARD_TEXT))
+
+        `when`(isWebUrlFunc(CLIPBOARD_TEXT)).thenReturn(false)
+        assertEquals(CLIPBOARD_TEXT, clipboardHandler.text)
+    }
+
+    @Test
+    fun `WHEN clipboard item MimeType is TEXT_URL THEN text is returned as safe URL`() {
+        assertEquals(null, clipboardHandler.text)
 
         clipboard.setPrimaryClip(
-            ClipData(clipboardUrl, arrayOf("text/x-moz-url"), ClipData.Item(clipboardUrl)),
+            ClipData(
+                CLIPBOARD_URL,
+                arrayOf("text/x-moz-url"),
+                ClipData.Item(CLIPBOARD_URL),
+            ),
         )
-        assertEquals(clipboardUrl, clipboardHandler.extractURL())
+        val expected = CLIPBOARD_URL.plus("1")
+        `when`(safeUrl.stripUnsafeUrlSchemes(testContext, CLIPBOARD_URL)).thenReturn(expected)
+        assertEquals(expected, clipboardHandler.text)
     }
 
     @Test
-    fun `text should return firstSafePrimaryClipItemText`() {
-        val safeResult = "safeResult"
-        clipboard.setPrimaryClip(ClipData.newPlainText(clipboardUrl, clipboardText))
-        clipboardHandler = spyk(clipboardHandler)
-        every { clipboardHandler getProperty "firstSafePrimaryClipItemText" } propertyType String::class returns safeResult
+    fun `WHEN clipboard item MimeType is not known THEN text returns null`() {
+        assertEquals(null, clipboardHandler.text)
 
-        val result = clipboardHandler.text
+        clipboard.setPrimaryClip(
+            ClipData(
+                CLIPBOARD_URL,
+                arrayOf("text/unknown"),
+                ClipData.Item(CLIPBOARD_URL),
+            ),
+        )
 
-        verify { clipboardHandler getProperty "firstSafePrimaryClipItemText" }
-        assertEquals(safeResult, result)
+        assertEquals(null, clipboardHandler.text)
     }
 
     @Test
-    fun `firstSafePrimaryClipItemText should return the result of SafeUrl#stripUnsafeUrlSchemes`() {
-        mockkObject(SafeUrl)
-        try {
-            every { SafeUrl.stripUnsafeUrlSchemes(any(), any()) } returns "safeResult"
-            clipboard.setPrimaryClip(ClipData.newHtmlText("Html", clipboardUrl, clipboardUrl))
+    fun `WHEN clipboard item MimeType is unsupported THEN text returns null`() {
+        assertEquals(null, clipboardHandler.text)
 
-            val result = clipboardHandler.firstSafePrimaryClipItemText
+        clipboard.setPrimaryClip(ClipData.newIntent("Intent", Intent()))
 
-            verify { SafeUrl.stripUnsafeUrlSchemes(testContext, clipboardUrl) }
-            assertEquals("safeResult", result)
-        } finally {
-            unmockkObject(SafeUrl)
-        }
+        assertEquals(null, clipboardHandler.text)
+    }
+
+    @Test
+    fun `WHEN clipboard item is null THEN extractURL returns null`() {
+        assertEquals(null, clipboardHandler.extractURL())
+    }
+
+    @Test
+    fun `WHEN text is not a valid URL extractURL THEN returns null`() {
+        assertEquals(null, clipboardHandler.extractURL())
+
+        clipboard.setPrimaryClip(ClipData.newPlainText("Text", CLIPBOARD_TEXT))
+
+        `when`(isWebUrlFunc(CLIPBOARD_TEXT)).thenReturn(false)
+        assertEquals(null, clipboardHandler.extractURL())
+    }
+
+    @Test
+    fun `WHEN text is a valid URL extractURL THEN returns the URL`() {
+        assertEquals(null, clipboardHandler.extractURL())
+
+        clipboard.setPrimaryClip(ClipData.newPlainText("Text", CLIPBOARD_URL))
+
+        `when`(isWebUrlFunc(CLIPBOARD_URL)).thenReturn(true)
+        `when`(safeUrl.stripUnsafeUrlSchemes(testContext, CLIPBOARD_URL)).thenReturn(CLIPBOARD_URL)
+        val expected = CLIPBOARD_URL.plus("1")
+        `when`(bestWebUrlFunc(CLIPBOARD_URL)).thenReturn(expected)
+        assertEquals(expected, clipboardHandler.extractURL())
     }
 }


### PR DESCRIPTION
Identified 2 potential causes of this crash.

1. The `extractURL` function asserted that `text` was a valid URL if the length was within `MAX_URI_LENGTH`.

2.The `stripUnsafeUrlSchemes` function was casting a null `unsafeText`to a String, so a null `safeUrl` would have been set to "null"  and returned as a valid URL.

My theory is that with `containsURL`returning true in `SearchDialogFragment` `onResume` eventually uses `requireComponents.core.engine.speculativeConnect(clipboardUrl)` and attempts to connect using the URL: `null` or another non-URL value causing the 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.
















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1859981