### PR TITLE
Bug 1847305 - Fix blocked upward scrolling gestures on some pages

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineView.kt
@@ -96,6 +96,27 @@ class GeckoEngineView @JvmOverloads constructor(
 
     init {
         addView(geckoView)
+
+        /**
+         * With the current design, we have a [NestedGeckoView] inside this
+         * [GeckoEngineView]. In our supported embedders, we wrap this with the
+         * AndroidX `SwipeRefreshLayout` to enable features like Pull-To-Refresh:
+         *
+         * ```
+         *  SwipeRefreshLayout
+         * └── GeckoEngineView
+         *    └── NestedGeckoView
+         * ```
+         *
+         * `SwipeRefreshLayout` only looks at the direct child to see if it has nested scrolling
+         * enabled. As we embed [NestedGeckoView] inside [GeckoEngineView], we change the hierarchy
+         * so that [NestedGeckoView] is no longer the direct child of `SwipeRefreshLayout`.
+         *
+         * To fix this we enable nested scrolling on the GeckoEngineView to emulate this
+         * information. This is required information for `View.requestDisallowInterceptTouchEvent`
+         * to work correctly in the [NestedGeckoView].
+         */
+        isNestedScrollingEnabled = true
     }
 
     /**

--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -82,6 +82,8 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
 
             MotionEvent.ACTION_DOWN -> {
                 // A new gesture started. Ask GV if it can handle this.
+                inputResultDetail = InputResultDetail.newInstance(false)
+                parent?.requestDisallowInterceptTouchEvent(true)
                 updateInputResult(event)
 
                 nestedOffsetY = 0
@@ -97,9 +99,6 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
             // We don't care about other touch events
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 stopNestedScroll()
-                // Reset handled status so that parents of this View would not get the old value
-                // when querying it for a newly started touch event.
-                inputResultDetail = InputResultDetail.newInstance(true)
             }
         }
 
@@ -127,6 +126,7 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
                     it?.scrollableDirections(),
                     it?.overscrollDirections(),
                 )
+                parent?.requestDisallowInterceptTouchEvent(false)
                 startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL)
             }
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,10 @@ permalink: /changelog/
 * **support-utils**
   * Recognize IPv6 literals in the address bar. [Bug 1803465](https://bugzilla.mozilla.org/show_bug.cgi?id=1803465)
 
+* **browser-engine-gecko**
+  * Enable nested scrolling on `GeckoEngineView` as required by `NestedGeckoView`. [Bug 1847305](https://bugzilla.mozilla.org/show_bug.cgi?id=1847305)
+  * `NestedGeckoView` now disallows touch interception until we receive a response from `GeckoView#onTouchEventForDetailResult`. [Bug 1847305](https://bugzilla.mozilla.org/show_bug.cgi?id=1847305)
+
 # 121.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v120..releases_v121)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/releases_v121/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)


### PR DESCRIPTION
~Fixed the current tests to pass. We have currently chosen not to
add new ones today after a large amount of investigation. Today, it
is too complicated in order to add something meaningful that would
test the effects of the patch and not the implementation.~

Fixed the current tests to pass.

The current tests are asserting implementation, so a new test was added
to test the behaviour by wrapping `NestedGeckoView` in a parent `View`
and counts the `onInterceptTouchEvent` calls it receives. When we are
in a gesture (starting with `ACTION_DOWN`) we deny the touch events to
the parent views until we receive a result from APZ.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1847305