### PR TITLE
Bug 1867297 - Remove the use of `BLOCKED_PERMISSIONS`

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
@@ -119,42 +119,6 @@ class AddonManager(
     }
 
     /**
-     * Installs the provided [Addon].
-     *
-     * @param addon the addon to install.
-     * @param onSuccess (optional) callback invoked if the addon was installed successfully,
-     * providing access to the [Addon] object.
-     * @param onError (optional) callback invoked if there was an error installing the addon.
-     */
-    fun installAddon(
-        addon: Addon,
-        onSuccess: ((Addon) -> Unit) = { },
-        onError: ((String, Throwable) -> Unit) = { _, _ -> },
-    ): CancellableOperation {
-        // Verify the add-on doesn't require blocked permissions
-        // only available to built-in extensions
-        BLOCKED_PERMISSIONS.forEach { blockedPermission ->
-            if (addon.permissions.any { it.equals(blockedPermission, ignoreCase = true) }) {
-                onError(addon.id, IllegalArgumentException("Addon requires invalid permission $blockedPermission"))
-                return CancellableOperation.Noop()
-            }
-        }
-
-        val pendingAction = addPendingAddonAction()
-        return runtime.installWebExtension(
-            id = addon.id,
-            url = addon.downloadUrl,
-            onSuccess = { ext ->
-                onAddonInstalled(ext, pendingAction, onSuccess)
-            },
-            onError = { id, throwable ->
-                completePendingAddonAction(pendingAction)
-                onError(id, throwable)
-            },
-        )
-    }
-
-    /**
      * Installs an [Addon] from the provided [url].
      *
      *  @param url the url pointing to either a resources path for locating the extension
@@ -444,10 +408,6 @@ class AddonManager(
     }
 
     companion object {
-        // List of invalid permissions for external add-ons i.e. permissions only
-        // granted to built-in extensions:
-        val BLOCKED_PERMISSIONS = listOf("geckoViewAddons", "nativeMessaging")
-
         // Size of the icon to load for extensions
         const val ADDON_ICON_SIZE = 48
 

--- a/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
+++ b/android-components/samples/browser/src/main/java/org/mozilla/samples/browser/addons/AddonsFragment.kt
@@ -197,7 +197,7 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
         isInstallationInProgress = true
 
         val installOperation = requireContext().components.addonManager.installAddon(
-            addon,
+            url = addon.downloadUrl,
             onSuccess = { installedAddon ->
                 context?.let {
                     adapter?.updateAddon(installedAddon)
@@ -206,7 +206,7 @@ class AddonsFragment : Fragment(), AddonsManagerAdapterDelegate {
                     showInstallationDialog(installedAddon)
                 }
             },
-            onError = { _, e ->
+            onError = { e ->
                 // No need to display an error message if installation was cancelled by the user.
                 if (e !is CancellationException) {
                     Toast.makeText(

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -176,14 +176,14 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
             binding?.let { announceForAccessibility(it.addonProgressOverlay.addOnsOverlayText.text) }
         }
         val installOperation = provideAddonManger().installAddon(
-            addon,
+            url = addon.downloadUrl,
             onSuccess = {
                 runIfFragmentIsAttached {
                     adapter?.updateAddon(it)
                     binding?.addonProgressOverlay?.overlayCardView?.visibility = View.GONE
                 }
             },
-            onError = { _, _ ->
+            onError = { _ ->
                 binding?.addonProgressOverlay?.overlayCardView?.visibility = View.GONE
             },
         )


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1867297