### PR TITLE
Bug 1867148 - Shorten the max runtime for complete jobs to 3min

### DIFF
--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -28,7 +28,7 @@ task-defaults:
     worker-type: b-android
     worker:
         docker-image: {in-tree: base}
-        max-run-time: 600
+        max-run-time: 180
     requires: all-resolved
     run:
         command:


### PR DESCRIPTION


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1867148