### PR TITLE
Bug 1795449 - onOpenOptionsPage should call URL via engine session.

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -276,15 +276,17 @@ class GeckoWebExtension(
 
             override fun onOpenOptionsPage(ext: GeckoNativeWebExtension) {
                 ext.metaData.optionsPageUrl?.let { optionsPageUrl ->
+                    val geckoEngineSession = GeckoEngineSession(
+                        runtime,
+                        defaultSettings = defaultSettings,
+                    )
                     tabHandler.onNewTab(
                         this@GeckoWebExtension,
-                        GeckoEngineSession(
-                            runtime,
-                            defaultSettings = defaultSettings,
-                        ),
+                        geckoEngineSession,
                         false,
                         optionsPageUrl,
                     )
+                    geckoEngineSession.loadUrl(optionsPageUrl)
                 }
             }
         }


### PR DESCRIPTION
onOpenOptionsPage implementation of AC calls tabHandler.onNewTab only. But this doesn't seem to call GeckoSession.loadUri.

So, if open_in_tab is false in Web extensions, Fenix shows blank page instead of specified option page.

I cannot write unit test for this since geckoEngineSession doesn't expose via onOpenOptionsPage.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
