### PR TITLE
Bug 1863278 - Refactor navigation and storage deletion in downloads UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/AppAndSystemHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/AppAndSystemHelper.kt
@@ -78,6 +78,27 @@ object AppAndSystemHelper {
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.R)
+    fun clearDownloadsFolder() {
+        val storageManager: StorageManager? = TestHelper.appContext.getSystemService(Context.STORAGE_SERVICE) as StorageManager?
+        val storageVolumes = storageManager!!.storageVolumes
+        val storageVolume: StorageVolume = storageVolumes[0]
+        val downloadsFolder = File(storageVolume.directory!!.path + "/Download/")
+
+        // Check if the downloads folder exists
+        if (downloadsFolder.exists() && downloadsFolder.isDirectory) {
+            val files = downloadsFolder.listFiles()
+
+            // Check if the folder is not empty
+            if (files != null && files.isNotEmpty()) {
+                // Delete all files in the folder
+                for (file in files) {
+                    file.delete()
+                }
+            }
+        }
+    }
+
     fun setNetworkEnabled(enabled: Boolean) {
         val networkDisconnectedIdlingResource = NetworkConnectionIdlingResource(false)
         val networkConnectedIdlingResource = NetworkConnectionIdlingResource(true)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSettingsDeleteBrowsingDataOnQuitTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSettingsDeleteBrowsingDataOnQuitTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.AppAndSystemHelper.deleteDownloadedFileOnStorage
+import org.mozilla.fenix.helpers.AppAndSystemHelper.clearDownloadsFolder
 import org.mozilla.fenix.helpers.AppAndSystemHelper.setNetworkEnabled
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -28,6 +28,7 @@ import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.restartApp
 import org.mozilla.fenix.ui.robots.clickPageObject
+import org.mozilla.fenix.ui.robots.downloadRobot
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -65,6 +66,9 @@ class ComposeSettingsDeleteBrowsingDataOnQuitTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
+
+        // Check and clear the downloads folder
+        clearDownloadsFolder()
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/416048
@@ -198,11 +202,8 @@ class ComposeSettingsDeleteBrowsingDataOnQuitTest {
             clickDeleteBrowsingOnQuitButtonSwitch()
             exitMenu()
         }
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
-        }.clickDownloadLink("smallZip.zip") {
-            verifyDownloadPrompt("smallZip.zip")
-        }.clickDownload {
+        downloadRobot {
+            openPageAndDownloadFile(url = downloadTestPage.toUri(), downloadFile = "smallZip.zip")
             verifyDownloadCompleteNotificationPopup()
         }.closeCompletedDownloadPrompt {
         }.goToHomescreen {
@@ -216,7 +217,6 @@ class ComposeSettingsDeleteBrowsingDataOnQuitTest {
         }.openDownloadsManager {
             verifyEmptyDownloadsList()
         }
-        deleteDownloadedFileOnStorage("smallZip.zip")
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/416053

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadFileTypesTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadFileTypesTest.kt
@@ -5,13 +5,15 @@
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.helpers.AppAndSystemHelper.clearDownloadsFolder
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
-import org.mozilla.fenix.ui.robots.navigationToolbar
+import org.mozilla.fenix.ui.robots.downloadRobot
 
 /**
  *  Test for verifying downloading a list of different file types:
@@ -27,6 +29,12 @@ class DownloadFileTypesTest(fileName: String) {
 
     @get:Rule
     val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
+
+    @After
+    fun tearDown() {
+        // Check and clear the downloads folder
+        clearDownloadsFolder()
+    }
 
     companion object {
         // Creating test data. The test will take each file name as a parameter and run it individually.
@@ -49,11 +57,8 @@ class DownloadFileTypesTest(fileName: String) {
     @SmokeTest
     @Test
     fun allFilesAppearInDownloadsMenuTest() {
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
-        }.clickDownloadLink(downloadFile) {
-            verifyDownloadPrompt(downloadFile)
-        }.clickDownload {
+        downloadRobot {
+            openPageAndDownloadFile(url = downloadTestPage.toUri(), downloadFile = downloadFile)
             verifyDownloadCompleteNotificationPopup()
         }.closeCompletedDownloadPrompt {
         }.openThreeDotMenu {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PDFViewerTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PDFViewerTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.AppAndSystemHelper.assertExternalAppOpens
-import org.mozilla.fenix.helpers.AppAndSystemHelper.deleteDownloadedFileOnStorage
+import org.mozilla.fenix.helpers.AppAndSystemHelper.clearDownloadsFolder
 import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_DOCS
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper
@@ -50,6 +50,9 @@ class PDFViewerTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
+
+        // Check and clear the downloads folder
+        clearDownloadsFolder()
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2048140
@@ -96,7 +99,6 @@ class PDFViewerTest {
         }.clickOpen("application/pdf") {
             assertExternalAppOpens(GOOGLE_DOCS)
         }
-        deleteDownloadedFileOnStorage(downloadFile)
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2283305

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeleteBrowsingDataOnQuitTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeleteBrowsingDataOnQuitTest.kt
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.AppAndSystemHelper.deleteDownloadedFileOnStorage
+import org.mozilla.fenix.helpers.AppAndSystemHelper
 import org.mozilla.fenix.helpers.AppAndSystemHelper.setNetworkEnabled
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -27,6 +27,7 @@ import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.restartApp
 import org.mozilla.fenix.ui.robots.clickPageObject
+import org.mozilla.fenix.ui.robots.downloadRobot
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -58,6 +59,9 @@ class SettingsDeleteBrowsingDataOnQuitTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
+
+        // Check and clear the downloads folder
+        AppAndSystemHelper.clearDownloadsFolder()
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/416048
@@ -191,11 +195,8 @@ class SettingsDeleteBrowsingDataOnQuitTest {
             clickDeleteBrowsingOnQuitButtonSwitch()
             exitMenu()
         }
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
-        }.clickDownloadLink("smallZip.zip") {
-            verifyDownloadPrompt("smallZip.zip")
-        }.clickDownload {
+        downloadRobot {
+            openPageAndDownloadFile(url = downloadTestPage.toUri(), downloadFile = "smallZip.zip")
             verifyDownloadCompleteNotificationPopup()
         }.closeCompletedDownloadPrompt {
         }.goToHomescreen {
@@ -209,7 +210,6 @@ class SettingsDeleteBrowsingDataOnQuitTest {
         }.openDownloadsManager {
             verifyEmptyDownloadsList()
         }
-        deleteDownloadedFileOnStorage("smallZip.zip")
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/416053

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -68,7 +68,10 @@ import java.time.LocalDate
 class BrowserRobot {
     private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
 
-    fun waitForPageToLoad() = progressBar.waitUntilGone(waitingTime)
+    fun waitForPageToLoad() {
+        progressBar.waitUntilGone(waitingTime)
+        Log.i("MozTestLog", "waitForPageToLoad: The page was loaded, the progress bar is gone")
+    }
 
     fun verifyCurrentPrivateSession(context: Context) {
         val selectedTab = context.components.core.store.state.selectedTab
@@ -1031,7 +1034,9 @@ class BrowserRobot {
     class Transition {
         fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
             mDevice.waitForIdle(waitingTime)
+            Log.i("MozTestLog", "openThreeDotMenu: Device was idle for $waitingTime")
             threeDotButton().perform(click())
+            Log.i("MozTestLog", "openThreeDotMenu: Clicked the main menu button")
 
             ThreeDotMenuMainRobot().interact()
             return ThreeDotMenuMainRobot.Transition()
@@ -1347,19 +1352,26 @@ private fun siteSecurityToolbarButton() =
 
 fun clickPageObject(item: UiObject) {
     for (i in 1..RETRY_COUNT) {
+        Log.i("MozTestLog", "clickPageObject: For loop i = $i")
         try {
+            Log.i("MozTestLog", "clickPageObject: Try block")
             item.waitForExists(waitingTime)
             item.click()
+            Log.i("MozTestLog", "clickPageObject: Clicked ${item.selector}")
 
             break
         } catch (e: UiObjectNotFoundException) {
+            Log.i("MozTestLog", "clickPageObject: Catch block")
             if (i == RETRY_COUNT) {
                 throw e
             } else {
                 browserScreen {
+                    Log.i("MozTestLog", "clickPageObject: Browser screen")
                 }.openThreeDotMenu {
+                    Log.i("MozTestLog", "clickPageObject: Opened main menu")
                 }.refreshPage {
                     progressBar.waitUntilGone(waitingTime)
+                    Log.i("MozTestLog", "clickPageObject: Page refreshed, progress bar is gone")
                 }
             }
         }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
@@ -7,6 +7,7 @@
 package org.mozilla.fenix.ui.robots
 
 import android.content.Intent
+import android.net.Uri
 import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -47,7 +48,36 @@ import org.mozilla.fenix.helpers.ext.waitNotNull
 
 class DownloadRobot {
 
-    fun verifyDownloadPrompt(fileName: String) = assertDownloadPrompt(fileName)
+    fun verifyDownloadPrompt(fileName: String) {
+        var currentTries = 0
+        while (currentTries++ < 3) {
+            Log.i("MozTestLog", "verifyDownloadPrompt: While loop currentTries = $currentTries")
+            try {
+                Log.i("MozTestLog", "verifyDownloadPrompt: Try block")
+                assertTrue(
+                    "Download prompt button not visible",
+                    mDevice.findObject(UiSelector().resourceId("$packageName:id/download_button"))
+                        .waitForExists(waitingTimeLong),
+                )
+                Log.i("MozTestLog", "verifyDownloadPrompt: Verified that the \"DOWNLOAD\" prompt button exists")
+                assertTrue(
+                    "$fileName title doesn't match",
+                    mDevice.findObject(UiSelector().text(fileName))
+                        .waitForExists(waitingTimeLong),
+                )
+                Log.i("MozTestLog", "verifyDownloadPrompt: Verified that the download prompt for $fileName exists")
+
+                break
+            } catch (e: AssertionError) {
+                Log.i("MozTestLog", "verifyDownloadPrompt: Catch block")
+                Log.e("DOWNLOAD_ROBOT", "Failed to find locator: ${e.localizedMessage}")
+
+                browserScreen {
+                }.clickDownloadLink(fileName) {
+                }
+            }
+        }
+    }
 
     fun verifyDownloadCompleteNotificationPopup() {
         assertTrue(
@@ -163,9 +193,20 @@ class DownloadRobot {
     fun clickMultiSelectRemoveButton() =
         itemWithResIdContainingText("$packageName:id/title", "Remove").click()
 
+    fun openPageAndDownloadFile(url: Uri, downloadFile: String) {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(url) {
+            waitForPageToLoad()
+        }.clickDownloadLink(downloadFile) {
+            verifyDownloadPrompt(downloadFile)
+        }.clickDownload {
+        }
+    }
+
     class Transition {
         fun clickDownload(interact: DownloadRobot.() -> Unit): Transition {
             downloadButton().click()
+            Log.i("MozTestLog", "clickDownload: Clicked \"DOWNLOAD\" button from prompt")
 
             DownloadRobot().interact()
             return Transition()
@@ -233,32 +274,6 @@ class DownloadRobot {
 fun downloadRobot(interact: DownloadRobot.() -> Unit): DownloadRobot.Transition {
     DownloadRobot().interact()
     return DownloadRobot.Transition()
-}
-
-private fun assertDownloadPrompt(fileName: String) {
-    var currentTries = 0
-    while (currentTries++ < 3) {
-        try {
-            assertTrue(
-                "Download prompt button not visible",
-                mDevice.findObject(UiSelector().resourceId("$packageName:id/download_button"))
-                    .waitForExists(waitingTimeLong),
-            )
-            assertTrue(
-                "$fileName title doesn't match",
-                mDevice.findObject(UiSelector().text(fileName))
-                    .waitForExists(waitingTimeLong),
-            )
-
-            break
-        } catch (e: AssertionError) {
-            Log.e("DOWNLOAD_ROBOT", "Failed to find locator: ${e.localizedMessage}")
-
-            browserScreen {
-            }.clickDownloadLink(fileName) {
-            }
-        }
-    }
 }
 
 private fun closeCompletedDownloadButton() =

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -8,6 +8,7 @@ package org.mozilla.fenix.ui.robots
 
 import android.net.Uri
 import android.os.Build
+import android.util.Log
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
@@ -154,9 +155,12 @@ class NavigationToolbarRobot {
             sessionLoadedIdlingResource = SessionLoadedIdlingResource()
 
             openEditURLView()
+            Log.i("MozTestLog", "enterURLAndEnterToBrowser: Opened edit mode URL view")
 
             awesomeBar().setText(url.toString())
+            Log.i("MozTestLog", "enterURLAndEnterToBrowser: Set toolbar text to: $url")
             mDevice.pressEnter()
+            Log.i("MozTestLog", "enterURLAndEnterToBrowser: Clicked enter on keyboard, submitted query")
 
             runWithIdleRes(sessionLoadedIdlingResource) {
                 assertTrue(

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -6,6 +6,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.swipeDown
@@ -321,8 +322,10 @@ class ThreeDotMenuMainRobot {
 
         fun refreshPage(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             refreshButton.also {
+                Log.i("MozTestLog", "refreshPage: Looking for refresh button")
                 it.waitForExists(waitingTime)
                 it.click()
+                Log.i("MozTestLog", "refreshPage: Clicked the refresh button")
             }
 
             BrowserRobot().interact()


### PR DESCRIPTION
Summary:
- Created `clearDownloadsFolder` which verifies if there are downloaded files on the device and added it to our `@ After `annotations
Tried adding it to `@ Before` as @jjSDET suggested but it didn't seem to properly work.

- Created `openPageAndDownloadFile` which contains the most used navigations and interactions from our download related UI tests and switched to using it where applicable.

✅ All 23 affected download tests successfully passed 75x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1863278