### PR TITLE
Bug 1864760 - Hide toolbar actions in BaseBrowserFragment toolbar

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -98,29 +98,32 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         }
 
         val isPrivate = (activity as HomeActivity).browsingModeManager.mode.isPrivate
-        val leadingAction = if (isPrivate && context.settings().feltPrivateBrowsingEnabled) {
-            BrowserToolbar.Button(
-                imageDrawable = AppCompatResources.getDrawable(
-                    context,
-                    R.drawable.mozac_ic_data_clearance_24,
-                )!!,
-                contentDescription = context.getString(R.string.browser_toolbar_erase),
-                iconTintColorResource = ThemeManager.resolveAttribute(R.attr.textPrimary, context),
-                listener = browserToolbarInteractor::onEraseButtonClicked,
-            )
-        } else {
-            BrowserToolbar.Button(
-                imageDrawable = AppCompatResources.getDrawable(
-                    context,
-                    R.drawable.mozac_ic_home_24,
-                )!!,
-                contentDescription = context.getString(R.string.browser_toolbar_home),
-                iconTintColorResource = ThemeManager.resolveAttribute(R.attr.textPrimary, context),
-                listener = browserToolbarInteractor::onHomeButtonClicked,
-            )
-        }
 
-        browserToolbarView.view.addNavigationAction(leadingAction)
+        if (!IncompleteRedesignToolbarFeature(context.settings()).isEnabled) {
+            val leadingAction = if (isPrivate && context.settings().feltPrivateBrowsingEnabled) {
+                BrowserToolbar.Button(
+                    imageDrawable = AppCompatResources.getDrawable(
+                        context,
+                        R.drawable.mozac_ic_data_clearance_24,
+                    )!!,
+                    contentDescription = context.getString(R.string.browser_toolbar_erase),
+                    iconTintColorResource = ThemeManager.resolveAttribute(R.attr.textPrimary, context),
+                    listener = browserToolbarInteractor::onEraseButtonClicked,
+                )
+            } else {
+                BrowserToolbar.Button(
+                    imageDrawable = AppCompatResources.getDrawable(
+                        context,
+                        R.drawable.mozac_ic_home_24,
+                    )!!,
+                    contentDescription = context.getString(R.string.browser_toolbar_home),
+                    iconTintColorResource = ThemeManager.resolveAttribute(R.attr.textPrimary, context),
+                    listener = browserToolbarInteractor::onHomeButtonClicked,
+                )
+            }
+
+            browserToolbarView.view.addNavigationAction(leadingAction)
+        }
 
         updateToolbarActions(isTablet = resources.getBoolean(R.bool.tablet))
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/TabPreview.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/TabPreview.kt
@@ -12,12 +12,14 @@ import android.view.View
 import android.widget.FrameLayout
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.doOnNextLayout
+import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
 import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
 import mozilla.components.concept.base.images.ImageLoadRequest
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.toolbar.IncompleteRedesignToolbarFeature
 import org.mozilla.fenix.databinding.TabPreviewBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
@@ -44,6 +46,10 @@ class TabPreview @JvmOverloads constructor(
                 ThemeManager.resolveAttribute(R.attr.bottomBarBackgroundTop, context),
             )
         }
+
+        val isNavBarEnabled = IncompleteRedesignToolbarFeature(context.settings()).isEnabled
+        binding.tabButton.isVisible = !isNavBarEnabled
+        binding.menuButton.isVisible = !isNavBarEnabled
 
         // Change view properties to avoid confusing the UI tests
         binding.tabButton.findViewById<View>(R.id.counter_box).id = View.NO_ID

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -28,6 +28,7 @@ import org.mozilla.fenix.customtabs.CustomTabToolbarIntegration
 import org.mozilla.fenix.customtabs.CustomTabToolbarMenu
 import org.mozilla.fenix.ext.bookmarkStorage
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.utils.ToolbarPopupWindow
@@ -171,6 +172,8 @@ class BrowserToolbarView(
                     isPrivate = customTabSession.content.private,
                 )
             } else {
+                val isNavBarEnabled = IncompleteRedesignToolbarFeature(context.settings()).isEnabled
+
                 DefaultToolbarIntegration(
                     this,
                     view,
@@ -178,6 +181,7 @@ class BrowserToolbarView(
                     lifecycleOwner,
                     sessionId = null,
                     isPrivate = components.core.store.state.selectedTab?.content?.private ?: false,
+                    isNavBarEnabled = isNavBarEnabled,
                     interactor = interactor,
                 )
             }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -83,6 +83,7 @@ class DefaultToolbarIntegration(
     lifecycleOwner: LifecycleOwner,
     sessionId: String? = null,
     isPrivate: Boolean,
+    isNavBarEnabled: Boolean = false,
     interactor: BrowserToolbarInteractor,
 ) : ToolbarIntegration(
     context = context,
@@ -115,40 +116,44 @@ class DefaultToolbarIntegration(
             DisplayToolbar.Indicators.HIGHLIGHT,
         )
 
-        val tabCounterMenu = FenixTabCounterMenu(
-            context = context,
-            onItemTapped = {
-                interactor.onTabCounterMenuItemTapped(it)
-            },
-            iconColor = if (isPrivate) {
-                ContextCompat.getColor(context, R.color.fx_mobile_private_text_color_primary)
-            } else {
-                null
-            },
-        ).also {
-            it.updateMenu(context.settings().toolbarPosition)
-        }
-
-        val tabsAction = TabCounterToolbarButton(
-            lifecycleOwner = lifecycleOwner,
-            showTabs = {
-                toolbar.hideKeyboard()
-                interactor.onTabCounterClicked()
-            },
-            store = store,
-            menu = tabCounterMenu,
-            showMaskInPrivateMode = context.settings().feltPrivateBrowsingEnabled,
-        )
-
-        val tabCount = if (isPrivate) {
-            store.state.privateTabs.size
+        if (isNavBarEnabled) {
+            toolbar.hideMenuButton()
         } else {
-            store.state.normalTabs.size
+            val tabCounterMenu = FenixTabCounterMenu(
+                context = context,
+                onItemTapped = {
+                    interactor.onTabCounterMenuItemTapped(it)
+                },
+                iconColor = if (isPrivate) {
+                    ContextCompat.getColor(context, R.color.fx_mobile_private_text_color_primary)
+                } else {
+                    null
+                },
+            ).also {
+                it.updateMenu(context.settings().toolbarPosition)
+            }
+
+            val tabsAction = TabCounterToolbarButton(
+                lifecycleOwner = lifecycleOwner,
+                showTabs = {
+                    toolbar.hideKeyboard()
+                    interactor.onTabCounterClicked()
+                },
+                store = store,
+                menu = tabCounterMenu,
+                showMaskInPrivateMode = context.settings().feltPrivateBrowsingEnabled,
+            )
+
+            val tabCount = if (isPrivate) {
+                store.state.privateTabs.size
+            } else {
+                store.state.normalTabs.size
+            }
+
+            tabsAction.updateCount(tabCount)
+
+            toolbar.addBrowserAction(tabsAction)
         }
-
-        tabsAction.updateCount(tabCount)
-
-        toolbar.addBrowserAction(tabsAction)
     }
 
     override fun start() {

--- a/fenix/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultToolbarIntegrationTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultToolbarIntegrationTest.kt
@@ -42,6 +42,7 @@ class DefaultToolbarIntegrationTest {
             sessionId = null,
             isPrivate = false,
             interactor = mockk(),
+            isNavBarEnabled = false,
         )
     }
 


### PR DESCRIPTION
### Screenshots
 Old | New
 --- | --- 
<img src="https://github.com/mozilla-mobile/firefox-android/assets/1811150/30006c78-5c5a-4045-a067-0f58b7deead4" width="300"> |  <img src="https://github.com/mozilla-mobile/firefox-android/assets/1811150/a4816bb6-a906-4c4b-a8d3-53cf61dcb624" width="300">




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1864760