### PR TITLE
Bug 1865226 - Ignore review checker store flaky tests

### DIFF
--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStoreTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStoreTest.kt
@@ -13,6 +13,7 @@ import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.middleware.CaptureActionsMiddleware
 import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertFalse
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.components.AppStore
@@ -253,6 +254,7 @@ class ReviewQualityCheckStoreTest {
             assertEquals(expected, tested.state)
         }
 
+    @Ignore("Flaky: https://bugzilla.mozilla.org/show_bug.cgi?id=1865318")
     @Test
     fun `GIVEN the user has opted in the feature WHEN the user expands settings THEN state should reflect that`() =
         runTest {
@@ -286,6 +288,7 @@ class ReviewQualityCheckStoreTest {
             }
         }
 
+    @Ignore("Flaky: https://bugzilla.mozilla.org/show_bug.cgi?id=1865318")
     @Test
     fun `GIVEN the user has opted in the feature WHEN the user collapses settings THEN state should reflect that`() =
         runTest {
@@ -328,6 +331,7 @@ class ReviewQualityCheckStoreTest {
             }
         }
 
+    @Ignore("Flaky: https://bugzilla.mozilla.org/show_bug.cgi?id=1865318")
     @Test
     fun `GIVEN the user has opted in the feature WHEN the user expands info card THEN state should reflect that`() =
         runTest {
@@ -361,6 +365,7 @@ class ReviewQualityCheckStoreTest {
             }
         }
 
+    @Ignore("Flaky: https://bugzilla.mozilla.org/show_bug.cgi?id=1865318")
     @Test
     fun `GIVEN the user has opted in the feature WHEN the user collapses info card THEN state should reflect that`() =
         runTest {
@@ -403,6 +408,7 @@ class ReviewQualityCheckStoreTest {
             }
         }
 
+    @Ignore("Flaky: https://bugzilla.mozilla.org/show_bug.cgi?id=1865318")
     @Test
     fun `GIVEN the user has opted in the feature WHEN the user expands highlights card THEN state should reflect that`() =
         runTest {
@@ -438,6 +444,7 @@ class ReviewQualityCheckStoreTest {
             }
         }
 
+    @Ignore("Flaky: https://bugzilla.mozilla.org/show_bug.cgi?id=1865318")
     @Test
     fun `GIVEN the user has opted in the feature WHEN the user collapses highlights card THEN state should reflect that`() =
         runTest {


### PR DESCRIPTION
### What
To unblock the CI, these have been marked to not run.

### Next Steps
Fix the tests and remove `@Ignore` with the mentioned bug.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1865226