### PR TITLE
Bug 1857875 - Fix SettingsAddonsTest.noCrashWithAddonInstalledTest scrolling issue in add-ons list

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.ui
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -115,7 +114,6 @@ class SettingsAddonsTest {
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/561600
     // Installs 3 add-on and checks that the app doesn't crash while navigating the app
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1857875 ")
     @SmokeTest
     @Test
     fun noCrashWithAddonInstalledTest() {
@@ -124,7 +122,7 @@ class SettingsAddonsTest {
 
         val uBlockAddon = "uBlock Origin"
         val tampermonkeyAddon = "Tampermonkey"
-        val privacyBadgerAddon = "Privacy Badger"
+        val darkReaderAddon = "Dark Reader"
         val trackingProtectionPage = getEnhancedTrackingProtectionAsset(mockWebServer)
 
         addonsMenu {
@@ -132,7 +130,7 @@ class SettingsAddonsTest {
             closeAddonInstallCompletePrompt()
             installAddon(tampermonkeyAddon, activityTestRule)
             closeAddonInstallCompletePrompt()
-            installAddon(privacyBadgerAddon, activityTestRule)
+            installAddon(darkReaderAddon, activityTestRule)
             closeAddonInstallCompletePrompt()
         }.goBack {
         }.openNavigationToolbar {


### PR DESCRIPTION
Replaced the add-on that required the most scrolling with one that's at the top of the list.
Also improved the scrolling method with the UISelector actions.
Ran the test 200 times on Firebase, with 0 failures.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1857875