### PR TITLE
Bug 1866260: Update guide to merging contributor PR and add the steps to replace Bors

### DIFF
--- a/fenix/docs/Guide-to-merging-contributor-PRs.md
+++ b/fenix/docs/Guide-to-merging-contributor-PRs.md
@@ -1,6 +1,6 @@
 # Guide to merging contributor PRs for Firefox Android team members
 
-Contributor PRs will run only a specific suite of CI tests (excluding UI tests) in order to protect secrets. Use the following steps when reviewing and merging a contributor PR. 
+Contributor PRs will run only a specific suite of CI tests (excluding UI tests) in order to protect secrets. Use the following steps when reviewing and merging a contributor PR.
 
 ## Process for landing contributor PR
 _Note: these instructions use https://cli.github.com/_
@@ -17,12 +17,57 @@ gh pr checkout 1234 # for https://github.com/mozilla-mobile/firefox-android/pull
 
 3. Review the code to make sure everything is clean.
 
-4. Once a Firefox Android team member has reviewed the PR and deemed it safe, comment the following to start UI tests.
-```bors try```
+4. ~~Once a Firefox Android team member has reviewed the PR and deemed it safe, comment the following to start UI tests.
+   ```bors try```~~  
+   `Bors` public instance is now offline, as they announced in [their newsletter](https://bugzilla.mozilla.org/show_bug.cgi?id=1850420). Please refer to section "Process for running UI tests on a contributor PR" above.
+
 
 5. Once the UI tests have all completed and passed, approve the PR and add `approved` and `needs landing` label the contributor's PR.
 
 6. Monitor the merging process to make sure it lands as expected.
+
+## Process for running UI tests on a contributor PR
+
+1. Make sure you have already checked out the contributor's branch onto your fork, following the previous session's first step.
+```sh
+git fetch --all
+gh pr checkout <PR number>
+
+# Example:
+gh pr checkout 1234 # for https://github.com/mozilla-mobile/firefox-android/pull/1234
+```
+
+3. Rename your local branch's to any name
+```
+git branch -m <new branch name>
+
+# Example: If the contributor's branch is named `eliserichards:my-fun-branch1`
+git branch -m ci-for-my-fun-branch1
+```
+
+3. Push branch to your fork using any branch name:
+```sh
+git push origin <pr-branch-name>
+
+# Example: If the contributor's branch is named `eliserichards:my-fun-branch1`
+git push origin ci-for-my-fun-branch1
+```
+
+4. Create a PR from _your fork's_ copy of the branch e.g. https://github.com/mozilla-mobile/firefox-android/compare/main...eliserichards:my-fun-branch1
+
+* Please note in the PR description which PR you are running CI for. Example: https://github.com/mozilla-mobile/firefox-android/pull/4577
+
+***
+
+**Once you create this PR, the CI for both the original and the duplicate PRs will run. When everything is green, you can merge either of them.**
+
+5. To land the original:
+* i. Make sure that contributor's branch hasn't diverged from yours (they must have the same SHA).
+* ii. The change has to be on the top of the main branch when it is first in line in the merge queue.
+* iii. It requires the needs-landing label.
+
+**NB**: Adding `needs-landing` label while failing to ensure the same SHA will block the mergify queue and will require manual intervention: mergify will trigger CI for the original PR again and wait for it to finish, but CI won’t run all the checks because there is no PR with the same SHA any more that backs it up. If that happens, talk to the release team.
+
 
 ## Process for updating contributor PR (if contributor needs help or is unresponsive)
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1866260