### PR TITLE
Bug 1865043 - Switch browsertime tests to use arm64 builds.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -16,7 +16,7 @@ only-for-build-types:
     - fenix-nightly-simulation
 
 only-for-abis:
-    - armeabi-v7a
+    - arm64-v8a
 
 task-defaults:
     attributes:
@@ -42,10 +42,10 @@ task-defaults:
         tier: 2
         platform:
             by-abi:
-                armeabi-v7a: android-hw-a51-11-0-aarch64-shippable-qr/opt
+                arm64-v8a: android-hw-a51-11-0-aarch64-shippable-qr/opt
     worker-type:
         by-abi:
-            armeabi-v7a: t-bitbar-gw-perf-a51
+            arm64-v8a: t-bitbar-gw-perf-a51
     worker:
         max-run-time: 3600
         env:

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -36,7 +36,7 @@ task-defaults:
                     subject: '[{product_name}] Raptor-Browsertime job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: []
+    run-on-tasks-for: [github-pull-request]
     treeherder:
         kind: test
         tier: 2

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -36,7 +36,7 @@ task-defaults:
                     subject: '[{product_name}] Raptor-Browsertime job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: [github-pull-request]
+    run-on-tasks-for: []
     treeherder:
         kind: test
         tier: 2


### PR DESCRIPTION
This patch switches the browsertime tests to use the arm64 builds.
https://bugzilla.mozilla.org/show_bug.cgi?id=1865043
https://bugzilla.mozilla.org/show_bug.cgi?id=1865043
https://bugzilla.mozilla.org/show_bug.cgi?id=1865043
https://bugzilla.mozilla.org/show_bug.cgi?id=1865043
https://bugzilla.mozilla.org/show_bug.cgi?id=1865043
https://bugzilla.mozilla.org/show_bug.cgi?id=1865043