### PR TITLE
Bug 1862536 - Add a Nimbus variable for Firefox Suggest providers.

### DIFF
--- a/android-components/.buildconfig.yml
+++ b/android-components/.buildconfig.yml
@@ -818,8 +818,10 @@ projects:
     - feature-session
     - lib-publicsuffixlist
     - lib-state
+    - service-nimbus
     - support-base
     - support-ktx
+    - support-locale
     - support-test
     - support-utils
     - tooling-lint

--- a/android-components/components/feature/fxsuggest/build.gradle
+++ b/android-components/components/feature/fxsuggest/build.gradle
@@ -4,6 +4,22 @@
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+buildscript {
+    repositories {
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
+    }
+
+    dependencies {
+        classpath "${ApplicationServicesConfig.groupId}:tooling-nimbus-gradle:${ApplicationServicesConfig.version}"
+    }
+}
+
+plugins {
+    id "com.jetbrains.python.envs" version "$python_envs_plugin"
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
@@ -36,6 +52,7 @@ dependencies {
     implementation project(':concept-awesomebar')
     implementation project(':concept-engine')
     implementation project(':feature-session')
+    implementation project(':service-nimbus')
     implementation project(':support-base')
     implementation project(':support-ktx')
 
@@ -54,4 +71,17 @@ dependencies {
 
 apply from: '../../../android-lint.gradle'
 apply from: '../../../publish.gradle'
+apply plugin: "org.mozilla.appservices.nimbus-gradle-plugin"
+nimbus {
+    // The path to the Nimbus feature manifest file
+    manifestFile = "fxsuggest.fml.yaml"
+
+    channels = [
+        debug: "debug",
+        release: "release",
+    ]
+
+    applicationServicesDir = gradle.hasProperty('localProperties.autoPublish.application-services.dir')
+        ? gradle.getProperty('localProperties.autoPublish.application-services.dir') : null
+}
 ext.configurePublish(config.componentsGroupId, archivesBaseName, project.ext.description)

--- a/android-components/components/feature/fxsuggest/fxsuggest.fml.yaml
+++ b/android-components/components/feature/fxsuggest/fxsuggest.fml.yaml
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+about:
+  description: Nimbus Feature Manifest for the Firefox Suggest feature.
+  android:
+    package: mozilla.components.feature.fxsuggest
+    class: .FxSuggestNimbus
+channels:
+  - debug
+  - release
+features:
+  awesomebar-suggestion-provider:
+    description: Configuration for the Firefox Suggest awesomebar suggestion provider.
+    variables:
+      available-suggestion-types:
+        description: >
+          A map of suggestion types to booleans that indicate whether or not the provider should
+          return suggestions of those types.
+        type: Map<SuggestionType, Boolean>
+        default: {
+          "amp": false,
+          "wikipedia": true,
+        }
+enums:
+  SuggestionType:
+    description: The type of a Firefox Suggest search suggestion.
+    variants:
+      amp:
+        description: A Firefox Suggestion from adMarketplace.
+      wikipedia:
+        description: A Firefox Suggestion for a Wikipedia page.

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
@@ -48,10 +48,14 @@ class FxSuggestSuggestionProvider(
             emptyList()
         } else {
             val providers = buildList() {
-                if (includeSponsoredSuggestions) {
+                val availableSuggestionTypes = FxSuggestNimbus.features
+                    .awesomebarSuggestionProvider
+                    .value()
+                    .availableSuggestionTypes
+                if (includeSponsoredSuggestions && availableSuggestionTypes[SuggestionType.AMP] == true) {
                     add(SuggestionProvider.AMP)
                 }
-                if (includeNonSponsoredSuggestions) {
+                if (includeNonSponsoredSuggestions && availableSuggestionTypes[SuggestionType.WIKIPEDIA] == true) {
                     add(SuggestionProvider.WIKIPEDIA)
                 }
             }

--- a/fenix/app/nimbus.fml.yaml
+++ b/fenix/app/nimbus.fml.yaml
@@ -141,6 +141,15 @@ import:
           download-button: true,
           open-in-app-button: true
         }
+  - path: ../../android-components/components/feature/fxsuggest/fxsuggest.fml.yaml
+    channel: release
+    features:
+      awesomebar-suggestion-provider:
+        - value:
+            available-suggestion-types: {
+              "amp": true,
+              "wikipedia": true,
+            }
 
 features:
   toolbar:


### PR DESCRIPTION
This commit adds the `suggestion-provider.available-suggestion-types` Nimbus variable, which holds a list of all available suggestion types that the `FxSuggestSuggestionProvider` can return. This lets us toggle suggestion types remotely as part of our experiments.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1862536