### PR TITLE
Bug 1868378 - Indicate the installation method when installing an add-on.

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -52,6 +52,7 @@ import mozilla.components.concept.engine.utils.EngineVersion
 import mozilla.components.concept.engine.webextension.Action
 import mozilla.components.concept.engine.webextension.ActionHandler
 import mozilla.components.concept.engine.webextension.EnableSource
+import mozilla.components.concept.engine.webextension.InstallationMethod
 import mozilla.components.concept.engine.webextension.TabHandler
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionDelegate
@@ -256,12 +257,16 @@ class GeckoEngine(
      */
     override fun installWebExtension(
         url: String,
+        installationMethod: InstallationMethod?,
         onSuccess: ((WebExtension) -> Unit),
         onError: ((Throwable) -> Unit),
     ): CancellableOperation {
         require(!url.isResourceUrl()) { "url shouldn't be a resource url" }
 
-        val geckoResult = runtime.webExtensionController.install(url).apply {
+        val geckoResult = runtime.webExtensionController.install(
+            url,
+            installationMethod?.toGeckoInstallationMethod(),
+        ).apply {
             then(
                 {
                     onExtensionInstalled(it!!, onSuccess)
@@ -1370,5 +1375,13 @@ internal fun ContentBlockingController.LogEntry.BlockingData.getBlockedCategory(
         Event.BLOCKED_SOCIALTRACKING_CONTENT, Event.COOKIES_BLOCKED_SOCIALTRACKER -> TrackingCategory.MOZILLA_SOCIAL
         Event.BLOCKED_TRACKING_CONTENT -> TrackingCategory.SCRIPTS_AND_SUB_RESOURCES
         else -> TrackingCategory.NONE
+    }
+}
+
+internal fun InstallationMethod.toGeckoInstallationMethod(): String? {
+    return when (this) {
+        InstallationMethod.MANAGER -> WebExtensionController.INSTALLATION_METHOD_MANAGER
+        InstallationMethod.FROM_FILE -> WebExtensionController.INSTALLATION_METHOD_FROM_FILE
+        else -> null
     }
 }

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/InstallationMethod.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/InstallationMethod.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.webextension
+
+/**
+ *  The method used to install a [WebExtension].
+ */
+enum class InstallationMethod {
+    /**
+     * Indicates the [WebExtension] was installed from the add-ons manager.
+     */
+    MANAGER,
+
+    /**
+     * Indicates the [WebExtension] was installed from a file.
+     */
+    FROM_FILE,
+}

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtensionRuntime.kt
@@ -43,6 +43,7 @@ interface WebExtensionRuntime {
      * @param url the url pointing to an XPI file. An error is thrown when a resource URL is passed.
      * @param onSuccess (optional) callback invoked if the extension was installed successfully,
      * providing access to the [WebExtension] object for bi-directional messaging.
+     * @param installationMethod (optional) the method used to install a [WebExtension].
      * @param onError (optional) callback invoked if there was an error installing the extension.
      * This callback is invoked with an [UnsupportedOperationException] in case the engine doesn't
      * have web extension support.
@@ -50,6 +51,7 @@ interface WebExtensionRuntime {
     @Suppress("LongParameterList")
     fun installWebExtension(
         url: String,
+        installationMethod: InstallationMethod? = null,
         onSuccess: ((WebExtension) -> Unit) = { },
         onError: ((Throwable) -> Unit) = { _ -> },
     ): CancellableOperation {

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/AddonManager.kt
@@ -23,6 +23,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.CancellableOperation
 import mozilla.components.concept.engine.webextension.DisabledFlags
 import mozilla.components.concept.engine.webextension.EnableSource
+import mozilla.components.concept.engine.webextension.InstallationMethod
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.concept.engine.webextension.WebExtensionRuntime
 import mozilla.components.concept.engine.webextension.isBlockListed
@@ -125,18 +126,21 @@ class AddonManager(
      *  within the APK file (e.g. resource://android/assets/extensions/my_web_ext) or to a
      *  local (e.g. resource://android/assets/extensions/my_web_ext.xpi) or remote
      *  (e.g. https://addons.mozilla.org/firefox/downloads/file/123/some_web_ext.xpi) XPI file.
+     * @param installationMethod (optional) the method used to install a [Addon].
      * @param onSuccess (optional) callback invoked if the addon was installed successfully,
      * providing access to the [Addon] object.
      * @param onError (optional) callback invoked if there was an error installing the addon.
      */
     fun installAddon(
         url: String,
+        installationMethod: InstallationMethod? = null,
         onSuccess: ((Addon) -> Unit) = { },
         onError: ((Throwable) -> Unit) = { _ -> },
     ): CancellableOperation {
         val pendingAction = addPendingAddonAction()
         return runtime.installWebExtension(
             url = url,
+            installationMethod = installationMethod,
             onSuccess = { ext ->
                 onAddonInstalled(ext, pendingAction, onSuccess)
             },

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonFilePicker.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonFilePicker.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import mozilla.components.concept.engine.webextension.InstallationMethod
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.AddonManager
 import mozilla.components.support.base.log.logger.Logger
@@ -61,6 +62,7 @@ class AddonFilePicker(
             }
             addonManager.installAddon(
                 fileUri,
+                InstallationMethod.FROM_FILE,
                 onSuccess,
                 onError,
             )

--- a/android-components/components/feature/addons/src/test/java/AddonManagerTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonManagerTest.kt
@@ -26,6 +26,7 @@ import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.BL
 import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.SIGNATURE
 import mozilla.components.concept.engine.webextension.DisabledFlags.Companion.USER
 import mozilla.components.concept.engine.webextension.EnableSource
+import mozilla.components.concept.engine.webextension.InstallationMethod
 import mozilla.components.concept.engine.webextension.Metadata
 import mozilla.components.concept.engine.webextension.WebExtension
 import mozilla.components.feature.addons.AddonManager.Companion.ADDON_ICON_SIZE
@@ -535,6 +536,7 @@ class AddonManagerTest {
         val manager = AddonManager(mock(), engine, mock(), mock())
         manager.installAddon(
             url = addon.downloadUrl,
+            installationMethod = InstallationMethod.MANAGER,
             onSuccess = {
                 installedAddon = it
             },
@@ -542,6 +544,7 @@ class AddonManagerTest {
 
         verify(engine).installWebExtension(
             any(),
+            eq(InstallationMethod.MANAGER),
             onSuccessCaptor.capture(),
             any(),
         )
@@ -568,15 +571,17 @@ class AddonManagerTest {
         val manager = AddonManager(mock(), engine, mock(), mock())
         manager.installAddon(
             url = addon.downloadUrl,
+            installationMethod = InstallationMethod.FROM_FILE,
             onError = { caught ->
                 throwable = caught
             },
         )
 
         verify(engine).installWebExtension(
-            any(),
-            any(),
-            onErrorCaptor.capture(),
+            url = any(),
+            installationMethod = eq(InstallationMethod.FROM_FILE),
+            onSuccess = any(),
+            onError = onErrorCaptor.capture(),
         )
 
         onErrorCaptor.value.invoke(IllegalStateException("test"))

--- a/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonFilePickerTest.kt
+++ b/android-components/components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonFilePickerTest.kt
@@ -9,10 +9,12 @@ import android.net.Uri
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.components.concept.engine.webextension.InstallationMethod
 import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.ui.AddonFilePicker
 import mozilla.components.feature.addons.ui.AddonOpenDocument
 import mozilla.components.support.test.any
+import mozilla.components.support.test.eq
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.whenever
@@ -83,6 +85,11 @@ class AddonFilePickerTest {
 
         filePicker.handleUriSelected(uri)
 
-        verify(addonManager).installAddon(any<String>(), any(), any())
+        verify(addonManager).installAddon(
+            url = any<String>(),
+            installationMethod = eq(InstallationMethod.FROM_FILE),
+            onSuccess = any(),
+            onError = any(),
+        )
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.launch
+import mozilla.components.concept.engine.webextension.InstallationMethod
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.AddonManagerException
@@ -177,6 +178,7 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
         }
         val installOperation = provideAddonManger().installAddon(
             url = addon.downloadUrl,
+            installationMethod = InstallationMethod.MANAGER,
             onSuccess = {
                 runIfFragmentIsAttached {
                     adapter?.updateAddon(it)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1868378