### PR TITLE
Bug 1866318 - Retry intent referrer access once

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix
 import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.StrictMode
@@ -126,7 +127,8 @@ class IntentReceiverActivity : Activity() {
             return
         }
         // NB: referrer can be spoofed by the calling application. Use with caution.
-        val r = referrer ?: return
+        val r = tryGettingReferrer() ?: return
+
         intent.putExtra(EXTRA_ACTIVITY_REFERRER_PACKAGE, r.host)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             // Category is supported for API>=26.
@@ -138,6 +140,25 @@ class IntentReceiverActivity : Activity() {
                     // At least we tried.
                 }
             }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun tryGettingReferrer(): Uri? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) {
+            return null
+        }
+
+        return try {
+            referrer
+        } catch (e: RuntimeException) {
+            try {
+                referrer
+            } catch (e: Exception) {
+                null
+            }
+        } catch (e: Exception) {
+            null
         }
     }
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1866318