### PR TITLE
Bug 1864399 - Use custom assertions in UI test robots

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/MatcherHelper.kt
@@ -97,9 +97,15 @@ object MatcherHelper {
         }
     }
 
-    fun assertCheckedItemWithResIdExists(vararg appItems: UiObject) {
+    fun assertCheckedItemWithResIdExists(vararg appItems: UiObject, exists: Boolean = true) {
         for (appItem in appItems) {
-            assertTrue(appItem.waitForExists(waitingTime))
+            if (exists) {
+                assertTrue("${appItem.selector} does not exist", appItem.waitForExists(waitingTime))
+                Log.i(TAG, "assertCheckedItemWithResIdExists: Verified ${appItem.selector} exists")
+            } else {
+                assertFalse("${appItem.selector} exists", appItem.waitForExists(waitingTimeShort))
+                Log.i(TAG, "assertItemContainingTextExists: Verified ${appItem.selector} does not exist")
+            }
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
@@ -103,12 +103,12 @@ class SettingsHomepageTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
         }.goToHomescreen {
-            verifyRecentlyVisitedSectionIsDisplayed()
+            verifyRecentlyVisitedSectionIsDisplayed(true)
         }.openThreeDotMenu {
         }.openCustomizeHome {
             clickRecentlyVisited()
         }.goBackToHomeScreen {
-            verifyRecentlyVisitedSectionIsNotDisplayed()
+            verifyRecentlyVisitedSectionIsDisplayed(false)
         }
     }
 
@@ -141,12 +141,12 @@ class SettingsHomepageTest {
         }.openThreeDotMenu {
         }.bookmarkPage {
         }.goToHomescreen {
-            verifyRecentBookmarksSectionIsDisplayed()
+            verifyRecentBookmarksSectionIsDisplayed(exists = true)
         }.openThreeDotMenu {
         }.openCustomizeHome {
             clickRecentBookmarksButton()
         }.goBackToHomeScreen {
-            verifyRecentBookmarksSectionIsNotDisplayed()
+            verifyRecentBookmarksSectionIsDisplayed(exists = false)
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/AddToHomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/AddToHomeScreenRobot.kt
@@ -13,8 +13,8 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
@@ -60,12 +60,8 @@ class AddToHomeScreenRobot {
         }
     }
 
-    fun verifyShortcutAdded(shortcutTitle: String) {
-        assertTrue(
-            mDevice.findObject(UiSelector().text(shortcutTitle))
-                .waitForExists(waitingTime),
-        )
-    }
+    fun verifyShortcutAdded(shortcutTitle: String) =
+        assertItemContainingTextExists(itemContainingText(shortcutTitle))
 
     class Transition {
         fun openHomeScreenShortcut(title: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -31,7 +31,6 @@ import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
@@ -41,6 +40,7 @@ import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
@@ -403,12 +403,7 @@ private fun assertBookmarkFolderIsNotCreated(title: String) {
             .resourceId("$packageName:id/bookmarks_wrapper"),
     ).waitForExists(waitingTime)
 
-    assertFalse(
-        mDevice.findObject(
-            UiSelector()
-                .textContains(title),
-        ).waitForExists(waitingTimeShort),
-    )
+    assertItemContainingTextExists(itemContainingText(title), exists = false)
 }
 
 private fun assertBookmarkFavicon(forUrl: Uri) = bookmarkFavicon(forUrl.toString()).check(
@@ -434,12 +429,12 @@ private fun assertBookmarkIsDeleted(expectedTitle: String) {
             .resourceId("$packageName:id/bookmarks_wrapper"),
     ).waitForExists(waitingTime)
 
-    assertFalse(
-        mDevice.findObject(
-            UiSelector()
-                .resourceId("$packageName:id/title")
-                .textContains(expectedTitle),
-        ).waitForExists(waitingTimeShort),
+    assertItemContainingTextExists(
+        itemWithResIdContainingText(
+            "$packageName:id/title",
+            expectedTitle,
+        ),
+        exists = false,
     )
 }
 private fun assertUndoDeleteSnackBarButton() =

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -46,6 +46,7 @@ import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
@@ -84,12 +85,11 @@ class BrowserRobot {
         sessionLoadedIdlingResource = SessionLoadedIdlingResource()
 
         runWithIdleRes(sessionLoadedIdlingResource) {
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector()
-                        .resourceId("$packageName:id/mozac_browser_toolbar_url_view")
-                        .textContains(url.replace("http://", "")),
-                ).waitForExists(waitingTime),
+            assertItemWithResIdAndTextExists(
+                itemWithResIdContainingText(
+                    "$packageName:id/mozac_browser_toolbar_url_view",
+                    url.replace("http://", ""),
+                ),
             )
         }
     }
@@ -119,10 +119,7 @@ class BrowserRobot {
         )
 
         runWithIdleRes(sessionLoadedIdlingResource) {
-            assertTrue(
-                "Page didn't load or doesn't contain the expected text",
-                mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemContainingText(expectedText))
         }
     }
 
@@ -154,7 +151,7 @@ class BrowserRobot {
 
         for (i in 1..RETRY_COUNT) {
             try {
-                assertTrue(cacheSizeInfo.waitForExists(waitingTime))
+                assertItemContainingTextExists(cacheSizeInfo)
                 break
             } catch (e: AssertionError) {
                 browserScreen {
@@ -164,25 +161,17 @@ class BrowserRobot {
         }
     }
 
-    fun verifyTabCounter(expectedText: String) {
-        val counter =
-            mDevice.findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/counter_text")
-                    .text(expectedText),
-            )
-        assertTrue(counter.waitForExists(waitingTime))
-    }
+    fun verifyTabCounter(expectedText: String) =
+        assertItemWithResIdAndTextExists(
+            itemWithResIdContainingText(
+                "$packageName:id/counter_text",
+                expectedText,
+            ),
+        )
 
     fun verifySnackBarText(expectedText: String) {
         mDevice.waitForObjects(mDevice.findObject(UiSelector().textContains(expectedText)))
-
-        assertTrue(
-            mDevice.findObject(
-                UiSelector()
-                    .textContains(expectedText),
-            ).waitForExists(waitingTime),
-        )
+        assertItemContainingTextExists(itemContainingText(expectedText))
     }
 
     fun verifyContextMenuForLocalHostLinks(containsURL: Uri) {
@@ -269,17 +258,13 @@ class BrowserRobot {
         )
     }
 
-    fun verifyNotificationDotOnMainMenu() {
-        assertTrue(
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/notification_dot"))
-                .waitForExists(waitingTime),
-        )
-    }
+    fun verifyNotificationDotOnMainMenu() =
+        assertItemWithResIdExists(itemWithResId("$packageName:id/notification_dot"))
 
     fun verifyHomeScreenButton() =
         homeScreenButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
-    fun verifySearchBar() = assertTrue(searchBar().waitForExists(waitingTime))
+    fun verifySearchBar() = assertItemWithResIdExists(searchBar())
 
     fun dismissContentContextMenu() {
         mDevice.pressBack()
@@ -304,17 +289,11 @@ class BrowserRobot {
 
     fun longClickPDFImage() = longClickPageObject(itemWithResId("pdfjs_internal_id_13R"))
 
-    fun verifyPDFReaderToolbarItems() {
-        assertTrue(
-            itemWithResIdAndText("download", "Download")
-                .waitForExists(waitingTime),
+    fun verifyPDFReaderToolbarItems() =
+        assertItemWithResIdAndTextExists(
+            itemWithResIdContainingText("download", "Download"),
+            itemWithResIdContainingText("openInApp", "Open in app"),
         )
-        assertTrue(
-            itemWithResIdAndText("openInApp", "Open in app")
-                .waitForExists(waitingTime),
-        )
-    }
-
     fun clickSubmitLoginButton() {
         clickPageObject(itemWithResId("submit"))
         itemWithResId("submit").waitUntilGone(waitingTime)
@@ -411,7 +390,7 @@ class BrowserRobot {
     fun clickSelectAddressButton() {
         for (i in 1..RETRY_COUNT) {
             try {
-                assertTrue(selectAddressButton().waitForExists(waitingTime))
+                assertItemWithResIdExists(selectAddressButton())
                 selectAddressButton().clickAndWaitForNewWindow(waitingTime)
 
                 break
@@ -465,7 +444,12 @@ class BrowserRobot {
 
     fun verifyCreditCardSuggestion(vararg creditCardNumbers: String) {
         for (creditCardNumber in creditCardNumbers) {
-            assertTrue(creditCardSuggestion(creditCardNumber).waitForExists(waitingTime))
+            assertItemWithResIdAndTextExists(
+                itemWithResIdContainingText(
+                    "$packageName:id/credit_card_number",
+                    creditCardNumber,
+                ),
+            )
         }
     }
 
@@ -474,10 +458,7 @@ class BrowserRobot {
             UiSelector()
                 .resourceId("$packageName:id/mozac_feature_login_multiselect_expand"),
         ).waitForExists(waitingTime)
-
-        assertTrue(
-            mDevice.findObject(UiSelector().textContains(userName)).waitForExists(waitingTime),
-        )
+        assertItemContainingTextExists(itemContainingText(userName))
     }
 
     fun verifyPrefilledLoginCredentials(userName: String, password: String, credentialsArePrefilled: Boolean) {
@@ -519,26 +500,17 @@ class BrowserRobot {
 
     fun verifyAutofilledAddress(streetAddress: String) {
         mDevice.waitForObjects(itemWithResIdAndText("streetAddress", streetAddress))
-        assertTrue(
-            itemWithResIdAndText("streetAddress", streetAddress)
-                .waitForExists(waitingTime),
-        )
+        assertItemWithResIdAndTextExists(itemWithResIdAndText("streetAddress", streetAddress))
     }
 
     fun verifyManuallyFilledAddress(apartment: String) {
         mDevice.waitForObjects(itemWithResIdAndText("apartment", apartment))
-        assertTrue(
-            itemWithResIdAndText("apartment", apartment)
-                .waitForExists(waitingTime),
-        )
+        assertItemWithResIdAndTextExists(itemWithResIdAndText("apartment", apartment))
     }
 
     fun verifyAutofilledCreditCard(creditCardNumber: String) {
         mDevice.waitForObjects(itemWithResIdAndText("cardNumber", creditCardNumber))
-        assertTrue(
-            itemWithResIdAndText("cardNumber", creditCardNumber)
-                .waitForExists(waitingTime),
-        )
+        assertItemWithResIdAndTextExists(itemWithResIdAndText("cardNumber", creditCardNumber))
     }
 
     fun verifyPrefilledPWALoginCredentials(userName: String, shortcutTitle: String) {
@@ -547,7 +519,7 @@ class BrowserRobot {
         var currentTries = 0
         while (currentTries++ < 3) {
             try {
-                assertTrue(itemWithResId("submit").waitForExists(waitingTime))
+                assertItemWithResIdExists(itemWithResId("submit"))
                 itemWithResId("submit").click()
                 assertTrue(itemWithResId("username").text.equals(userName))
                 break
@@ -572,11 +544,7 @@ class BrowserRobot {
     fun verifyTrackingProtectionWebContent(state: String) {
         for (i in 1..RETRY_COUNT) {
             try {
-                assertTrue(
-                    mDevice.findObject(
-                        UiSelector().textContains(state),
-                    ).waitForExists(waitingTimeLong),
-                )
+                assertItemContainingTextExists(itemContainingText(state))
 
                 break
             } catch (e: AssertionError) {
@@ -637,12 +605,7 @@ class BrowserRobot {
 
         for (i in 1..RETRY_COUNT) {
             try {
-                assertTrue(
-                    mDevice.findObject(
-                        UiSelector()
-                            .text("Selected date is: $currentDate"),
-                    ).waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemContainingText("Selected date is: $currentDate"))
 
                 break
             } catch (e: AssertionError) {
@@ -655,34 +618,21 @@ class BrowserRobot {
             }
         }
 
-        assertTrue(
-            mDevice.findObject(
-                UiSelector()
-                    .text("Selected date is: $currentDate"),
-            ).waitForExists(waitingTime),
-        )
+        assertItemContainingTextExists(itemContainingText("Selected date is: $currentDate"))
     }
 
     fun verifyNoDateIsSelected() {
         val currentDate = LocalDate.now()
-
-        assertFalse(
-            mDevice.findObject(
-                UiSelector()
-                    .text("Selected date is: $currentDate"),
-            ).waitForExists(waitingTimeShort),
+        assertItemContainingTextExists(
+            itemContainingText("Selected date is: $currentDate"),
+            exists = false,
         )
     }
 
     fun verifySelectedTime(hour: Int, minute: Int) {
         for (i in 1..RETRY_COUNT) {
             try {
-                assertTrue(
-                    mDevice.findObject(
-                        UiSelector()
-                            .text("Selected time is: $hour:$minute"),
-                    ).waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemContainingText("Selected time is: $hour:$minute"))
 
                 break
             } catch (e: AssertionError) {
@@ -696,24 +646,13 @@ class BrowserRobot {
                 clickPageObject(itemWithResId("submitTime"))
             }
         }
-
-        assertTrue(
-            mDevice.findObject(
-                UiSelector()
-                    .text("Selected time is: $hour:$minute"),
-            ).waitForExists(waitingTime),
-        )
+        assertItemContainingTextExists(itemContainingText("Selected time is: $hour:$minute"))
     }
 
     fun verifySelectedColor(hexValue: String) {
         for (i in 1..RETRY_COUNT) {
             try {
-                assertTrue(
-                    mDevice.findObject(
-                        UiSelector()
-                            .text("Selected color is: $hexValue"),
-                    ).waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemContainingText("Selected color is: $hexValue"))
 
                 break
             } catch (e: AssertionError) {
@@ -726,12 +665,7 @@ class BrowserRobot {
             }
         }
 
-        assertTrue(
-            mDevice.findObject(
-                UiSelector()
-                    .text("Selected color is: $hexValue"),
-            ).waitForExists(waitingTime),
-        )
+        assertItemContainingTextExists(itemContainingText("Selected color is: $hexValue"))
     }
 
     fun verifySelectedDropDownOption(optionName: String) {
@@ -743,12 +677,7 @@ class BrowserRobot {
                         .resourceId("submitOption"),
                 ).waitForExists(waitingTime)
 
-                assertTrue(
-                    mDevice.findObject(
-                        UiSelector()
-                            .text("Selected option is: $optionName"),
-                    ).waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemContainingText("Selected option is: $optionName"))
 
                 break
             } catch (e: AssertionError) {
@@ -760,31 +689,14 @@ class BrowserRobot {
             }
         }
 
-        assertTrue(
-            mDevice.findObject(
-                UiSelector()
-                    .text("Selected option is: $optionName"),
-            ).waitForExists(waitingTime),
-        )
+        assertItemContainingTextExists(itemContainingText("Selected option is: $optionName"))
     }
 
-    fun verifyNoTimeIsSelected(hour: Int, minute: Int) {
-        assertFalse(
-            mDevice.findObject(
-                UiSelector()
-                    .text("Selected date is: $hour:$minute"),
-            ).waitForExists(waitingTimeShort),
-        )
-    }
+    fun verifyNoTimeIsSelected(hour: Int, minute: Int) =
+        assertItemContainingTextExists(itemContainingText("Selected date is: $hour:$minute"), exists = false)
 
-    fun verifyColorIsNotSelected(hexValue: String) {
-        assertFalse(
-            mDevice.findObject(
-                UiSelector()
-                    .text("Selected date is: $hexValue"),
-            ).waitForExists(waitingTimeShort),
-        )
-    }
+    fun verifyColorIsNotSelected(hexValue: String) =
+        assertItemContainingTextExists(itemContainingText("Selected date is: $hexValue"), exists = false)
 
     fun verifyCookieBannerExists(exists: Boolean) {
         for (i in 1..RETRY_COUNT) {
@@ -907,16 +819,7 @@ class BrowserRobot {
         }
     }
 
-    fun verifySurveyButton() {
-        val button = mDevice.findObject(
-            UiSelector().text(
-                getStringResource(
-                    R.string.preferences_take_survey,
-                ),
-            ),
-        )
-        assertTrue(button.waitForExists(waitingTime))
-    }
+    fun verifySurveyButton() = assertItemContainingTextExists(itemContainingText(getStringResource(R.string.preferences_take_survey)))
 
     fun verifySurveyButtonDoesNotExist() {
         val button = mDevice.findObject(
@@ -929,25 +832,13 @@ class BrowserRobot {
         assertTrue(button.waitUntilGone(waitingTime))
     }
 
-    fun verifySurveyNoThanksButton() {
-        val button = mDevice.findObject(
-            UiSelector().text(
-                getStringResource(
-                    R.string.preferences_not_take_survey,
-                ),
-            ),
+    fun verifySurveyNoThanksButton() =
+        assertItemContainingTextExists(
+            itemContainingText(getStringResource(R.string.preferences_not_take_survey)),
         )
-        assertTrue(button.waitForExists(waitingTime))
-    }
 
-    fun verifyHomeScreenSurveyCloseButton() {
-        val button = mDevice.findObject(
-            UiSelector().descriptionContains(
-                "Close",
-            ),
-        )
-        assertTrue(button.waitForExists(waitingTime))
-    }
+    fun verifyHomeScreenSurveyCloseButton() =
+        assertItemWithDescriptionExists(itemWithDescription("Close"))
 
     fun clickOpenLinksInAppsDismissCFRButton() =
         itemWithResIdContainingText(
@@ -1076,10 +967,7 @@ class BrowserRobot {
                     )
 
                     tabsCounter().click()
-                    assertTrue(
-                        itemWithResId("$packageName:id/new_tab_button")
-                            .waitForExists(waitingTime),
-                    )
+                    assertItemWithResIdExists(itemWithResId("$packageName:id/new_tab_button"))
 
                     break
                 } catch (e: AssertionError) {
@@ -1091,10 +979,7 @@ class BrowserRobot {
                 }
             }
 
-            assertTrue(
-                itemWithResId("$packageName:id/new_tab_button")
-                    .waitForExists(waitingTime),
-            )
+            assertItemWithResIdExists(itemWithResId("$packageName:id/new_tab_button"))
 
             TabDrawerRobot().interact()
             return TabDrawerRobot.Transition()
@@ -1355,9 +1240,6 @@ private fun progressBar() =
 private fun suggestedLogins() = itemWithResId("$packageName:id/loginSelectBar")
 private fun selectAddressButton() = itemWithResId("$packageName:id/select_address_header")
 private fun selectCreditCardButton() = itemWithResId("$packageName:id/select_credit_card_header")
-
-private fun creditCardSuggestion(creditCardNumber: String) =
-    itemWithResIdAndText("$packageName:id/credit_card_number", "$creditCardNumber")
 
 private fun siteSecurityToolbarButton() =
     itemWithResId("$packageName:id/mozac_browser_toolbar_security_indicator")

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
@@ -20,12 +20,12 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
@@ -40,27 +40,16 @@ import org.mozilla.fenix.helpers.ext.waitNotNull
 class CollectionRobot {
 
     fun verifySelectCollectionScreen() {
-        assertTrue(
-            mDevice.findObject(UiSelector().text("Select collection"))
-                .exists(),
+        assertItemContainingTextExists(
+            itemContainingText("Select collection"),
+            itemContainingText("Add new collection"),
         )
-        assertTrue(
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/collections_list"))
-                .exists(),
-        )
-        assertTrue(
-            mDevice.findObject(UiSelector().text("Add new collection"))
-                .exists(),
-        )
+        assertItemWithResIdExists(itemWithResId("$packageName:id/collections_list"))
     }
 
     fun clickAddNewCollection() = addNewCollectionButton().click()
 
-    fun verifyCollectionNameTextField() {
-        assertTrue(
-            mainMenuEditCollectionNameField().waitForExists(waitingTime),
-        )
-    }
+    fun verifyCollectionNameTextField() = assertItemWithResIdExists(mainMenuEditCollectionNameField())
 
     // names a collection saved from tab drawer
     fun typeCollectionNameAndSave(collectionName: String) {
@@ -87,9 +76,7 @@ class CollectionRobot {
     fun verifyTabSavedInCollection(title: String, visible: Boolean = true) {
         if (visible) {
             scrollToElementByText(title)
-            assertTrue(
-                collectionListItem(title).waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(collectionListItem(title))
         } else {
             assertTrue(
                 collectionListItem(title).waitUntilGone(waitingTime),
@@ -97,23 +84,11 @@ class CollectionRobot {
         }
     }
 
-    fun verifyCollectionTabUrl(visible: Boolean, url: String) {
-        val tabUrl = mDevice.findObject(UiSelector().text(url))
+    fun verifyCollectionTabUrl(visible: Boolean, url: String) =
+        assertItemContainingTextExists(itemContainingText(url), exists = visible)
 
-        if (visible) {
-            assertTrue(tabUrl.exists())
-        } else {
-            assertFalse(tabUrl.exists())
-        }
-    }
-
-    fun verifyShareCollectionButtonIsVisible(visible: Boolean) {
-        if (visible) {
-            assertTrue(shareCollectionButton().exists())
-        } else {
-            assertFalse(shareCollectionButton().exists())
-        }
-    }
+    fun verifyShareCollectionButtonIsVisible(visible: Boolean) =
+        assertItemWithDescriptionExists(shareCollectionButton(), exists = visible)
 
     fun verifyCollectionMenuIsVisible(visible: Boolean, rule: ComposeTestRule) {
         if (visible) {
@@ -159,17 +134,8 @@ class CollectionRobot {
             .performClick()
     }
 
-    fun verifyCollectionItemRemoveButtonIsVisible(title: String, visible: Boolean) {
-        if (visible) {
-            assertTrue(
-                removeTabFromCollectionButton(title).exists(),
-            )
-        } else {
-            assertFalse(
-                removeTabFromCollectionButton(title).exists(),
-            )
-        }
-    }
+    fun verifyCollectionItemRemoveButtonIsVisible(title: String, visible: Boolean) =
+        assertItemContainingTextExists(removeTabFromCollectionButton(title), exists = visible)
 
     fun removeTabFromCollection(title: String) = removeTabFromCollectionButton(title).click()
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
@@ -39,7 +39,6 @@ import androidx.test.espresso.action.GeneralLocation
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import junit.framework.TestCase
 import org.hamcrest.Matcher
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants
@@ -109,8 +108,9 @@ class ComposeTabDrawerRobot(private val composeTestRule: HomeActivityComposeTest
 
     fun verifyNoExistingOpenTabs(vararg titles: String) {
         titles.forEach { title ->
-            TestCase.assertFalse(
-                itemContainingText(title).waitForExists(TestAssetHelper.waitingTimeShort),
+            assertItemContainingTextExists(
+                itemContainingText(title),
+                exists = false,
             )
         }
     }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
@@ -12,13 +12,14 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
-import junit.framework.TestCase.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
@@ -55,26 +56,20 @@ class CustomTabRobot {
         findInPageButton().check(matches(isDisplayed()))
     }
 
-    fun verifyPoweredByTextIsDisplayed() {
-        assertTrue(
-            mDevice.findObject(UiSelector().textContains("POWERED BY $appName"))
-                .waitForExists(waitingTime),
-        )
-    }
+    fun verifyPoweredByTextIsDisplayed() =
+        assertItemContainingTextExists(itemContainingText("POWERED BY $appName"))
 
     fun verifyOpenInBrowserButtonExists() {
         openInBrowserButton().check(matches(isDisplayed()))
     }
 
-    fun verifyBackButtonExists() = assertTrue(backButton().waitForExists(waitingTime))
+    fun verifyBackButtonExists() = assertItemWithDescriptionExists(itemWithDescription("Back"))
 
-    fun verifyForwardButtonExists() = assertTrue(forwardButton().waitForExists(waitingTime))
+    fun verifyForwardButtonExists() = assertItemWithDescriptionExists(itemWithDescription("Forward"))
 
-    fun verifyRefreshButtonExists() = assertTrue(refreshButton().waitForExists(waitingTime))
+    fun verifyRefreshButtonExists() = assertItemWithDescriptionExists(itemWithDescription("Refresh"))
 
-    fun verifyCustomMenuItem(label: String) {
-        assertTrue(mDevice.findObject(UiSelector().text(label)).waitForExists(waitingTime))
-    }
+    fun verifyCustomMenuItem(label: String) = assertItemContainingTextExists(itemContainingText(label))
 
     fun verifyCustomTabCloseButton() {
         closeButton().check(matches(isDisplayed()))
@@ -95,12 +90,8 @@ class CustomTabRobot {
             waitingTime,
         )
 
-        assertTrue(
-            mDevice.findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/mozac_browser_toolbar_title_view")
-                    .textContains(title),
-            ).waitForExists(waitingTime),
+        assertItemWithResIdAndTextExists(
+            itemWithResIdContainingText("$packageName:id/mozac_browser_toolbar_title_view", title),
         )
     }
 
@@ -182,12 +173,6 @@ private fun desktopSiteButton() = onView(withId(R.id.switch_widget))
 private fun findInPageButton() = onView(withText("Find in page"))
 
 private fun openInBrowserButton() = onView(withText("Open in $appName"))
-
-private fun refreshButton() = mDevice.findObject(UiSelector().description("Refresh"))
-
-private fun forwardButton() = mDevice.findObject(UiSelector().description("Forward"))
-
-private fun backButton() = mDevice.findObject(UiSelector().description("Back"))
 
 private fun closeButton() = onView(withContentDescription("Return to previous app"))
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
@@ -24,7 +24,6 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers.allOf
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.AppAndSystemHelper.assertExternalAppOpens
 import org.mozilla.fenix.helpers.AppAndSystemHelper.getPermissionAllowID
@@ -108,7 +107,8 @@ class DownloadRobot {
 
     fun verifyPhotosAppOpens() = assertExternalAppOpens(GOOGLE_APPS_PHOTOS)
 
-    fun verifyDownloadedFileName(fileName: String) = assertItemContainingTextExists(itemContainingText(fileName))
+    fun verifyDownloadedFileName(fileName: String) =
+        assertItemContainingTextExists(itemContainingText(fileName))
 
     fun verifyDownloadedFileIcon() = assertItemWithResIdExists(itemWithResId("$packageName:id/favicon"))
 
@@ -120,14 +120,8 @@ class DownloadRobot {
         Log.i(TAG, "verifyEmptyDownloadsList: Verified \"No downloaded files\" list message")
     }
 
-    fun waitForDownloadsListToExist() {
-        assertTrue(
-            "Downloads list either empty or not displayed",
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/download_list"))
-                .waitForExists(waitingTime),
-        )
-        Log.i(TAG, "waitForDownloadsListToExist: Verified that the download list exists")
-    }
+    fun waitForDownloadsListToExist() =
+        assertItemWithResIdExists(itemWithResId("$packageName:id/download_list"))
 
     fun openDownloadedFile(fileName: String) {
         downloadedFile(fileName)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/EnhancedTrackingProtectionRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/EnhancedTrackingProtectionRobot.kt
@@ -17,14 +17,15 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import junit.framework.TestCase.assertTrue
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.not
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
@@ -42,10 +43,7 @@ class EnhancedTrackingProtectionRobot {
     fun verifyETPSwitchVisibility(visible: Boolean) = assertETPSwitchVisibility(visible)
 
     fun verifyCrossSiteCookiesBlocked(isBlocked: Boolean) {
-        assertTrue(
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/cross_site_tracking"))
-                .waitForExists(waitingTime),
-        )
+        assertItemWithResIdExists(itemWithResId("$packageName:id/cross_site_tracking"))
         crossSiteCookiesBlockListButton.click()
         // Verifies the trackers block/allow list
         onView(withId(R.id.details_blocking_header))
@@ -63,10 +61,7 @@ class EnhancedTrackingProtectionRobot {
     }
 
     fun verifySocialMediaTrackersBlocked(isBlocked: Boolean) {
-        assertTrue(
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/social_media_trackers"))
-                .waitForExists(waitingTime),
-        )
+        assertItemWithResIdExists(itemWithResId("$packageName:id/social_media_trackers"))
         socialTrackersBlockListButton.click()
         // Verifies the trackers block/allow list
         onView(withId(R.id.details_blocking_header))
@@ -85,10 +80,7 @@ class EnhancedTrackingProtectionRobot {
     }
 
     fun verifyFingerprintersBlocked(isBlocked: Boolean) {
-        assertTrue(
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/fingerprinters"))
-                .waitForExists(waitingTime),
-        )
+        assertItemWithResIdExists(itemWithResId("$packageName:id/fingerprinters"))
         fingerprintersBlockListButton.click()
         // Verifies the trackers block/allow list
         onView(withId(R.id.details_blocking_header))
@@ -107,10 +99,7 @@ class EnhancedTrackingProtectionRobot {
     }
 
     fun verifyCryptominersBlocked(isBlocked: Boolean) {
-        assertTrue(
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/cryptominers"))
-                .waitForExists(waitingTime),
-        )
+        assertItemWithResIdExists(itemWithResId("$packageName:id/cryptominers"))
         cryptominersBlockListButton.click()
         // Verifies the trackers block/allow list
         onView(withId(R.id.details_blocking_header))
@@ -129,10 +118,7 @@ class EnhancedTrackingProtectionRobot {
     }
 
     fun verifyTrackingContentBlocked(isBlocked: Boolean) {
-        assertTrue(
-            mDevice.findObject(UiSelector().text("Tracking Content"))
-                .waitForExists(waitingTime),
-        )
+        assertItemContainingTextExists(itemWithText("Tracking Content"))
         trackingContentBlockListButton.click()
         // Verifies the trackers block/allow list
         onView(withId(R.id.details_blocking_header))
@@ -304,9 +290,5 @@ private val fingerprintersBlockListButton =
 private fun assertSecuritySheetIsCompletelyDisplayed() {
     mDevice.findObject(UiSelector().description(getStringResource(R.string.quick_settings_sheet)))
         .waitForExists(waitingTime)
-    assertTrue(
-        mDevice.findObject(
-            UiSelector().resourceId("$packageName:id/quick_action_sheet"),
-        ).waitForExists(waitingTime),
-    )
+    assertItemWithResIdExists(itemWithResId("$packageName:id/quick_action_sheet"))
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -21,13 +21,14 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
@@ -60,13 +61,8 @@ class HistoryRobot {
         assertVisitedTimeTitle()
     }
 
-    fun verifyHistoryItemExists(shouldExist: Boolean, item: String) {
-        if (shouldExist) {
-            assertTrue(mDevice.findObject(UiSelector().textContains(item)).waitForExists(waitingTime))
-        } else {
-            assertFalse(mDevice.findObject(UiSelector().textContains(item)).waitForExists(waitingTimeShort))
-        }
-    }
+    fun verifyHistoryItemExists(shouldExist: Boolean, item: String) =
+        assertItemContainingTextExists(itemContainingText(item), exists = shouldExist)
 
     fun verifyFirstTestPageTitle(title: String) = assertTestPageTitle(title)
 
@@ -111,22 +107,15 @@ class HistoryRobot {
         snackBarUndoButton().click()
     }
 
-    fun verifySearchGroupDisplayed(shouldBeDisplayed: Boolean, searchTerm: String, groupSize: Int) {
+    fun verifySearchGroupDisplayed(shouldBeDisplayed: Boolean, searchTerm: String, groupSize: Int) =
         // checks if the search group exists in the Recently visited section
-        if (shouldBeDisplayed) {
-            assertTrue(
-                mDevice.findObject(UiSelector().text(searchTerm))
-                    .getFromParent(UiSelector().text("$groupSize sites"))
-                    .waitForExists(waitingTimeShort),
-            )
-        } else {
-            assertFalse(
-                mDevice.findObject(UiSelector().text(searchTerm))
-                    .getFromParent(UiSelector().text("$groupSize sites"))
-                    .waitForExists(waitingTimeShort),
-            )
-        }
-    }
+        assertItemContainingTextExists(
+            itemContainingText(searchTerm)
+                .getFromParent(
+                    UiSelector().text("$groupSize sites"),
+                ),
+            exists = shouldBeDisplayed,
+        )
 
     fun openSearchGroup(searchTerm: String) {
         mDevice.findObject(UiSelector().text(searchTerm)).waitForExists(waitingTime)
@@ -208,10 +197,11 @@ private fun assertTestPageTitle(title: String) = testPageTitle()
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
     .check(matches(withText(title)))
 
-private fun assertDeleteConfirmationMessage() {
-    assertTrue(deleteHistoryPromptTitle().waitForExists(waitingTime))
-    assertTrue(deleteHistoryPromptSummary().waitForExists(waitingTime))
-}
+private fun assertDeleteConfirmationMessage() =
+    assertItemWithResIdAndTextExists(
+        itemWithResIdContainingText("$packageName:id/title", getStringResource(R.string.delete_history_prompt_title)),
+        itemWithResIdContainingText("$packageName:id/body", getStringResource(R.string.delete_history_prompt_body_2)),
+    )
 
 private fun assertCopySnackBarText() = snackBarText().check(matches(withText("URL copied")))
 
@@ -222,22 +212,6 @@ private fun snackBarUndoButton() = onView(withId(R.id.snackbar_btn))
 
 private fun assertUndoDeleteSnackBarButton() =
     snackBarUndoButton().check(matches(withText("UNDO")))
-
-private fun deleteHistoryPromptTitle() =
-    mDevice
-        .findObject(
-            UiSelector()
-                .textContains(getStringResource(R.string.delete_history_prompt_title))
-                .resourceId("$packageName:id/title"),
-        )
-
-private fun deleteHistoryPromptSummary() =
-    mDevice
-        .findObject(
-            UiSelector()
-                .textContains(getStringResource(R.string.delete_history_prompt_body_2))
-                .resourceId("$packageName:id/body"),
-        )
 
 private fun deleteHistoryEverythingOption() =
     mDevice

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -65,6 +65,8 @@ import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.appName
@@ -117,23 +119,8 @@ class HomeScreenRobot {
     fun verifyTabCounter(numberOfOpenTabs: String) =
         assertItemWithResIdAndTextExists(tabCounter(numberOfOpenTabs))
 
-    fun verifyWallpaperImageApplied(isEnabled: Boolean) {
-        if (isEnabled) {
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector().resourceId("$packageName:id/wallpaperImageView"),
-                ).waitForExists(waitingTimeShort),
-            )
-        } else {
-            assertFalse(
-                mDevice.findObject(
-                    UiSelector().resourceId("$packageName:id/wallpaperImageView"),
-                ).waitForExists(waitingTimeShort),
-            )
-        }
-
-        mDevice.findObject(UiSelector())
-    }
+    fun verifyWallpaperImageApplied(isEnabled: Boolean) =
+        assertItemWithResIdExists(itemWithResId("$packageName:id/wallpaperImageView"), exists = isEnabled)
 
     // Upgrading users onboarding dialog
     fun verifyUpgradingUserOnboardingFirstScreen(testRule: ComposeTestRule) {
@@ -258,29 +245,26 @@ class HomeScreenRobot {
 
     fun verifyJumpBackInSectionIsDisplayed() {
         scrollToElementByText(getStringResource(R.string.recent_tabs_header))
-        assertTrue(jumpBackInSection().waitForExists(waitingTime))
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.recent_tabs_header)))
     }
-    fun verifyJumpBackInSectionIsNotDisplayed() = assertJumpBackInSectionIsNotDisplayed()
+    fun verifyJumpBackInSectionIsNotDisplayed() =
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.recent_tabs_header)), exists = false)
     fun verifyJumpBackInItemTitle(testRule: ComposeTestRule, itemTitle: String) =
         assertJumpBackInItemTitle(testRule, itemTitle)
     fun verifyJumpBackInItemWithUrl(testRule: ComposeTestRule, itemUrl: String) =
         assertJumpBackInItemWithUrl(testRule, itemUrl)
     fun verifyJumpBackInShowAllButton() = assertJumpBackInShowAllButton()
-    fun verifyRecentlyVisitedSectionIsDisplayed() = assertRecentlyVisitedSectionIsDisplayed()
-    fun verifyRecentlyVisitedSectionIsNotDisplayed() = assertRecentlyVisitedSectionIsNotDisplayed()
-    fun verifyRecentBookmarksSectionIsDisplayed() = assertRecentBookmarksSectionIsDisplayed()
-    fun verifyRecentBookmarksSectionIsNotDisplayed() = assertRecentBookmarksSectionIsNotDisplayed()
-    fun verifyPocketSectionIsDisplayed() = assertPocketSectionIsDisplayed()
-    fun verifyPocketSectionIsNotDisplayed() = assertPocketSectionIsNotDisplayed()
+    fun verifyRecentlyVisitedSectionIsDisplayed(exists: Boolean) = assertRecentlyVisitedSectionIsDisplayed(exists)
+    fun verifyRecentBookmarksSectionIsDisplayed(exists: Boolean) = assertRecentBookmarksSectionIsDisplayed(exists)
+    fun verifyPocketSectionIsDisplayed(exists: Boolean) = assertPocketSectionIsDisplayed(exists)
 
     fun verifyRecentlyVisitedSearchGroupDisplayed(shouldBeDisplayed: Boolean, searchTerm: String, groupSize: Int) {
         // checks if the search group exists in the Recently visited section
         if (shouldBeDisplayed) {
             scrollToElementByText("Recently visited")
-            assertTrue(
-                mDevice.findObject(UiSelector().text(searchTerm))
-                    .getFromParent(UiSelector().text("$groupSize sites"))
-                    .waitForExists(waitingTimeShort),
+            assertItemContainingTextExists(
+                itemContainingText(searchTerm)
+                    .getFromParent(UiSelector().text("$groupSize sites")),
             )
         } else {
             assertTrue(
@@ -294,7 +278,7 @@ class HomeScreenRobot {
     // Collections elements
     fun verifyCollectionIsDisplayed(title: String, collectionExists: Boolean = true) {
         if (collectionExists) {
-            assertTrue(mDevice.findObject(UiSelector().text(title)).waitForExists(waitingTime))
+            assertItemContainingTextExists(itemContainingText(title))
         } else {
             assertTrue(mDevice.findObject(UiSelector().text(title)).waitUntilGone(waitingTime))
         }
@@ -319,24 +303,10 @@ class HomeScreenRobot {
     fun verifyThoughtProvokingStories(enabled: Boolean) {
         if (enabled) {
             scrollToElementByText(getStringResource(R.string.pocket_stories_header_1))
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector()
-                        .textContains(
-                            getStringResource(R.string.pocket_stories_header_1),
-                        ),
-                ).waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemContainingText(getStringResource(R.string.pocket_stories_header_1)))
         } else {
             homeScreenList().scrollToEnd(LISTS_MAXSWIPES)
-            assertFalse(
-                mDevice.findObject(
-                    UiSelector()
-                        .textContains(
-                            getStringResource(R.string.pocket_stories_header_1),
-                        ),
-                ).waitForExists(waitingTimeShort),
-            )
+            assertItemContainingTextExists(itemContainingText(getStringResource(R.string.pocket_stories_header_1)), exists = false)
         }
     }
 
@@ -377,33 +347,16 @@ class HomeScreenRobot {
     fun verifyDiscoverMoreStoriesButton() {
         pocketStoriesList
             .scrollIntoView(UiSelector().text("Discover more"))
-        assertTrue(
-            mDevice.findObject(UiSelector().text("Discover more"))
-                .waitForExists(waitingTimeShort),
-        )
+        assertItemContainingTextExists(itemWithText("Discover more"))
     }
 
     fun verifyStoriesByTopic(enabled: Boolean) {
         if (enabled) {
             scrollToElementByText(getStringResource(R.string.pocket_stories_categories_header))
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector()
-                        .textContains(
-                            getStringResource(R.string.pocket_stories_categories_header),
-                        ),
-                ).waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemContainingText(getStringResource(R.string.pocket_stories_categories_header)))
         } else {
             homeScreenList().scrollToEnd(LISTS_MAXSWIPES)
-            assertFalse(
-                mDevice.findObject(
-                    UiSelector()
-                        .textContains(
-                            getStringResource(R.string.pocket_stories_categories_header),
-                        ),
-                ).waitForExists(waitingTimeShort),
-            )
+            assertItemContainingTextExists(itemContainingText(getStringResource(R.string.pocket_stories_categories_header)), exists = false)
         }
     }
 
@@ -429,26 +382,16 @@ class HomeScreenRobot {
 
     fun verifyPoweredByPocket() {
         homeScreenList().scrollIntoView(mDevice.findObject(UiSelector().resourceId("pocket.header")))
-        assertTrue(mDevice.findObject(UiSelector().resourceId("pocket.header.title")).exists())
+        assertItemWithResIdAndTextExists(itemWithResId("pocket.header.title"))
     }
 
     fun verifyCustomizeHomepageButton(enabled: Boolean) {
         if (enabled) {
             scrollToElementByText(getStringResource(R.string.browser_menu_customize_home_1))
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector()
-                        .textContains("Customize homepage"),
-                ).waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemContainingText("Customize homepage"))
         } else {
             homeScreenList().scrollToEnd(LISTS_MAXSWIPES)
-            assertFalse(
-                mDevice.findObject(
-                    UiSelector()
-                        .textContains("Customize homepage"),
-                ).waitForExists(waitingTimeShort),
-            )
+            assertItemContainingTextExists(itemContainingText("Customize homepage"), exists = false)
         }
     }
 
@@ -964,25 +907,23 @@ private fun assertSponsoredShortcutTitle(sponsoredShortcutTitle: String, positio
 
 private fun assertNotExistingTopSitesList(title: String) {
     mDevice.findObject(UiSelector().text(title)).waitUntilGone(waitingTime)
-
-    assertFalse(
-        mDevice.findObject(
-            UiSelector()
-                .resourceId("$packageName:id/top_site_title")
-                .textContains(title),
-        ).waitForExists(waitingTimeShort),
+    assertItemWithResIdAndTextExists(
+        itemWithResIdContainingText(
+            "$packageName:id/top_site_title",
+            title,
+        ),
+        exists = false,
     )
 }
 
-private fun assertSponsoredTopSitesNotDisplayed() {
-    assertFalse(
-        mDevice.findObject(
-            UiSelector()
-                .resourceId("$packageName:id/top_site_subtitle")
-                .textContains(getStringResource(R.string.top_sites_sponsored_label)),
-        ).waitForExists(waitingTimeShort),
+private fun assertSponsoredTopSitesNotDisplayed() =
+    assertItemWithResIdAndTextExists(
+        itemWithResIdContainingText(
+            "$packageName:id/top_site_subtitle",
+            getStringResource(R.string.top_sites_sponsored_label),
+        ),
+        exists = false,
     )
-}
 
 private fun assertTopSiteContextMenuItems() {
     mDevice.waitNotNull(
@@ -995,8 +936,6 @@ private fun assertTopSiteContextMenuItems() {
     )
 }
 
-private fun assertJumpBackInSectionIsNotDisplayed() = assertFalse(jumpBackInSection().waitForExists(waitingTimeShort))
-
 private fun assertJumpBackInItemTitle(testRule: ComposeTestRule, itemTitle: String) =
     testRule.onNodeWithTag("recent.tab.title", useUnmergedTree = true).assert(hasText(itemTitle))
 
@@ -1004,43 +943,20 @@ private fun assertJumpBackInItemWithUrl(testRule: ComposeTestRule, itemUrl: Stri
     testRule.onNodeWithTag("recent.tab.url", useUnmergedTree = true).assert(hasText(itemUrl))
 
 private fun assertJumpBackInShowAllButton() =
-    assertTrue(
-        mDevice
-            .findObject(
-                UiSelector()
-                    .textContains(getStringResource(R.string.recent_tabs_show_all)),
-            ).waitForExists(waitingTime),
-    )
+    assertItemContainingTextExists(itemContainingText(getStringResource(R.string.recent_tabs_show_all)))
 
-private fun assertRecentlyVisitedSectionIsDisplayed() = assertTrue(recentlyVisitedSection().waitForExists(waitingTime))
+private fun assertRecentlyVisitedSectionIsDisplayed(exists: Boolean) =
+    assertItemContainingTextExists(itemContainingText(getStringResource(R.string.history_metadata_header_2)), exists = exists)
 
-private fun assertRecentlyVisitedSectionIsNotDisplayed() = assertFalse(recentlyVisitedSection().waitForExists(waitingTimeShort))
+private fun assertRecentBookmarksSectionIsDisplayed(exists: Boolean) =
+    assertItemContainingTextExists(itemContainingText(getStringResource(R.string.recently_saved_title)), exists = exists)
 
-private fun assertRecentBookmarksSectionIsDisplayed() =
-    assertTrue(recentBookmarksSection().waitForExists(waitingTime))
-
-private fun assertRecentBookmarksSectionIsNotDisplayed() =
-    assertFalse(recentBookmarksSection().waitForExists(waitingTimeShort))
-
-private fun assertPocketSectionIsDisplayed() = assertTrue(pocketSection().waitForExists(waitingTime))
-
-private fun assertPocketSectionIsNotDisplayed() = assertFalse(pocketSection().waitForExists(waitingTimeShort))
+private fun assertPocketSectionIsDisplayed(exists: Boolean) =
+    assertItemContainingTextExists(itemContainingText(getStringResource(R.string.pocket_stories_header_1)), exists = exists)
 
 private fun saveTabsToCollectionButton() = onView(withId(R.id.add_tabs_to_collections_button))
 
 private fun tabsCounter() = onView(withId(R.id.tab_button))
-
-private fun jumpBackInSection() =
-    mDevice.findObject(UiSelector().textContains(getStringResource(R.string.recent_tabs_header)))
-
-private fun recentlyVisitedSection() =
-    mDevice.findObject(UiSelector().textContains(getStringResource(R.string.history_metadata_header_2)))
-
-private fun recentBookmarksSection() =
-    mDevice.findObject(UiSelector().textContains(getStringResource(R.string.recently_saved_title)))
-
-private fun pocketSection() =
-    mDevice.findObject(UiSelector().textContains(getStringResource(R.string.pocket_stories_header_1)))
 
 private fun sponsoredShortcut(sponsoredShortcutTitle: String) =
     mDevice.findObject(

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -31,7 +31,6 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.not
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants
@@ -39,7 +38,10 @@ import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
@@ -80,30 +82,17 @@ class NavigationToolbarRobot {
     }
 
     fun verifyClipboardSuggestionsAreDisplayed(link: String = "", shouldBeDisplayed: Boolean) {
-        when (shouldBeDisplayed) {
-            true -> {
-                assertTrue(
-                    mDevice.findObject(UiSelector().resourceId("$packageName:id/fill_link_from_clipboard"))
-                        .waitForExists(waitingTime),
-                )
-
-                assertTrue(
-                    mDevice.findObject(UiSelector().resourceId("$packageName:id/clipboard_url").text(link))
-                        .waitForExists(waitingTime),
-                )
-            }
-            false -> {
-                assertFalse(
-                    mDevice.findObject(UiSelector().resourceId("$packageName:id/fill_link_from_clipboard"))
-                        .waitForExists(waitingTimeShort),
-                )
-
-                assertFalse(
-                    mDevice.findObject(UiSelector().resourceId("$packageName:id/clipboard_url").text(link))
-                        .waitForExists(waitingTimeShort),
-                )
-            }
-        }
+        assertItemWithResIdExists(
+            itemWithResId("$packageName:id/fill_link_from_clipboard"),
+            exists = shouldBeDisplayed,
+        )
+        assertItemWithResIdAndTextExists(
+            itemWithResIdAndText(
+                "$packageName:id/clipboard_url",
+                link,
+            ),
+            exists = shouldBeDisplayed,
+        )
     }
 
     fun longClickEditModeToolbar() =
@@ -135,10 +124,8 @@ class NavigationToolbarRobot {
 
     // New unified search UI selector
     fun verifyDefaultSearchEngine(engineName: String) =
-        assertTrue(
-            searchSelectorButton
-                .getChild(UiSelector().description(engineName))
-                .waitForExists(waitingTime),
+        assertItemWithResIdExists(
+            searchSelectorButton.getChild(UiSelector().description(engineName)),
         )
 
     fun verifyTextSelectionOptions(vararg textSelectionOptions: String) {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
@@ -9,12 +9,13 @@ import android.content.Context
 import android.util.Log
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.Constants.TAG
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndDescriptionExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper
@@ -36,8 +37,7 @@ class NotificationRobot {
             notificationFound = mDevice.findObject(notification).waitForExists(waitingTime)
         }
 
-        assertTrue(notificationFound)
-        Log.i(TAG, "verifySystemNotificationExists: Verified that $notificationMessage notification exists")
+        assertItemContainingTextExists(itemWithText(notificationMessage))
     }
 
     fun clearNotifications() {
@@ -67,9 +67,7 @@ class NotificationRobot {
     fun verifySystemNotificationDoesNotExist(notificationMessage: String) {
         Log.i(TAG, "verifySystemNotificationDoesNotExist: Waiting for $notificationMessage notification to be gone")
         mDevice.findObject(UiSelector().textContains(notificationMessage)).waitUntilGone(waitingTime)
-        assertFalse(
-            mDevice.findObject(UiSelector().textContains(notificationMessage)).waitForExists(waitingTimeShort),
-        )
+        assertItemContainingTextExists(itemContainingText(notificationMessage), exists = false)
         Log.i(TAG, "verifySystemNotificationDoesNotExist: Verified that $notificationMessage notification does not exist")
     }
 
@@ -107,9 +105,8 @@ class NotificationRobot {
         }
     }
 
-    fun verifyMediaSystemNotificationButtonState(action: String) {
-        assertTrue(mediaSystemNotificationButton(action).waitForExists(waitingTime))
-    }
+    fun verifyMediaSystemNotificationButtonState(action: String) =
+        assertItemWithResIdAndDescriptionExists(mediaSystemNotificationButton(action))
 
     fun expandNotificationMessage() {
         while (!notificationHeader.exists()) {
@@ -167,10 +164,9 @@ class NotificationRobot {
                 }
                 // Not all download related system notifications can be dismissed
                 if (shouldDismissNotification) {
-                    assertFalse(itemContainingText(appName).waitForExists(waitingTimeShort))
-                    Log.i(TAG, "swipeDownloadNotification: Verified that $appName notification does not exist")
+                    assertItemContainingTextExists(itemContainingText(appName), exists = false)
                 } else {
-                    assertTrue(itemContainingText(appName).waitForExists(waitingTimeShort))
+                    assertItemContainingTextExists(itemContainingText(appName))
                     Log.i(TAG, "swipeDownloadNotification: Verified that $appName notification exist")
                 }
 
@@ -210,9 +206,7 @@ class NotificationRobot {
 
         fun clickClosePrivateTabsNotification(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
             try {
-                assertTrue(
-                    closePrivateTabsNotification().exists(),
-                )
+                assertItemContainingTextExists(closePrivateTabsNotification())
             } catch (e: AssertionError) {
                 notificationTray().flingToEnd(1)
             }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/PwaRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/PwaRobot.kt
@@ -5,14 +5,14 @@
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.uiautomator.UiSelector
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.helpers.AppAndSystemHelper.isExternalAppBrowserActivityInCurrentTask
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 
 class PwaRobot {
-    fun verifyCustomTabToolbarIsNotDisplayed() = assertFalse(customTabToolbar().exists())
+    fun verifyCustomTabToolbarIsNotDisplayed() = assertItemWithResIdExists(customTabToolbar(), exists = false)
     fun verifyPwaActivityInCurrentTask() = assertTrue(isExternalAppBrowserActivityInCurrentTask())
 
     class Transition

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -29,7 +29,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.AppAndSystemHelper.grantSystemPermission
@@ -39,9 +38,12 @@ import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.Constants.SPEECH_RECOGNITION
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
@@ -53,12 +55,7 @@ import org.mozilla.fenix.helpers.TestHelper.waitForObjects
  * Implementation of Robot Pattern for the search fragment.
  */
 class SearchRobot {
-    fun verifySearchView() =
-        assertTrue(
-            mDevice.findObject(
-                UiSelector().resourceId("$packageName:id/search_wrapper"),
-            ).waitForExists(waitingTime),
-        )
+    fun verifySearchView() = assertItemWithResIdExists(itemWithResId("$packageName:id/search_wrapper"))
 
     fun verifySearchToolbar(isDisplayed: Boolean) =
         assertItemWithResIdExists(
@@ -66,25 +63,11 @@ class SearchRobot {
             exists = isDisplayed,
         )
 
-    fun verifyScanButtonVisibility(visible: Boolean = true) {
-        if (visible) {
-            assertTrue(
-                scanButton.waitForExists(waitingTime),
-            )
-        } else {
-            assertTrue(
-                scanButton.waitUntilGone(waitingTime),
-            )
-        }
-    }
+    fun verifyScanButtonVisibility(visible: Boolean = true) =
+        assertItemWithDescriptionExists(scanButton, exists = visible)
 
-    fun verifyVoiceSearchButtonVisibility(enabled: Boolean) {
-        if (enabled) {
-            assertTrue(voiceSearchButton.waitForExists(waitingTime))
-        } else {
-            assertFalse(voiceSearchButton.waitForExists(waitingTimeShort))
-        }
-    }
+    fun verifyVoiceSearchButtonVisibility(enabled: Boolean) =
+        assertItemWithDescriptionExists(voiceSearchButton, exists = enabled)
 
     // Device or AVD requires a Google Services Android OS installation
     fun startVoiceSearch() {
@@ -154,33 +137,14 @@ class SearchRobot {
         }
     }
 
-    fun verifyAllowSuggestionsInPrivateModeDialog() {
-        assertTrue(
-            mDevice.findObject(
-                UiSelector().text(getStringResource(R.string.search_suggestions_onboarding_title)),
-            ).waitForExists(waitingTime),
+    fun verifyAllowSuggestionsInPrivateModeDialog() =
+        assertItemContainingTextExists(
+            itemWithText(getStringResource(R.string.search_suggestions_onboarding_title)),
+            itemWithText(getStringResource(R.string.search_suggestions_onboarding_text)),
+            itemWithText("Learn more"),
+            itemWithText(getStringResource(R.string.search_suggestions_onboarding_allow_button)),
+            itemWithText(getStringResource(R.string.search_suggestions_onboarding_do_not_allow_button)),
         )
-        assertTrue(
-            mDevice.findObject(
-                UiSelector().text(getStringResource(R.string.search_suggestions_onboarding_text)),
-            ).exists(),
-        )
-        assertTrue(
-            mDevice.findObject(
-                UiSelector().text("Learn more"),
-            ).exists(),
-        )
-        assertTrue(
-            mDevice.findObject(
-                UiSelector().text(getStringResource(R.string.search_suggestions_onboarding_allow_button)),
-            ).exists(),
-        )
-        assertTrue(
-            mDevice.findObject(
-                UiSelector().text(getStringResource(R.string.search_suggestions_onboarding_do_not_allow_button)),
-            ).exists(),
-        )
-    }
 
     fun denySuggestionsInPrivateMode() {
         mDevice.findObject(
@@ -194,17 +158,14 @@ class SearchRobot {
         ).click()
     }
 
-    fun verifySearchSelectorButton() {
-        assertTrue(searchSelectorButton.waitForExists(waitingTime))
-    }
+    fun verifySearchSelectorButton() = assertItemWithResIdExists(searchSelectorButton)
 
     fun clickSearchSelectorButton() {
         searchSelectorButton.waitForExists(waitingTime)
         searchSelectorButton.click()
     }
 
-    fun verifySearchEngineIcon(name: String) =
-        assertTrue(itemWithDescription(name).waitForExists(waitingTime))
+    fun verifySearchEngineIcon(name: String) = assertItemWithDescriptionExists(itemWithDescription(name))
 
     fun verifySearchBarPlaceholder(text: String) {
         browserToolbarEditView().waitForExists(waitingTime)
@@ -216,9 +177,8 @@ class SearchRobot {
     fun verifySearchShortcutListContains(vararg searchEngineName: String, shouldExist: Boolean = true) {
         searchEngineName.forEach {
             if (shouldExist) {
-                assertTrue(
-                    searchShortcutList.getChild(UiSelector().text(it))
-                        .waitForExists(waitingTimeShort),
+                assertItemWithResIdExists(
+                    searchShortcutList.getChild(UiSelector().text(it)),
                 )
             } else {
                 assertTrue(
@@ -363,11 +323,7 @@ class SearchRobot {
             mDevice.pressEnter()
 
             runWithIdleRes(sessionLoadedIdlingResource) {
-                assertTrue(
-                    mDevice.findObject(
-                        UiSelector().resourceId("$packageName:id/browserLayout"),
-                    ).waitForExists(waitingTime),
-                )
+                assertItemWithResIdExists(itemWithResId("$packageName:id/browserLayout"))
             }
 
             BrowserRobot().interact()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -41,7 +41,6 @@ import junit.framework.AssertionFailedError
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.endsWith
 import org.hamcrest.Matchers.allOf
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.AppAndSystemHelper.isPackageInstalled
 import org.mozilla.fenix.helpers.Constants.LISTS_MAXSWIPES
@@ -187,8 +186,8 @@ class SettingsRobot {
     // ABOUT SECTION
     fun verifyAboutHeading() = assertAboutHeading()
 
-    fun verifyRateOnGooglePlay() = assertTrue(rateOnGooglePlayHeading().waitForExists(waitingTime))
-    fun verifyAboutFirefoxPreview() = assertTrue(aboutFirefoxHeading().waitForExists(waitingTime))
+    fun verifyRateOnGooglePlay() = assertItemContainingTextExists(rateOnGooglePlayHeading())
+    fun verifyAboutFirefoxPreview() = assertItemContainingTextExists(aboutFirefoxHeading())
     fun verifyGooglePlayRedirect() = assertGooglePlayRedirect()
 
     fun verifySettingsOptionSummary(setting: String, summary: String) {
@@ -640,10 +639,7 @@ private fun aboutFirefoxHeading(): UiObject {
     for (i in 1..RETRY_COUNT) {
         try {
             settingsList().scrollToEnd(LISTS_MAXSWIPES)
-            assertTrue(
-                mDevice.findObject(UiSelector().text("About $appName"))
-                    .waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemWithText("About $appName"))
 
             break
         } catch (e: AssertionError) {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
@@ -26,14 +26,13 @@ import androidx.test.uiautomator.UiSelector
 import mozilla.components.support.utils.ext.getPackageInfoCompat
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.LISTS_MAXSWIPES
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.appName
-import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.settings.SupportUtils
 import java.text.SimpleDateFormat
@@ -156,11 +155,7 @@ private fun assertCrashes() {
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
         .perform(click())
 
-    assertTrue(
-        mDevice.findObject(
-            UiSelector().textContains("No crash reports have been submitted."),
-        ).waitForExists(waitingTime),
-    )
+    assertItemContainingTextExists(itemContainingText("No crash reports have been submitted."))
 
     for (i in 1..3) {
         Espresso.pressBack()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
@@ -36,6 +36,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestHelper.appName
@@ -51,17 +52,8 @@ import org.mozilla.fenix.helpers.ext.waitNotNull
  */
 
 class SettingsSubMenuAddonsManagerRobot {
-    fun verifyAddonsListIsDisplayed(shouldBeDisplayed: Boolean) {
-        if (shouldBeDisplayed) {
-            assertTrue(
-                addonsList().waitForExists(waitingTime),
-            )
-        } else {
-            assertTrue(
-                addonsList().waitUntilGone(waitingTime),
-            )
-        }
-    }
+    fun verifyAddonsListIsDisplayed(shouldBeDisplayed: Boolean) =
+        assertItemWithResIdExists(addonsList(), exists = shouldBeDisplayed)
 
     fun verifyAddonPermissionPrompt(addonName: String) {
         mDevice.waitNotNull(Until.findObject(By.text("Add $addonName?")), waitingTime)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
@@ -17,7 +17,6 @@ import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.endsWith
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
@@ -88,11 +87,7 @@ class SettingsSubMenuAutofillRobot {
             addAddressButton,
         )
         for (savedAddressDetail in savedAddressDetails) {
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector().textContains(savedAddressDetail),
-                ).waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemContainingText(savedAddressDetail))
             Log.i(TAG, "verifyManageAddressesSection: Verified saved address detail: $savedAddressDetail exists")
         }
     }
@@ -289,7 +284,7 @@ class SettingsSubMenuAutofillRobot {
         Log.i(TAG, "clickCountryOption: Clicked \"Country or region\" $country dropdown option")
     }
     fun verifyAddAddressButton() {
-        assertTrue(addAddressButton.waitForExists(waitingTime))
+        assertItemContainingTextExists(addAddressButton)
         Log.i(TAG, "verifyAddAddressButton: Verified \"Add address\" button exists")
     }
 
@@ -381,7 +376,7 @@ class SettingsSubMenuAutofillRobot {
         expiryYearOption(expiryYear).click()
     }
 
-    fun verifyAddCreditCardsButton() = assertTrue(addCreditCardButton.waitForExists(waitingTime))
+    fun verifyAddCreditCardsButton() = assertItemContainingTextExists(addCreditCardButton)
 
     fun fillAndSaveCreditCard(cardNumber: String, cardName: String, expiryMonth: String, expiryYear: String) {
         creditCardNumberTextInput.waitForExists(waitingTime)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
@@ -17,6 +17,7 @@ import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.TestHelper.mDevice
@@ -191,7 +192,7 @@ private fun assertOpenTabsDescription(tabNumber: String) =
     openTabsDescription(tabNumber).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertBrowsingHistoryDescription(addresses: String) =
-    assertTrue(browsingHistoryDescription(addresses).waitForExists(waitingTime))
+    assertItemContainingTextExists(browsingHistoryDescription(addresses))
 
 private fun assertDeleteBrowsingDataSnackbar() {
     assertTrue(

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot.kt
@@ -14,15 +14,13 @@ import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiSelector
-import junit.framework.TestCase.assertTrue
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
-import org.hamcrest.CoreMatchers.not
-import org.hamcrest.Matchers.contains
-import org.junit.Assert.assertFalse
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
@@ -35,10 +33,8 @@ class SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot {
     fun verifyNavigationToolBarHeader() = assertNavigationToolBarHeader()
 
     fun verifyTPExceptionsDefaultView() {
-        assertTrue(
-            mDevice.findObject(
-                UiSelector().text("Exceptions let you disable tracking protection for selected sites."),
-            ).waitForExists(waitingTime),
+        assertItemContainingTextExists(
+            itemWithText("Exceptions let you disable tracking protection for selected sites."),
         )
         learnMoreLink.check(matches(isDisplayed()))
     }
@@ -52,17 +48,7 @@ class SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot {
 
     fun verifySiteExceptionExists(siteUrl: String, shouldExist: Boolean) {
         exceptionsList.waitForExists(waitingTime)
-        if (shouldExist) {
-            assertTrue(
-                mDevice.findObject(UiSelector().textContains(siteUrl))
-                    .waitForExists(waitingTime),
-            )
-        } else {
-            assertFalse(
-                mDevice.findObject(UiSelector().textContains(siteUrl))
-                    .waitForExists(waitingTimeShort),
-            )
-        }
+        assertItemContainingTextExists(itemContainingText(siteUrl), exists = shouldExist)
     }
 
     class Transition {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuExperimentsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuExperimentsRobot.kt
@@ -7,12 +7,10 @@ package org.mozilla.fenix.ui.robots
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.uiautomator.UiSelector
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
 
@@ -50,17 +48,13 @@ class SettingsSubMenuExperimentsRobot {
 
     fun verifyExperimentEnrolled(title: String) {
         itemContainingText(title).click()
-        assertTrue(
-            checkIcon().waitForExists(waitingTimeShort),
-        )
+        assertItemWithResIdExists(checkIcon())
         goBackButton().click()
     }
 
     fun verifyExperimentNotEnrolled(title: String) {
         itemContainingText(title).click()
-        assertFalse(
-            checkIcon().waitForExists(waitingTimeShort),
-        )
+        assertItemWithResIdExists(checkIcon(), exists = false)
         goBackButton().click()
     }
 
@@ -68,13 +62,9 @@ class SettingsSubMenuExperimentsRobot {
         val branch = itemWithResId("$packageName:id/nimbus_branch_name")
 
         itemContainingText(title).click()
-        assertTrue(
-            checkIcon().waitForExists(waitingTimeShort),
-        )
+        assertItemWithResIdExists(checkIcon())
         branch.click()
-        assertFalse(
-            checkIcon().waitForExists(waitingTimeShort),
-        )
+        assertItemWithResIdExists(checkIcon(), exists = false)
     }
 }
 private fun goBackButton() = onView(withContentDescription(R.string.action_bar_up_description))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -20,8 +20,9 @@ import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.Matchers
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.mDevice
@@ -98,11 +99,8 @@ class SettingsSubMenuHomepageRobot {
         mDevice.findObject(UiSelector().description(wallpaperName)).click()
 
     fun verifySnackBarText(expectedText: String) =
-        assertTrue(
-            mDevice.findObject(
-                UiSelector()
-                    .textContains(expectedText),
-            ).waitForExists(waitingTimeShort),
+        assertItemContainingTextExists(
+            itemContainingText(expectedText),
         )
 
     fun verifySponsoredShortcutsCheckBox(checked: Boolean) = assertSponsoredShortcutsCheckBox(checked)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLanguageRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLanguageRobot.kt
@@ -13,6 +13,8 @@ import androidx.test.uiautomator.UiSelector
 import junit.framework.TestCase.assertTrue
 import org.hamcrest.CoreMatchers
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
@@ -31,8 +33,7 @@ class SettingsSubMenuLanguageRobot {
         language(languageName).click()
     }
 
-    fun verifyLanguageHeaderIsTranslated(translation: String) =
-        assertTrue(mDevice.findObject(UiSelector().text(translation)).waitForExists(waitingTime))
+    fun verifyLanguageHeaderIsTranslated(translation: String) = assertItemContainingTextExists(itemWithText(translation))
 
     fun verifySelectedLanguage(language: String) {
         languagesList.waitForExists(waitingTime)
@@ -53,9 +54,8 @@ class SettingsSubMenuLanguageRobot {
         searchBar.text = text
     }
 
-    fun verifySearchResultsContains(languageName: String) {
-        assertTrue(language(languageName).waitForExists(waitingTime))
-    }
+    fun verifySearchResultsContains(languageName: String) =
+        assertItemContainingTextExists(language(languageName))
 
     fun clearSearchBar() {
         onView(withId(R.id.search_close_btn)).click()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuPrivateBrowsingRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuPrivateBrowsingRobot.kt
@@ -19,9 +19,10 @@ import androidx.test.uiautomator.By.text
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertCheckedItemWithResIdExists
+import org.mozilla.fenix.helpers.MatcherHelper.checkedItemWithResId
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.TestHelper.mDevice
@@ -137,7 +138,10 @@ private fun assertOpenLinksInPrivateTabEnabled() =
     openLinksInPrivateTabSwitch().check(matches(isEnabled(true)))
 
 private fun assertOpenLinksInPrivateTabOff() {
-    assertFalse(mDevice.findObject(UiSelector().resourceId("android:id/switch_widget")).isChecked())
+    assertCheckedItemWithResIdExists(
+        checkedItemWithResId("android:id/switch_widget", isChecked = true),
+        exists = false,
+    )
     openLinksInPrivateTabSwitch()
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
@@ -45,8 +45,11 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.DataGenerationHelper.getAvailableSearchEngines
 import org.mozilla.fenix.helpers.DataGenerationHelper.getRegionSearchEnginesList
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.hasCousin
 import org.mozilla.fenix.helpers.TestHelper.mDevice
@@ -91,9 +94,8 @@ class SettingsSubMenuSearchRobot {
             .check(matches(hasSibling(withText("Edit engines visible in the search menu"))))
     }
 
-    fun verifyEnginesShortcutsListHeader() {
-        assertTrue(itemWithText("Engines visible on the search menu").exists())
-    }
+    fun verifyEnginesShortcutsListHeader() =
+        assertItemContainingTextExists(itemWithText("Engines visible on the search menu"))
 
     fun verifyAddressBarSectionHeader() {
         onView(withText("Address bar - Firefox Suggest")).check(matches(isDisplayed()))
@@ -109,7 +111,7 @@ class SettingsSubMenuSearchRobot {
         defaultSearchEngineOption("DuckDuckGo")
             .check(matches(hasSibling(withId(R.id.engine_icon))))
             .check(matches(isDisplayed()))
-        assertTrue(addSearchEngineButton.exists())
+        assertItemContainingTextExists(addSearchEngineButton)
     }
 
     fun verifyManageShortcutsList(testRule: ComposeTestRule) {
@@ -121,7 +123,7 @@ class SettingsSubMenuSearchRobot {
                 .assertIsDisplayed()
         }
 
-        assertTrue(addSearchEngineButton.exists())
+        assertItemContainingTextExists(addSearchEngineButton)
     }
 
     /**
@@ -239,13 +241,8 @@ class SettingsSubMenuSearchRobot {
 
     fun openAddSearchEngineMenu() = addSearchEngineButton.click()
 
-    fun verifyEngineListContains(searchEngineName: String, shouldExist: Boolean) {
-        if (shouldExist) {
-            assertTrue(itemWithText(searchEngineName).waitForExists(waitingTimeShort))
-        } else {
-            assertFalse(itemWithText(searchEngineName).waitForExists(waitingTimeShort))
-        }
-    }
+    fun verifyEngineListContains(searchEngineName: String, shouldExist: Boolean) =
+        assertItemContainingTextExists(itemWithText(searchEngineName), exists = shouldExist)
 
     fun verifyDefaultSearchEngineSelected(searchEngineName: String) {
         defaultSearchEngineOption(searchEngineName).check(matches(isChecked(true)))
@@ -264,44 +261,27 @@ class SettingsSubMenuSearchRobot {
         try {
             mDevice.findObject(By.res("$packageName:id/edit_engine_name")).clear()
             mDevice.findObject(By.res("$packageName:id/edit_engine_name")).text = engineName
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector()
-                        .resourceId("$packageName:id/edit_engine_name")
-                        .text(engineName),
-                ).waitForExists(waitingTime),
+            assertItemWithResIdAndTextExists(
+                itemWithResIdAndText("$packageName:id/edit_engine_name", engineName),
             )
 
             mDevice.findObject(By.res("$packageName:id/edit_search_string")).clear()
             mDevice.findObject(By.res("$packageName:id/edit_search_string")).text = engineURL
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector()
-                        .resourceId("$packageName:id/edit_search_string")
-                        .text(engineURL),
-                ).waitForExists(waitingTime),
+            assertItemWithResIdAndTextExists(
+                itemWithResIdAndText("$packageName:id/edit_search_string", engineURL),
             )
         } catch (e: AssertionError) {
             println("The name or the search string were not set properly")
 
             mDevice.findObject(By.res("$packageName:id/edit_engine_name")).clear()
             mDevice.findObject(By.res("$packageName:id/edit_engine_name")).setText(engineName)
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector()
-                        .resourceId("$packageName:id/edit_engine_name")
-                        .text(engineName),
-                ).waitForExists(waitingTime),
+            assertItemWithResIdAndTextExists(
+                itemWithResIdAndText("$packageName:id/edit_engine_name", engineName),
             )
-
             mDevice.findObject(By.res("$packageName:id/edit_search_string")).clear()
             mDevice.findObject(By.res("$packageName:id/edit_search_string")).setText(engineURL)
-            assertTrue(
-                mDevice.findObject(
-                    UiSelector()
-                        .resourceId("$packageName:id/edit_search_string")
-                        .text(engineURL),
-                ).waitForExists(waitingTime),
+            assertItemWithResIdAndTextExists(
+                itemWithResIdAndText("$packageName:id/edit_search_string", engineURL),
             )
         }
     }
@@ -344,11 +324,7 @@ class SettingsSubMenuSearchRobot {
 
     fun saveEditSearchEngine() {
         onView(withId(R.id.save_button)).click()
-        assertTrue(
-            mDevice.findObject(
-                UiSelector().textContains("Saved"),
-            ).waitForExists(waitingTime),
-        )
+        assertItemContainingTextExists(itemContainingText("Saved"))
     }
 
     fun verifyInvalidTemplateSearchStringFormatError() {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsCommonRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsCommonRobot.kt
@@ -14,7 +14,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
@@ -240,20 +239,12 @@ private fun assertCheckAutoPayRadioButtonDefault() {
 
 private fun assertBlockedByAndroid() {
     blockedByAndroidContainer().waitForExists(waitingTime)
-    assertTrue(
-        mDevice.findObject(
-            UiSelector().textContains(getStringResource(R.string.phone_feature_blocked_by_android)),
-        ).waitForExists(waitingTimeShort),
-    )
+    assertItemContainingTextExists(itemContainingText(getStringResource(R.string.phone_feature_blocked_by_android)))
 }
 
 private fun assertUnblockedByAndroid() {
     blockedByAndroidContainer().waitUntilGone(waitingTime)
-    assertFalse(
-        mDevice.findObject(
-            UiSelector().textContains(getStringResource(R.string.phone_feature_blocked_by_android)),
-        ).waitForExists(waitingTimeShort),
-    )
+    assertItemContainingTextExists(itemContainingText(getStringResource(R.string.phone_feature_blocked_by_android)), exists = false)
 }
 
 private fun blockedByAndroidContainer() = mDevice.findObject(UiSelector().resourceId("$packageName:id/permissions_blocked_container"))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SitePermissionsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SitePermissionsRobot.kt
@@ -10,9 +10,10 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.uiautomator.UiSelector
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
@@ -21,10 +22,7 @@ import org.mozilla.fenix.helpers.click
 class SitePermissionsRobot {
     fun verifyMicrophonePermissionPrompt(url: String) {
         try {
-            assertTrue(
-                mDevice.findObject(UiSelector().text("Allow $url to use your microphone?"))
-                    .waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemWithText("Allow $url to use your microphone?"))
             assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
             assertTrue(allowPagePermissionButton.text.equals("Allow"))
         } catch (e: AssertionError) {
@@ -32,10 +30,7 @@ class SitePermissionsRobot {
             }.openThreeDotMenu {
             }.refreshPage {
             }.clickStartMicrophoneButton {
-                assertTrue(
-                    mDevice.findObject(UiSelector().text("Allow $url to use your microphone?"))
-                        .waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemWithText("Allow $url to use your microphone?"))
                 assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
                 assertTrue(allowPagePermissionButton.text.equals("Allow"))
             }
@@ -44,10 +39,7 @@ class SitePermissionsRobot {
 
     fun verifyCameraPermissionPrompt(url: String) {
         try {
-            assertTrue(
-                mDevice.findObject(UiSelector().text("Allow $url to use your camera?"))
-                    .waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemWithText("Allow $url to use your camera?"))
             assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
             assertTrue(allowPagePermissionButton.text.equals("Allow"))
         } catch (e: AssertionError) {
@@ -55,10 +47,7 @@ class SitePermissionsRobot {
             }.openThreeDotMenu {
             }.refreshPage {
             }.clickStartCameraButton {
-                assertTrue(
-                    mDevice.findObject(UiSelector().text("Allow $url to use your camera?"))
-                        .waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemWithText("Allow $url to use your camera?"))
                 assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
                 assertTrue(allowPagePermissionButton.text.equals("Allow"))
             }
@@ -66,20 +55,14 @@ class SitePermissionsRobot {
     }
 
     fun verifyAudioVideoPermissionPrompt(url: String) {
-        assertTrue(
-            mDevice.findObject(UiSelector().text("Allow $url to use your camera and microphone?"))
-                .waitForExists(waitingTime),
-        )
+        assertItemContainingTextExists(itemWithText("Allow $url to use your camera and microphone?"))
         assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
         assertTrue(allowPagePermissionButton.text.equals("Allow"))
     }
 
     fun verifyLocationPermissionPrompt(url: String) {
         try {
-            assertTrue(
-                mDevice.findObject(UiSelector().text("Allow $url to use your location?"))
-                    .waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemWithText("Allow $url to use your location?"))
             assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
             assertTrue(allowPagePermissionButton.text.equals("Allow"))
         } catch (e: AssertionError) {
@@ -87,10 +70,7 @@ class SitePermissionsRobot {
             }.openThreeDotMenu {
             }.refreshPage {
             }.clickGetLocationButton {
-                assertTrue(
-                    mDevice.findObject(UiSelector().text("Allow $url to use your location?"))
-                        .waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemWithText("Allow $url to use your location?"))
                 assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
                 assertTrue(allowPagePermissionButton.text.equals("Allow"))
             }
@@ -100,10 +80,7 @@ class SitePermissionsRobot {
     fun verifyNotificationsPermissionPrompt(url: String, blocked: Boolean = false) {
         if (!blocked) {
             try {
-                assertTrue(
-                    mDevice.findObject(UiSelector().text("Allow $url to send notifications?"))
-                        .waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemWithText("Allow $url to send notifications?"))
                 assertTrue(denyPagePermissionButton.text.equals("Never"))
                 assertTrue(allowPagePermissionButton.text.equals("Always"))
             } catch (e: AssertionError) {
@@ -111,10 +88,7 @@ class SitePermissionsRobot {
                 }.openThreeDotMenu {
                 }.refreshPage {
                 }.clickOpenNotificationButton {
-                    assertTrue(
-                        mDevice.findObject(UiSelector().text("Allow $url to send notifications?"))
-                            .waitForExists(waitingTime),
-                    )
+                    assertItemContainingTextExists(itemWithText("Allow $url to send notifications?"))
                     assertTrue(denyPagePermissionButton.text.equals("Never"))
                     assertTrue(allowPagePermissionButton.text.equals("Always"))
                 }
@@ -122,19 +96,13 @@ class SitePermissionsRobot {
         } else {
             /* if "Never" was selected in a previous step, or if the app is not allowed,
                the Notifications permission prompt won't be displayed anymore */
-            assertFalse(
-                mDevice.findObject(UiSelector().text("Allow $url to send notifications?"))
-                    .exists(),
-            )
+            assertItemContainingTextExists(itemWithText("Allow $url to send notifications?"), exists = false)
         }
     }
 
     fun verifyPersistentStoragePermissionPrompt(url: String) {
         try {
-            assertTrue(
-                mDevice.findObject(UiSelector().text("Allow $url to store data in persistent storage?"))
-                    .waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemWithText("Allow $url to store data in persistent storage?"))
             assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
             assertTrue(allowPagePermissionButton.text.equals("Allow"))
         } catch (e: AssertionError) {
@@ -142,10 +110,7 @@ class SitePermissionsRobot {
             }.openThreeDotMenu {
             }.refreshPage {
             }.clickRequestPersistentStorageAccessButton {
-                assertTrue(
-                    mDevice.findObject(UiSelector().text("Allow $url to store data in persistent storage?"))
-                        .waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemWithText("Allow $url to store data in persistent storage?"))
                 assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
                 assertTrue(allowPagePermissionButton.text.equals("Allow"))
             }
@@ -154,10 +119,7 @@ class SitePermissionsRobot {
 
     fun verifyDRMContentPermissionPrompt(url: String) {
         try {
-            assertTrue(
-                mDevice.findObject(UiSelector().text("Allow $url to play DRM-controlled content?"))
-                    .waitForExists(waitingTime),
-            )
+            assertItemContainingTextExists(itemWithText("Allow $url to store data in persistent storage?"))
             assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
             assertTrue(allowPagePermissionButton.text.equals("Allow"))
         } catch (e: AssertionError) {
@@ -165,10 +127,7 @@ class SitePermissionsRobot {
             }.openThreeDotMenu {
             }.refreshPage {
             }.clickRequestDRMControlledContentAccessButton {
-                assertTrue(
-                    mDevice.findObject(UiSelector().text("Allow $url to play DRM-controlled content?"))
-                        .waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemWithText("Allow $url to store data in persistent storage?"))
                 assertTrue(denyPagePermissionButton.text.equals("Don’t allow"))
                 assertTrue(allowPagePermissionButton.text.equals("Allow"))
             }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SiteSecurityRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SiteSecurityRobot.kt
@@ -13,9 +13,10 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.uiautomator.UiSelector
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
+import org.mozilla.fenix.helpers.MatcherHelper.assertCheckedItemWithResIdAndTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.mDevice
@@ -41,23 +42,31 @@ class SiteSecurityRobot {
 
 private fun assertQuickActionSheet(url: String = "", isConnectionSecure: Boolean) {
     quickActionSheet().waitForExists(waitingTime)
-    assertTrue(quickActionSheetUrl(url.tryGetHostFromUrl()).waitForExists(waitingTime))
-    assertTrue(quickActionSheetSecurityInfo(isConnectionSecure).waitForExists(waitingTime))
-    assertTrue(quickActionSheetTrackingProtectionSwitch().waitForExists(waitingTime))
-    assertTrue(quickActionSheetClearSiteData().waitForExists(waitingTime))
+    assertCheckedItemWithResIdAndTextExists(
+        quickActionSheetUrl(url.tryGetHostFromUrl()),
+        quickActionSheetSecurityInfo(isConnectionSecure),
+    )
+    assertItemWithResIdExists(
+        quickActionSheetTrackingProtectionSwitch(),
+        quickActionSheetClearSiteData(),
+    )
 }
 
 private fun assertSecureConnectionSubMenu(pageTitle: String = "", url: String = "", isConnectionSecure: Boolean) {
     secureConnectionSubMenu().waitForExists(waitingTime)
-    assertTrue(secureConnectionSubMenuPageTitle(pageTitle).waitForExists(waitingTime))
-    assertTrue(secureConnectionSubMenuPageUrl(url).waitForExists(waitingTime))
-    assertTrue(secureConnectionSubMenuLockIcon().waitForExists(waitingTime))
-    assertTrue(secureConnectionSubMenuSecurityInfo(isConnectionSecure).waitForExists(waitingTime))
-    assertTrue(secureConnectionSubMenuCertificateInfo().waitForExists(waitingTime))
+    assertCheckedItemWithResIdAndTextExists(
+        secureConnectionSubMenuPageTitle(pageTitle),
+        secureConnectionSubMenuPageUrl(url),
+        secureConnectionSubMenuSecurityInfo(isConnectionSecure),
+    )
+    assertItemWithResIdExists(
+        secureConnectionSubMenuLockIcon(),
+        secureConnectionSubMenuCertificateInfo(),
+    )
 }
 
 private fun assertClearSiteDataPrompt(url: String) {
-    assertTrue(clearSiteDataPrompt(url).waitForExists(waitingTime))
+    assertCheckedItemWithResIdAndTextExists(clearSiteDataPrompt(url))
     cancelClearSiteDataButton.check(matches(isDisplayed()))
     deleteSiteDataButton.check(matches(isDisplayed()))
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
@@ -12,8 +12,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
-import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
@@ -27,12 +28,9 @@ class SyncSignInRobot {
     fun verifyAccountSettingsMenuHeader() = assertAccountSettingsMenuHeader()
     fun verifyTurnOnSyncMenu() {
         mDevice.findObject(UiSelector().resourceId("$packageName:id/container")).waitForExists(waitingTime)
-        assertTrue(
-            mDevice.findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/signInScanButton")
-                    .resourceId("$packageName:id/signInEmailButton"),
-            ).waitForExists(waitingTime),
+        assertItemWithResIdExists(
+            itemWithResId("$packageName:id/signInScanButton"),
+            itemWithResId("$packageName:id/signInEmailButton"),
         )
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SystemSettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SystemSettingsRobot.kt
@@ -9,6 +9,8 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndDescription
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper
@@ -63,10 +65,7 @@ fun systemSettings(interact: SystemSettingsRobot.() -> Unit): SystemSettingsRobo
 private fun assertSystemNotificationsView() {
     mDevice.findObject(UiSelector().resourceId("com.android.settings:id/list"))
         .waitForExists(waitingTime)
-    assertTrue(
-        mDevice.findObject(UiSelector().textContains("All ${TestHelper.appName} notifications"))
-            .waitForExists(waitingTime),
-    )
+    assertItemContainingTextExists(itemContainingText("All ${TestHelper.appName} notifications"))
 }
 
 private val allSystemSettingsNotificationsToggle =

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -31,7 +31,6 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import androidx.test.uiautomator.Until.findObject
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.anyOf
@@ -42,6 +41,7 @@ import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
@@ -210,14 +210,8 @@ class TabDrawerRobot {
         }
     }
 
-    fun verifySnackBarText(expectedText: String) {
-        assertTrue(
-            "SnackBar message: $expectedText - not found",
-            mDevice.findObject(
-                UiSelector().textContains(expectedText),
-            ).waitForExists(waitingTime),
-        )
-    }
+    fun verifySnackBarText(expectedText: String) =
+        assertItemContainingTextExists(itemContainingText(expectedText))
 
     fun snackBarButtonClick(expectedText: String) {
         val snackBarButton =
@@ -231,8 +225,7 @@ class TabDrawerRobot {
         snackBarButton.click()
     }
 
-    fun verifyTabMediaControlButtonState(action: String) =
-        assertTrue(tabMediaControlButton(action).waitForExists(waitingTime))
+    fun verifyTabMediaControlButtonState(action: String) = assertItemWithDescriptionExists(tabMediaControlButton(action))
 
     fun clickTabMediaControlButton(action: String) {
         tabMediaControlButton(action).also {
@@ -530,9 +523,7 @@ private fun assertExistingOpenTabs(vararg tabTitles: String) {
 
 private fun assertNoExistingOpenTabs(vararg tabTitles: String) {
     for (title in tabTitles) {
-        assertFalse(
-            tabItem(title).waitForExists(waitingTimeShort),
-        )
+        assertItemContainingTextExists(tabItem(title), exists = false)
     }
 }
 
@@ -540,12 +531,7 @@ private fun assertExistingTabList() {
     mDevice.findObject(
         UiSelector().resourceId("$packageName:id/tabsTray"),
     ).waitForExists(waitingTime)
-
-    assertTrue(
-        mDevice.findObject(
-            UiSelector().resourceId("$packageName:id/tray_list_item"),
-        ).waitForExists(waitingTime),
-    )
+    assertItemWithResIdExists(itemWithResId("$packageName:id/tray_list_item"))
 }
 
 private fun assertNoOpenTabsInNormalBrowsing() =

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -26,7 +26,6 @@ import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.allOf
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
@@ -37,6 +36,7 @@ import org.mozilla.fenix.helpers.MatcherHelper.assertCheckedItemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithDescriptionExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdAndTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.checkedItemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithDescription
@@ -159,10 +159,7 @@ class ThreeDotMenuMainRobot {
     fun verifyAddonAvailableInMainMenu(addonName: String) {
         for (i in 1..RETRY_COUNT) {
             try {
-                assertTrue(
-                    "Addon not listed in the Add-ons sub-menu",
-                    mDevice.findObject(UiSelector().textContains(addonName)).waitForExists(waitingTime),
-                )
+                assertItemContainingTextExists(itemContainingText(addonName))
                 break
             } catch (e: AssertionError) {
                 if (i == RETRY_COUNT) {
@@ -179,7 +176,7 @@ class ThreeDotMenuMainRobot {
     }
 
     fun verifyTrackersBlockedByUblock() {
-        assertTrue(itemWithResId("$packageName:id/badge_text").waitForExists(waitingTime))
+        assertItemWithResIdExists(itemWithResId("$packageName:id/badge_text"))
         assertTrue(itemWithResId("$packageName:id/badge_text").text.toInt() > 0)
     }
 
@@ -231,7 +228,7 @@ class ThreeDotMenuMainRobot {
             mDevice.waitNotNull(Until.findObject(By.text("Bookmarks")), waitingTime)
 
             bookmarksButton.click()
-            assertTrue(mDevice.findObject(UiSelector().resourceId("$packageName:id/bookmark_list")).waitForExists(waitingTime))
+            assertItemWithResIdExists(itemWithResId("$packageName:id/bookmark_list"))
 
             BookmarksRobot().interact()
             return BookmarksRobot.Transition()
@@ -532,13 +529,13 @@ private fun assertReaderViewAppearanceButton(visible: Boolean) {
             threeDotMenuRecyclerView().perform(swipeUp())
             maxSwipes--
         }
-        assertTrue(readerViewAppearanceToggle().exists())
+        assertItemContainingTextExists(readerViewAppearanceToggle())
     } else {
         while (!readerViewAppearanceToggle().exists() && maxSwipes != 0) {
             threeDotMenuRecyclerView().perform(swipeUp())
             maxSwipes--
         }
-        assertFalse(readerViewAppearanceToggle().exists())
+        assertItemContainingTextExists(readerViewAppearanceToggle(), exists = false)
     }
 }
 


### PR DESCRIPTION
All UI tests successfully ran 5x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1864399