### PR TITLE
Bug 1861694 - Use analysis status to restore (re)analysis state

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -228,17 +228,6 @@ sealed class AppAction : Action {
         data class ShoppingSheetStateUpdated(val expanded: Boolean) : ShoppingAction()
 
         /**
-         * [ShoppingAction] used to add a product to a set of products that are being analysed.
-         */
-        data class AddToProductAnalysed(val productPageUrl: String) : ShoppingAction()
-
-        /**
-         * [ShoppingAction] used to remove a product from the set of products that are being
-         * analysed.
-         */
-        data class RemoveFromProductAnalysed(val productPageUrl: String) : ShoppingAction()
-
-        /**
          * [ShoppingAction] used to update the expansion state of the highlights card.
          */
         data class HighlightsCardExpanded(

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/shopping/ShoppingState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/shopping/ShoppingState.kt
@@ -7,14 +7,11 @@ package org.mozilla.fenix.components.appstate.shopping
 /**
  * State for shopping feature that's required to live the lifetime of a session.
  *
- * @property productsInAnalysis Set of product urls that are currently being analysed or were being
- * analysed when the sheet was closed.
  * @property shoppingSheetExpanded Boolean indicating if the shopping sheet is expanded and visible.
  * @property productCardState Map of product url to [CardState] that contains the state of different
  * cards in the shopping sheet.
  */
 data class ShoppingState(
-    val productsInAnalysis: Set<String> = emptySet(),
     val shoppingSheetExpanded: Boolean? = null,
     val productCardState: Map<String, CardState> = emptyMap(),
 ) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/shopping/ShoppingStateReducer.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/shopping/ShoppingStateReducer.kt
@@ -24,18 +24,6 @@ internal object ShoppingStateReducer {
                 ),
             )
 
-            is ShoppingAction.AddToProductAnalysed -> state.copy(
-                shoppingState = state.shoppingState.copy(
-                    productsInAnalysis = state.shoppingState.productsInAnalysis + action.productPageUrl,
-                ),
-            )
-
-            is ShoppingAction.RemoveFromProductAnalysed -> state.copy(
-                shoppingState = state.shoppingState.copy(
-                    productsInAnalysis = state.shoppingState.productsInAnalysis - action.productPageUrl,
-                ),
-            )
-
             is ShoppingAction.HighlightsCardExpanded -> {
                 val updatedValue =
                     state.shoppingState.productCardState[action.productPageUrl]?.copy(

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/di/ReviewQualityCheckMiddlewareProvider.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/di/ReviewQualityCheckMiddlewareProvider.kt
@@ -45,9 +45,9 @@ object ReviewQualityCheckMiddlewareProvider {
     ): List<ReviewQualityCheckMiddleware> =
         listOf(
             providePreferencesMiddleware(settings, browserStore, appStore, scope),
-            provideNetworkMiddleware(browserStore, appStore, context, scope),
+            provideNetworkMiddleware(browserStore, context, scope),
             provideNavigationMiddleware(TabsUseCases.SelectOrAddUseCase(browserStore), context),
-            provideTelemetryMiddleware(browserStore, appStore),
+            provideTelemetryMiddleware(),
         )
 
     private fun providePreferencesMiddleware(
@@ -65,13 +65,11 @@ object ReviewQualityCheckMiddlewareProvider {
 
     private fun provideNetworkMiddleware(
         browserStore: BrowserStore,
-        appStore: AppStore,
         context: Context,
         scope: CoroutineScope,
     ) = ReviewQualityCheckNetworkMiddleware(
         reviewQualityCheckService = DefaultReviewQualityCheckService(browserStore),
         networkChecker = DefaultNetworkChecker(context),
-        appStore = appStore,
         scope = scope,
     )
 
@@ -83,11 +81,6 @@ object ReviewQualityCheckMiddlewareProvider {
         GetReviewQualityCheckSumoUrl(context),
     )
 
-    private fun provideTelemetryMiddleware(
-        browserStore: BrowserStore,
-        appStore: AppStore,
-    ) = ReviewQualityCheckTelemetryMiddleware(
-        browserStore = browserStore,
-        appStore = appStore,
-    )
+    private fun provideTelemetryMiddleware() =
+        ReviewQualityCheckTelemetryMiddleware()
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckService.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckService.kt
@@ -42,11 +42,6 @@ interface ReviewQualityCheckService {
     suspend fun analysisStatus(): AnalysisStatusDto?
 
     /**
-     * Returns the selected tab url.
-     */
-    fun selectedTabUrl(): String?
-
-    /**
      * Fetches product recommendations related to the product user is browsing in the current tab.
      *
      * @return [ProductRecommendation] if request succeeds, null otherwise.
@@ -125,9 +120,6 @@ class DefaultReviewQualityCheckService(
             }
         }
     }
-
-    override fun selectedTabUrl(): String? =
-        browserStore.state.selectedTab?.content?.url
 
     override suspend fun productRecommendation(shouldRecordAvailableTelemetry: Boolean): ProductRecommendation? =
         withContext(Dispatchers.Main) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckTelemetryMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckTelemetryMiddleware.kt
@@ -4,13 +4,10 @@
 
 package org.mozilla.fenix.shopping.middleware
 
-import mozilla.components.browser.state.selector.selectedTab
-import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.lib.state.MiddlewareContext
 import mozilla.components.lib.state.Store
 import org.mozilla.fenix.GleanMetrics.Shopping
 import org.mozilla.fenix.GleanMetrics.ShoppingSettings
-import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckAction
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckMiddleware
 import org.mozilla.fenix.shopping.store.ReviewQualityCheckState
@@ -22,10 +19,7 @@ private const val ACTION_DISABLED = "disabled"
 /**
  * Middleware that captures telemetry events for the review quality check feature.
  */
-class ReviewQualityCheckTelemetryMiddleware(
-    private val browserStore: BrowserStore,
-    private val appStore: AppStore,
-) : ReviewQualityCheckMiddleware {
+class ReviewQualityCheckTelemetryMiddleware : ReviewQualityCheckMiddleware {
 
     override fun invoke(
         context: MiddlewareContext<ReviewQualityCheckState, ReviewQualityCheckAction>,
@@ -108,9 +102,8 @@ class ReviewQualityCheckTelemetryMiddleware(
             }
 
             is ReviewQualityCheckAction.UpdateProductReview -> {
-                val productPageUrl = browserStore.state.selectedTab?.content?.url
                 val state = store.state
-                if (state.isStaleAnalysis() && !isProductInAnalysis(productPageUrl)) {
+                if (state.isStaleAnalysis() && !action.restoreAnalysis) {
                     Shopping.surfaceStaleAnalysisShown.record()
                 }
             }
@@ -167,9 +160,4 @@ class ReviewQualityCheckTelemetryMiddleware(
         this is ReviewQualityCheckState.OptedIn &&
             this.productReviewState is ReviewQualityCheckState.OptedIn.ProductReviewState.AnalysisPresent &&
             this.productReviewState.analysisStatus == AnalysisStatus.NEEDS_ANALYSIS
-
-    private fun isProductInAnalysis(
-        productPageUrl: String?,
-    ): Boolean =
-        appStore.state.shoppingState.productsInAnalysis.contains(productPageUrl)
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckAction.kt
@@ -89,8 +89,14 @@ sealed interface ReviewQualityCheckAction : Action {
 
     /**
      * Triggered as a result of a [NetworkAction] to update the [ProductReviewState].
+     *
+     * @property productReviewState The product review state to update.
+     * @property restoreAnalysis Signals whether the analysis will be restored right after the update.
      */
-    data class UpdateProductReview(val productReviewState: ProductReviewState) : UpdateAction, TelemetryAction
+    data class UpdateProductReview(
+        val productReviewState: ProductReviewState,
+        val restoreAnalysis: Boolean,
+    ) : UpdateAction, TelemetryAction
 
     /**
      * Triggered as a result of a [NetworkAction] to update the [RecommendedProductState].

--- a/fenix/app/src/test/java/org/mozilla/fenix/components/appstate/ShoppingActionTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/appstate/ShoppingActionTest.kt
@@ -48,38 +48,6 @@ class ShoppingActionTest {
     }
 
     @Test
-    fun `WHEN product analysed is added THEN state should reflect that`() {
-        val store = AppStore()
-
-        store.dispatch(AppAction.ShoppingAction.AddToProductAnalysed("pdp")).joinBlocking()
-
-        val expected = ShoppingState(
-            productsInAnalysis = setOf("pdp"),
-        )
-
-        assertEquals(expected, store.state.shoppingState)
-    }
-
-    @Test
-    fun `WHEN product analysed is removed THEN state should reflect that`() {
-        val store = AppStore(
-            initialState = AppState(
-                shoppingState = ShoppingState(
-                    productsInAnalysis = setOf("pdp"),
-                ),
-            ),
-        )
-
-        store.dispatch(AppAction.ShoppingAction.RemoveFromProductAnalysed("pdp")).joinBlocking()
-
-        val expected = ShoppingState(
-            productsInAnalysis = emptySet(),
-        )
-
-        assertEquals(expected, store.state.shoppingState)
-    }
-
-    @Test
     fun `WHEN product analysis highlights card is expanded THEN state should reflect that`() {
         val store = AppStore(initialState = AppState(shoppingState = ShoppingState()))
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckService.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/shopping/fake/FakeReviewQualityCheckService.kt
@@ -13,7 +13,6 @@ class FakeReviewQualityCheckService(
     private val productAnalysis: (Int) -> ProductAnalysis? = { null },
     private val reanalysis: AnalysisStatusDto? = null,
     private val status: AnalysisStatusDto? = null,
-    private val selectedTabUrl: String? = null,
     private val productRecommendation: () -> ProductRecommendation? = { null },
     private val recordClick: (String) -> Unit = {},
     private val recordImpression: (String) -> Unit = {},
@@ -30,8 +29,6 @@ class FakeReviewQualityCheckService(
     override suspend fun reanalyzeProduct(): AnalysisStatusDto? = reanalysis
 
     override suspend fun analysisStatus(): AnalysisStatusDto? = status
-
-    override fun selectedTabUrl(): String? = selectedTabUrl
 
     override suspend fun productRecommendation(shouldRecordAvailableTelemetry: Boolean): ProductRecommendation? {
         return productRecommendation.invoke()


### PR DESCRIPTION
### What
Use analysis status api to see if the product analysis is in progress and then show the progress bar

### How
– Previously this state was being saved in `AppState`, it wasn't not needed as the API is providing that state. Remove all the actions and logic related to that. As a result, this will also result in the situation when one client starts the (re)analysis, and if another client opens the same product analysis, the reanalysis will be shown to be in progress since the API provides that.
– Add logic to fetch `analysisStatus` in `ReviewQualityCheckNetworkMiddleware` and update the state accordingly.
– Update the tests
– As a good side effect, the `ReviewQualityCheckTelemetryMiddleware` has been simplified as it doesn't need to rely on `AppStore` anymore but the action param guides it when to track stale analysis surface shown.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1861694