### PR TITLE
Bug 1862775 - Send telemetry on "Powered by Fakespot by Mozilla" tap

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -10867,6 +10867,25 @@ shopping:
     metadata:
       tags:
         - Shopping
+  surface_powered_by_fakespot_link_clicked:
+    type: event
+    description: |
+      The user clicked the "Fakespot by Mozilla" link at the bottom of review checker
+      sheet.
+    send_in_pings:
+      - events
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1862775
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/4354#issuecomment-1794341141
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - Shopping
 
 shopping.settings:
   component_opted_out:

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckTelemetryMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckTelemetryMiddleware.kt
@@ -108,6 +108,10 @@ class ReviewQualityCheckTelemetryMiddleware : ReviewQualityCheckMiddleware {
             is ReviewQualityCheckAction.OptOutCompleted -> {
                 Shopping.surfaceOnboardingDisplayed.record()
             }
+
+            is ReviewQualityCheckAction.OpenPoweredByLink -> {
+                Shopping.surfacePoweredByFakespotLinkClicked.record()
+            }
         }
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
@@ -119,7 +119,7 @@ sealed interface ReviewQualityCheckAction : Action {
     /**
      * Triggered when the user clicks on the "Powered by" link in the footer.
      */
-    object OpenPoweredByLink : NavigationMiddlewareAction
+    object OpenPoweredByLink : NavigationMiddlewareAction, TelemetryAction
 
     /**
      * Triggered when the user clicks on learn more link on the opt in card.

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckTelemetryMiddlewareTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckTelemetryMiddlewareTest.kt
@@ -196,4 +196,12 @@ class ReviewQualityCheckTelemetryMiddlewareTest {
 
         assertNotNull(Shopping.surfaceOnboardingDisplayed.testGetValue())
     }
+
+    @Test
+    fun `WHEN the user is tapped the 'Powered by Fakespot by Mozilla' link THEN the link clicked telemetry is recorded`() {
+        store.dispatch(ReviewQualityCheckAction.OpenPoweredByLink).joinBlocking()
+        store.waitUntilIdle()
+
+        assertNotNull(Shopping.surfacePoweredByFakespotLinkClicked.testGetValue())
+    }
 }


### PR DESCRIPTION
Added `surface_powered_by_fakespot_link_clicked` telemetry probe that is sent when the user taps the "Powered by Fakespot by Mozilla" footer link in Review Checker Sheet.

Ping: 
```
{
      "timestamp": 24228,
      "category": "shopping",
      "name": "surface_powered_by_fakespot_link_clicked"
},
```


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1862775