### PR TITLE
Bug 1862403 - Remove unneeded states from RecommendedProductState

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductRecommendationMapper.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ProductRecommendationMapper.kt
@@ -18,7 +18,7 @@ private const val MAXIMUM_FRACTION_DIGITS = 2
  * Maps [ProductRecommendation] to [RecommendedProductState].
  */
 fun ProductRecommendation?.toRecommendedProductState(): RecommendedProductState =
-    this?.toRecommendedProduct() ?: RecommendedProductState.Error
+    this?.toRecommendedProduct() ?: RecommendedProductState.Initial
 
 private fun ProductRecommendation.toRecommendedProduct(): RecommendedProductState.Product =
     RecommendedProductState.Product(

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckNetworkMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckNetworkMiddleware.kt
@@ -19,7 +19,6 @@ import org.mozilla.fenix.shopping.store.ReviewQualityCheckMiddleware
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent.AnalysisStatus
-import org.mozilla.fenix.shopping.store.ReviewQualityCheckState.RecommendedProductState
 
 /**
  * Middleware that handles network requests for the review quality check feature.
@@ -162,7 +161,6 @@ class ReviewQualityCheckNetworkMiddleware(
         if (currentState is ReviewQualityCheckState.OptedIn &&
             currentState.productRecommendationsPreference == true
         ) {
-            dispatch(UpdateRecommendedProduct(RecommendedProductState.Loading))
             reviewQualityCheckService.productRecommendation().toRecommendedProductState().also {
                 dispatch(UpdateRecommendedProduct(it))
             }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckState.kt
@@ -165,16 +165,6 @@ sealed interface ReviewQualityCheckState : State {
         object Initial : RecommendedProductState
 
         /**
-         * The state when the recommended product is loading.
-         */
-        object Loading : RecommendedProductState
-
-        /**
-         * The state when an error has occurred while fetching the recommended product.
-         */
-        object Error : RecommendedProductState
-
-        /**
          * The state when the recommended product is available.
          *
          * @property aid The unique identifier of the product.

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductRecommendationMapperTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductRecommendationMapperTest.kt
@@ -18,9 +18,9 @@ class ProductRecommendationMapperTest {
     val localeTestRule = LocaleTestRule(Locale.US)
 
     @Test
-    fun `WHEN ProductRecommendation is null THEN it is mapped to Error`() {
+    fun `WHEN ProductRecommendation is null THEN it is mapped to Initial`() {
         val actual = null.toRecommendedProductState()
-        val expected = ReviewQualityCheckState.RecommendedProductState.Error
+        val expected = ReviewQualityCheckState.RecommendedProductState.Initial
 
         assertEquals(expected, actual)
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStoreTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStoreTest.kt
@@ -686,7 +686,7 @@ class ReviewQualityCheckStoreTest {
         }
 
     @Test
-    fun `GIVEN product recommendations are enabled WHEN a product analysis is fetched successfully and product recommendation fails THEN product recommendations state should be error`() =
+    fun `GIVEN product recommendations are enabled WHEN a product analysis is fetched successfully and product recommendation fails THEN product recommendations state should be initial`() =
         runTest {
             val tested = ReviewQualityCheckStore(
                 middleware = provideReviewQualityCheckMiddleware(
@@ -709,7 +709,7 @@ class ReviewQualityCheckStoreTest {
 
             val expected = ReviewQualityCheckState.OptedIn(
                 productReviewState = ProductAnalysisTestData.analysisPresent(
-                    recommendedProductState = ReviewQualityCheckState.RecommendedProductState.Error,
+                    recommendedProductState = ReviewQualityCheckState.RecommendedProductState.Initial,
                 ),
                 productRecommendationsPreference = true,
                 productVendor = ProductVendor.BEST_BUY,


### PR DESCRIPTION
Removed unneeded states from RecommendedProductState: Loading and Error, because the UI only uses the other 2 states.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1862403