### PR TITLE
Bug 1863754 - Disable sponsored and non-sponsored suggestions when Firefox Suggest is disabled.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -185,9 +185,9 @@ fun createInitialSearchFragmentState(
         showSessionSuggestionsForCurrentEngine = false,
         showAllSessionSuggestions = true,
         showSponsoredSuggestions = activity.browsingModeManager.mode == BrowsingMode.Normal &&
-            settings.showSponsoredSuggestions,
+            settings.enableFxSuggest && settings.showSponsoredSuggestions,
         showNonSponsoredSuggestions = activity.browsingModeManager.mode == BrowsingMode.Normal &&
-            settings.showNonSponsoredSuggestions,
+            settings.enableFxSuggest && settings.showNonSponsoredSuggestions,
         tabId = tabId,
         pastedText = pastedText,
         searchAccessPoint = searchAccessPoint,
@@ -281,9 +281,9 @@ private fun searchStateReducer(state: SearchFragmentState, action: SearchFragmen
                 showAllSyncedTabsSuggestions = action.settings.shouldShowSyncedTabsSuggestions,
                 showSessionSuggestionsForCurrentEngine = false, // we'll show all local tabs
                 showSponsoredSuggestions = action.browsingMode == BrowsingMode.Normal &&
-                    action.settings.showSponsoredSuggestions,
+                    action.settings.enableFxSuggest && action.settings.showSponsoredSuggestions,
                 showNonSponsoredSuggestions = action.browsingMode == BrowsingMode.Normal &&
-                    action.settings.showNonSponsoredSuggestions,
+                    action.settings.enableFxSuggest && action.settings.showNonSponsoredSuggestions,
                 showAllSessionSuggestions = true,
             )
         is SearchFragmentAction.SearchShortcutEngineSelected ->

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
@@ -64,6 +64,7 @@ class SearchFragmentStoreTest {
         every { settings.shouldShowHistorySuggestions } returns true
         every { settings.shouldShowSearchSuggestions } returns true
         every { settings.shouldShowSearchSuggestionsInPrivate } returns false
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -130,6 +131,7 @@ class SearchFragmentStoreTest {
         every { settings.shouldShowHistorySuggestions } returns true
         every { settings.shouldShowSearchSuggestions } returns true
         every { settings.shouldShowSearchSuggestionsInPrivate } returns false
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -224,6 +226,25 @@ class SearchFragmentStoreTest {
                 searchAccessPoint = MetricsUtils.Source.SHORTCUT,
             ),
         )
+    }
+
+    @Test
+    fun `GIVEN sponsored and non-sponsored suggestions are enabled and Firefox Suggest is disabled WHEN the initial state is created THEN neither are displayed`() {
+        activity.browsingModeManager.mode = BrowsingMode.Normal
+        every { components.core.store.state } returns BrowserState()
+        every { settings.enableFxSuggest } returns false
+        every { settings.showSponsoredSuggestions } returns true
+        every { settings.showNonSponsoredSuggestions } returns true
+
+        val initialState = createInitialSearchFragmentState(
+            activity,
+            components,
+            tabId = null,
+            pastedText = "pastedText",
+            searchAccessPoint = MetricsUtils.Source.ACTION,
+        )
+        assertFalse(initialState.showSponsoredSuggestions)
+        assertFalse(initialState.showNonSponsoredSuggestions)
     }
 
     @Test
@@ -415,6 +436,7 @@ class SearchFragmentStoreTest {
     fun `GIVEN sponsored suggestions are enabled WHEN the default search engine is selected THEN sponsored suggestions are displayed`() = runTest {
         val initialState = emptyDefaultState(showSponsoredSuggestions = false, showNonSponsoredSuggestions = false)
         val store = SearchFragmentStore(initialState)
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns false
 
@@ -435,6 +457,7 @@ class SearchFragmentStoreTest {
     fun `GIVEN non-sponsored suggestions are enabled WHEN the default search engine is selected THEN non-sponsored suggestions are displayed`() = runTest {
         val initialState = emptyDefaultState(showSponsoredSuggestions = false, showNonSponsoredSuggestions = false)
         val store = SearchFragmentStore(initialState)
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns false
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -452,9 +475,10 @@ class SearchFragmentStoreTest {
     }
 
     @Test
-    fun `GIVEN sponsored and non-sponsored suggestions are enabled WHEN the default search engine is selected THEN both are displayed`() = runTest {
+    fun `GIVEN sponsored and non-sponsored suggestions are enabled and Firefox Suggest is enabled WHEN the default search engine is selected THEN both are displayed`() = runTest {
         val initialState = emptyDefaultState(showSponsoredSuggestions = false, showNonSponsoredSuggestions = false)
         val store = SearchFragmentStore(initialState)
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -472,9 +496,31 @@ class SearchFragmentStoreTest {
     }
 
     @Test
+    fun `GIVEN sponsored and non-sponsored suggestions are enabled and Firefox Suggest is disabled WHEN the default search engine is selected THEN neither are displayed`() = runTest {
+        val initialState = emptyDefaultState(showSponsoredSuggestions = true, showNonSponsoredSuggestions = true)
+        val store = SearchFragmentStore(initialState)
+        every { settings.enableFxSuggest } returns false
+        every { settings.showSponsoredSuggestions } returns true
+        every { settings.showNonSponsoredSuggestions } returns true
+
+        store.dispatch(
+            SearchFragmentAction.SearchDefaultEngineSelected(
+                engine = searchEngine,
+                browsingMode = BrowsingMode.Normal,
+                settings = settings,
+            ),
+        ).join()
+
+        assertNotSame(initialState, store.state)
+        assertFalse(store.state.showSponsoredSuggestions)
+        assertFalse(store.state.showNonSponsoredSuggestions)
+    }
+
+    @Test
     fun `GIVEN sponsored and non-sponsored suggestions are disabled WHEN the default search engine is selected THEN neither are displayed`() = runTest {
         val initialState = emptyDefaultState(showSponsoredSuggestions = true, showNonSponsoredSuggestions = true)
         val store = SearchFragmentStore(initialState)
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns false
         every { settings.showNonSponsoredSuggestions } returns false
 
@@ -496,6 +542,7 @@ class SearchFragmentStoreTest {
         val initialState =
             emptyDefaultState(showSponsoredSuggestions = true, showNonSponsoredSuggestions = true)
         val store = SearchFragmentStore(initialState)
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -517,6 +564,7 @@ class SearchFragmentStoreTest {
         val initialState =
             emptyDefaultState(showSponsoredSuggestions = true, showNonSponsoredSuggestions = true)
         val store = SearchFragmentStore(initialState)
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -532,6 +580,7 @@ class SearchFragmentStoreTest {
         val initialState =
             emptyDefaultState(showSponsoredSuggestions = true, showNonSponsoredSuggestions = true)
         val store = SearchFragmentStore(initialState)
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -547,6 +596,7 @@ class SearchFragmentStoreTest {
         val initialState =
             emptyDefaultState(showSponsoredSuggestions = true, showNonSponsoredSuggestions = true)
         val store = SearchFragmentStore(initialState)
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -569,6 +619,7 @@ class SearchFragmentStoreTest {
         every { settings.shouldShowSyncedTabsSuggestions } returns false
         every { settings.shouldShowSearchSuggestions } returns true
         every { settings.shouldShowSearchSuggestionsInPrivate } returns true
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -611,6 +662,7 @@ class SearchFragmentStoreTest {
         every { settings.shouldShowSyncedTabsSuggestions } returns false
         every { settings.shouldShowSearchSuggestions } returns true
         every { settings.shouldShowSearchSuggestionsInPrivate } returns true
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -652,6 +704,7 @@ class SearchFragmentStoreTest {
         every { settings.shouldShowBookmarkSuggestions } returns true
         every { settings.shouldShowSyncedTabsSuggestions } returns true
         every { settings.shouldShowSearchSuggestions } returns true
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -721,6 +774,7 @@ class SearchFragmentStoreTest {
         every { settings.shouldShowHistorySuggestions } returns true
         every { settings.shouldShowBookmarkSuggestions } returns false
         every { settings.shouldShowSyncedTabsSuggestions } returns false
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 
@@ -762,6 +816,7 @@ class SearchFragmentStoreTest {
         every { settings.shouldShowSyncedTabsSuggestions } returns true
         every { settings.shouldShowSearchSuggestions } returns true
         every { settings.shouldShowSearchSuggestionsInPrivate } returns true
+        every { settings.enableFxSuggest } returns true
         every { settings.showSponsoredSuggestions } returns true
         every { settings.showNonSponsoredSuggestions } returns true
 


### PR DESCRIPTION
This commit fixes an issue where it was possible for Firefox to show sponsored and non-sponsored suggestions if the user explicitly disabled and re-enabled the settings, and then unenrolled from the experiment. In that case, the `show{Non}SponsoredSuggestions` settings would still be `true` because they were user-set, even though `enableFxSuggest` was now `false`.

As of this commit, the `show{Non}SponsoredSuggestions` settings are only used if `enableFxSuggest` is `true`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1863754