### PR TITLE
Bug 1861173 - Correctly increment shopping CFR counter

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -237,7 +237,7 @@ class DefaultBrowserToolbarController(
      * As described in: https://bugzilla.mozilla.org/show_bug.cgi?id=1861173#c0
      */
     private fun updateShoppingCfrSettings() = with(activity.settings()) {
-        reviewQualityCheckCFRClosedCounter.inc()
+        reviewQualityCheckCFRClosedCounter++
         if (reviewQualityCheckCfrDisplayTimeInMillis != 0L &&
             reviewQualityCheckCFRClosedCounter >= MAX_DISPLAY_NUMBER_SHOPPING_CFR
         ) {

--- a/fenix/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -402,6 +402,7 @@ class DefaultBrowserToolbarControllerTest {
             every { reviewQualityCheckCfrDisplayTimeInMillis } returns System.currentTimeMillis()
             every { reviewQualityCheckCfrDisplayTimeInMillis = any() } just Runs
             every { reviewQualityCheckCFRClosedCounter } returns 1
+            every { reviewQualityCheckCFRClosedCounter = 2 } just Runs
             every { shouldShowReviewQualityCheckCFR } returns true
         }
         every { activity.settings() } returns mockSettings
@@ -419,6 +420,7 @@ class DefaultBrowserToolbarControllerTest {
             every { reviewQualityCheckCfrDisplayTimeInMillis } returns System.currentTimeMillis()
             every { reviewQualityCheckCfrDisplayTimeInMillis = any() } just Runs
             every { reviewQualityCheckCFRClosedCounter } returns 2
+            every { reviewQualityCheckCFRClosedCounter = 3 } just Runs
             every { shouldShowReviewQualityCheckCFR } returns true
         }
         every { activity.settings() } returns mockSettings
@@ -435,6 +437,7 @@ class DefaultBrowserToolbarControllerTest {
         val mockSettings = mockk<Settings> {
             every { reviewQualityCheckCfrDisplayTimeInMillis } returns System.currentTimeMillis()
             every { reviewQualityCheckCFRClosedCounter } returns 3
+            every { reviewQualityCheckCFRClosedCounter = 4 } just Runs
             every { shouldShowReviewQualityCheckCFR } returns true
             every { shouldShowReviewQualityCheckCFR = any() } just Runs
         }


### PR DESCRIPTION
Using `.inc()` was wrong due to it returning the incremented value and not incrementing the already existing one. This patch aims to fix that, therefore showing the CFR correctly for max 3 times.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1861173