### PR TITLE
Bug 1839075 - Corrects timeout duration for CopyDownloadFeature

### DIFF
--- a/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/temporary/CopyDownloadFeature.kt
+++ b/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/temporary/CopyDownloadFeature.kt
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit
  *  - temporarily cache the downloaded resources
  *  - copy the resource to the device clipboard.
  *
- * with a 1 second timeout to ensure a smooth UX.
+ * with a 1 minute timeout to ensure a smooth UX.
  *
  * To finish the process in this small timeframe the feature is recommended to be used only for images.
  *
@@ -62,7 +62,7 @@ class CopyDownloadFeature(
     /**
      * At most time to allow for the file to be downloaded.
      */
-    private val operationTimeoutMs by lazy { TimeUnit.MINUTES.toMinutes(1) }
+    private val operationTimeoutMs by lazy { TimeUnit.MINUTES.toMillis(1) }
 
     override fun start() {
         scope = store.flowScoped { flow ->


### PR DESCRIPTION
Previous line always returned `1`. Now it will return `1000`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1839075