### PR TITLE
Bug 1868249 - Prevent multiple add-on installations at one the time.

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoResult.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.CancellableOperation
 import org.mozilla.geckoview.GeckoResult
+import java.lang.Exception
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.resume
@@ -43,10 +44,15 @@ fun <T> GeckoResult<T>.asCancellableOperation(): CancellableOperation {
             val result = CompletableDeferred<Boolean>()
             geckoResult.cancel().then(
                 {
+                    // Notify the geckoResult that there were able to cancel the request
+                    if (it == null || it == false) {
+                        geckoResult.completeExceptionally(Exception("Unable to cancel"))
+                    }
                     result.complete(it ?: false)
                     GeckoResult<Void>()
                 },
                 { throwable ->
+                    geckoResult.completeExceptionally(throwable)
                     result.completeExceptionally(throwable)
                     GeckoResult<Void>()
                 },

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -192,10 +192,9 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
         binding?.addonProgressOverlay?.cancelButton?.setOnClickListener {
             lifecycleScope.launch(Dispatchers.Main) {
                 val safeBinding = binding
-                // Hide the installation progress overlay once cancellation is successful.
-                if (installOperation.cancel().await()) {
-                    safeBinding?.addonProgressOverlay?.overlayCardView?.visibility = View.GONE
-                }
+                // Hide the installation progress overlay once cancellation is finished.
+                installOperation.cancel().await()
+                safeBinding?.addonProgressOverlay?.overlayCardView?.visibility = View.GONE
             }
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/extension/WebExtensionPromptFeature.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/extension/WebExtensionPromptFeature.kt
@@ -48,10 +48,6 @@ class WebExtensionPromptFeature(
      */
     var onAddonChanged: (Addon) -> Unit = {}
 
-    /**
-     * Whether or not an add-on installation is in progress.
-     */
-    private var isInstallationInProgress = false
     private var scope: CoroutineScope? = null
 
     /**
@@ -221,7 +217,7 @@ class WebExtensionPromptFeature(
         forOptionalPermissions: Boolean = false,
         optionalPermissions: List<String> = emptyList(),
     ) {
-        if (isInstallationInProgress || hasExistingPermissionDialogFragment()) {
+        if (hasExistingPermissionDialogFragment()) {
             return
         }
 
@@ -327,7 +323,7 @@ class WebExtensionPromptFeature(
     }
 
     private fun showPostInstallationDialog(addon: Addon) {
-        if (!isInstallationInProgress && !hasExistingAddonPostInstallationDialogFragment()) {
+        if (!hasExistingAddonPostInstallationDialogFragment()) {
             // Fragment may not be attached to the context anymore during onConfirmButtonClicked handling,
             // but we still want to be able to process user selection of the 'allowInPrivateBrowsing' pref.
             // This is a best-effort attempt to do so - retain a weak reference to the application context


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1868249