### PR TITLE
Bug 1862425 - Allow to control QPS prefs using nimbus.

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -776,6 +776,53 @@ class GeckoEngine(
                 field = value
             }
 
+        override var queryParameterStripping: Boolean = false
+            set(value) {
+                with(runtime.settings.contentBlocking) {
+                    if (this.queryParameterStrippingEnabled != value) {
+                        this.queryParameterStrippingEnabled = value
+                    }
+                }
+                field = value
+            }
+
+        override var queryParameterStrippingPrivateBrowsing: Boolean = false
+            set(value) {
+                with(runtime.settings.contentBlocking) {
+                    if (this.queryParameterStrippingPrivateBrowsingEnabled != value) {
+                        this.queryParameterStrippingPrivateBrowsingEnabled = value
+                    }
+                }
+                field = value
+            }
+
+        @Suppress("SpreadOperator")
+        override var queryParameterStrippingAllowList: String = ""
+            set(value) {
+                with(runtime.settings.contentBlocking) {
+                    if (this.queryParameterStrippingAllowList.joinToString() != value) {
+                        this.setQueryParameterStrippingAllowList(
+                            *value.split(",")
+                                .toTypedArray(),
+                        )
+                    }
+                }
+                field = value
+            }
+
+        @Suppress("SpreadOperator")
+        override var queryParameterStrippingStripList: String = ""
+            set(value) {
+                with(runtime.settings.contentBlocking) {
+                    if (this.queryParameterStrippingStripList.joinToString() != value) {
+                        this.setQueryParameterStrippingStripList(
+                            *value.split(",").toTypedArray(),
+                        )
+                    }
+                }
+                field = value
+            }
+
         override var remoteDebuggingEnabled: Boolean
             get() = runtime.settings.remoteDebuggingEnabled
             set(value) { runtime.settings.remoteDebuggingEnabled = value }

--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicy.kt
@@ -14,6 +14,7 @@ import org.mozilla.geckoview.GeckoRuntimeSettings
  * Converts a [TrackingProtectionPolicy] into a GeckoView setting that can be used with [GeckoRuntimeSettings.Builder].
  * Also contains the cookie banner handling settings for regular and private browsing.
  */
+@Suppress("SpreadOperator")
 fun TrackingProtectionPolicy.toContentBlockingSetting(
     safeBrowsingPolicy: Array<EngineSession.SafeBrowsingPolicy> = arrayOf(EngineSession.SafeBrowsingPolicy.RECOMMENDED),
     cookieBannerHandlingMode: EngineSession.CookieBannerHandlingMode = EngineSession.CookieBannerHandlingMode.DISABLED,
@@ -22,6 +23,10 @@ fun TrackingProtectionPolicy.toContentBlockingSetting(
     cookieBannerHandlingDetectOnlyMode: Boolean = false,
     cookieBannerGlobalRulesEnabled: Boolean = false,
     cookieBannerGlobalRulesSubFramesEnabled: Boolean = false,
+    queryParameterStripping: Boolean = false,
+    queryParameterStrippingPrivateBrowsing: Boolean = false,
+    queryParameterStrippingAllowList: String = "",
+    queryParameterStrippingStripList: String = "",
 ) = ContentBlocking.Settings.Builder().apply {
     enhancedTrackingProtectionLevel(getEtpLevel())
     antiTracking(getAntiTrackingPolicy())
@@ -35,6 +40,10 @@ fun TrackingProtectionPolicy.toContentBlockingSetting(
     cookieBannerHandlingDetectOnlyMode(cookieBannerHandlingDetectOnlyMode)
     cookieBannerGlobalRulesEnabled(cookieBannerGlobalRulesEnabled)
     cookieBannerGlobalRulesSubFramesEnabled(cookieBannerGlobalRulesSubFramesEnabled)
+    queryParameterStrippingEnabled(queryParameterStripping)
+    queryParameterStrippingPrivateBrowsingEnabled(queryParameterStrippingPrivateBrowsing)
+    queryParameterStrippingAllowList(*queryParameterStrippingAllowList.split(",").toTypedArray())
+    queryParameterStrippingStripList(*queryParameterStrippingStripList.split(",").toTypedArray())
 }.build()
 
 /**

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt
@@ -317,6 +317,10 @@ class GeckoEngineTest {
         assertEquals(contentBlockingSettings.cookieBannerDetectOnlyMode, engine.settings.cookieBannerHandlingDetectOnlyMode)
         assertEquals(contentBlockingSettings.cookieBannerGlobalRulesEnabled, engine.settings.cookieBannerHandlingGlobalRules)
         assertEquals(contentBlockingSettings.cookieBannerGlobalRulesSubFramesEnabled, engine.settings.cookieBannerHandlingGlobalRulesSubFrames)
+        assertEquals(contentBlockingSettings.queryParameterStrippingEnabled, engine.settings.queryParameterStripping)
+        assertEquals(contentBlockingSettings.queryParameterStrippingPrivateBrowsingEnabled, engine.settings.queryParameterStrippingPrivateBrowsing)
+        assertEquals(contentBlockingSettings.queryParameterStrippingAllowList[0], engine.settings.queryParameterStrippingAllowList)
+        assertEquals(contentBlockingSettings.queryParameterStrippingStripList[0], engine.settings.queryParameterStrippingStripList)
 
         try {
             engine.settings.domStorageEnabled
@@ -603,6 +607,46 @@ class GeckoEngineTest {
         engine.settings.cookieBannerHandlingGlobalRulesSubFrames = true
 
         verify(mockRuntime.settings.contentBlocking, never()).setCookieBannerGlobalRulesSubFramesEnabled(true)
+    }
+
+    @Test
+    fun `setQueryParameterStripping is only invoked when the value is changed`() {
+        val mockRuntime = mock<GeckoRuntime>()
+        val settings = spy(ContentBlocking.Settings.Builder().build())
+        whenever(mockRuntime.settings).thenReturn(mock())
+        whenever(mockRuntime.settings.contentBlocking).thenReturn(settings)
+
+        val engine = GeckoEngine(testContext, runtime = mockRuntime)
+
+        engine.settings.queryParameterStripping = true
+
+        verify(mockRuntime.settings.contentBlocking).setQueryParameterStrippingEnabled(true)
+
+        reset(settings)
+
+        engine.settings.queryParameterStripping = true
+
+        verify(mockRuntime.settings.contentBlocking, never()).setQueryParameterStrippingEnabled(true)
+    }
+
+    @Test
+    fun `setQueryParameterStrippingPrivateBrowsingEnabled is only invoked when the value is changed`() {
+        val mockRuntime = mock<GeckoRuntime>()
+        val settings = spy(ContentBlocking.Settings.Builder().build())
+        whenever(mockRuntime.settings).thenReturn(mock())
+        whenever(mockRuntime.settings.contentBlocking).thenReturn(settings)
+
+        val engine = GeckoEngine(testContext, runtime = mockRuntime)
+
+        engine.settings.queryParameterStrippingPrivateBrowsing = true
+
+        verify(mockRuntime.settings.contentBlocking).setQueryParameterStrippingPrivateBrowsingEnabled(true)
+
+        reset(settings)
+
+        engine.settings.queryParameterStrippingPrivateBrowsing = true
+
+        verify(mockRuntime.settings.contentBlocking, never()).setQueryParameterStrippingPrivateBrowsingEnabled(true)
     }
 
     @Test

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/ext/TrackingProtectionPolicyKtTest.kt
@@ -33,6 +33,10 @@ class TrackingProtectionPolicyKtTest {
         assertEquals(EngineSession.CookieBannerHandlingMode.DISABLED.mode, setting.cookieBannerMode)
         assertEquals(EngineSession.CookieBannerHandlingMode.REJECT_ALL.mode, setting.cookieBannerModePrivateBrowsing)
         assertFalse(setting.cookieBannerDetectOnlyMode)
+        assertFalse(setting.queryParameterStrippingEnabled)
+        assertFalse(setting.queryParameterStrippingPrivateBrowsingEnabled)
+        assertEquals("", setting.queryParameterStrippingAllowList[0])
+        assertEquals("", setting.queryParameterStrippingStripList[0])
 
         val policyWithSafeBrowsing =
             TrackingProtectionPolicy.recommended().toContentBlockingSetting(
@@ -42,6 +46,10 @@ class TrackingProtectionPolicyKtTest {
                 cookieBannerHandlingDetectOnlyMode = true,
                 cookieBannerGlobalRulesEnabled = true,
                 cookieBannerGlobalRulesSubFramesEnabled = true,
+                queryParameterStripping = true,
+                queryParameterStrippingPrivateBrowsing = true,
+                queryParameterStrippingAllowList = "AllowList",
+                queryParameterStrippingStripList = "StripList",
             )
         assertEquals(0, policyWithSafeBrowsing.safeBrowsingCategories)
         assertEquals(cookieBannerSetting.mode, policyWithSafeBrowsing.cookieBannerMode)
@@ -49,6 +57,10 @@ class TrackingProtectionPolicyKtTest {
         assertTrue(policyWithSafeBrowsing.cookieBannerDetectOnlyMode)
         assertTrue(policyWithSafeBrowsing.cookieBannerGlobalRulesEnabled)
         assertTrue(policyWithSafeBrowsing.cookieBannerGlobalRulesSubFramesEnabled)
+        assertTrue(policyWithSafeBrowsing.queryParameterStrippingEnabled)
+        assertTrue(policyWithSafeBrowsing.queryParameterStrippingPrivateBrowsingEnabled)
+        assertEquals("AllowList", policyWithSafeBrowsing.queryParameterStrippingAllowList[0])
+        assertEquals("StripList", policyWithSafeBrowsing.queryParameterStrippingStripList[0])
     }
 
     @Test

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Settings.kt
@@ -81,6 +81,32 @@ abstract class Settings {
     open var cookieBannerHandlingGlobalRulesSubFrames: Boolean by UnsupportedSetting()
 
     /**
+     * Setting to control the cookie banner enables / disables the URL query string
+     * stripping in normal browsing mode which strips query parameters from loading
+     * URIs to prevent bounce (redirect) tracking.
+     */
+    open var queryParameterStripping: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control the cookie banner enables / disables the URL query string
+     * stripping in private browsing mode which strips query parameters from loading
+     * URIs to prevent bounce (redirect) tracking.
+     */
+    open var queryParameterStrippingPrivateBrowsing: Boolean by UnsupportedSetting()
+
+    /**
+     * Setting to control the list that contains sites where should
+     * exempt from query stripping.
+     */
+    open var queryParameterStrippingAllowList: String by UnsupportedSetting()
+
+    /**
+     * Setting to control the list which contains query parameters that are needed to be stripped
+     * from  URIs. The query parameters are separated by a space.
+     */
+    open var queryParameterStrippingStripList: String by UnsupportedSetting()
+
+    /**
      * Setting to intercept and override requests.
      */
     open var requestInterceptor: RequestInterceptor? by UnsupportedSetting()
@@ -259,6 +285,10 @@ data class DefaultSettings(
     override var cookieBannerHandlingDetectOnlyMode: Boolean = false,
     override var cookieBannerHandlingGlobalRules: Boolean = false,
     override var cookieBannerHandlingGlobalRulesSubFrames: Boolean = false,
+    override var queryParameterStripping: Boolean = false,
+    override var queryParameterStrippingPrivateBrowsing: Boolean = false,
+    override var queryParameterStrippingAllowList: String = "",
+    override var queryParameterStrippingStripList: String = "",
 ) : Settings()
 
 class UnsupportedSetting<T> {

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt
@@ -128,6 +128,10 @@ class SettingsTest {
         assertFalse(settings.loginAutofillEnabled)
         assertNull(settings.clearColor)
         assertFalse(settings.enterpriseRootsEnabled)
+        assertFalse(settings.queryParameterStripping)
+        assertFalse(settings.queryParameterStrippingPrivateBrowsing)
+        assertEquals("", settings.queryParameterStrippingAllowList)
+        assertEquals("", settings.queryParameterStrippingStripList)
         assertEquals(EngineSession.CookieBannerHandlingMode.DISABLED, settings.cookieBannerHandlingMode)
         assertEquals(EngineSession.CookieBannerHandlingMode.DISABLED, settings.cookieBannerHandlingModePrivateBrowsing)
 
@@ -166,7 +170,10 @@ class SettingsTest {
             loginAutofillEnabled = true,
             clearColor = Color.BLUE,
             enterpriseRootsEnabled = true,
-            cookieBannerHandlingMode = EngineSession.CookieBannerHandlingMode.DISABLED,
+            queryParameterStripping = true,
+            queryParameterStrippingPrivateBrowsing = true,
+            queryParameterStrippingAllowList = "AllowList",
+            queryParameterStrippingStripList = "StripList",
             cookieBannerHandlingModePrivateBrowsing = EngineSession.CookieBannerHandlingMode.REJECT_ALL,
             cookieBannerHandlingDetectOnlyMode = true,
             cookieBannerHandlingGlobalRules = true,
@@ -203,6 +210,10 @@ class SettingsTest {
         assertTrue(defaultSettings.forceUserScalableContent)
         assertEquals(Color.BLUE, defaultSettings.clearColor)
         assertTrue(defaultSettings.enterpriseRootsEnabled)
+        assertTrue(defaultSettings.queryParameterStripping)
+        assertTrue(defaultSettings.queryParameterStrippingPrivateBrowsing)
+        assertEquals("AllowList", defaultSettings.queryParameterStrippingAllowList)
+        assertEquals("StripList", defaultSettings.queryParameterStrippingStripList)
         assertEquals(EngineSession.CookieBannerHandlingMode.DISABLED, defaultSettings.cookieBannerHandlingMode)
         assertEquals(EngineSession.CookieBannerHandlingMode.REJECT_ALL, defaultSettings.cookieBannerHandlingModePrivateBrowsing)
         assertTrue(defaultSettings.cookieBannerHandlingDetectOnlyMode)

--- a/fenix/app/nimbus.fml.yaml
+++ b/fenix/app/nimbus.fml.yaml
@@ -232,7 +232,38 @@ features:
             "jump-back-in-cfr": true,
           }
         }
-
+  query-parameter-stripping:
+    description: Features for query parameter stripping.
+    variables:
+      sections-enabled:
+        description: "This property provides a lookup table of whether or not the given section should be enabled."
+        type: Map<QueryParameterStrippingSection, String>
+        default:
+          {
+            "query-parameter-stripping": "0",
+            "query-parameter-stripping-pmb": "0",
+            "query-parameter-stripping-allow-list": "",
+            "query-parameter-stripping-strip-list": "",
+          }
+    defaults:
+      - channel: developer
+        value: {
+          "sections-enabled": {
+            "query-parameter-stripping": "0",
+            "query-parameter-stripping-pmb": "0",
+            "query-parameter-stripping-allow-list": "",
+            "query-parameter-stripping-strip-list": "",
+          }
+        }
+      - channel: nightly
+        value: {
+          "sections-enabled": {
+            "query-parameter-stripping": "0",
+            "query-parameter-stripping-pmb": "0",
+            "query-parameter-stripping-allow-list": "",
+            "query-parameter-stripping-strip-list": "",
+          }
+        }
   cookie-banners:
     description: Features for cookie banner handling.
     variables:
@@ -246,7 +277,7 @@ features:
             "feature-setting-value-pbm": 0,
             "feature-setting-detect-only": 0,
             "feature-setting-global-rules": 0,
-            "feature-setting-global-rules-sub-frames": 0
+            "feature-setting-global-rules-sub-frames": 0,
           }
     defaults:
       - channel: developer
@@ -257,7 +288,7 @@ features:
             "feature-setting-value-pbm": 0,
             "feature-setting-detect-only": 0,
             "feature-setting-global-rules": 0,
-            "feature-setting-global-rules-sub-frames": 0
+            "feature-setting-global-rules-sub-frames": 0,
           }
         }
       - channel: nightly
@@ -268,7 +299,7 @@ features:
             "feature-setting-value-pbm": 0,
             "feature-setting-detect-only": 0,
             "feature-setting-global-rules": 0,
-            "feature-setting-global-rules-sub-frames": 0
+            "feature-setting-global-rules-sub-frames": 0,
           }
         }
   unified-search:
@@ -477,6 +508,25 @@ types:
         feature-setting-global-rules-sub-frames:
           description: An integer either 0 or 1 indicating if cookie banner global rules sub-frames
             should be enabled or disabled. 0 for setting to be disabled, and 1 for enabling the setting.
+
+    QueryParameterStrippingSection:
+      description: The identifiers for the options for the Query Parameter Stripping feature.
+      variants:
+        query-parameter-stripping:
+          description: An integer either 0 or 1 indicating if query parameter stripping
+            should be enabled or disabled in normal mode. 0 for setting to be disabled,
+            and 1 for enabling the setting.
+        query-parameter-stripping-pmb:
+          description: An integer either 0 or 1 indicating if query parameter stripping
+            should be enabled or disabled in private mode. 0 for setting to be disabled,
+            and 1 for enabling the setting.
+        query-parameter-stripping-allow-list:
+          description: An string separated by commas indicating the sites where should
+            from query stripping should be exempted.
+        query-parameter-stripping-strip-list:
+          description: An string separated by commas indicating the list of query params
+            to be stripped from URIs. This list will be merged with records
+            coming from RemoteSettings.
 
     OnboardingPanel:
       description: The types of onboarding panels in the onboarding page

--- a/fenix/app/src/main/java/org/mozilla/fenix/gecko/GeckoProvider.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/gecko/GeckoProvider.kt
@@ -121,6 +121,14 @@ object GeckoProvider {
                     context.settings().shouldEnableCookieBannerGlobalRules,
                     cookieBannerGlobalRulesSubFramesEnabled =
                     context.settings().shouldEnableCookieBannerGlobalRulesSubFrame,
+                    queryParameterStripping =
+                    context.settings().shouldEnableQueryParameterStripping,
+                    queryParameterStrippingPrivateBrowsing =
+                    context.settings().shouldEnableQueryParameterStrippingPrivateBrowsing,
+                    queryParameterStrippingAllowList =
+                    context.settings().queryParameterStrippingAllowList,
+                    queryParameterStrippingStripList =
+                    context.settings().queryParameterStrippingStripList,
                 ),
             )
             .consoleOutput(context.components.settings.enableGeckoLogs)

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -46,6 +46,11 @@ import org.mozilla.fenix.nimbus.CookieBannersSection
 import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.nimbus.HomeScreenSection
 import org.mozilla.fenix.nimbus.Mr2022Section
+import org.mozilla.fenix.nimbus.QueryParameterStrippingSection
+import org.mozilla.fenix.nimbus.QueryParameterStrippingSection.QUERY_PARAMETER_STRIPPING
+import org.mozilla.fenix.nimbus.QueryParameterStrippingSection.QUERY_PARAMETER_STRIPPING_ALLOW_LIST
+import org.mozilla.fenix.nimbus.QueryParameterStrippingSection.QUERY_PARAMETER_STRIPPING_PMB
+import org.mozilla.fenix.nimbus.QueryParameterStrippingSection.QUERY_PARAMETER_STRIPPING_STRIP_LIST
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
 import org.mozilla.fenix.settings.logins.SavedLoginsSortingStrategyMenu
@@ -634,6 +639,18 @@ class Settings(private val appContext: Context) : PreferencesHolder {
 
     val shouldEnableCookieBannerGlobalRulesSubFrame: Boolean
         get() = cookieBannersSection[CookieBannersSection.FEATURE_SETTING_GLOBAL_RULES_SUB_FRAMES] == 1
+
+    val shouldEnableQueryParameterStripping: Boolean
+        get() = queryParameterStrippingSection[QUERY_PARAMETER_STRIPPING] == "1"
+
+    val shouldEnableQueryParameterStrippingPrivateBrowsing: Boolean
+        get() = queryParameterStrippingSection[QUERY_PARAMETER_STRIPPING_PMB] == "1"
+
+    val queryParameterStrippingAllowList: String
+        get() = queryParameterStrippingSection[QUERY_PARAMETER_STRIPPING_ALLOW_LIST].orEmpty()
+
+    val queryParameterStrippingStripList: String
+        get() = queryParameterStrippingSection[QUERY_PARAMETER_STRIPPING_STRIP_LIST].orEmpty()
 
     /**
      * Declared as a function for performance purposes. This could be declared as a variable using
@@ -1472,6 +1489,10 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     private val cookieBannersSection: Map<CookieBannersSection, Int>
         get() =
             FxNimbus.features.cookieBanners.value().sectionsEnabled
+
+    private val queryParameterStrippingSection: Map<QueryParameterStrippingSection, String>
+        get() =
+            FxNimbus.features.queryParameterStripping.value().sectionsEnabled
 
     private val homescreenSections: Map<HomeScreenSection, Boolean>
         get() =


### PR DESCRIPTION
This requires a new GV version containing https://phabricator.services.mozilla.com/D192496

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1862425