### PR TITLE
Bug 1869134 - Don't crash on SyncScopedKeyMissingInServerResponse

### DIFF
--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Exceptions.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/Exceptions.kt
@@ -37,6 +37,12 @@ typealias FxaOriginMismatchException = mozilla.appservices.fxaclient.FxaExceptio
 typealias FxaNoExistingAuthFlow = mozilla.appservices.fxaclient.FxaException.NoExistingAuthFlow
 
 /**
+ * Thrown when a scoped key was missing in the server response when requesting the OLD_SYNC scope.
+ */
+typealias FxaSyncScopedKeyMissingException =
+    mozilla.appservices.fxaclient.FxaException.SyncScopedKeyMissingInServerResponse
+
+/**
  * Thrown when the Rust library hits an unexpected error that isn't a panic.
  * This may indicate library misuse, network errors, etc.
  */


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1869134