### PR TITLE
Bug 1854566 - Fix verifyCreditCardRedirectionsToAutofillSectionAfterInterruptionTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/AppAndSystemHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/AppAndSystemHelper.kt
@@ -38,8 +38,10 @@ import org.junit.Assert.assertEquals
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
+import org.mozilla.fenix.helpers.Constants.PackageName.PIXEL_LAUNCHER
 import org.mozilla.fenix.helpers.Constants.PackageName.YOUTUBE_APP
 import org.mozilla.fenix.helpers.Constants.TAG
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.helpers.idlingresource.NetworkConnectionIdlingResource
@@ -295,12 +297,14 @@ object AppAndSystemHelper {
         )
     }
 
-    fun bringAppToForeground() {
-        mDevice.pressRecentApps()
-        mDevice.findObject(UiSelector().resourceId("${TestHelper.packageName}:id/container")).waitForExists(
-            TestAssetHelper.waitingTime,
-        )
-    }
+    /**
+     * Brings the app to foregorund by clicking it in the recent apps tray.
+     * The package name is related to the home screen experience for the Pixel phones produced by Google.
+     * The recent apps tray on API 30 will always display only 2 apps, even if previously were opened more.
+     * The index of the most recent opened app will always have index 2, meaning that the previously opened app will have index 1.
+     */
+    fun bringAppToForeground() =
+        mDevice.findObject(UiSelector().index(2).packageName(PIXEL_LAUNCHER)).clickAndWaitForNewWindow(waitingTimeShort)
 
     fun verifyKeyboardVisibility(isExpectedToBeVisible: Boolean = true) {
         mDevice.waitForIdle()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
@@ -22,6 +22,7 @@ object Constants {
         const val PHONE_APP = "com.android.dialer"
         const val ANDROID_SETTINGS = "com.android.settings"
         const val PRINT_SPOOLER = "com.android.printspooler"
+        const val PIXEL_LAUNCHER = "com.google.android.apps.nexuslauncher"
     }
 
     const val SPEECH_RECOGNITION = "android.speech.action.RECOGNIZE_SPEECH"

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CreditCardAutofillTest.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.ui
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -575,7 +574,6 @@ class CreditCardAutofillTest {
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1512791
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1854566")
     @Test
     fun verifyCreditCardRedirectionsToAutofillSectionAfterInterruptionTest() {
         homeScreen {


### PR DESCRIPTION
Summary:
The test failed when attempting to bring forward again Fenix.
Instead of Fenix, the "Phone" app was restored, this mostly likely happened because this shard contained telephone redirect related UI tests (`telephoneLinkTest` & `telephoneLinkPWATest`) 

After investigating, if there is more that 1 app in the "Recent apps" tray, and you put an app in background using the "recent apps" button, and press it again, the second app will be resumed. (it does the trick only if you have one open app)

To overcome this problem, I've changed the way we bring Fenix forward, namely by clicking it in the "recent apps" tray.
The "Recent apps" tray will always display only 2 apps, even if previously were opened more than 2 .
Based on this, the index of the most recent app (Fenix) will always be 2, and the other one will have index 1. 

Successfully passed 100x on Firebase ✅ 

<img width="1319" alt="image" src="https://github.com/mozilla-mobile/firefox-android/assets/51314259/e57baeac-8383-4b0a-b46a-4807396db867">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1854566