### PR TITLE
Bug 1864829 - New Firefox suggest related UI smoke tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -809,4 +809,51 @@ class SearchTest {
             }
         }
     }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2348361
+    @SmokeTest
+    @Test
+    fun verifyFirefoxSuggestSponsoredSearchResultsTest() {
+        runWithCondition(appContext.settings().enableFxSuggest) {
+            navigationToolbar {
+            }.clickUrlbar {
+                typeSearch(searchTerm = "Amazon")
+                verifySearchEngineSuggestionResults(
+                    rule = activityTestRule,
+                    searchSuggestions = arrayOf(
+                        "Firefox Suggest",
+                        "Amazon.com - Official Site",
+                        "Sponsored",
+                    ),
+                    searchTerm = "Amazon",
+                )
+            }
+        }
+    }
+
+    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2348374
+    @SmokeTest
+    @Test
+    fun verifyFirefoxSuggestNonSponsoredSearchResultsTest() {
+        runWithCondition(appContext.settings().enableFxSuggest) {
+            navigationToolbar {
+            }.clickUrlbar {
+                typeSearch(searchTerm = "Marvel")
+                verifySearchEngineSuggestionResults(
+                    rule = activityTestRule,
+                    searchSuggestions = arrayOf(
+                        "Firefox Suggest",
+                        "Wikipedia - Marvel Cinematic Universe",
+                    ),
+                    searchTerm = "Marvel",
+                )
+                verifySuggestionsAreNotDisplayed(
+                    rule = activityTestRule,
+                    searchSuggestions = arrayOf(
+                        "Sponsored",
+                    ),
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
New Firefox suggest related UI smoke tests.
Both UI tests successfully passed 100x on Firebase ✅ 

[List with all keywords](https://drive.google.com/file/d/1o2nLj1L1IAHZCSUL08QHd7sJCEpS8ZZ0/view)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1864829