### PR TITLE
Bug 1855976 - Initial Runtime Translations Support

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -42,6 +42,11 @@ import mozilla.components.concept.engine.content.blocking.TrackingProtectionExce
 import mozilla.components.concept.engine.history.HistoryTrackingDelegate
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.engine.serviceworker.ServiceWorkerDelegate
+import mozilla.components.concept.engine.translate.Language
+import mozilla.components.concept.engine.translate.LanguageModel
+import mozilla.components.concept.engine.translate.ModelManagementOptions
+import mozilla.components.concept.engine.translate.TranslationSupport
+import mozilla.components.concept.engine.translate.TranslationsRuntime
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
@@ -66,6 +71,7 @@ import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.mozilla.geckoview.GeckoSession
 import org.mozilla.geckoview.GeckoWebExecutor
+import org.mozilla.geckoview.TranslationsController
 import org.mozilla.geckoview.WebExtensionController
 import org.mozilla.geckoview.WebNotification
 import java.lang.ref.WeakReference
@@ -81,7 +87,7 @@ class GeckoEngine(
     executorProvider: () -> GeckoWebExecutor = { GeckoWebExecutor(runtime) },
     override val trackingProtectionExceptionStore: TrackingProtectionExceptionStorage =
         GeckoTrackingProtectionExceptionStorage(runtime),
-) : Engine, WebExtensionRuntime {
+) : Engine, WebExtensionRuntime, TranslationsRuntime {
     private val executor by lazy { executorProvider.invoke() }
     private val localeUpdater = LocaleSettingUpdater(context, runtime)
 
@@ -646,6 +652,185 @@ class GeckoEngine(
             },
             {
                     throwable ->
+                onError(throwable)
+                GeckoResult<Void>()
+            },
+        )
+    }
+
+    /**
+     * Convenience method for handling unexpected null returns from GeckoView.
+     *
+     * @return A standard throwable for unexpected null values.
+     */
+    private fun translationsUnexpectedNull(): Throwable {
+        val errorMessage = "Unexpectedly returned a null value."
+        return IllegalStateException(errorMessage)
+    }
+
+    /**
+     * See [Engine.isTranslationsEngineSupported].
+     */
+    override fun isTranslationsEngineSupported(
+        onSuccess: (Boolean) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        TranslationsController.RuntimeTranslation.isTranslationsEngineSupported().then(
+            {
+                if (it != null) {
+                    onSuccess(it)
+                } else {
+                    onError(translationsUnexpectedNull())
+                }
+                GeckoResult<Void>()
+            },
+            { throwable ->
+                onError(throwable)
+                GeckoResult<Void>()
+            },
+        )
+    }
+
+    /**
+     * See [Engine.getTranslationsPairDownloadSize].
+     */
+    override fun getTranslationsPairDownloadSize(
+        fromLanguage: String,
+        toLanguage: String,
+        onSuccess: (Long) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        TranslationsController.RuntimeTranslation.checkPairDownloadSize(fromLanguage, toLanguage).then(
+            {
+                if (it != null) {
+                    onSuccess(it)
+                } else {
+                    onError(translationsUnexpectedNull())
+                }
+                GeckoResult<Void>()
+            },
+            { throwable ->
+                onError(throwable)
+                GeckoResult<Void>()
+            },
+        )
+    }
+
+    /**
+     * See [Engine.getTranslationsModelDownloadStates].
+     */
+    override fun getTranslationsModelDownloadStates(
+        onSuccess: (List<LanguageModel>) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        TranslationsController.RuntimeTranslation.listModelDownloadStates().then(
+            {
+                if (it != null) {
+                    var listOfModels = mutableListOf<LanguageModel>()
+                    for (each in it) {
+                        var language = each.language?.let {
+                                language ->
+                            Language(language.code, each.language?.localizedDisplayName)
+                        }
+                        var model = LanguageModel(language, each.isDownloaded, each.size)
+                        listOfModels.add(model)
+                    }
+                    onSuccess(listOfModels)
+                } else {
+                    onError(translationsUnexpectedNull())
+                }
+                GeckoResult<Void>()
+            },
+            { throwable ->
+                onError(throwable)
+                GeckoResult<Void>()
+            },
+        )
+    }
+
+    /**
+     * See [Engine.getSupportedTranslationLanguages].
+     */
+    override fun getSupportedTranslationLanguages(
+        onSuccess: (TranslationSupport) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        TranslationsController.RuntimeTranslation.listSupportedLanguages().then(
+            {
+                if (it != null) {
+                    var listOfFromLanguages = mutableListOf<Language>()
+                    var listOfToLanguages = mutableListOf<Language>()
+
+                    if (it.fromLanguages != null) {
+                        for (each in it.fromLanguages!!) {
+                            listOfFromLanguages.add(Language(each.code, each.localizedDisplayName))
+                        }
+                    }
+
+                    if (it.toLanguages != null) {
+                        for (each in it.toLanguages!!) {
+                            listOfToLanguages.add(Language(each.code, each.localizedDisplayName))
+                        }
+                    }
+
+                    onSuccess(TranslationSupport(listOfFromLanguages, listOfToLanguages))
+                } else {
+                    onError(translationsUnexpectedNull())
+                }
+                GeckoResult<Void>()
+            },
+            { throwable ->
+                onError(throwable)
+                GeckoResult<Void>()
+            },
+        )
+    }
+
+    /**
+     * See [Engine.manageTranslationsLanguageModel].
+     */
+    override fun manageTranslationsLanguageModel(
+        options: ModelManagementOptions,
+        onSuccess: () -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        val geckoOptions =
+            TranslationsController.RuntimeTranslation.ModelManagementOptions.Builder()
+                .operation(options.operation.toString())
+                .operationLevel(options.operationLevel.toString())
+
+        options.languageToManage?.let { geckoOptions.languageToManage(it) }
+
+        TranslationsController.RuntimeTranslation.manageLanguageModel(geckoOptions.build()).then(
+            {
+                onSuccess()
+                GeckoResult<Void>()
+            },
+            { throwable ->
+                onError(throwable)
+                GeckoResult<Void>()
+            },
+        )
+    }
+
+    /**
+     * See [Engine.getUserPreferredLanguages].
+     */
+    override fun getUserPreferredLanguages(
+        onSuccess: (List<String>) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        TranslationsController.RuntimeTranslation.preferredLanguages().then(
+            {
+                if (it != null) {
+                    onSuccess(it)
+                } else {
+                    onError(translationsUnexpectedNull())
+                }
+
+                GeckoResult<Void>()
+            },
+            { throwable ->
                 onError(throwable)
                 GeckoResult<Void>()
             },

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/Engine.kt
@@ -15,6 +15,7 @@ import mozilla.components.concept.engine.activity.OrientationDelegate
 import mozilla.components.concept.engine.content.blocking.TrackerLog
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionExceptionStorage
 import mozilla.components.concept.engine.serviceworker.ServiceWorkerDelegate
+import mozilla.components.concept.engine.translate.TranslationsRuntime
 import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webnotifications.WebNotificationDelegate
@@ -25,7 +26,7 @@ import org.json.JSONObject
 /**
  * Entry point for interacting with the engine implementation.
  */
-interface Engine : WebExtensionRuntime, DataCleanable {
+interface Engine : WebExtensionRuntime, TranslationsRuntime, DataCleanable {
 
     /**
      * Describes a combination of browsing data types stored by the engine.

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/Language.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/Language.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.translate
+
+/**
+ * The language container for presenting language information to the user.
+ *
+ * @property code The BCP 47 code that represents the language.
+ * @property localizedDisplayName The translations engine localized display name of the language.
+ */
+data class Language(
+    val code: String,
+    val localizedDisplayName: String? = null,
+)

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/LanguageModel.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/LanguageModel.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.translate
+
+/**
+ * The language model container for representing language model state to the user.
+ *
+ * Please note, a single LanguageModel is usually comprised of
+ * an aggregation of multiple machine learning models on the translations engine level. The engine
+ * has already handled this abstraction.
+ *
+ * @property language The specified language the language model set can process.
+ * @property isDownloaded If all the necessary models are downloaded.
+ * @property size The size of the total model download(s).
+ */
+data class LanguageModel(
+    val language: Language? = null,
+    val isDownloaded: Boolean = false,
+    val size: Long? = null,
+)

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/ModelManagementOptions.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/ModelManagementOptions.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.translate
+
+/**
+ * The operations that can be performed on a given language model.
+ *
+ * @property languageToManage The BCP 47 language code to manage the models for.
+ * May be null when performing operations not at the "language" scope or level.
+ * @property operation The operation to perform.
+ * @property operationLevel At what scope or level the operations should be performed at.
+ */
+data class ModelManagementOptions(
+    val languageToManage: String? = null,
+    val operation: ModelOperation,
+    val operationLevel: OperationLevel,
+)

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/ModelOperation.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/ModelOperation.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.translate
+
+/**
+ * The operations that can be performed on a language model.
+ */
+enum class ModelOperation(val operation: String) {
+    /**
+     * Download the model(s).
+     */
+    DOWNLOAD("download"),
+
+    /**
+     * Delete the model(s).
+     */
+    DELETE("delete"),
+}

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/OperationLevel.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/OperationLevel.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.translate
+
+/**
+ * The level or scope of a model operation.
+ */
+enum class OperationLevel(val operationLevel: String) {
+    /**
+     * Complete the operation for a given language.
+     */
+    LANGUAGE("language"),
+
+    /**
+     * Complete the operation on cache elements.
+     * (Elements that do not fully make a downloaded language package or [LanguageModel].)
+     */
+    CACHE("cache"),
+
+    /**
+     * Complete the operation all models.
+     */
+    ALL("all"),
+}

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationSupport.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationSupport.kt
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.translate
+
+/**
+ * The list of supported languages that may be translated to and translated from. Usually
+ * a given language will be bi-directional (translate both to and from),
+ * but this is not guaranteed, which is why the support response is two lists.
+ *
+ * @property fromLanguages The languages that the machine learning model may translate from.
+ * @property toLanguages The languages that the machine learning model may translate to.
+ */
+data class TranslationSupport(
+    val fromLanguages: List<Language>? = null,
+    val toLanguages: List<Language>? = null,
+)

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationsRuntime.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationsRuntime.kt
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.translate
+
+private var unsupportedError = "Translations support is not available in this engine."
+
+/**
+ * Entry point for interacting with runtime translation options.
+ */
+interface TranslationsRuntime {
+
+    /**
+     * Checks if the translations engine is supported or not. The engine only
+     * supports certain architectures.
+     *
+     * An example use case is checking if translations options should ever be displayed.
+     *
+     * @param onSuccess Callback invoked when successful with the compatibility status of running
+     * translations.
+     * @param onError Callback invoked if an issue occurred when determining status.
+     */
+    fun isTranslationsEngineSupported(
+        onSuccess: (Boolean) -> Unit,
+        onError: (Throwable) -> Unit,
+    ): Unit = onError(UnsupportedOperationException(unsupportedError))
+
+    /**
+     * Queries what language models are downloaded and will return the download size
+     * for the given language pair or else return an error.
+     *
+     * An example use case is checking how large of a download will occur for a given
+     * specifc translation.
+     *
+     * @param fromLanguage The language the translations engine will use to translate from.
+     * @param toLanguage The language the translations engine will use to translate to.
+     * @param onSuccess Callback invoked if the pair download size was fetched successfully. With
+     * the size in bytes that will be required to complete for the download. Zero bytes indicates
+     * no download is required.
+     * @param onError Callback invoked if an issue occurred when checking sizes.
+     */
+    fun getTranslationsPairDownloadSize(
+        fromLanguage: String,
+        toLanguage: String,
+        onSuccess: (Long) -> Unit,
+        onError: (Throwable) -> Unit,
+    ): Unit = onError(UnsupportedOperationException(unsupportedError))
+
+    /**
+     * Aggregates the states of complete models downloaded. Note, this function does not aggregate
+     * the cache or state of incomplete models downloaded.
+     *
+     * An example use case is listing the current install states of the language models.
+     *
+     * @param onSuccess Callback invoked if the states were correctly aggregated as a list.
+     * @param onError Callback invoked if an issue occurred when aggregating model state.
+     */
+    fun getTranslationsModelDownloadStates(
+        onSuccess: (List<LanguageModel>) -> Unit,
+        onError: (Throwable) -> Unit,
+    ): Unit = onError(UnsupportedOperationException(unsupportedError))
+
+    /**
+     * Fetches a list of to and from languages supported by the translations engine.
+     *
+     * An example use case is is for populating translation options.
+     *
+     * @param onSuccess Callback invoked if the list of to and from languages was retrieved.
+     * @param onError Callback invoked if an issue occurred.
+     */
+    fun getSupportedTranslationLanguages(
+        onSuccess: (TranslationSupport) -> Unit,
+        onError: (Throwable) -> Unit,
+    ): Unit = onError(UnsupportedOperationException(unsupportedError))
+
+    /**
+     * Use to download and delete complete model sets for a given language. Can bulk update all
+     * models, a given language set, or the cache or incomplete models (models that are not a part
+     * of a complete language set).
+     *
+     * An example use case is for managing deleting and installing model sets.
+     *
+     * @param options The options for the operation.
+     * @param onSuccess Callback invoked if the operation completed successfully.
+     * @param onError Callback invoked if an issue occurred.
+     */
+    fun manageTranslationsLanguageModel(
+        options: ModelManagementOptions,
+        onSuccess: () -> Unit,
+        onError: (Throwable) -> Unit,
+    ): Unit = onError(UnsupportedOperationException(unsupportedError))
+
+    /**
+     * Retrieves the user preferred languages using the app language(s), web requested language(s),
+     * and OS language(s).
+     *
+     * An example use case is presenting translate "to language" options for the user. Note, the
+     * user's predicted first choice is also available via the state of the translation.
+     *
+     * @param onSuccess Callback invoked if the operation completed successfully with a list of user
+     * preferred languages.
+     * @param onError Callback invoked if an issue occurred.
+     */
+    fun getUserPreferredLanguages(
+        onSuccess: (List<String>) -> Unit,
+        onError: (Throwable) -> Unit,
+    ): Unit = onError(UnsupportedOperationException(unsupportedError))
+}


### PR DESCRIPTION
This patch adds some of the core runtime translations functionality from GeckoView:

* `isTranslationsEngineSupported` - If the toolkit translation engine is supported or not.
* `checkPairDownloadSize` - A way to check translation pair download sizes before completing a translation operation.
* `listModelDownloadStates` - List download states of the language models.
* `manageLanguageModel` - A way to manage the download state of language models.
* `listSupportedLanguages` - List of supported languages.
* `preferredLanguages` - A list of the user's preferred languages.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1855976