### PR TITLE
Bug 1868940 - Cannot install an add-on a from local file on Android <10.

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -711,7 +711,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
     @VisibleForTesting
     internal fun setupInstallAddonFromFilePreference(settings: Settings) {
         with(requirePreference<Preference>(R.string.pref_key_install_local_addon)) {
-            isVisible = settings.showSecretDebugMenuThisSession
+            // Below Android 10, the OS doesn't seem to recognize
+            // the "application/x-xpinstall" mime type (for XPI files).
+            isVisible =
+                settings.showSecretDebugMenuThisSession && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
         }
     }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.settings
 
+import android.os.Build
 import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.preference.Preference
@@ -98,6 +99,7 @@ class SettingsFragmentTest {
     }
 
     @Test
+    @org.robolectric.annotation.Config(sdk = [Build.VERSION_CODES.Q])
     fun `Install add-on from file pref is visible if debug menu active and feature is enabled`() = runTestOnMain {
         val settingsFragment = SettingsFragment()
         val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
@@ -122,6 +124,29 @@ class SettingsFragmentTest {
         settingsFragment.setupInstallAddonFromFilePreference(settings)
         assertTrue(preference.isVisible)
         unmockkObject(Config)
+    }
+
+    @Test
+    @org.robolectric.annotation.Config(sdk = [Build.VERSION_CODES.P])
+    fun `Install add-on from file pref is invisible below Android 10`() = runTestOnMain {
+        val settingsFragment = SettingsFragment()
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
+
+        activity.supportFragmentManager.beginTransaction()
+            .add(settingsFragment, "test")
+            .commitNow()
+
+        advanceUntilIdle()
+
+        val preference = settingsFragment.findPreference<Preference>(
+            settingsFragment.getPreferenceKey(R.string.pref_key_install_local_addon),
+        )
+
+        val settings: Settings = mockk(relaxed = true)
+
+        every { settings.showSecretDebugMenuThisSession } returns true
+        settingsFragment.setupInstallAddonFromFilePreference(settings)
+        assertFalse(preference!!.isVisible)
     }
 
     @Test


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1868940