### PR TITLE
Bug 1864070 - Add secret setting to enable the debug drawer

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/data/DebugSettingsDataStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/data/DebugSettingsDataStore.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.debugsettings.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/**
+ * [DataStore] for accessing debugging settings.
+ */
+val Context.debugSettings: DataStore<Preferences> by preferencesDataStore(name = "debug_settings")
+
+private val DEBUG_DRAWER_ENABLED = booleanPreferencesKey("debug_drawer_enabled")
+
+/**
+ * Updates whether the debug drawer is enabled.
+ *
+ * @param enabled Whether the debug drawer is enabled.
+ */
+suspend fun DataStore<Preferences>.updateDebugDrawerEnabled(enabled: Boolean) {
+    edit { preferences ->
+        preferences[DEBUG_DRAWER_ENABLED] = enabled
+    }
+}
+
+/**
+ * [Flow] for checking whether the Debug Drawer is enabled.
+ */
+val DataStore<Preferences>.debugDrawerEnabled: Flow<Boolean>
+    get() = data.map { preferences ->
+        preferences[DEBUG_DRAWER_ENABLED] ?: false
+    }

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -78,6 +78,7 @@
     <string name="pref_key_home_blocklist">pref_key_home_blocklist</string>
     <string name="pref_key_hidden_engines_restored" translatable="false">pref_key_hidden_engines_restored</string>
     <string name="pref_key_enable_fxsuggest" translatable="false">pref_key_fxsuggest_enabled</string>
+    <string name="pref_key_enable_debug_drawer" translatable="false">pref_key_enable_debug_drawer</string>
 
     <!-- Data Choices -->
     <string name="pref_key_telemetry" translatable="false">pref_key_telemetry</string>

--- a/fenix/app/src/main/res/values/static_strings.xml
+++ b/fenix/app/src/main/res/values/static_strings.xml
@@ -74,6 +74,8 @@
     <string name="preferences_debug_settings_toolbar_redesign" translatable="false">Enable Toolbar Redesign incomplete portions</string>
     <!-- Label for enabling Felt Privacy -->
     <string name="preferences_debug_felt_privacy" translatable="false">Enable Felt Privacy</string>
+    <!-- Label for enabling the Debug Drawer -->
+    <string name="preferences_debug_settings_debug_drawer" translatable="false">Enable Debug Drawer</string>
 
     <!-- A secret menu option in the tabs tray for making a tab inactive for testing. -->
     <string name="inactive_tabs_menu_item">Make inactive</string>

--- a/fenix/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/fenix/app/src/main/res/xml/secret_settings_preferences.xml
@@ -45,6 +45,11 @@
         app:iconSpaceReserved="false"
         android:title="@string/preferences_debug_felt_privacy"
         />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/pref_key_enable_debug_drawer"
+        android:title="@string/preferences_debug_settings_debug_drawer"
+        app:iconSpaceReserved="false" />
     <EditTextPreference
         android:key="@string/pref_key_custom_glean_server_url"
         android:title="@string/preferences_debug_settings_custom_glean_server_url"


### PR DESCRIPTION
After some iteration of exploring the use of the legacy Preferences API + AppState, I've opted to use DataStore here instead. With this approach, we'll have an API that's easy to consume in Compose while also not introducing a huge hack into SecretSettingsFragment in order to handle our use case of an observable preference.

[DataStore is currently being leveraged for Pocket](https://searchfox.org/mozilla-mobile/source/firefox-android/fenix/app/src/main/java/org/mozilla/fenix/datastore/DataStores.kt), so there is no library addition here.

Hopefully, this will serve as a potential migration path for the rest of our settings. 

In order to get the secret settings into the debug drawer, I'll likely need to convert all of them to Compose + DataStore.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
4. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
5. Click on `View task in Taskcluster` in the new `DETAILS` section.
6. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1864070