### PR TITLE
Bug 1858947 - Expose Shopping API reportBackInStock to AC

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -888,6 +888,34 @@ class GeckoEngineSession(
     }
 
     /**
+     * See [EngineSession.reportBackInStock]
+     */
+    override fun reportBackInStock(
+        url: String,
+        onResult: (String) -> Unit,
+        onException: (Throwable) -> Unit,
+    ) {
+        geckoSession.reportBackInStock(url).then({
+                response ->
+            val errorMessage = "Invalid value: unable to report back in stock from Gecko Engine."
+            if (response == null) {
+                logger.error(errorMessage)
+                onException(
+                    java.lang.IllegalStateException(errorMessage),
+                )
+                return@then GeckoResult()
+            }
+            onResult(response)
+            GeckoResult<String>()
+        }, {
+                throwable ->
+            logger.error("Request for reporting back in stock failed.", throwable)
+            onException(throwable)
+            GeckoResult()
+        })
+    }
+
+    /**
      * Convenience method for the error when session translation is not available.
      */
     private fun sessionTranslationNotAvailable(): Throwable {

--- a/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
+++ b/android-components/components/browser/engine-system/src/main/java/mozilla/components/browser/engine/system/SystemEngineSession.kt
@@ -493,6 +493,17 @@ class SystemEngineSession(
     }
 
     /**
+     * See [EngineSession.reportBackInStock]
+     */
+    override fun reportBackInStock(
+        url: String,
+        onResult: (String) -> Unit,
+        onException: (Throwable) -> Unit,
+    ) {
+        throw UnsupportedOperationException("Reporting back in stock is not available in this engine")
+    }
+
+    /**
      * See [EngineSession.requestTranslate]
      */
     override fun requestTranslate(

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -110,6 +110,11 @@ class EngineObserverTest {
                 onResult: (Boolean) -> Unit,
                 onException: (Throwable) -> Unit,
             ) {}
+            override fun reportBackInStock(
+                url: String,
+                onResult: (String) -> Unit,
+                onException: (Throwable) -> Unit,
+            ) {}
             override fun sendImpressionAttributionEvent(
                 aid: String,
                 onResult: (Boolean) -> Unit,
@@ -226,6 +231,11 @@ class EngineObserverTest {
                 onResult: (Boolean) -> Unit,
                 onException: (Throwable) -> Unit,
             ) {}
+            override fun reportBackInStock(
+                url: String,
+                onResult: (String) -> Unit,
+                onException: (Throwable) -> Unit,
+            ) {}
             override fun requestTranslate(
                 fromLanguage: String,
                 toLanguage: String,
@@ -332,6 +342,11 @@ class EngineObserverTest {
             override fun sendImpressionAttributionEvent(
                 aid: String,
                 onResult: (Boolean) -> Unit,
+                onException: (Throwable) -> Unit,
+            ) {}
+            override fun reportBackInStock(
+                url: String,
+                onResult: (String) -> Unit,
                 onException: (Throwable) -> Unit,
             ) {}
             override fun requestTranslate(

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -969,6 +969,18 @@ abstract class EngineSession(
     )
 
     /**
+     * Reports when a product is back in stock.
+     *
+     * @param onResult callback invoked if the engine API returns a valid response.
+     * @param onException callback invoked if there was an error getting the response.
+     */
+    abstract fun reportBackInStock(
+        url: String,
+        onResult: (String) -> Unit,
+        onException: (Throwable) -> Unit,
+    )
+
+    /**
      * Requests the [EngineSession] to translate the current session's contents.
      *
      * @param fromLanguage The BCP 47 language tag that the page should be translated from.

--- a/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
+++ b/android-components/components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt
@@ -1051,6 +1051,12 @@ open class DummyEngineSession : EngineSession() {
         onException: (Throwable) -> Unit,
     ) {}
 
+    override fun reportBackInStock(
+        url: String,
+        onResult: (String) -> Unit,
+        onException: (Throwable) -> Unit,
+    ) {}
+
     override fun requestTranslate(
         fromLanguage: String,
         toLanguage: String,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ permalink: /changelog/
 * [Gecko](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/plugins/dependencies/src/main/java/Gecko.kt)
 * [Configuration](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/.config.yml)
 
+* **concept-engine**
+  * Add `reportBackInStock` API to `EngineSession` to allow reporting a shopping product is back in stock. [Bug 1858947](https://bugzilla.mozilla.org/show_bug.cgi?id=1858947)
+
 * **feature-media**
   * Added `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permission to the `AndroidManifest.xml`.
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1858947