### PR TITLE
Bug 1867498 - Add report add-on button in detail view

### DIFF
--- a/android-components/components/feature/addons/src/main/res/values/strings.xml
+++ b/android-components/components/feature/addons/src/main/res/values/strings.xml
@@ -117,8 +117,10 @@
     <string name="mozac_feature_addons_details">Details</string>
     <!-- Displays a page with all the permissions of an add-on. -->
     <string name="mozac_feature_addons_permissions">Permissions</string>
-    <!-- This is button that remove (uninstall an add-on). -->
+    <!-- This is a button to remove (i.e. uninstall) an add-on. -->
     <string name="mozac_feature_addons_remove">Remove</string>
+    <!-- This is a button to report an add-on. -->
+    <string name="mozac_feature_addons_report">Report</string>
     <!-- This is the title of a dialog that asks the users if they to install or not an add-on. %1$s is the add-on name. -->
     <string name="mozac_feature_addons_permissions_dialog_title">Add %1$s?</string>
     <!-- This is the title of a dialog that asks the users to grant optional permissions. %1$s is the add-on name. -->

--- a/fenix/app/src/main/res/layout/fragment_installed_add_on_details.xml
+++ b/fenix/app/src/main/res/layout/fragment_installed_add_on_details.xml
@@ -99,6 +99,13 @@
                 android:layout_marginHorizontal="16dp"
                 android:layout_below="@id/permissions"
                 android:text="@string/mozac_feature_addons_remove" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/report_add_on"
+                style="@style/NeutralButton"
+                android:layout_marginHorizontal="16dp"
+                android:layout_below="@id/remove_add_on"
+                android:text="@string/mozac_feature_addons_report" />
         </RelativeLayout>
     </ScrollView>
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1867498