### PR TITLE
Bug 1868371 - Add more test data to Fx suggest related UI tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/DataGenerationHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/DataGenerationHelper.kt
@@ -22,6 +22,8 @@ import org.junit.Assert
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.utils.IntentUtils
+import java.time.LocalDate
+import java.time.LocalTime
 
 object DataGenerationHelper {
     val appContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -73,6 +75,33 @@ object DataGenerationHelper {
         val clipData = ClipData.newPlainText("label", message)
 
         clipBoard.setPrimaryClip(clipData)
+    }
+
+    /**
+     * Returns the date and time placeholder used in sponsored Fx suggest links.
+     */
+    fun getSponsoredFxSuggestPlaceHolder(): String {
+        val currentDate = LocalDate.now()
+        val currentTime = LocalTime.now()
+        val currentDay = currentDate.dayOfMonth
+        val currentMonth = currentDate.monthValue
+        val currentYear = currentDate.year
+        val currentHour = currentTime.hour
+        var placeholder: String
+
+        if (currentMonth < 10 && currentDay < 10 && currentHour < 10) {
+            placeholder = "$currentYear" + "0" + "$currentMonth" + "0" + "$currentDay" + "0" + "$currentHour"
+        } else if (currentMonth < 10 && currentDay < 10) {
+            placeholder = "$currentYear" + "0" + "$currentMonth" + "0" + "$currentDay$currentHour"
+        } else if (currentMonth < 10 && currentHour < 10) {
+            placeholder = "$currentYear" + "0" + "$currentMonth" + "$currentDay" + "0" + "$currentHour"
+        } else if (currentDay < 10 && currentHour < 10) {
+            placeholder = "$currentYear$currentMonth" + "0" + "$currentDay" + "0" + "$currentHour"
+        } else {
+            placeholder = "$currentYear$currentMonth$currentDay$currentHour"
+        }
+
+        return placeholder
     }
 
     /**


### PR DESCRIPTION
Based on this [suggestion](https://github.com/mozilla-mobile/firefox-android/pull/4546#pullrequestreview-1744598867):

- Created a map for sponsored/non sponsored suggestions which will be randomly used in the UI tests
- Created `getSponsoredFxSuggestPlaceHolder` helper to help us properly check the sponsored suggestions links (some of the links contain a placeholder `%YYYYMMDDHH%`)

All 7 UI tests successfully passed 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1868371