### PR TITLE
Bug 1864645 - Focus: Do not send legacy ID in other built-in pings

### DIFF
--- a/focus-android/app/metrics.yaml
+++ b/focus-android/app/metrics.yaml
@@ -240,13 +240,9 @@ legacy_ids:
   client_id:
     type: uuid
     description: |
-      Sets the legacy client ID as part of the deletion-reqest and other pings.
+      Sets the legacy client ID as part of the deletion-request ping.
     send_in_pings:
       - deletion-request
-      - metrics
-      - events
-      - baseline
-      - activation
     bugs:
       - https://github.com/mozilla-mobile/focus-android/issues/4545
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1805256
@@ -258,9 +254,6 @@ legacy_ids:
       - android-probes@mozilla.com
       - tlong@mozilla.com
     expires: never
-    no_lint:
-      - BASELINE_PING
-      - METRIC_ON_EVENTS_LIFETIME
 
 browser.search:
   with_ads:


### PR DESCRIPTION
This essentially reverts 1216dfff92897e998b15b1c99398e644453dd620 (in parts). The metrics was added to all pings a while back to aid validation. This is now not needed anymore.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1864645