### PR TITLE
Bug 1865889 - Swap out Pixel2.arm [API 26] in robo-arm for Motorola G20

### DIFF
--- a/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm-robo-test.yml
@@ -14,8 +14,8 @@ gcloud:
     clearPackageData: true
 
   device:
-    - model: Pixel2.arm
-      version: 26
+    - model: java
+      version: 30
       locale: en_US
     - model: Pixel2.arm
       version: 27


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1865889
```
┌────────────┬─────────────────────┬───────────────┬─────────────────┐
│  MODEL_ID  │      MODEL_NAME     │ OS_VERSION_ID │ DEVICE_CAPACITY │
├────────────┼─────────────────────┼───────────────┼─────────────────┤
│ F01L       │ F-01L               │ 27            │ High            │
│ SH-01L     │ AQUOS sense2 SH-01L │ 28            │ High            │
│ a10        │ Galaxy A10          │ 29            │ High            │
│ b0q        │ Galaxy S22 Ultra    │ 33            │ High            │
│ b4q        │ Galaxy Z Flip4      │ 33            │ High            │
│ cactus     │ Redmi 6A            │ 27            │ High            │
│ dm3q       │ SM-S918U1           │ 33            │ High            │
│ gts8uwifi  │ Galaxy Tab S8 Ultra │ 33            │ High            │
│ husky      │ Pixel 8 Pro         │ 34            │ High            │
│ java       │ Motorola G20        │ 30            │ High            │
│ oriole     │ Pixel 6             │ 31            │ High            │
│ oriole     │ Pixel 6             │ 32            │ High            │
│ panther    │ Pixel 7             │ 33            │ High            │
│ r11        │ Google Pixel Watch  │ 30            │ High            │
│ redfin     │ Pixel 5             │ 30            │ High            │
│ shiba      │ Pixel 8             │ 34            │ High            │
│ starqlteue │ Galaxy S9           │ 26            │ High            │
│ tangorpro  │ Pixel Tablet        │ 33            │ High            │
│ x1q        │ Galaxy S20          │ 29            │ High            │
└────────────┴─────────────────────┴───────────────┴─────────────────┘
```
https://bugzilla.mozilla.org/show_bug.cgi?id=1865889
https://bugzilla.mozilla.org/show_bug.cgi?id=1865889