### PR TITLE
Bug 1859393 - Add CFR when the first cookie banner gets cleared.

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -8530,7 +8530,38 @@ cookie_banners:
     metadata:
       tags:
         - Privacy&Security
-
+  cfr_shown:
+    type: event
+    description: The cookie banner cfr has been shown
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1859393
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1859393#c2
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - Privacy&Security
+  cfr_dismissal:
+    type: event
+    description: |
+      The cookie banners CFR was dismissed by the user by interacting
+      with the outside of the popup
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1859393
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1859393#c2
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - Privacy&Security
 site_permissions:
   prompt_shown:
     type: event

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarCFRPresenter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarCFRPresenter.kt
@@ -8,9 +8,17 @@ import android.content.Context
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -34,8 +42,11 @@ import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.compose.cfr.CFRPopup
 import mozilla.components.compose.cfr.CFRPopup.PopupAlignment.INDICATOR_CENTERED_IN_ANCHOR
 import mozilla.components.compose.cfr.CFRPopupProperties
+import mozilla.components.concept.engine.EngineSession.CookieBannerHandlingStatus
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.service.glean.private.NoExtras
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
+import org.mozilla.fenix.GleanMetrics.CookieBanners
 import org.mozilla.fenix.GleanMetrics.Shopping
 import org.mozilla.fenix.GleanMetrics.TrackingProtection
 import org.mozilla.fenix.R
@@ -106,6 +117,24 @@ class BrowserToolbarCFRPresenter(
                         }.filter { popup == null && it == 100 }.collect {
                             scope?.cancel()
                             showTcpCfr()
+                        }
+                }
+            }
+            ToolbarCFR.COOKIE_BANNERS -> {
+                scope = browserStore.flowScoped { flow ->
+                    flow.mapNotNull { it.findCustomTabOrSelectedTab(sessionId) }
+                        .ifAnyChanged { tab ->
+                            arrayOf(
+                                tab.cookieBanner,
+                            )
+                        }
+                        .filter {
+                            it.content.private && it.cookieBanner == CookieBannerHandlingStatus.HANDLED
+                        }
+                        .collect {
+                            scope?.cancel()
+                            settings.shouldShowCookieBannersCFR = false
+                            showCookieBannersCFR()
                         }
                 }
             }
@@ -189,6 +218,10 @@ class BrowserToolbarCFRPresenter(
         settings.shouldShowTotalCookieProtectionCFR && (
             settings.openTabsCount >= CFR_MINIMUM_NUMBER_OPENED_TABS
             ) -> ToolbarCFR.TCP
+
+        isPrivate && settings.shouldShowCookieBannersCFR && settings.shouldUseCookieBannerPrivateMode -> {
+            ToolbarCFR.COOKIE_BANNERS
+        }
 
         shoppingExperienceFeature.isEnabled &&
             settings.shouldShowReviewQualityCheckCFR -> whichShoppingCFR()
@@ -326,6 +359,64 @@ class BrowserToolbarCFRPresenter(
     }
 
     @VisibleForTesting
+    @Suppress("LongMethod")
+    internal fun showCookieBannersCFR() {
+        CFRPopup(
+            anchor = toolbar.findViewById(
+                R.id.mozac_browser_toolbar_security_indicator,
+            ),
+            properties = CFRPopupProperties(
+                popupAlignment = INDICATOR_CENTERED_IN_ANCHOR,
+                popupBodyColors = listOf(
+                    getColor(context, R.color.fx_mobile_layer_color_gradient_end),
+                    getColor(context, R.color.fx_mobile_layer_color_gradient_start),
+                ),
+                popupVerticalOffset = CFR_TO_ANCHOR_VERTICAL_PADDING.dp,
+                dismissButtonColor = getColor(context, R.color.fx_mobile_icon_color_oncolor),
+                indicatorDirection = if (settings.toolbarPosition == ToolbarPosition.TOP) {
+                    CFRPopup.IndicatorDirection.UP
+                } else {
+                    CFRPopup.IndicatorDirection.DOWN
+                },
+            ),
+            onDismiss = {
+                CookieBanners.cfrDismissal.record(NoExtras())
+            },
+            text = {
+                FirefoxTheme {
+                    Column {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_cookies_disabled),
+                                contentDescription = null,
+                                tint = FirefoxTheme.colors.iconPrimary,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = context.getString(R.string.cookie_banner_cfr_title),
+                                color = FirefoxTheme.colors.textOnColorPrimary,
+                                style = FirefoxTheme.typography.subtitle2,
+                            )
+                        }
+                        Text(
+                            text = context.getString(R.string.cookie_banner_cfr_message),
+                            color = FirefoxTheme.colors.textOnColorPrimary,
+                            style = FirefoxTheme.typography.body2,
+                            modifier = Modifier.padding(top = 2.dp),
+                        )
+                    }
+                }
+            },
+        ).run {
+            popup = this
+            show()
+            CookieBanners.cfrShown.record(NoExtras())
+        }
+    }
+
+    @VisibleForTesting
     internal fun showShoppingCFR(shouldShowOptedInCFR: Boolean) {
         CFRPopup(
             anchor = toolbar.findViewById(
@@ -395,5 +486,5 @@ class BrowserToolbarCFRPresenter(
  * The CFR to be shown in the toolbar.
  */
 private enum class ToolbarCFR {
-    TCP, SHOPPING, SHOPPING_OPTED_IN, ERASE, NONE
+    TCP, SHOPPING, SHOPPING_OPTED_IN, ERASE, COOKIE_BANNERS, NONE
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -778,6 +778,15 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = { feltPrivateBrowsingEnabled },
     )
 
+    /**
+     * Indicates if the cookie banners CRF should be shown.
+     */
+    var shouldShowCookieBannersCFR by lazyFeatureFlagPreference(
+        appContext.getPreferenceKey(R.string.pref_key_should_show_cookie_banners_action_popup),
+        featureFlag = true,
+        default = { shouldShowCookieBannerUI },
+    )
+
     val blockCookiesSelectionInCustomTrackingProtection by stringPreference(
         key = appContext.getPreferenceKey(R.string.pref_key_tracking_protection_custom_cookies_select),
         default = if (enabledTotalCookieProtection) {

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -275,6 +275,8 @@
     <string name="pref_key_should_show_total_cookie_protection_popup" translatable="false">pref_key_should_show_total_cookie_protection_popup</string>
     <!-- A value  of `true` means the erase action popup has not been shown yet -->
     <string name="pref_key_should_show_erase_action_popup" translatable="false">pref_key_should_show_erase_action_popup</string>
+    <!-- A value  of `true` means the cookie banners handling action popup has not been shown yet -->
+    <string name="pref_key_should_show_cookie_banners_action_popup" translatable="false">pref_key_should_show_cookie_banners_action_popup</string>
 
     <string name="pref_key_debug_settings" translatable="false">pref_key_debug_settings</string>
 

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -498,6 +498,10 @@
     <string name="reduce_cookie_banner_dialog_snackbar_text" moz:RemovedIn="121" tools:ignore="UnusedResources">You’ll see fewer cookie requests</string>
     <!-- Change setting text button, for the cookie banner re-engagement dialog -->
     <string name="reduce_cookie_banner_dialog_change_setting_button" moz:RemovedIn="121" tools:ignore="UnusedResources">Allow</string>
+    <!--Title for the cookie banner re-engagement CFR -->
+    <string name="cookie_banner_cfr_title">Firefox just refused cookies for you</string>
+    <!--Message for the cookie banner re-engagement CFR -->
+    <string name="cookie_banner_cfr_message">Less distractions, less cookies tracking you on this site.</string>
 
     <!-- Description of the preference to enable "HTTPS-Only" mode. -->
     <string name="preferences_https_only_summary">Automatically attempts to connect to sites using HTTPS encryption protocol for increased security.</string>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1859393