### PR TITLE
Bug 1864759 - Add secret setting and nimbus flag for toolbar redesign

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -78,4 +78,14 @@ object FeatureFlags {
      * Enable Meta attribution.
      */
     val metaAttributionEnabled = Config.channel.isNightlyOrDebug
+
+    /**
+     * Enable Toolbar Redesign components and behaviors ready for Nightly.
+     */
+    val completeToolbarRedesignEnabled = Config.channel.isNightlyOrDebug
+
+    /**
+     * Enable Toolbar Redesign partial components and behaviors.
+     */
+    val incompleteToolbarRedesignEnabled = Config.channel.isDebug
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/RedesignToolbarFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/RedesignToolbarFeature.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import org.mozilla.fenix.utils.Settings
+
+/**
+ * An abstraction for the Toolbar Redesign feature.
+ */
+interface RedesignToolbarFeature {
+
+    /**
+     * Returns true if the toolbar redesign feature is enabled.
+     */
+    val isEnabled: Boolean
+}
+
+/**
+ * The complete portions of the redesigned Toolbar ready for Nightly.
+ *
+ */
+class CompleteRedesignToolbarFeature(
+    private val settings: Settings,
+) : RedesignToolbarFeature {
+
+    override val isEnabled: Boolean
+        get() = settings.enableRedesignToolbar
+}
+
+/**
+ * The incomplete portions of the redesigned Toolbar still in progress.
+ *
+ */
+class IncompleteRedesignToolbarFeature(
+    private val settings: Settings,
+) : RedesignToolbarFeature {
+
+    override val isEnabled: Boolean
+        get() = settings.enableIncompleteToolbarRedesign
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -48,6 +48,12 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
 
+        requirePreference<SwitchPreference>(R.string.pref_key_toolbar_use_redesign_incomplete).apply {
+            isVisible = Config.channel.isDebug
+            isChecked = context.settings().enableIncompleteToolbarRedesign
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
         requirePreference<SwitchPreference>(R.string.pref_key_enable_tabs_tray_to_compose).apply {
             isVisible = true
             isChecked = context.settings().enableTabsTrayToCompose

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1942,4 +1942,24 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = { enableFxSuggest },
         featureFlag = FeatureFlags.fxSuggest,
     )
+
+    /**
+     * Indicates if the user is shown new redesigned Toolbar UI.
+     */
+    var enableRedesignToolbar by lazyFeatureFlagPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_toolbar_use_redesign),
+        default = { false },
+        featureFlag = FeatureFlags.completeToolbarRedesignEnabled,
+    )
+
+    /**
+     * Indicates if the user is shown incomplete new redesigned Toolbar UI components and behaviors.
+     *
+     * DEV ONLY
+     */
+    var enableIncompleteToolbarRedesign by lazyFeatureFlagPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_toolbar_use_redesign_incomplete),
+        default = { false },
+        featureFlag = FeatureFlags.incompleteToolbarRedesignEnabled,
+    )
 }

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -138,6 +138,10 @@
     <string name="pref_key_toolbar_top" translatable="false">pref_key_toolbar_top</string>
     <string name="pref_key_toolbar_bottom" translatable="false">pref_key_toolbar_bottom</string>
 
+    <!-- Toolbar Redesign -->
+    <string name="pref_key_toolbar_use_redesign" translatable="false">pref_key_toolbar_use_redesign</string>
+    <string name="pref_key_toolbar_use_redesign_incomplete" translatable="false">pref_key_toolbar_use_redesign_incomplete</string>
+
     <!-- Privacy Pop Window -->
     <string name="pref_key_privacy_pop_window" translatable="false">pref_key_privacy_pop_window</string>
 

--- a/fenix/app/src/main/res/values/static_strings.xml
+++ b/fenix/app/src/main/res/values/static_strings.xml
@@ -70,6 +70,8 @@
     <string name="preferences_debug_settings_translations" translatable="false">Enable Firefox Translations</string>
     <!-- Label for enabling Firefox Suggest -->
     <string name="preferences_debug_settings_fxsuggest" translatable="false">Enable Firefox Suggest</string>
+    <!-- Label for enabling Toolbar Redesign incomplete portions -->
+    <string name="preferences_debug_settings_toolbar_redesign" translatable="false">Enable Toolbar Redesign incomplete portions</string>
     <!-- Label for enabling Felt Privacy -->
     <string name="preferences_debug_felt_privacy" translatable="false">Enable Felt Privacy</string>
 

--- a/fenix/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/fenix/app/src/main/res/xml/secret_settings_preferences.xml
@@ -27,6 +27,11 @@
         app:iconSpaceReserved="false" />
     <SwitchPreference
         android:defaultValue="false"
+        android:key="@string/pref_key_toolbar_use_redesign_incomplete"
+        android:title="@string/preferences_debug_settings_toolbar_redesign"
+        app:iconSpaceReserved="false" />
+    <SwitchPreference
+        android:defaultValue="false"
         android:key="@string/pref_key_enable_translations"
         android:title="@string/preferences_debug_settings_translations"
         app:iconSpaceReserved="false" />


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1864759