### PR TITLE
Bug 1863700 - Add more logs to functions related to download tests and other refactoring work

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
@@ -62,12 +62,12 @@ object MatcherHelper {
     fun assertItemWithResIdExists(vararg appItems: UiObject, exists: Boolean = true) {
         if (exists) {
             for (appItem in appItems) {
-                assertTrue(appItem.waitForExists(waitingTime))
+                assertTrue("${appItem.selector} does not exist", appItem.waitForExists(waitingTime))
                 Log.i(TAG, "assertItemWithResIdExists: Verified ${appItem.selector} exists")
             }
         } else {
             for (appItem in appItems) {
-                assertFalse(appItem.waitForExists(waitingTimeShort))
+                assertFalse("${appItem.selector} exists", appItem.waitForExists(waitingTimeShort))
                 Log.i(TAG, "assertItemWithResIdExists: Verified ${appItem.selector} does not exist")
             }
         }
@@ -76,10 +76,10 @@ object MatcherHelper {
     fun assertItemContainingTextExists(vararg appItems: UiObject, exists: Boolean = true) {
         for (appItem in appItems) {
             if (exists) {
-                assertTrue(appItem.waitForExists(waitingTime))
+                assertTrue("${appItem.selector} does not exist", appItem.waitForExists(waitingTime))
                 Log.i(TAG, "assertItemContainingTextExists: Verified ${appItem.selector} exists")
             } else {
-                assertFalse(appItem.waitForExists(waitingTimeShort))
+                assertFalse("${appItem.selector} exists", appItem.waitForExists(waitingTimeShort))
                 Log.i(TAG, "assertItemContainingTextExists: Verified ${appItem.selector} does not exist")
             }
         }
@@ -88,10 +88,10 @@ object MatcherHelper {
     fun assertItemWithDescriptionExists(vararg appItems: UiObject, exists: Boolean = true) {
         for (appItem in appItems) {
             if (exists) {
-                assertTrue(appItem.waitForExists(waitingTime))
+                assertTrue("${appItem.selector} does not exist", appItem.waitForExists(waitingTime))
                 Log.i(TAG, "assertItemContainingTextExists: Verified ${appItem.selector} exists")
             } else {
-                assertFalse(appItem.waitForExists(waitingTimeShort))
+                assertFalse("${appItem.selector} exists", appItem.waitForExists(waitingTimeShort))
                 Log.i(TAG, "assertItemContainingTextExists: Verified ${appItem.selector} does not exist")
             }
         }
@@ -118,9 +118,11 @@ object MatcherHelper {
     fun assertItemWithResIdAndTextExists(vararg appItems: UiObject, exists: Boolean = true) {
         for (appItem in appItems) {
             if (exists) {
-                assertTrue(appItem.waitForExists(waitingTime))
+                assertTrue("${appItem.selector} does not exist", appItem.waitForExists(waitingTime))
+                Log.i(TAG, "assertItemWithResIdExists: Verified ${appItem.selector} exists")
             } else {
-                assertFalse(appItem.waitForExists(waitingTimeShort))
+                assertFalse("${appItem.selector} exists", appItem.waitForExists(waitingTimeShort))
+                Log.i(TAG, "assertItemWithResIdExists: Verified ${appItem.selector} does not exist")
             }
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.helpers
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import android.view.View
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onView
@@ -32,6 +33,7 @@ import org.junit.Assert
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
@@ -120,6 +122,7 @@ object TestHelper {
             mDevice.findObject(UiSelector().resourceId("$packageName:id/toolbar"))
         while (!toolbar.waitForExists(waitingTimeShort)) {
             mDevice.pressBack()
+            Log.i(TAG, "exitMenu: Exiting app settings menus using device back button")
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSettingsDeleteBrowsingDataOnQuitTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSettingsDeleteBrowsingDataOnQuitTest.kt
@@ -205,7 +205,7 @@ class ComposeSettingsDeleteBrowsingDataOnQuitTest {
         downloadRobot {
             openPageAndDownloadFile(url = downloadTestPage.toUri(), downloadFile = "smallZip.zip")
             verifyDownloadCompleteNotificationPopup()
-        }.closeCompletedDownloadPrompt {
+        }.closeDownloadPrompt {
         }.goToHomescreen {
         }.openThreeDotMenu {
             clickQuit()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadFileTypesTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadFileTypesTest.kt
@@ -60,7 +60,7 @@ class DownloadFileTypesTest(fileName: String) {
         downloadRobot {
             openPageAndDownloadFile(url = downloadTestPage.toUri(), downloadFile = downloadFile)
             verifyDownloadCompleteNotificationPopup()
-        }.closeCompletedDownloadPrompt {
+        }.closeDownloadPrompt {
         }.openThreeDotMenu {
         }.openDownloadsManager {
             waitForDownloadsListToExist()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -201,7 +201,7 @@ class DownloadTest {
         downloadRobot {
             openPageAndDownloadFile(url = downloadTestPage.toUri(), downloadFile = firstDownloadedFile)
             verifyDownloadedFileName(firstDownloadedFile)
-        }.closeCompletedDownloadPrompt {
+        }.closeDownloadPrompt {
         }.clickDownloadLink(secondDownloadedFile) {
             verifyDownloadPrompt(secondDownloadedFile)
         }.clickDownload {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeleteBrowsingDataOnQuitTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeleteBrowsingDataOnQuitTest.kt
@@ -198,7 +198,7 @@ class SettingsDeleteBrowsingDataOnQuitTest {
         downloadRobot {
             openPageAndDownloadFile(url = downloadTestPage.toUri(), downloadFile = "smallZip.zip")
             verifyDownloadCompleteNotificationPopup()
-        }.closeCompletedDownloadPrompt {
+        }.closeDownloadPrompt {
         }.goToHomescreen {
         }.openThreeDotMenu {
             clickQuit()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -1007,17 +1007,20 @@ class BrowserRobot {
         )
     }
 
-    fun clickStayInPrivateBrowsingPromptButton() =
+    fun clickStayInPrivateBrowsingPromptButton() {
         itemWithResIdContainingText(
             "$packageName:id/deny_button",
             getStringResource(R.string.mozac_feature_downloads_cancel_active_private_downloads_deny),
         ).click()
+        Log.i(TAG, "clickStayInPrivateBrowsingPromptButton: Clicked \"STAY IN PRIVATE BROWSING\" prompt button")
+    }
 
     fun clickCancelPrivateDownloadsPromptButton() {
         itemWithResIdContainingText(
             "$packageName:id/accept_button",
             getStringResource(R.string.mozac_feature_downloads_cancel_active_downloads_accept),
         ).click()
+        Log.i(TAG, "clickCancelPrivateDownloadsPromptButton: Clicked \"CANCEL DOWNLOADS\" prompt button")
 
         mDevice.waitForWindowUpdate(packageName, waitingTime)
     }
@@ -1025,6 +1028,7 @@ class BrowserRobot {
     fun fillPdfForm(name: String) {
         // Set PDF form text for the text box
         itemWithResId("pdfjs_internal_id_10R").setText(name)
+        Log.i(TAG, "fillPdfForm: Set PDF form text box text to: $name")
         mDevice.waitForWindowUpdate(packageName, waitingTime)
         if (
             !itemWithResId("pdfjs_internal_id_11R").exists() &&
@@ -1034,15 +1038,17 @@ class BrowserRobot {
         ) {
             // Close the keyboard
             mDevice.pressBack()
+            Log.i(TAG, "fillPdfForm: Closing the keyboard using device back button")
         }
         // Click PDF form check box
         itemWithResId("pdfjs_internal_id_11R").click()
+        Log.i(TAG, "fillPdfForm: Clicked PDF form check box")
     }
 
     class Transition {
         fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
             mDevice.waitForIdle(waitingTime)
-            Log.i(TAG, "openThreeDotMenu: Device was idle for $waitingTime")
+            Log.i(TAG, "openThreeDotMenu: Device was idle for $waitingTime ms")
             threeDotButton().perform(click())
             Log.i(TAG, "openThreeDotMenu: Clicked the main menu button")
 
@@ -1127,6 +1133,7 @@ class BrowserRobot {
 
         fun openNotificationShade(interact: NotificationRobot.() -> Unit): NotificationRobot.Transition {
             mDevice.openNotification()
+            Log.i(TAG, "openNotificationShade: Opened notification tray")
 
             NotificationRobot().interact()
             return NotificationRobot.Transition()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
@@ -23,7 +23,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
@@ -32,12 +31,15 @@ import org.mozilla.fenix.helpers.AppAndSystemHelper.getPermissionAllowID
 import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_APPS_PHOTOS
 import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
@@ -55,18 +57,8 @@ class DownloadRobot {
             Log.i(TAG, "verifyDownloadPrompt: While loop currentTries = $currentTries")
             try {
                 Log.i(TAG, "verifyDownloadPrompt: Try block")
-                assertTrue(
-                    "Download prompt button not visible",
-                    mDevice.findObject(UiSelector().resourceId("$packageName:id/download_button"))
-                        .waitForExists(waitingTimeLong),
-                )
-                Log.i(TAG, "verifyDownloadPrompt: Verified that the \"DOWNLOAD\" prompt button exists")
-                assertTrue(
-                    "$fileName title doesn't match",
-                    mDevice.findObject(UiSelector().text(fileName))
-                        .waitForExists(waitingTimeLong),
-                )
-                Log.i(TAG, "verifyDownloadPrompt: Verified that the download prompt for $fileName exists")
+                assertItemWithResIdExists(itemWithResId("$packageName:id/download_button"))
+                assertItemContainingTextExists(itemContainingText(fileName))
 
                 break
             } catch (e: AssertionError) {
@@ -81,48 +73,28 @@ class DownloadRobot {
     }
 
     fun verifyDownloadCompleteNotificationPopup() {
-        assertTrue(
-            "Download notification Open button not found",
-            mDevice.findObject(UiSelector().text("Open"))
-                .waitForExists(waitingTime),
+        assertItemContainingTextExists(
+            itemContainingText(getStringResource(R.string.mozac_feature_downloads_button_open)),
+            itemContainingText(getStringResource(R.string.mozac_feature_downloads_completed_notification_text2)),
         )
-        assertTrue(
-            "Download completed notification text doesn't match",
-            mDevice.findObject(UiSelector().textContains("Download completed"))
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            "Downloaded file name not visible",
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/download_dialog_filename"))
-                .waitForExists(waitingTime),
-        )
+        assertItemWithResIdExists(itemWithResId("$packageName:id/download_dialog_filename"))
     }
 
     fun verifyDownloadFailedPrompt(fileName: String) {
-        assertTrue(
-            itemWithResId("$packageName:id/download_dialog_icon")
-                .waitForExists(waitingTime),
-        )
-        assertTrue(
-            "Download dialog title not displayed",
-            itemWithResIdAndText(
+        assertItemWithResIdExists(itemWithResId("$packageName:id/download_dialog_icon"))
+        assertItemWithResIdAndTextExists(
+            itemWithResIdContainingText(
                 "$packageName:id/download_dialog_title",
-                "Download failed",
-            ).waitForExists(waitingTime),
-        )
-        assertTrue(
-            "Download file name not displayed",
+                getStringResource(R.string.mozac_feature_downloads_failed_notification_text2),
+            ),
             itemWithResIdContainingText(
                 "$packageName:id/download_dialog_filename",
                 fileName,
-            ).waitForExists(waitingTime),
-        )
-        assertTrue(
-            "Try again button not displayed",
-            itemWithResIdAndText(
+            ),
+            itemWithResIdContainingText(
                 "$packageName:id/download_dialog_action_button",
-                "Try Again",
-            ).waitForExists(waitingTime),
+                getStringResource(R.string.mozac_feature_downloads_button_try_again),
+            ),
         )
     }
 
@@ -131,68 +103,78 @@ class DownloadRobot {
             "$packageName:id/download_dialog_action_button",
             "Try Again",
         ).click()
+        Log.i(TAG, "clickTryAgainButton: Clicked \"TRY AGAIN\" in app prompt button")
     }
 
     fun verifyPhotosAppOpens() = assertExternalAppOpens(GOOGLE_APPS_PHOTOS)
 
-    fun verifyDownloadedFileName(fileName: String) {
-        assertTrue(
-            "$fileName not found in Downloads list",
-            mDevice.findObject(UiSelector().text(fileName))
-                .waitForExists(waitingTime),
-        )
-    }
+    fun verifyDownloadedFileName(fileName: String) = assertItemContainingTextExists(itemContainingText(fileName))
 
-    fun verifyDownloadedFileIcon() = assertDownloadedFileIcon()
+    fun verifyDownloadedFileIcon() = assertItemWithResIdExists(itemWithResId("$packageName:id/favicon"))
 
     fun verifyEmptyDownloadsList() {
+        Log.i(TAG, "verifyEmptyDownloadsList: Looking for empty download list")
         mDevice.findObject(UiSelector().resourceId("$packageName:id/download_empty_view"))
             .waitForExists(waitingTime)
         onView(withText("No downloaded files")).check(matches(isDisplayed()))
+        Log.i(TAG, "verifyEmptyDownloadsList: Verified \"No downloaded files\" list message")
     }
 
-    fun waitForDownloadsListToExist() =
+    fun waitForDownloadsListToExist() {
         assertTrue(
             "Downloads list either empty or not displayed",
             mDevice.findObject(UiSelector().resourceId("$packageName:id/download_list"))
                 .waitForExists(waitingTime),
         )
+        Log.i(TAG, "waitForDownloadsListToExist: Verified that the download list exists")
+    }
 
     fun openDownloadedFile(fileName: String) {
         downloadedFile(fileName)
             .check(matches(isDisplayed()))
             .click()
+        Log.i(TAG, "openDownloadedFile: Clicked downloaded file: $fileName")
     }
 
-    fun deleteDownloadedItem(fileName: String) =
+    fun deleteDownloadedItem(fileName: String) {
         onView(
             allOf(
                 withId(R.id.overflow_menu),
                 hasSibling(withText(fileName)),
             ),
         ).click()
+        Log.i(TAG, "deleteDownloadedItem: Deleted downloaded file: $fileName using trash bin icon")
+    }
 
-    fun longClickDownloadedItem(title: String) =
+    fun longClickDownloadedItem(title: String) {
         onView(
             allOf(
                 withId(R.id.title),
                 withText(title),
             ),
         ).perform(longClick())
+        Log.i(TAG, "longClickDownloadedItem: Long clicked downloaded file: $title")
+    }
 
-    fun selectDownloadedItem(title: String) =
+    fun selectDownloadedItem(title: String) {
         onView(
             allOf(
                 withId(R.id.title),
                 withText(title),
             ),
         ).perform(click())
+        Log.i(TAG, "selectDownloadedItem: Selected downloaded file: $title")
+    }
 
-    fun openMultiSelectMoreOptionsMenu() =
+    fun openMultiSelectMoreOptionsMenu() {
         itemWithDescription(getStringResource(R.string.content_description_menu)).click()
+        Log.i(TAG, "openMultiSelectMoreOptionsMenu: Clicked multi-select more options button")
+    }
 
-    fun clickMultiSelectRemoveButton() =
+    fun clickMultiSelectRemoveButton() {
         itemWithResIdContainingText("$packageName:id/title", "Remove").click()
+        Log.i(TAG, "clickMultiSelectRemoveButton: Clicked multi-select remove button")
+    }
 
     fun openPageAndDownloadFile(url: Uri, downloadFile: String) {
         navigationToolbar {
@@ -213,44 +195,42 @@ class DownloadRobot {
             return Transition()
         }
 
-        fun closeCompletedDownloadPrompt(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            closeCompletedDownloadButton().click()
-
-            BrowserRobot().interact()
-            return BrowserRobot.Transition()
-        }
-
         fun closeDownloadPrompt(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             itemWithResId("$packageName:id/download_dialog_close_button").click()
+            Log.i(TAG, "closeDownloadPrompt: Dismissed download prompt by clicking close prompt button")
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
 
         fun clickOpen(type: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            Log.i(TAG, "clickOpen: Looking for \"OPEN\" download prompt button")
             openDownloadButton().waitForExists(waitingTime)
             openDownloadButton().click()
+            Log.i(TAG, "clickOpen: Clicked \"OPEN\" download prompt button")
 
             // verify open intent is matched with associated data type
             Intents.intended(
-                CoreMatchers.allOf(
+                allOf(
                     IntentMatchers.hasAction(Intent.ACTION_VIEW),
                     IntentMatchers.hasType(type),
                 ),
             )
+            Log.i(TAG, "clickOpen: Verified that open intent is matched with associated data type")
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
 
         fun clickAllowPermission(interact: DownloadRobot.() -> Unit): Transition {
+            Log.i(TAG, "clickAllowPermission: Looking for \"ALLOW\" permission button")
             mDevice.waitNotNull(
                 Until.findObject(By.res(getPermissionAllowID() + ":id/permission_allow_button")),
                 waitingTime,
             )
 
-            val allowPermissionButton = mDevice.findObject(By.res(getPermissionAllowID() + ":id/permission_allow_button"))
-            allowPermissionButton.click()
+            mDevice.findObject(By.res(getPermissionAllowID() + ":id/permission_allow_button")).click()
+            Log.i(TAG, "clickAllowPermission: Clicked \"ALLOW\" permission button")
 
             DownloadRobot().interact()
             return Transition()
@@ -258,6 +238,7 @@ class DownloadRobot {
 
         fun exitDownloadsManagerToBrowser(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             onView(withContentDescription("Navigate up")).click()
+            Log.i(TAG, "exitDownloadsManagerToBrowser: Exited download manager to browser by clicking the navigate up toolbar button")
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
@@ -265,6 +246,7 @@ class DownloadRobot {
 
         fun goBack(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
             goBackButton().click()
+            Log.i(TAG, "exitDownloadsManagerToBrowser: Exited download manager to home screen by clicking the navigate up toolbar button")
 
             HomeScreenRobot().interact()
             return HomeScreenRobot.Transition()
@@ -277,12 +259,6 @@ fun downloadRobot(interact: DownloadRobot.() -> Unit): DownloadRobot.Transition 
     return DownloadRobot.Transition()
 }
 
-private fun closeCompletedDownloadButton() =
-    onView(withId(R.id.download_dialog_close_button))
-
-private fun closePromptButton() =
-    onView(withId(R.id.close_button))
-
 private fun downloadButton() =
     onView(withId(R.id.download_button))
         .check(matches(isDisplayed()))
@@ -291,12 +267,5 @@ private fun openDownloadButton() =
     mDevice.findObject(UiSelector().resourceId("$packageName:id/download_dialog_action_button"))
 
 private fun downloadedFile(fileName: String) = onView(withText(fileName))
-
-private fun assertDownloadedFileIcon() =
-    assertTrue(
-        "Downloaded file icon not found",
-        mDevice.findObject(UiSelector().resourceId("$packageName:id/favicon"))
-            .exists(),
-    )
 
 private fun goBackButton() = onView(withContentDescription("Navigate up"))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
@@ -6,11 +6,13 @@ package org.mozilla.fenix.ui.robots
 
 import android.app.NotificationManager
 import android.content.Context
+import android.util.Log
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
@@ -29,34 +31,46 @@ class NotificationRobot {
 
         while (!notificationFound) {
             scrollToEnd()
+            Log.i(TAG, "verifySystemNotificationExists: Scrolling to the end of the notification tray")
+            Log.i(TAG, "verifySystemNotificationExists: Looking for $notificationMessage notification")
             notificationFound = mDevice.findObject(notification).waitForExists(waitingTime)
         }
 
         assertTrue(notificationFound)
+        Log.i(TAG, "verifySystemNotificationExists: Verified that $notificationMessage notification exists")
     }
 
     fun clearNotifications() {
         if (clearButton.exists()) {
+            Log.i(TAG, "clearNotifications: Verified that clear notifications button exists")
             clearButton.click()
+            Log.i(TAG, "clearNotifications: Clicked clear notifications button")
         } else {
             scrollToEnd()
+            Log.i(TAG, "clearNotifications: Scrolled to end of notifications tray")
             if (clearButton.exists()) {
+                Log.i(TAG, "clearNotifications: Verified that clear notifications button exists")
                 clearButton.click()
+                Log.i(TAG, "clearNotifications: Clicked clear notifications button")
             } else if (notificationTray().exists()) {
                 mDevice.pressBack()
+                Log.i(TAG, "clearNotifications: Dismiss notifications tray by clicking device back button")
             }
         }
     }
 
     fun cancelAllShownNotifications() {
         cancelAll()
+        Log.i(TAG, "cancelAllShownNotifications: Canceled all system notifications")
     }
 
     fun verifySystemNotificationDoesNotExist(notificationMessage: String) {
+        Log.i(TAG, "verifySystemNotificationDoesNotExist: Waiting for $notificationMessage notification to be gone")
         mDevice.findObject(UiSelector().textContains(notificationMessage)).waitUntilGone(waitingTime)
         assertFalse(
             mDevice.findObject(UiSelector().textContains(notificationMessage)).waitForExists(waitingTimeShort),
         )
+        Log.i(TAG, "verifySystemNotificationDoesNotExist: Verified that $notificationMessage notification does not exist")
     }
 
     fun verifyPrivateTabsNotification() {
@@ -71,9 +85,11 @@ class NotificationRobot {
 
     fun clickDownloadNotificationControlButton(action: String) {
         for (i in 1..RETRY_COUNT) {
+            Log.i(TAG, "clickPageObject: For loop i = $i")
             try {
                 assertItemWithResIdAndTextExists(downloadSystemNotificationButton(action))
                 downloadSystemNotificationButton(action).clickAndWaitForNewWindow(waitingTimeShort)
+                Log.i(TAG, "clickDownloadNotificationControlButton: Clicked app notification $action button and waits for a new window for $waitingTimeShort ms")
                 assertItemWithResIdAndTextExists(
                     downloadSystemNotificationButton(action),
                     exists = false,
@@ -81,10 +97,12 @@ class NotificationRobot {
 
                 break
             } catch (e: AssertionError) {
+                Log.i(TAG, "clickDownloadNotificationControlButton: Catch block")
                 if (i == RETRY_COUNT) {
                     throw e
                 }
                 mDevice.waitForWindowUpdate(packageName, waitingTimeShort)
+                Log.i(TAG, "clickDownloadNotificationControlButton: Waited $waitingTimeShort ms for window update")
             }
         }
     }
@@ -96,17 +114,21 @@ class NotificationRobot {
     fun expandNotificationMessage() {
         while (!notificationHeader.exists()) {
             scrollToEnd()
+            Log.i(TAG, "expandNotificationMessage: Scrolled to end of notification tray")
         }
 
         if (notificationHeader.exists()) {
             // expand the notification
             notificationHeader.click()
+            Log.i(TAG, "expandNotificationMessage: Clicked the app notification")
 
             // double check if notification actions are viewable by checking for action existence; otherwise scroll again
             while (!mDevice.findObject(UiSelector().resourceId("android:id/action0")).exists() &&
                 !mDevice.findObject(UiSelector().resourceId("android:id/actions_container")).exists()
             ) {
+                Log.i(TAG, "expandNotificationMessage: App notification action buttons do not exist")
                 scrollToEnd()
+                Log.i(TAG, "expandNotificationMessage: Scrolled to end of notification tray")
             }
         }
     }
@@ -119,9 +141,12 @@ class NotificationRobot {
     ) {
         // In case it fails, retry max 3x the swipe action on download system notifications
         for (i in 1..RETRY_COUNT) {
+            Log.i(TAG, "swipeDownloadNotification: For loop i = $i")
             try {
+                Log.i(TAG, "swipeDownloadNotification: Try block")
                 var retries = 0
                 while (itemContainingText(appName).exists() && retries++ < 3) {
+                    Log.i(TAG, "swipeDownloadNotification: While loop retries = $retries")
                     // Swipe left the download system notification
                     if (direction == "Left") {
                         itemContainingText(appName)
@@ -129,6 +154,7 @@ class NotificationRobot {
                                 it.waitForExists(waitingTime)
                                 it.swipeLeft(3)
                             }
+                        Log.i(TAG, "swipeDownloadNotification: Swiped left download notification")
                     } else {
                         // Swipe right the download system notification
                         itemContainingText(appName)
@@ -136,17 +162,21 @@ class NotificationRobot {
                                 it.waitForExists(waitingTime)
                                 it.swipeRight(3)
                             }
+                        Log.i(TAG, "swipeDownloadNotification: Swiped right download notification")
                     }
                 }
                 // Not all download related system notifications can be dismissed
                 if (shouldDismissNotification) {
                     assertFalse(itemContainingText(appName).waitForExists(waitingTimeShort))
+                    Log.i(TAG, "swipeDownloadNotification: Verified that $appName notification does not exist")
                 } else {
                     assertTrue(itemContainingText(appName).waitForExists(waitingTimeShort))
+                    Log.i(TAG, "swipeDownloadNotification: Verified that $appName notification exist")
                 }
 
                 break
             } catch (e: AssertionError) {
+                Log.i(TAG, "swipeDownloadNotification: Catch block")
                 if (i == RETRY_COUNT) {
                     throw e
                 } else {
@@ -157,6 +187,7 @@ class NotificationRobot {
                         if (canExpandNotification) {
                             // In all cases the download system notification title will be the app name
                             verifySystemNotificationExists(appName)
+                            Log.i(TAG, "swipeDownloadNotification: Verified that $appName notification exist")
                             expandNotificationMessage()
                         } else {
                             // Using the download completed system notification summary to bring in to view an properly verify it
@@ -169,8 +200,10 @@ class NotificationRobot {
     }
 
     fun clickNotification(notificationMessage: String) {
+        Log.i(TAG, "clickNotification: Looking for $notificationMessage notification")
         mDevice.findObject(UiSelector().text(notificationMessage)).waitForExists(waitingTime)
         mDevice.findObject(UiSelector().text(notificationMessage)).clickAndWaitForNewWindow(waitingTimeShort)
+        Log.i(TAG, "clickNotification: Clicked $notificationMessage notification and waiting for $waitingTimeShort ms for a new window")
     }
 
     class Transition {
@@ -192,6 +225,7 @@ class NotificationRobot {
 
         fun closeNotificationTray(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             mDevice.pressBack()
+            Log.i(TAG, "closeNotificationTray: Closed notification tray using device back button")
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.ui.robots
 
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
@@ -20,6 +21,7 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.allOf
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
@@ -137,6 +139,7 @@ class ShareOverlayRobot {
     class Transition {
         fun clickSaveAsPDF(interact: DownloadRobot.() -> Unit): DownloadRobot.Transition {
             itemContainingText("Save as PDF").click()
+            Log.i(TAG, "clickSaveAsPDF: Clicked \"SAVE AS PDF\" share overlay button")
 
             DownloadRobot().interact()
             return DownloadRobot.Transition()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -209,7 +209,9 @@ class ThreeDotMenuMainRobot {
 
         fun openDownloadsManager(interact: DownloadRobot.() -> Unit): DownloadRobot.Transition {
             threeDotMenuRecyclerView().perform(swipeDown())
+            Log.i(TAG, "openDownloadsManager: Swiped up main menu")
             downloadsButton.click()
+            Log.i(TAG, "openDownloadsManager: Clicked main menu \"DOWNLOADS\" button")
 
             DownloadRobot().interact()
             return DownloadRobot.Transition()
@@ -310,6 +312,7 @@ class ThreeDotMenuMainRobot {
 
         fun clickShareButton(interact: ShareOverlayRobot.() -> Unit): ShareOverlayRobot.Transition {
             shareButton.click()
+            Log.i(TAG, "clickShareButton: Clicked main menu share button")
             mDevice.waitNotNull(Until.findObject(By.text("ALL ACTIONS")), waitingTime)
 
             ShareOverlayRobot().interact()


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1863700