### PR TITLE
Bug 1859585 - WebExtensionSupport should update installExtensions entries on AddonManagerDelegate.onReady calls

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -382,6 +382,10 @@ class GeckoEngine(
                 webExtensionDelegate.onEnabled(GeckoWebExtension(extension, runtime))
             }
 
+            override fun onReady(extension: org.mozilla.geckoview.WebExtension) {
+                webExtensionDelegate.onReady(GeckoWebExtension(extension, runtime))
+            }
+
             override fun onUninstalled(extension: org.mozilla.geckoview.WebExtension) {
                 webExtensionDelegate.onUninstalled(GeckoWebExtension(extension, runtime))
             }

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionDelegate.kt
@@ -42,6 +42,13 @@ interface WebExtensionDelegate {
     fun onDisabled(extension: WebExtension) = Unit
 
     /**
+     * Invoked when a web extension was started successfully.
+     *
+     * @param extension The extension that has completed its startup.
+     */
+    fun onReady(extension: WebExtension) = Unit
+
+    /**
      * Invoked when a web extension in private browsing allowed is set.
      *
      * @param extension the modified [WebExtension] instance.

--- a/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
+++ b/android-components/components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt
@@ -275,6 +275,10 @@ object WebExtensionSupport {
                     store.dispatch(WebExtensionAction.UpdateWebExtensionEnabledAction(extension.id, false))
                 }
 
+                override fun onReady(extension: WebExtension) {
+                    installedExtensions[extension.id] = extension
+                }
+
                 override fun onAllowedInPrivateBrowsingChanged(extension: WebExtension) {
                     installedExtensions[extension.id] = extension
                     store.dispatch(


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1859585