### PR TITLE
Bug 1865904 - Add correct default elevation to FAB

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/button/FloatingActionButton.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/button/FloatingActionButton.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.FloatingActionButtonDefaults
+import androidx.compose.material.FloatingActionButtonElevation
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +37,8 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * @param modifier [Modifier] to be applied to the action button.
  * @param contentDescription The content description to describe the icon.
  * @param label Text to be displayed next to the icon.
+ * @param elevation [FloatingActionButtonElevation] used to resolve the elevation for this FAB in different states.
+ * This controls the size of the shadow below the FAB.
  * @param onClick Invoked when the button is clicked.
  */
 @Composable
@@ -43,6 +47,7 @@ fun FloatingActionButton(
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
     label: String? = null,
+    elevation: FloatingActionButtonElevation = FloatingActionButtonDefaults.elevation(defaultElevation = 5.dp),
     onClick: () -> Unit,
 ) {
     FloatingActionButton(
@@ -50,6 +55,7 @@ fun FloatingActionButton(
         modifier = modifier,
         backgroundColor = FirefoxTheme.colors.actionPrimary,
         contentColor = FirefoxTheme.colors.textActionPrimary,
+        elevation = elevation,
     ) {
         Row(
             modifier = Modifier


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1865904