### PR TITLE
Bug 1863319 - Fenix: fix flaky tests in TabbedBrowsingTest

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
@@ -19,17 +19,25 @@ import org.mozilla.fenix.helpers.TestHelper.mDevice
  */
 object MatcherHelper {
 
-    fun itemWithResId(resourceId: String) =
-        mDevice.findObject(UiSelector().resourceId(resourceId))
+    fun itemWithResId(resourceId: String): UiObject {
+        Log.i(TAG, "Looking for item with resource id: $resourceId")
+        return mDevice.findObject(UiSelector().resourceId(resourceId))
+    }
 
-    fun itemContainingText(itemText: String) =
-        mDevice.findObject(UiSelector().textContains(itemText))
+    fun itemContainingText(itemText: String): UiObject {
+        Log.i(TAG, "Looking for item with text: $itemText")
+        return mDevice.findObject(UiSelector().textContains(itemText))
+    }
 
-    fun itemWithText(itemText: String) =
-        mDevice.findObject(UiSelector().text(itemText))
+    fun itemWithText(itemText: String): UiObject {
+        Log.i(TAG, "Looking for item with text: $itemText")
+        return mDevice.findObject(UiSelector().text(itemText))
+    }
 
-    fun itemWithDescription(description: String) =
-        mDevice.findObject(UiSelector().descriptionContains(description))
+    fun itemWithDescription(description: String): UiObject {
+        Log.i(TAG, "Looking for item with description: $description")
+        return mDevice.findObject(UiSelector().descriptionContains(description))
+    }
 
     fun checkedItemWithResId(resourceId: String, isChecked: Boolean) =
         mDevice.findObject(UiSelector().resourceId(resourceId).checked(isChecked))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/WaitNotNull.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/WaitNotNull.kt
@@ -4,9 +4,11 @@
 
 package org.mozilla.fenix.helpers.ext
 
+import android.util.Log
 import androidx.test.uiautomator.SearchCondition
 import androidx.test.uiautomator.UiDevice
 import org.junit.Assert.assertNotNull
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.TestAssetHelper
 
 /**
@@ -17,4 +19,8 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 fun UiDevice.waitNotNull(
     searchCondition: SearchCondition<*>,
     waitTime: Long = TestAssetHelper.waitingTime,
-) = assertNotNull(wait(searchCondition, waitTime))
+) {
+    Log.i(TAG, "Wait not null: $searchCondition")
+    assertNotNull(wait(searchCondition, waitTime))
+    Log.i(TAG, "Found $searchCondition not null")
+}

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeTabbedBrowsingTest.kt
@@ -18,7 +18,6 @@ import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.AppAndSystemHelper.verifyKeyboardVisibility
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper
 import org.mozilla.fenix.helpers.RetryTestRule
@@ -118,9 +117,9 @@ class ComposeTabbedBrowsingTest {
         }
     }
 
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/903604
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2349580
     @Test
-    fun closingTabsMethodsTest() {
+    fun closingTabsTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -133,24 +132,31 @@ class ComposeTabbedBrowsingTest {
         }
         browserScreen {
             verifyTabCounter("1")
-        }.openComposeTabDrawer(composeTestRule) {
-            closeTab()
         }
-        homeScreen {
-            verifyTabCounter("0")
-        }.openNavigationToolbar {
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/903604
+    @Test
+    fun swipeToCloseTabsTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
+            waitForPageToLoad()
         }.openComposeTabDrawer(composeTestRule) {
             verifyExistingOpenTabs("Test_Page_1")
             swipeTabRight("Test_Page_1")
+            verifySnackBarText("Tab closed")
         }
         homeScreen {
             verifyTabCounter("0")
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
+            waitForPageToLoad()
         }.openComposeTabDrawer(composeTestRule) {
             verifyExistingOpenTabs("Test_Page_1")
             swipeTabLeft("Test_Page_1")
+            verifySnackBarText("Tab closed")
         }
         homeScreen {
             verifyTabCounter("0")
@@ -159,10 +165,10 @@ class ComposeTabbedBrowsingTest {
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/903591
     @Test
-    fun closingPrivateTabsMethodsTest() {
+    fun closingPrivateTabsTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        homeScreen { }.togglePrivateBrowsingMode()
+        homeScreen { }.togglePrivateBrowsingMode(switchPBModeOn = true)
         navigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
         }.openComposeTabDrawer(composeTestRule) {
@@ -173,29 +179,6 @@ class ComposeTabbedBrowsingTest {
         }
         browserScreen {
             verifyTabCounter("1")
-        }.openComposeTabDrawer(composeTestRule) {
-            closeTab()
-        }
-        homeScreen {
-            verifyTabCounter("0")
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-        }.openComposeTabDrawer(composeTestRule) {
-            verifyExistingOpenTabs("Test_Page_1")
-            swipeTabRight("Test_Page_1")
-            verifySnackBarText("Private tab closed")
-        }
-        homeScreen {
-            verifyTabCounter("0")
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-        }.openComposeTabDrawer(composeTestRule) {
-            verifyExistingOpenTabs("Test_Page_1")
-            swipeTabLeft("Test_Page_1")
-            verifySnackBarText("Private tab closed")
-        }
-        homeScreen {
-            verifyTabCounter("0")
         }
     }
 
@@ -348,74 +331,129 @@ class ComposeTabbedBrowsingTest {
         }
     }
 
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/927315
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/927314
     @Test
-    fun tabsCounterShortcutMenuTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+    fun tabsCounterShortcutMenuCloseTabTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            waitForPageToLoad()
+        }.goToHomescreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(secondWebPage.url) {
+            waitForPageToLoad()
+        }
         navigationToolbar {
         }.openTabButtonShortcutsMenu {
             verifyTabButtonShortcutMenuItems()
         }.closeTabFromShortcutsMenu {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
-        navigationToolbar {
-        }.openTabButtonShortcutsMenu {
-        }.openNewPrivateTabFromShortcutsMenu {
-            verifyKeyboardVisibility()
-            verifySearchBarPlaceholder("Search or enter address")
-            // dismiss search dialog
-        }.dismissSearchBar {
-            verifyPrivateBrowsingHomeScreenItems()
-        }
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
-        navigationToolbar {
-        }.openTabButtonShortcutsMenu {
-        }.openNewTabFromShortcutsMenu {
-            verifyKeyboardVisibility()
-            verifySearchBarPlaceholder("Search or enter address")
-            // dismiss search dialog
-        }.dismissSearchBar {
-            verifyHomeWordmark()
-            verifyNavigationToolbar()
+            browserScreen {
+                verifyTabCounter("1")
+                verifyPageContent(firstWebPage.content)
+            }
         }
     }
 
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/927314
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2343663
     @Test
-    fun privateTabsCounterShortcutMenuTest() {
+    fun tabsCounterShortcutMenuNewPrivateTabTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        homeScreen {}.togglePrivateBrowsingMode()
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
-        navigationToolbar {
-        }.openTabButtonShortcutsMenu {
-            verifyTabButtonShortcutMenuItems()
-        }.closeTabFromShortcutsMenu {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
         navigationToolbar {
         }.openTabButtonShortcutsMenu {
         }.openNewPrivateTabFromShortcutsMenu {
-            verifyKeyboardVisibility()
             verifySearchBarPlaceholder("Search or enter address")
-            // dismiss search dialog
         }.dismissSearchBar {
-            verifyCommonMythsLink()
+            verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = true)
         }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2343662
+    @Test
+    fun tabsCounterShortcutMenuNewTabTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
         navigationToolbar {
         }.openTabButtonShortcutsMenu {
         }.openNewTabFromShortcutsMenu {
-            verifyKeyboardVisibility()
             verifySearchBarPlaceholder("Search or enter address")
-            // dismiss search dialog
         }.dismissSearchBar {
-            // Verify normal browsing homescreen
-            verifyExistingTopSitesList()
+            verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = false)
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/927315
+    @Test
+    fun privateTabsCounterShortcutMenuCloseTabTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
+
+        homeScreen {}.togglePrivateBrowsingMode(switchPBModeOn = true)
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            waitForPageToLoad()
+        }.goToHomescreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(secondWebPage.url) {
+            waitForPageToLoad()
+        }
+        navigationToolbar {
+        }.openTabButtonShortcutsMenu {
+            verifyTabButtonShortcutMenuItems()
+        }.closeTabFromShortcutsMenu {
+            browserScreen {
+                verifyTabCounter("1")
+                verifyPageContent(firstWebPage.content)
+            }
+        }.openTabButtonShortcutsMenu {
+        }.closeTabFromShortcutsMenu {
+            homeScreen {
+                verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = true)
+            }
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2344199
+    @Test
+    fun privateTabsCounterShortcutMenuNewPrivateTabTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {}.togglePrivateBrowsingMode(switchPBModeOn = true)
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+            waitForPageToLoad()
+        }
+        navigationToolbar {
+        }.openTabButtonShortcutsMenu {
+        }.openNewPrivateTabFromShortcutsMenu {
+            verifySearchBarPlaceholder("Search or enter address")
+        }.dismissSearchBar {
+            verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = true)
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2344198
+    @Test
+    fun privateTabsCounterShortcutMenuNewTabTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {}.togglePrivateBrowsingMode(switchPBModeOn = true)
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+            verifyPageContent(defaultWebPage.content)
+        }
+        navigationToolbar {
+        }.openTabButtonShortcutsMenu {
+        }.openNewTabFromShortcutsMenu {
+            verifySearchToolbar(isDisplayed = true)
+        }.dismissSearchBar {
+            verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = false)
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
@@ -369,6 +369,7 @@ class CreditCardAutofillTest {
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1512794
+    @Ignore("Failing, see https://bugzilla.mozilla.org/show_bug.cgi?id=1853625")
     @Test
     fun verifyMultipleCreditCardsCanBeAddedTest() {
         val creditCardFormPage = TestAssetHelper.getCreditCardFormAsset(mockWebServer)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.ui
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -114,6 +115,7 @@ class SettingsAddonsTest {
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/561600
     // Installs 3 add-on and checks that the app doesn't crash while navigating the app
+    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1857875 ")
     @SmokeTest
     @Test
     fun noCrashWithAddonInstalledTest() {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -17,7 +17,6 @@ import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.AppAndSystemHelper.verifyKeyboardVisibility
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper
 import org.mozilla.fenix.helpers.RetryTestRule
@@ -110,9 +109,9 @@ class TabbedBrowsingTest {
         }
     }
 
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/903604
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2349580
     @Test
-    fun closingTabsMethodsTest() {
+    fun closingTabsTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -125,13 +124,17 @@ class TabbedBrowsingTest {
         }
         browserScreen {
             verifyTabCounter("1")
-        }.openTabDrawer {
-            closeTab()
         }
-        homeScreen {
-            verifyTabCounter("0")
-        }.openNavigationToolbar {
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/903604
+    @Test
+    fun swipeToCloseTabsTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
+            waitForPageToLoad()
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
             swipeTabRight("Test_Page_1")
@@ -141,6 +144,7 @@ class TabbedBrowsingTest {
             verifyTabCounter("0")
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
+            waitForPageToLoad()
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
             swipeTabLeft("Test_Page_1")
@@ -153,10 +157,10 @@ class TabbedBrowsingTest {
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/903591
     @Test
-    fun closingPrivateTabsMethodsTest() {
+    fun closingPrivateTabsTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        homeScreen { }.togglePrivateBrowsingMode()
+        homeScreen { }.togglePrivateBrowsingMode(switchPBModeOn = true)
         navigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
         }.openTabDrawer {
@@ -168,29 +172,6 @@ class TabbedBrowsingTest {
         }
         browserScreen {
             verifyTabCounter("1")
-        }.openTabDrawer {
-            closeTab()
-        }
-        homeScreen {
-            verifyTabCounter("0")
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-            swipeTabRight("Test_Page_1")
-            verifySnackBarText("Private tab closed")
-        }
-        homeScreen {
-            verifyTabCounter("0")
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-            swipeTabLeft("Test_Page_1")
-            verifySnackBarText("Private tab closed")
-        }
-        homeScreen {
-            verifyTabCounter("0")
         }
     }
 
@@ -375,76 +356,129 @@ class TabbedBrowsingTest {
         }
     }
 
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/927315
-    @Test
-    fun tabsCounterShortcutMenuTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
-        navigationToolbar {
-        }.openTabButtonShortcutsMenu {
-            verifyTabButtonShortcutMenuItems()
-        }.closeTabFromShortcutsMenu {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
-        navigationToolbar {
-        }.openTabButtonShortcutsMenu {
-        }.openNewPrivateTabFromShortcutsMenu {
-            verifyKeyboardVisibility()
-            verifySearchBarPlaceholder("Search or enter address")
-            // dismiss search dialog
-        }.dismissSearchBar {
-            verifyPrivateBrowsingHomeScreenItems()
-        }
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
-        navigationToolbar {
-        }.openTabButtonShortcutsMenu {
-        }.openNewTabFromShortcutsMenu {
-            verifyKeyboardVisibility()
-            verifySearchBarPlaceholder("Search or enter address")
-            // dismiss search dialog
-        }.dismissSearchBar {
-            verifyHomeWordmark()
-            verifyNavigationToolbar()
-        }
-    }
-
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/927314
     @Test
-    fun privateTabsCounterShortcutMenuTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+    fun tabsCounterShortcutMenuCloseTabTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
-        homeScreen {}.togglePrivateBrowsingMode()
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            waitForPageToLoad()
+        }.goToHomescreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(secondWebPage.url) {
             waitForPageToLoad()
         }
         navigationToolbar {
         }.openTabButtonShortcutsMenu {
             verifyTabButtonShortcutMenuItems()
         }.closeTabFromShortcutsMenu {
+            browserScreen {
+                verifyTabCounter("1")
+                verifyPageContent(firstWebPage.content)
+            }
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2343663
+    @Test
+    fun tabsCounterShortcutMenuNewPrivateTabTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
         navigationToolbar {
         }.openTabButtonShortcutsMenu {
         }.openNewPrivateTabFromShortcutsMenu {
-            verifyKeyboardVisibility()
             verifySearchBarPlaceholder("Search or enter address")
-            // dismiss search dialog
         }.dismissSearchBar {
-            verifyCommonMythsLink()
+            verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = true)
         }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2343662
+    @Test
+    fun tabsCounterShortcutMenuNewTabTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {}
         navigationToolbar {
         }.openTabButtonShortcutsMenu {
         }.openNewTabFromShortcutsMenu {
-            verifyKeyboardVisibility()
             verifySearchBarPlaceholder("Search or enter address")
-            // dismiss search dialog
         }.dismissSearchBar {
-            // Verify normal browsing homescreen
-            verifyExistingTopSitesList()
+            verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = false)
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/927315
+    @Test
+    fun privateTabsCounterShortcutMenuCloseTabTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
+
+        homeScreen {}.togglePrivateBrowsingMode(switchPBModeOn = true)
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            waitForPageToLoad()
+        }.goToHomescreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(secondWebPage.url) {
+            waitForPageToLoad()
+        }
+        navigationToolbar {
+        }.openTabButtonShortcutsMenu {
+            verifyTabButtonShortcutMenuItems()
+        }.closeTabFromShortcutsMenu {
+            browserScreen {
+                verifyTabCounter("1")
+                verifyPageContent(firstWebPage.content)
+            }
+        }.openTabButtonShortcutsMenu {
+        }.closeTabFromShortcutsMenu {
+            homeScreen {
+                verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = true)
+            }
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2344199
+    @Test
+    fun privateTabsCounterShortcutMenuNewPrivateTabTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {}.togglePrivateBrowsingMode(switchPBModeOn = true)
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+            waitForPageToLoad()
+        }
+        navigationToolbar {
+        }.openTabButtonShortcutsMenu {
+        }.openNewPrivateTabFromShortcutsMenu {
+            verifySearchBarPlaceholder("Search or enter address")
+        }.dismissSearchBar {
+            verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = true)
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2344198
+    @Test
+    fun privateTabsCounterShortcutMenuNewTabTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {}.togglePrivateBrowsingMode(switchPBModeOn = true)
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+            verifyPageContent(defaultWebPage.content)
+        }
+        navigationToolbar {
+        }.openTabButtonShortcutsMenu {
+        }.openNewTabFromShortcutsMenu {
+            verifySearchToolbar(isDisplayed = true)
+        }.dismissSearchBar {
+            verifyIfInPrivateOrNormalMode(privateBrowsingEnabled = false)
         }
     }
 
@@ -496,12 +530,9 @@ class TabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
         }.openTabDrawer {
         }.openNewTab {
-        }.submitQuery(secondWebPage.url.toString()) {
-        }
-
+        }.submitQuery(secondWebPage.url.toString()) {}
         closeApp(activityTestRule)
         restartApp(activityTestRule)
-
         homeScreen {
             verifyPrivateBrowsingHomeScreenItems()
         }.openTabDrawer {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.PickerActions
@@ -70,7 +71,7 @@ class BrowserRobot {
     private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
 
     fun waitForPageToLoad() {
-        progressBar.waitUntilGone(waitingTime)
+        progressBar().waitUntilGone(waitingTime)
         Log.i(TAG, "waitForPageToLoad: The page was loaded, the progress bar is gone")
     }
 
@@ -109,7 +110,6 @@ class BrowserRobot {
      *  document.querySelector('#testContent').innerText == expectedText
      *
      */
-
     fun verifyPageContent(expectedText: String) {
         sessionLoadedIdlingResource = SessionLoadedIdlingResource()
 
@@ -190,10 +190,10 @@ class BrowserRobot {
         // If the link is not re-directing to an external app the "Open link in external app" option is not available
         assertItemContainingTextExists(
             contextMenuLinkUrl(containsURL.toString()),
-            contextMenuOpenLinkInNewTab,
-            contextMenuOpenLinkInPrivateTab,
-            contextMenuCopyLink,
-            contextMenuShareLink,
+            contextMenuOpenLinkInNewTab(),
+            contextMenuOpenLinkInPrivateTab(),
+            contextMenuCopyLink(),
+            contextMenuShareLink(),
         )
     }
 
@@ -202,12 +202,12 @@ class BrowserRobot {
         // If the link is not directing to another local asset the "Download link" option is not available
         assertItemContainingTextExists(
             contextMenuLinkUrl(containsURL),
-            contextMenuOpenLinkInNewTab,
-            contextMenuOpenLinkInPrivateTab,
-            contextMenuCopyLink,
-            contextMenuDownloadLink,
-            contextMenuShareLink,
-            contextMenuOpenInExternalApp,
+            contextMenuOpenLinkInNewTab(),
+            contextMenuOpenLinkInPrivateTab(),
+            contextMenuCopyLink(),
+            contextMenuDownloadLink(),
+            contextMenuShareLink(),
+            contextMenuOpenInExternalApp(),
         )
     }
 
@@ -216,11 +216,11 @@ class BrowserRobot {
         // If the link is not re-directing to an external app the "Open link in external app" option is not available
         assertItemContainingTextExists(
             contextMenuLinkUrl(containsURL.toString()),
-            contextMenuOpenLinkInNewTab,
-            contextMenuOpenLinkInPrivateTab,
-            contextMenuCopyLink,
-            contextMenuDownloadLink,
-            contextMenuShareLink,
+            contextMenuOpenLinkInNewTab(),
+            contextMenuOpenLinkInPrivateTab(),
+            contextMenuCopyLink(),
+            contextMenuDownloadLink(),
+            contextMenuShareLink(),
         )
     }
 
@@ -382,9 +382,9 @@ class BrowserRobot {
     fun clickSuggestedLoginsButton() {
         for (i in 1..RETRY_COUNT) {
             try {
-                mDevice.waitForObjects(suggestedLogins)
-                suggestedLogins.click()
-                mDevice.waitForObjects(suggestedLogins)
+                mDevice.waitForObjects(suggestedLogins())
+                suggestedLogins().click()
+                mDevice.waitForObjects(suggestedLogins())
                 break
             } catch (e: UiObjectNotFoundException) {
                 if (i == RETRY_COUNT) {
@@ -411,8 +411,8 @@ class BrowserRobot {
     fun clickSelectAddressButton() {
         for (i in 1..RETRY_COUNT) {
             try {
-                assertTrue(selectAddressButton.waitForExists(waitingTime))
-                selectAddressButton.clickAndWaitForNewWindow(waitingTime)
+                assertTrue(selectAddressButton().waitForExists(waitingTime))
+                selectAddressButton().clickAndWaitForNewWindow(waitingTime)
 
                 break
             } catch (e: AssertionError) {
@@ -428,7 +428,7 @@ class BrowserRobot {
         }
     }
 
-    fun verifySelectAddressButtonExists(exists: Boolean) = assertItemWithResIdExists(selectAddressButton, exists = exists)
+    fun verifySelectAddressButtonExists(exists: Boolean) = assertItemWithResIdExists(selectAddressButton(), exists = exists)
 
     fun changeCreditCardExpiryDate(expiryDate: String) =
         itemWithResId("expiryMonthAndYear").setText(expiryDate)
@@ -461,7 +461,7 @@ class BrowserRobot {
         )
 
     fun verifySelectCreditCardPromptExists(exists: Boolean) =
-        assertItemWithResIdExists(selectCreditCardButton, exists = exists)
+        assertItemWithResIdExists(selectCreditCardButton(), exists = exists)
 
     fun verifyCreditCardSuggestion(vararg creditCardNumbers: String) {
         for (creditCardNumber in creditCardNumbers) {
@@ -622,7 +622,7 @@ class BrowserRobot {
         }
     }
 
-    fun selectTime(hour: Int, minute: Int) =
+    fun selectTime(hour: Int, minute: Int): ViewInteraction =
         onView(
             isAssignableFrom(TimePicker::class.java),
         ).inRoot(
@@ -630,6 +630,11 @@ class BrowserRobot {
         ).perform(PickerActions.setTime(hour, minute))
 
     fun verifySelectedDate() {
+        val currentDate = LocalDate.now()
+        val currentDay = currentDate.dayOfMonth
+        val currentMonth = currentDate.month
+        val currentYear = currentDate.year
+
         for (i in 1..RETRY_COUNT) {
             try {
                 assertTrue(
@@ -659,6 +664,8 @@ class BrowserRobot {
     }
 
     fun verifyNoDateIsSelected() {
+        val currentDate = LocalDate.now()
+
         assertFalse(
             mDevice.findObject(
                 UiSelector()
@@ -782,7 +789,7 @@ class BrowserRobot {
     fun verifyCookieBannerExists(exists: Boolean) {
         for (i in 1..RETRY_COUNT) {
             try {
-                assertItemWithResIdExists(cookieBanner, exists = exists)
+                assertItemWithResIdExists(cookieBanner(), exists = exists)
                 break
             } catch (e: AssertionError) {
                 if (i == RETRY_COUNT) {
@@ -796,7 +803,7 @@ class BrowserRobot {
                 }
             }
         }
-        assertItemWithResIdExists(cookieBanner, exists = exists)
+        assertItemWithResIdExists(cookieBanner(), exists = exists)
     }
 
     fun verifyOpenLinkInAnotherAppPrompt() {
@@ -893,7 +900,7 @@ class BrowserRobot {
                     browserScreen {
                     }.openThreeDotMenu {
                     }.refreshPage {
-                        progressBar.waitUntilGone(waitingTimeLong)
+                        waitForPageToLoad()
                     }
                 }
             }
@@ -1294,23 +1301,24 @@ class BrowserRobot {
         }
 
         fun clickSurveyButton(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            surveyButton.waitForExists(waitingTime)
-            surveyButton.click()
+            surveyButton().waitForExists(waitingTime)
+            surveyButton().click()
 
             BrowserRobot().interact()
             return Transition()
         }
 
         fun clickNoThanksSurveyButton(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            surveyNoThanksButton.waitForExists(waitingTime)
-            surveyNoThanksButton.click()
+            surveyNoThanksButton().waitForExists(waitingTime)
+            surveyNoThanksButton().click()
 
             BrowserRobot().interact()
             return Transition()
         }
+
         fun clickHomeScreenSurveyCloseButton(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            homescreenSurveyCloseButton.waitForExists(waitingTime)
-            homescreenSurveyCloseButton.click()
+            homescreenSurveyCloseButton().waitForExists(waitingTime)
+            homescreenSurveyCloseButton().click()
 
             BrowserRobot().interact()
             return Transition()
@@ -1323,9 +1331,9 @@ fun browserScreen(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
     return BrowserRobot.Transition()
 }
 
-fun navURLBar() = itemWithResId("$packageName:id/toolbar")
+private fun navURLBar() = itemWithResId("$packageName:id/toolbar")
 
-fun searchBar() = itemWithResId("$packageName:id/mozac_browser_toolbar_url_view")
+private fun searchBar() = itemWithResId("$packageName:id/mozac_browser_toolbar_url_view")
 
 fun homeScreenButton() = onView(withContentDescription(R.string.browser_toolbar_home))
 
@@ -1334,19 +1342,15 @@ private fun threeDotButton() = onView(withContentDescription("Menu"))
 private fun tabsCounter() =
     mDevice.findObject(By.res("$packageName:id/counter_root"))
 
-private val progressBar =
+private fun progressBar() =
     itemWithResId("$packageName:id/mozac_browser_toolbar_progress")
 
-private val suggestedLogins = itemWithResId("$packageName:id/loginSelectBar")
-private val selectAddressButton = itemWithResId("$packageName:id/select_address_header")
-private val selectCreditCardButton = itemWithResId("$packageName:id/select_credit_card_header")
+private fun suggestedLogins() = itemWithResId("$packageName:id/loginSelectBar")
+private fun selectAddressButton() = itemWithResId("$packageName:id/select_address_header")
+private fun selectCreditCardButton() = itemWithResId("$packageName:id/select_credit_card_header")
 
 private fun creditCardSuggestion(creditCardNumber: String) =
-    mDevice.findObject(
-        UiSelector()
-            .resourceId("$packageName:id/credit_card_number")
-            .textContains(creditCardNumber),
-    )
+    itemWithResIdAndText("$packageName:id/credit_card_number", "$creditCardNumber")
 
 private fun siteSecurityToolbarButton() =
     itemWithResId("$packageName:id/mozac_browser_toolbar_security_indicator")
@@ -1371,7 +1375,7 @@ fun clickPageObject(item: UiObject) {
                 }.openThreeDotMenu {
                     Log.i(TAG, "clickPageObject: Opened main menu")
                 }.refreshPage {
-                    progressBar.waitUntilGone(waitingTime)
+                    waitForPageToLoad()
                     Log.i(TAG, "clickPageObject: Page refreshed, progress bar is gone")
                 }
             }
@@ -1393,7 +1397,7 @@ fun longClickPageObject(item: UiObject) {
                 browserScreen {
                 }.openThreeDotMenu {
                 }.refreshPage {
-                    progressBar.waitUntilGone(waitingTime)
+                    waitForPageToLoad()
                 }
             }
         }
@@ -1425,7 +1429,7 @@ fun setPageObjectText(webPageItem: UiObject, text: String) {
                 browserScreen {
                 }.openThreeDotMenu {
                 }.refreshPage {
-                    progressBar.waitUntilGone(waitingTime)
+                    waitForPageToLoad()
                 }
             }
         }
@@ -1437,11 +1441,7 @@ fun clearTextFieldItem(item: UiObject) {
     item.clearTextField()
 }
 
-private val currentDate = LocalDate.now()
-private val currentDay = currentDate.dayOfMonth
-private val currentMonth = currentDate.month
-private val currentYear = currentDate.year
-private val cookieBanner = itemWithResId("startsiden-gdpr-disclaimer")
+private fun cookieBanner() = itemWithResId("startsiden-gdpr-disclaimer")
 
 // Context menu items
 // Link URL
@@ -1449,34 +1449,34 @@ private fun contextMenuLinkUrl(linkUrl: String) =
     itemContainingText(linkUrl)
 
 // Open link in new tab option
-private val contextMenuOpenLinkInNewTab =
+private fun contextMenuOpenLinkInNewTab() =
     itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_new_tab))
 
 // Open link in private tab option
-private val contextMenuOpenLinkInPrivateTab =
+private fun contextMenuOpenLinkInPrivateTab() =
     itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_private_tab))
 
 // Copy link option
-private val contextMenuCopyLink =
+private fun contextMenuCopyLink() =
     itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_copy_link))
 
 // Download link option
-private val contextMenuDownloadLink =
+private fun contextMenuDownloadLink() =
     itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_download_link))
 
 // Share link option
-private val contextMenuShareLink =
+private fun contextMenuShareLink() =
     itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_share_link))
 
 // Open in external app option
-private val contextMenuOpenInExternalApp =
+private fun contextMenuOpenInExternalApp() =
     itemContainingText(getStringResource(R.string.mozac_feature_contextmenu_open_link_in_external_app))
 
-private val surveyButton =
+private fun surveyButton() =
     itemContainingText(getStringResource(R.string.preferences_take_survey))
 
-private val surveyNoThanksButton =
+private fun surveyNoThanksButton() =
     itemContainingText(getStringResource(R.string.preferences_not_take_survey))
 
-private val homescreenSurveyCloseButton =
+private fun homescreenSurveyCloseButton() =
     itemWithDescription("Close")

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -498,6 +498,10 @@ class HomeScreenRobot {
         )
     }
 
+    fun verifyIfInPrivateOrNormalMode(privateBrowsingEnabled: Boolean) {
+        assert(isPrivateModeEnabled() == privateBrowsingEnabled)
+    }
+
     class Transition {
 
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
@@ -563,17 +567,16 @@ class HomeScreenRobot {
             return SyncSignInRobot.Transition()
         }
 
-        fun togglePrivateBrowsingMode() {
-            if (
-                !itemWithResIdAndDescription(
-                    "$packageName:id/privateBrowsingButton",
-                    "Disable private browsing",
-                ).exists()
-            ) {
-                mDevice.findObject(UiSelector().resourceId("$packageName:id/privateBrowsingButton"))
-                    .waitForExists(
-                        waitingTime,
-                    )
+        fun togglePrivateBrowsingMode(switchPBModeOn: Boolean = true) {
+            // Switch to private browsing homescreen
+            if (switchPBModeOn && !isPrivateModeEnabled()) {
+                privateBrowsingButton.waitForExists(waitingTime)
+                privateBrowsingButton.click()
+            }
+
+            // Switch to normal browsing homescreen
+            if (!switchPBModeOn && isPrivateModeEnabled()) {
+                privateBrowsingButton.waitForExists(waitingTime)
                 privateBrowsingButton.click()
             }
         }
@@ -1053,6 +1056,13 @@ private val homeScreen =
     itemWithResId("$packageName:id/homeLayout")
 private val privateBrowsingButton =
     itemWithResId("$packageName:id/privateBrowsingButton")
+
+private fun isPrivateModeEnabled(): Boolean =
+    itemWithResIdAndDescription(
+        "$packageName:id/privateBrowsingButton",
+        "Disable private browsing",
+    ).exists()
+
 private val homepageWordmark =
     itemWithResId("$packageName:id/wordmark")
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -41,6 +41,7 @@ import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
@@ -165,13 +166,9 @@ class NavigationToolbarRobot {
 
             runWithIdleRes(sessionLoadedIdlingResource) {
                 assertTrue(
-                    mDevice.findObject(
-                        UiSelector().resourceId("$packageName:id/browserLayout"),
-                    ).waitForExists(waitingTime) || mDevice.findObject(
-                        UiSelector().resourceId("$packageName:id/download_button"),
-                    ).waitForExists(waitingTime) || mDevice.findObject(
-                        UiSelector().text(getStringResource(R.string.tcp_cfr_message)),
-                    ).waitForExists(waitingTime),
+                    itemWithResId("$packageName:id/browserLayout").waitForExists(waitingTime) ||
+                        itemWithResId("$packageName:id/download_button").waitForExists(waitingTime) ||
+                        itemWithText(getStringResource(R.string.tcp_cfr_message)).waitForExists(waitingTime),
                 )
             }
 
@@ -295,8 +292,9 @@ class NavigationToolbarRobot {
         }
 
         fun openTabButtonShortcutsMenu(interact: NavigationToolbarRobot.() -> Unit): Transition {
-            mDevice.waitNotNull(Until.findObject(By.desc("Tabs")))
+            mDevice.waitNotNull(Until.findObject(By.res("$packageName:id/counter_root")))
             tabsCounter().click(LONG_CLICK_DURATION)
+            Log.i(TAG, "Tabs counter long-click successful.")
 
             NavigationToolbarRobot().interact()
             return Transition()
@@ -314,6 +312,7 @@ class NavigationToolbarRobot {
                         ViewActions.click(),
                     ),
                 )
+            Log.i(TAG, "Clicked the tab shortcut Close tab button.")
 
             NavigationToolbarRobot().interact()
             return Transition()
@@ -321,7 +320,7 @@ class NavigationToolbarRobot {
 
         fun openNewTabFromShortcutsMenu(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
             mDevice.waitForIdle(waitingTime)
-
+            Log.i(TAG, "Looking for tab shortcut New tab button.")
             onView(withId(R.id.mozac_browser_menu_recyclerView))
                 .perform(
                     RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
@@ -331,6 +330,7 @@ class NavigationToolbarRobot {
                         ViewActions.click(),
                     ),
                 )
+            Log.i(TAG, "Clicked the tab shortcut New tab button.")
 
             SearchRobot().interact()
             return SearchRobot.Transition()
@@ -338,7 +338,7 @@ class NavigationToolbarRobot {
 
         fun openNewPrivateTabFromShortcutsMenu(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
             mDevice.waitForIdle(waitingTime)
-
+            Log.i(TAG, "Looking for tab shortcut New private tab button.")
             onView(withId(R.id.mozac_browser_menu_recyclerView))
                 .perform(
                     RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
@@ -348,6 +348,7 @@ class NavigationToolbarRobot {
                         ViewActions.click(),
                     ),
                 )
+            Log.i(TAG, "Clicked the tab shortcut New private tab button.")
 
             SearchRobot().interact()
             return SearchRobot.Transition()
@@ -380,15 +381,11 @@ fun navigationToolbar(interact: NavigationToolbarRobot.() -> Unit): NavigationTo
 }
 
 fun openEditURLView() {
-    mDevice.waitNotNull(
-        Until.findObject(By.res("$packageName:id/toolbar")),
-        waitingTime,
-    )
+    urlBar().waitForExists(waitingTime)
     urlBar().click()
-    mDevice.waitNotNull(
-        Until.findObject(By.res("$packageName:id/mozac_browser_toolbar_edit_url_view")),
-        waitingTime,
-    )
+    Log.i(TAG, "openEditURLView: URL bar clicked.")
+    itemWithResId("$packageName:id/mozac_browser_toolbar_edit_url_view").waitForExists(waitingTime)
+    Log.i(TAG, "openEditURLView: Edit URL bar displayed.")
 }
 
 private fun assertNoHistoryBookmarks() {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -334,10 +334,9 @@ class SearchRobot {
         private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
 
         fun dismissSearchBar(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
-            mDevice.waitForIdle()
-            closeSoftKeyboard()
-            mDevice.pressBack()
             try {
+                searchWrapper().waitForExists(waitingTime)
+                mDevice.pressBack()
                 assertTrue(searchWrapper().waitUntilGone(waitingTimeShort))
             } catch (e: AssertionError) {
                 mDevice.pressBack()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -6,6 +6,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import android.view.View
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
@@ -131,6 +132,7 @@ class TabDrawerRobot {
         var retries = 0 // number of retries before failing, will stop at 2
         do {
             closeTabButton().click()
+            Log.i("MozTestLog", "Clicked the close tab button in tabs tray. Retry #$retries")
             retries++
         } while (closeTabButton().exists() && retries < 3)
     }
@@ -158,7 +160,9 @@ class TabDrawerRobot {
                         ),
                     ),
                 ).perform(swipeRight())
+                Log.i("MozTestLog", "Tab $title swiped right from tabs tray. Retry # $i")
                 assertTrue(
+                    "Tab $title swipe right was unsuccessful.",
                     itemWithResIdContainingText(
                         "$packageName:id/mozac_browser_tabstray_title",
                         title,
@@ -188,7 +192,9 @@ class TabDrawerRobot {
                         ),
                     ),
                 ).perform(swipeLeft())
+                Log.i("MozTestLog", "Tab $title swiped left from tabs tray. Retry # $i")
                 assertTrue(
+                    "Tab $title swipe left was unsuccessful.",
                     itemWithResIdContainingText(
                         "$packageName:id/mozac_browser_tabstray_title",
                         title,
@@ -206,8 +212,9 @@ class TabDrawerRobot {
 
     fun verifySnackBarText(expectedText: String) {
         assertTrue(
+            "SnackBar message: $expectedText - not found",
             mDevice.findObject(
-                UiSelector().text(expectedText),
+                UiSelector().textContains(expectedText),
             ).waitForExists(waitingTime),
         )
     }
@@ -513,8 +520,10 @@ private fun assertExistingOpenTabs(vararg tabTitles: String) {
             tabsList
                 .getChildByText(UiSelector().text(title), title, true)
             assertTrue(
+                "Tab $title not found",
                 tabItem(title).waitForExists(waitingTimeLong),
             )
+            Log.i("MozTestLog", "Tab $title found in tabs tray.")
         }
     }
 }


### PR DESCRIPTION
Split the large tests into smaller ones. 
Matched them with new manual tests in TestRail.
Added more logging for easier debugging.
Removed keyboard visibility verification.
All of which improved the crash rates, from ~10-15/100 runs to 2-3/100 runs.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1863319
https://bugzilla.mozilla.org/show_bug.cgi?id=1853625
https://bugzilla.mozilla.org/show_bug.cgi?id=1857875