### PR TITLE
Bug 1866293 - Add support for installing an add-on a from local file.

### DIFF
--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt
@@ -57,7 +57,6 @@ import org.mozilla.geckoview.GeckoSession.PromptDelegate.FilePrompt.Capture.ANY
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FilePrompt.Capture.NONE
 import org.mozilla.geckoview.GeckoSession.PromptDelegate.FilePrompt.Capture.USER
 import org.robolectric.Shadows.shadowOf
-import java.io.FileInputStream
 import java.security.InvalidParameterException
 import java.util.Calendar
 import java.util.Calendar.YEAR
@@ -705,14 +704,13 @@ class GeckoPromptDelegateTest {
         val mockUri: Uri = mock()
 
         doReturn(contentResolver).`when`(context).contentResolver
-        doReturn(mock<FileInputStream>()).`when`(contentResolver).openInputStream(any())
 
         var filePickerRequest: PromptRequest.File = mock()
 
         val promptDelegate = spy(GeckoPromptDelegate(mockSession))
 
         // Prevent the file from being copied
-        doReturn(0L).`when`(promptDelegate).copyFile(any(), any())
+        doReturn(mockUri).`when`(promptDelegate).toFileUri(any(), any())
 
         mockSession.register(
             object : EngineSession.Observer {

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
@@ -38,6 +38,29 @@ interface WebExtensionRuntime {
     }
 
     /**
+     * Installs a [WebExtension] from the provided [url] in this engine.
+     *
+     * @param url the url pointing to either a resources path for locating the extension
+     * within the APK file (e.g. resource://android/assets/extensions/my_web_ext) or to a
+     * local (e.g. resource://android/assets/extensions/my_web_ext.xpi) or remote
+     * (e.g. https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi) XPI file.
+     * @param onSuccess (optional) callback invoked if the extension was installed successfully,
+     * providing access to the [WebExtension] object for bi-directional messaging.
+     * @param onError (optional) callback invoked if there was an error installing the extension.
+     * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
+     * have web extension support.
+     */
+    @Suppress("LongParameterList")
+    fun installWebExtension(
+        url: String,
+        onSuccess: ((WebExtension) -> Unit) = { },
+        onError: ((Throwable) -> Unit) = { _ -> },
+    ): CancellableOperation {
+        onError(UnsupportedOperationException("Web extension support is not available in this engine"))
+        return CancellableOperation.Noop()
+    }
+
+    /**
      * Updates the provided [extension] if a new version is available.
      *
      * @param extension the extension to be updated.

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonFilePicker.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonFilePicker.kt
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.addons.ui
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.AddonManager
+import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.ktx.android.net.toFileUri
+
+/**
+ * Allows to launch a file picker to select an add-on file.
+ * @param context the application context
+ * @param onInstallationFailed (optional) callback invoked if there was an error installing the add-on.
+ */
+class AddonFilePicker(
+    val context: Context,
+    private val addonManager: AddonManager,
+    private val onInstallationFailed: (() -> Unit) = { },
+) {
+    internal lateinit var activityLauncher: ActivityResultLauncher<Array<String>>
+    private val logger = Logger("AddonFilePicker")
+
+    /**
+     * Launch an Android file picker where the user can select an add-on file.
+     * @returns a [Boolean] indicating if the file picker was launched successfully or not.
+     */
+    fun launch(): Boolean {
+        return try {
+            activityLauncher.launch(emptyArray())
+            true
+        } catch (e: ActivityNotFoundException) {
+            logger.error("Unable to find an app to select an XPI file", e)
+            false
+        }
+    }
+
+    /**
+     * Registers a listener for file picker results.
+     * @param resultCaller The [ActivityResultCaller] on which results will be observed.
+     */
+    fun registerForResults(resultCaller: ActivityResultCaller) {
+        activityLauncher =
+            resultCaller.registerForActivityResult(AddonOpenDocument(), ::handleUriSelected)
+    }
+
+    internal fun handleUriSelected(uri: Uri?) {
+        uri?.let {
+            val fileUri = convertToFileUri(uri)
+            val onSuccess: ((Addon) -> Unit) = {
+                logger.info("Add-on from $fileUri installed successfully")
+            }
+            val onError: ((Throwable) -> Unit) = { throwable ->
+                onInstallationFailed()
+                logger.error("Unable to install add-on from $fileUri", throwable)
+            }
+            addonManager.installAddon(
+                fileUri,
+                onSuccess,
+                onError,
+            )
+        }
+    }
+
+    internal fun convertToFileUri(uri: Uri): String = uri.toFileUri(context, "XPIs").toString()
+}
+
+internal open class AddonOpenDocument : ActivityResultContracts.OpenDocument() {
+    override fun createIntent(context: Context, input: Array<String>): Intent {
+        // We're restricting the mime type to XPI files, because that's expected by GeckoView currently.
+        return super.createIntent(context, arrayOf("application/x-xpinstall"))
+    }
+}

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonFilePickerTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonFilePickerTest.kt
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.addons.mozilla.components.feature.addons.ui
+
+import android.content.ActivityNotFoundException
+import android.net.Uri
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.feature.addons.AddonManager
+import mozilla.components.feature.addons.ui.AddonFilePicker
+import mozilla.components.feature.addons.ui.AddonOpenDocument
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class AddonFilePickerTest {
+
+    private lateinit var filePicker: AddonFilePicker
+    private lateinit var addonManager: AddonManager
+
+    @Before
+    fun setup() {
+        addonManager = mock()
+        filePicker = spy(
+            AddonFilePicker(testContext, addonManager),
+        )
+    }
+
+    @Test
+    fun `WHEN registerForResults is called THEN register AddonOpenDocument`() {
+        val resultCaller: ActivityResultCaller = mock()
+
+        whenever(resultCaller.registerForActivityResult(any<AddonOpenDocument>(), any())).thenReturn(mock())
+
+        filePicker.registerForResults(resultCaller)
+
+        verify(resultCaller).registerForActivityResult(any<AddonOpenDocument>(), any())
+    }
+
+    @Test
+    fun `WHEN launch is called THEN delegate to the activityLauncher`() {
+        val activityLauncher: ActivityResultLauncher<Array<String>> = mock()
+
+        filePicker.activityLauncher = activityLauncher
+
+        val wasOpened = filePicker.launch()
+
+        verify(activityLauncher).launch(any())
+        assertTrue(wasOpened)
+    }
+
+    @Test
+    fun `GIVEN a file picker is not present WHEN launch is called THEN return false`() {
+        val activityLauncher: ActivityResultLauncher<Array<String>> = mock()
+
+        filePicker.activityLauncher = activityLauncher
+        whenever(activityLauncher.launch(any())).thenThrow(ActivityNotFoundException())
+
+        val wasOpened = filePicker.launch()
+
+        verify(activityLauncher).launch(any())
+        assertFalse(wasOpened)
+    }
+
+    @Test
+    fun `WHEN handleUriSelected is called THEN return false`() {
+        val uri: Uri = mock()
+
+        doReturn("file:///data/data/XPIs/addon.xpi").`when`(filePicker).convertToFileUri(uri)
+
+        filePicker.handleUriSelected(uri)
+
+        verify(addonManager).installAddon(any<String>(), any(), any())
+    }
+}

--- a/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/net/Uri.kt
+++ b/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/net/Uri.kt
@@ -11,9 +11,12 @@ import android.os.Build
 import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
 import androidx.annotation.VisibleForTesting
+import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.kotlin.sanitizeFileName
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
+import java.io.InputStream
 import java.util.UUID
 
 internal val commonPrefixes = listOf("www.", "mobile.", "m.")
@@ -128,6 +131,36 @@ fun Uri.getFileName(contentResolver: ContentResolver): String {
  */
 fun Uri.getFileExtension(contentResolver: ContentResolver): String {
     return MimeTypeMap.getSingleton().getExtensionFromMimeType(contentResolver.getType(this)) ?: ""
+}
+
+/**
+ * Copy the content of [this] [Uri] into a temporary file in the given [dirToCopy]
+ * @return A "file://" [Uri] which contains the content of [this] [Uri].
+ */
+fun Uri.toFileUri(context: Context, dirToCopy: String = "/temps"): Uri {
+    val contentResolver = context.contentResolver
+    val cacheUploadDirectory = File(context.cacheDir, dirToCopy)
+
+    if (!cacheUploadDirectory.exists()) {
+        cacheUploadDirectory.mkdir()
+    }
+
+    val temporalFile = File(cacheUploadDirectory, getFileName(contentResolver))
+    try {
+        contentResolver.openInputStream(this)!!.use { inStream ->
+            copyFile(temporalFile, inStream)
+        }
+    } catch (e: IOException) {
+        Logger("Uri.kt").warn("Could not convert uri to file uri", e)
+    }
+    return Uri.parse("file:///${Uri.encode(temporalFile.absolutePath)}")
+}
+
+@VisibleForTesting
+internal fun copyFile(temporalFile: File, inStream: InputStream): Long {
+    return FileOutputStream(temporalFile).use { outStream ->
+        inStream.copyTo(outStream)
+    }
 }
 
 @VisibleForTesting

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -36,6 +36,7 @@ import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
+import mozilla.components.feature.addons.ui.AddonFilePicker
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.ktx.android.view.showKeyboard
 import mozilla.components.ui.widgets.withCenterAlignedButtons
@@ -70,6 +71,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private val args by navArgs<SettingsFragmentArgs>()
     private lateinit var accountUiView: AccountUiView
+    private lateinit var addonFilePicker: AddonFilePicker
     private val profilerViewModel: ProfilerViewModel by activityViewModels()
 
     @VisibleForTesting
@@ -106,6 +108,18 @@ class SettingsFragment : PreferenceFragmentCompat() {
             httpClient = requireComponents.core.client,
             updateFxAAllowDomesticChinaServerMenu = ::updateFxAAllowDomesticChinaServerMenu,
         )
+
+        addonFilePicker = AddonFilePicker(
+            requireContext(),
+            requireComponents.addonManager,
+        ) {
+            Toast.makeText(
+                context,
+                getString(R.string.mozac_feature_addons_failed_to_install_generic),
+                Toast.LENGTH_LONG,
+            ).show()
+        }
+        addonFilePicker.registerForResults(this)
 
         // It's important to update the account UI state in onCreate since that ensures we'll never
         // display an incorrect state in the UI. We take care to not also call it as part of onResume
@@ -386,6 +400,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
             resources.getString(R.string.pref_key_nimbus_experiments) -> {
                 SettingsFragmentDirections.actionSettingsFragmentToNimbusExperimentsFragment()
             }
+            resources.getString(R.string.pref_key_install_local_addon) -> {
+                addonFilePicker.launch()
+                null
+            }
             resources.getString(R.string.pref_key_override_amo_collection) -> {
                 val context = requireContext()
                 val dialogView = LayoutInflater.from(context).inflate(R.layout.amo_collection_override_dialog, null)
@@ -488,6 +506,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 (requireContext().components.core.engine.profiler?.isProfilerActive() != null)
         }
         setupCookieBannerPreference()
+        setupInstallAddonFromFilePreference(requireContext().settings())
         setupAmoCollectionOverridePreference(requireContext().settings())
         setupGeckoLogsPreference(requireContext().settings())
         setupAllowDomesticChinaFxaServerPreference()
@@ -695,6 +714,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
                     return super.onPreferenceChange(preference, newValue)
                 }
             }
+        }
+    }
+
+    @VisibleForTesting
+    internal fun setupInstallAddonFromFilePreference(settings: Settings) {
+        with(requirePreference<Preference>(R.string.pref_key_install_local_addon)) {
+            isVisible = settings.showSecretDebugMenuThisSession
         }
     }
 

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -38,6 +38,7 @@
     <string name="pref_key_delete_browsing_data_on_quit_categories" translatable="false">pref_key_delete_browsing_data_on_quit_categories</string>
     <string name="pref_key_last_known_mode_private" translatable="false">pref_key_last_known_mode_private</string>
     <string name="pref_key_addons" translatable="false">pref_key_addons</string>
+    <string name="pref_key_install_local_addon" translatable="false">pref_key_install_local_addon</string>
     <string name="pref_key_override_amo_user" translatable="false">pref_key_override_amo_user</string>
     <string name="pref_key_override_amo_collection" translatable="false">pref_key_override_amo_collection</string>
     <string name="pref_key_enable_gecko_logs" translatable="false">pref_key_enable_gecko_logs</string>

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -610,6 +610,8 @@
 
     <!-- Preference for add_ons -->
     <string name="preferences_addons">Add-ons</string>
+    <!-- Preference for installing a local add-on -->
+    <string name="preferences_install_local_addon">Install add-on from file</string>
     <!-- Preference for notifications -->
     <string name="preferences_notifications">Notifications</string>
     <!-- Summary for notification preference indicating notifications are allowed -->

--- a/fenix/app/src/main/res/xml/preferences.xml
+++ b/fenix/app/src/main/res/xml/preferences.xml
@@ -150,6 +150,12 @@
             android:title="@string/preferences_addons" />
 
         <androidx.preference.Preference
+            android:key="@string/pref_key_install_local_addon"
+            app:iconSpaceReserved="false"
+            app:isPreferenceVisible="false"
+            android:title="@string/preferences_install_local_addon" />
+
+        <androidx.preference.Preference
             android:key="@string/pref_key_override_amo_collection"
             app:iconSpaceReserved="false"
             android:title="@string/preferences_customize_amo_collection" />

--- a/fenix/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
@@ -31,6 +31,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
@@ -57,6 +58,7 @@ class SettingsFragmentTest {
         every { testContext.components.core.engine.profiler } returns mockk(relaxed = true)
         every { testContext.components.core.client } returns client
         every { testContext.components.settings } returns mockk(relaxed = true)
+        every { testContext.components.addonManager } returns mockk(relaxed = true)
         every { testContext.components.analytics } returns mockk(relaxed = true)
         every { testContext.components.backgroundServices } returns mockk(relaxed = true)
 
@@ -93,6 +95,33 @@ class SettingsFragmentTest {
         every { settings.showSecretDebugMenuThisSession } returns true
         settingsFragment.setupAmoCollectionOverridePreference(settings)
         assertTrue(preferenceAmoCollectionOverride.isVisible)
+    }
+
+    @Test
+    fun `Install add-on from file pref is visible if debug menu active and feature is enabled`() = runTestOnMain {
+        val settingsFragment = SettingsFragment()
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
+
+        activity.supportFragmentManager.beginTransaction()
+            .add(settingsFragment, "test")
+            .commitNow()
+
+        advanceUntilIdle()
+
+        val preference = settingsFragment.findPreference<Preference>(
+            settingsFragment.getPreferenceKey(R.string.pref_key_install_local_addon),
+        )
+
+        settingsFragment.setupInstallAddonFromFilePreference(mockk(relaxed = true))
+        assertNotNull(preference)
+        assertFalse(preference!!.isVisible)
+
+        val settings: Settings = mockk(relaxed = true)
+
+        every { settings.showSecretDebugMenuThisSession } returns true
+        settingsFragment.setupInstallAddonFromFilePreference(settings)
+        assertTrue(preference.isVisible)
+        unmockkObject(Config)
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.














### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1866293