### PR TITLE
Support for handling EXTRA_HEADERS custom tab intent key in Firefox Focus

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/CustomTabSessionState.kt
@@ -77,6 +77,7 @@ fun createCustomTab(
     private: Boolean = false,
     webAppManifest: WebAppManifest? = null,
     initialLoadFlags: EngineSession.LoadUrlFlags = EngineSession.LoadUrlFlags.none(),
+    initialAdditionalHeaders: Map<String, String>? = null
 ): CustomTabSessionState {
     return CustomTabSessionState(
         id = id,
@@ -94,6 +95,7 @@ fun createCustomTab(
             engineSession = engineSession,
             crashed = crashed,
             initialLoadFlags = initialLoadFlags,
+            initialAdditionalHeaders = initialAdditionalHeaders
         ),
     )
 }

--- a/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/CustomTabsUseCases.kt
+++ b/android-components/components/feature/tabs/src/main/java/mozilla/components/feature/tabs/CustomTabsUseCases.kt
@@ -39,13 +39,17 @@ class CustomTabsUseCases(
             additionalHeaders: Map<String, String>? = null,
             source: SessionState.Source,
         ): String {
-            val loadUrlFlags = EngineSession.LoadUrlFlags.external()
+            var loadUrlFlags = EngineSession.LoadUrlFlags.external()
+            if (additionalHeaders != null) {
+                loadUrlFlags = EngineSession.LoadUrlFlags.select(loadUrlFlags.value, EngineSession.LoadUrlFlags.ALLOW_ADDITIONAL_HEADERS)
+            }
             val tab = createCustomTab(
                 url = url,
                 private = private,
                 source = source,
                 config = customTabConfig,
                 initialLoadFlags = loadUrlFlags,
+                initialAdditionalHeaders = additionalHeaders
             )
 
             store.dispatch(CustomTabListAction.AddCustomTabAction(tab))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **extra-headers**:
+  * Added support for handling the [`EXTRA_HEADERS`](https://developer.android.com/reference/android/provider/Browser#EXTRA_HEADERS) intent key.
+
 # 121.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v120..releases_v121)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/releases_v121/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)

--- a/focus-android/app/src/main/java/org/mozilla/focus/session/IntentProcessor.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/session/IntentProcessor.kt
@@ -63,6 +63,25 @@ class IntentProcessor(
         createSessionFromIntent(context, intent)
     }
 
+
+    private fun getAdditionalHeaders(intent: SafeIntent): Map<String, String>? {
+        val pairs = intent.getBundleExtra(Browser.EXTRA_HEADERS)
+        val headers = mutableMapOf<String, String>()
+        pairs?.keySet()?.forEach { key ->
+            val header = pairs.getString(key)
+            if (header != null) {
+                headers[key] = header
+            } else {
+                throw IllegalArgumentException("getAdditionalHeaders() intent bundle contains wrong key value pair")
+            }
+        }
+        return if (headers.isEmpty()) {
+            null
+        } else {
+            headers
+        }
+    }
+
     @Suppress("ComplexMethod", "ReturnCount")
     private fun createSessionFromIntent(context: Context, intent: SafeIntent): Result {
         when (intent.action) {
@@ -157,6 +176,7 @@ class IntentProcessor(
                     createCustomTabConfigFromIntent(intent.unsafe, context.resources),
                     private = true,
                     source = source,
+                    additionalHeaders = getAdditionalHeaders(intent)
                 ),
             )
         } else {
@@ -166,6 +186,7 @@ class IntentProcessor(
                     source = source,
                     selectTab = true,
                     private = true,
+                    additionalHeaders = getAdditionalHeaders(intent)
                 ),
             )
         }
@@ -183,6 +204,7 @@ class IntentProcessor(
                 createCustomTabConfigFromIntent(intent.unsafe, context.resources),
                 private = true,
                 source = source,
+                additionalHeaders = getAdditionalHeaders(intent)
             )
             Pair(Result.CustomTab(tabId), tabId)
         } else {
@@ -190,6 +212,7 @@ class IntentProcessor(
                 url,
                 source = source,
                 private = true,
+                additionalHeaders = getAdditionalHeaders(intent)
             )
             Pair(Result.Tab(tabId), tabId)
         }

--- a/focus-android/app/src/main/java/org/mozilla/focus/session/IntentProcessor.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/session/IntentProcessor.kt
@@ -7,6 +7,7 @@ package org.mozilla.focus.session
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.provider.Browser
 import android.text.TextUtils
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.feature.customtabs.createCustomTabConfigFromIntent


### PR DESCRIPTION
These code changes will introduce support for the EXTRA_HEADERS custom tab intent key in Firefox Focus ( https://developer.android.com/reference/android/provider/Browser#EXTRA_HEADERS ).

One additional consideration to be made here is contained within the following Chromium issue discussion thread, but I am currently unsure of how to properly accommodate such concerns idiomatically within the Firefox Focus codebase.
https://bugs.chromium.org/p/chromium/issues/detail?id=873178#c26

I have not included any unit test implementations, but testing can easily be done using the following companion app after the debug build of Firefox Focus is installed and designated as the default browser.
https://github.com/PierceLBrooks/android-browser-helper/tree/plb_firefox-focus/demos/custom-tabs-headers

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
