### PR TITLE
Bug 1865086 - More FxA error reporting

### DIFF
--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FirefoxAccount.kt
@@ -94,6 +94,8 @@ class FirefoxAccount internal constructor(
         persistCallback.setCallback(callback)
     }
 
+    internal fun getAuthState() = inner.getAuthState()
+
     override suspend fun beginOAuthFlow(
         scopes: Set<String>,
         entryPoint: FxAEntryPoint,

--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/FxaDeviceConstellation.kt
@@ -29,11 +29,11 @@ import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 
-internal sealed class FxaDeviceConstellationException : Exception() {
+internal sealed class FxaDeviceConstellationException(message: String? = null) : Exception(message) {
     /**
      * Failure while ensuring device capabilities.
      */
-    class EnsureCapabilitiesFailed : FxaDeviceConstellationException()
+    class EnsureCapabilitiesFailed(message: String? = null) : FxaDeviceConstellationException(message)
 }
 
 /**
@@ -106,7 +106,9 @@ class FxaDeviceConstellation(
                     // actually expected to do any work: everything should have been done by initializeDevice.
                     // So if it did, and failed, let's report this so that we're aware of this!
                     // See https://github.com/mozilla-mobile/android-components/issues/8164
-                    crashReporter?.submitCaughtException(FxaDeviceConstellationException.EnsureCapabilitiesFailed())
+                    crashReporter?.submitCaughtException(
+                        FxaDeviceConstellationException.EnsureCapabilitiesFailed(e.toString()),
+                    )
                     ServiceResult.AuthError
                 } catch (e: FxaException) {
                     ServiceResult.OtherError


### PR DESCRIPTION
 Include the exception message when reporting
 FxaDeviceConstellationException.EnsureCapabilitiesFailed
 (https://bugzilla.mozilla.org/show_bug.cgi?id=1865086)

 Report restoring an FxA account that's not connected
 (https://bugzilla.mozilla.org/show_bug.cgi?id=1864667)

 Report a breadcrumb if we queue multiple auth recovery attempts at once
 (https://bugzilla.mozilla.org/show_bug.cgi?id=1864994)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1865086