### PR TITLE
Bug 1868886: Fix Nightly Font Telemetry

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/components/FontParserTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/components/FontParserTest.kt
@@ -13,7 +13,7 @@ class FontParserTest {
          Changing the below constant causes _all_ Nightly users to send a (large) Telemetry event containing
          their font information. Do not change this value unless you explicitly intend this.
          */
-        assertEquals(2, FontEnumerationWorker.kDesiredSubmissions)
+        assertEquals(3, FontEnumerationWorker.kDesiredSubmissions)
     }
 
     @Test

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/fonts/FontEnumerationWorker.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/fonts/FontEnumerationWorker.kt
@@ -89,6 +89,7 @@ class FontEnumerationWorker(
         val submission = JSONObject()
 
         run {
+            submission.put("submission", kDesiredSubmissions)
             submission.put("brand", Build.BRAND)
             submission.put("device", Build.DEVICE)
             submission.put("hardware", Build.HARDWARE)
@@ -206,6 +207,6 @@ class FontEnumerationWorker(
          * we wish to perform another data collection effort on the Nightly
          * population.
          */
-        const val kDesiredSubmissions: Int = 2
+        const val kDesiredSubmissions: Int = 3
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/fonts/FontParser.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/fonts/FontParser.kt
@@ -59,10 +59,18 @@ data class FontMetric(
  */
 object FontParser {
     /**
-     * Parse a font file and return a FontMetric object describing it
+     * Parse a font file and return a FontMetric object describing it.
+     * These functions are very similar, because this one is used in
+     * real devices, the other in unit tests. Outside tests, the
+     * FileInputStream does not support the reset() method
      */
     fun parse(path: String): FontMetric {
-        return parse(path, FileInputStream(path))
+        val hash = calculateFileHash(FileInputStream(path))
+        val fontDetails = FontMetric(path, hash)
+
+        readFontFile(FileInputStream(path), fontDetails)
+
+        return fontDetails
     }
 
     /**


### PR DESCRIPTION
Unfortunately, the data we got back was flawed; and I hadn't noticed: the device information was present, but the font data was just populating the errors array instead of the fonts array. The FileInputStream on live devices doesn't support reset, so it's been replaced with two separate FileInputStreams.

Also bump the integer to cause another resubmission from Nightly users, and include the submission integer.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1868886