### PR TITLE
Bug 1742344 - Unbreak imgur.io on Android in PBM

### DIFF
--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/data/shims.js
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/data/shims.js
@@ -327,10 +327,7 @@ const AVAILABLE_SHIMS = [
     bug: "1773110",
     runFirst: "private-browsing-web-api-fixes.js",
     matches: [
-      "*://*.imgur.com/js/vendor.*.bundle.js",
-      "*://*.imgur.io/js/vendor.*.bundle.js",
-      "*://www.rva311.com/static/js/main.*.chunk.js",
-      "*://web-assets.toggl.com/app/assets/scripts/*.js", // bug 1783919
+      "*://*.imgur.io/js/vendor.*.js", // Mobile: imgur.io (bug 1742344); desktop: imgur.com (unaffected)
     ],
     onlyIfPrivateBrowsing: true,
   },

--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Mozilla Android Components - Web Compatibility Interventions",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "120.1.0",
+  "version": "120.2.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "webcompat@mozilla.org",

--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/shims/private-browsing-web-api-fixes.js
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/shims/private-browsing-web-api-fixes.js
@@ -13,5 +13,7 @@
  * browsing mode for those sites.
  */
 
+// caches.keys() rejects in private browsing mode:
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1742344#c4
+// Can be removed once bug 1714354 is fixed.
 delete window.wrappedJSObject.caches;
-delete window.wrappedJSObject.indexedDB;


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1742344