### PR TITLE
Bug 1857553 - [a11y] Mark up the Review Checker highlights as lists.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ProductAnalysis.kt
@@ -36,6 +36,10 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.CollectionItemInfo
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.collectionItemInfo
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -311,19 +315,52 @@ private fun HighlightsCard(
                     .fillMaxWidth()
                     .animateContentSize(animationSpec = spring()),
             ) {
-                highlightsToDisplay.forEach { highlight ->
-                    HighlightTitle(highlight.key)
+                highlightsToDisplay.onEachIndexed { indexHighlightTitle, highlight ->
+                    Box(
+                        modifier = Modifier.semantics {
+                            collectionInfo = CollectionInfo(rowCount = highlightsToDisplay.size, columnCount = 1)
+                        },
+                    ) {
+                        HighlightTitle(
+                            highlightType = highlight.key,
+                            modifier = Modifier.semantics {
+                                collectionItemInfo = CollectionItemInfo(
+                                    rowIndex = indexHighlightTitle,
+                                    rowSpan = 1,
+                                    columnIndex = 1,
+                                    columnSpan = 1,
+                                )
+                            },
+                        )
+                    }
 
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    highlight.value.forEach {
-                        HighlightText(it)
+                    Column(
+                        modifier = Modifier.semantics {
+                            collectionInfo =
+                                CollectionInfo(rowCount = highlight.value.size, columnCount = 1)
+                        },
+                    ) {
+                        highlight.value.onEachIndexed { index, text ->
+                            HighlightText(
+                                text = text,
+                                modifier = Modifier.semantics {
+                                    collectionItemInfo = CollectionItemInfo(
+                                        rowIndex = index,
+                                        rowSpan = 1,
+                                        columnIndex = 1,
+                                        columnSpan = 1,
+                                    )
+                                },
+                            )
 
-                        Spacer(modifier = Modifier.height(4.dp))
-                    }
+                            Spacer(modifier = Modifier.height(4.dp))
+                        }
 
-                    if (highlightsToDisplay.entries.last().key != highlight.key) {
-                        Spacer(modifier = Modifier.height(16.dp))
+                        if (highlightsToDisplay.entries.last().key != highlight.key) {
+                            Spacer(modifier = Modifier.height(16.dp))
+                        }
                     }
                 }
             }
@@ -370,9 +407,13 @@ private fun HighlightsCard(
 }
 
 @Composable
-private fun HighlightText(text: String) {
+private fun HighlightText(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
     ) {
         Spacer(modifier = Modifier.width(32.dp))
 
@@ -385,9 +426,13 @@ private fun HighlightText(text: String) {
 }
 
 @Composable
-private fun HighlightTitle(highlightType: HighlightType) {
+private fun HighlightTitle(
+    highlightType: HighlightType,
+    modifier: Modifier = Modifier,
+) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
     ) {
         val highlight = remember(highlightType) { highlightType.toHighlight() }
 


### PR DESCRIPTION
Before, when the screen reader was used, all highlights were announced as static texts.

Now by using collectionInfo and collectionItemInfo,informations like location and the position of the highlight in the list and the size of the list are announced for each category of highlights and for each highlight.

#### Before

https://github.com/mozilla-mobile/firefox-android/assets/122524342/bafd4170-d3d9-454c-a7c9-975937382094

#### After

https://github.com/mozilla-mobile/firefox-android/assets/122524342/68bf9438-c310-44ba-a140-3aac5b043acf




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1857553