### PR TITLE
Bug 1867184 - Decode URLs on copy and share

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,9 @@ permalink: /changelog/
 * **concept-engine**
   * Add `reportBackInStock` API to `EngineSession` to allow reporting a shopping product is back in stock. [Bug 1858947](https://bugzilla.mozilla.org/show_bug.cgi?id=1858947)
 
+* **feature-share**
+  * URLs are now decoded when sharing and copying to clipboard. [Bug 1867184](https://bugzilla.mozilla.org/show_bug.cgi?id=1867184)
+
 * **feature-media**
   * Added `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permission to the `AndroidManifest.xml`.
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -248,7 +248,7 @@ class DefaultShareController(
             // https://github.com/mozilla-mobile/android-components/issues/2879
             Uri.parse(url).getQueryParameter("url") ?: url
         } else {
-            url
+            Uri.decode(url)
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/ToolbarPopupWindow.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/ToolbarPopupWindow.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.utils
 
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
+import android.net.Uri
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
@@ -119,12 +120,13 @@ object ToolbarPopupWindow {
         store: BrowserStore,
         customTabId: String? = null,
     ): String? {
-        return if (customTabId != null) {
+        var url = if (customTabId != null) {
             val customTab = store.state.findCustomTab(customTabId)
             customTab?.content?.url
         } else {
             val selectedTab = store.state.selectedTab
             selectedTab?.readerState?.activeUrl ?: selectedTab?.content?.url
         }
+        return Uri.decode(url)
     }
 }

--- a/fenix/app/src/test/java/org/mozilla/fenix/utils/ToolbarPopupWindowTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/utils/ToolbarPopupWindowTest.kt
@@ -39,6 +39,22 @@ class ToolbarPopupWindowTest {
         store = BrowserStore(BrowserState(tabs = listOf(regularTab), selectedTabId = regularTab.id))
         assertEquals("http://firefox.com", ToolbarPopupWindow.getUrlForClipboard(store))
 
+        // Non-ASCII custom tab to test url decoding
+        val UTF8CustomTabSession = createCustomTab("https://ru.wikipedia.org/wiki/Браузер")
+        store = BrowserStore(BrowserState(customTabs = listOf(UTF8CustomTabSession)))
+        assertEquals(
+            "https://ru.wikipedia.org/wiki/Браузер",
+            ToolbarPopupWindow.getUrlForClipboard(store, UTF8CustomTabSession.id),
+        )
+
+        // Non-ASCII regular tab to test url decoding
+        val URF8regularTab = createTab(url = "https://ru.wikipedia.org/wiki/Заглавная_страница")
+        store = BrowserStore(BrowserState(tabs = listOf(URF8regularTab), selectedTabId = URF8regularTab.id))
+        assertEquals(
+            "https://ru.wikipedia.org/wiki/Заглавная_страница",
+            ToolbarPopupWindow.getUrlForClipboard(store),
+        )
+
         // Reader Tab
         val readerTab = createTab(
             url = "moz-extension://1234",


### PR DESCRIPTION
Fixes [1867184](https://bugzilla.mozilla.org/show_bug.cgi?id=1867184)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1867184