### PR TITLE
Bug 1868197 - Remove onInstallationFailed callback from AddonFilePicker.

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonFilePicker.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonFilePicker.kt
@@ -24,7 +24,6 @@ import mozilla.components.support.ktx.android.net.toFileUri
 class AddonFilePicker(
     val context: Context,
     private val addonManager: AddonManager,
-    private val onInstallationFailed: (() -> Unit) = { },
 ) {
     internal lateinit var activityLauncher: ActivityResultLauncher<Array<String>>
     private val logger = Logger("AddonFilePicker")
@@ -59,7 +58,6 @@ class AddonFilePicker(
                 logger.info("Add-on from $fileUri installed successfully")
             }
             val onError: ((Throwable) -> Unit) = { throwable ->
-                onInstallationFailed()
                 logger.error("Unable to install add-on from $fileUri", throwable)
             }
             addonManager.installAddon(

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -112,13 +112,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         addonFilePicker = AddonFilePicker(
             requireContext(),
             requireComponents.addonManager,
-        ) {
-            Toast.makeText(
-                context,
-                getString(R.string.mozac_feature_addons_failed_to_install_generic),
-                Toast.LENGTH_LONG,
-            ).show()
-        }
+        )
         addonFilePicker.registerForResults(this)
 
         // It's important to update the account UI state in onCreate since that ensures we'll never


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1868197