### PR TITLE
Bug 1866617 - IntentReceiverActivity should be ignored when onTaskRemoved of AbstractPrivateNotificationService

### DIFF
--- a/android-components/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationService.kt
+++ b/android-components/components/feature/privatemode/src/main/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationService.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.IBinder
 import androidx.annotation.CallSuper
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.VISIBILITY_SECRET
 import androidx.core.app.NotificationManagerCompat.IMPORTANCE_LOW
@@ -224,14 +225,17 @@ abstract class AbstractPrivateNotificationService(
 
         // List of Intent actions that will get ignored when they are in the root intent that gets
         // passed to onTaskRemoved().
-        private val ignoreTaskActions = listOf(
+        @VisibleForTesting
+        internal val ignoreTaskActions = listOf(
             "mozilla.components.feature.pwa.VIEW_PWA",
         )
 
         // List of Intent components classes that will get ignored when they are in the root intent
         // that gets passed to onTaskRemoved().
-        private val ignoreTaskComponentClasses = listOf(
+        @VisibleForTesting
+        internal val ignoreTaskComponentClasses = listOf(
             "org.mozilla.fenix.customtabs.ExternalAppBrowserActivity",
+            "org.mozilla.fenix.IntentReceiverActivity",
         )
     }
 }

--- a/android-components/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationServiceTest.kt
+++ b/android-components/components/feature/privatemode/src/test/java/mozilla/components/feature/privatemode/notification/AbstractPrivateNotificationServiceTest.kt
@@ -7,6 +7,7 @@ package mozilla.components.feature.privatemode.notification
 import android.app.Notification
 import android.app.NotificationManager
 import android.app.Service
+import android.content.ComponentName
 import android.content.Intent
 import android.content.SharedPreferences
 import androidx.core.app.NotificationCompat
@@ -21,6 +22,8 @@ import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.privatemode.notification.AbstractPrivateNotificationService.Companion.ACTION_ERASE
+import mozilla.components.feature.privatemode.notification.AbstractPrivateNotificationService.Companion.ignoreTaskActions
+import mozilla.components.feature.privatemode.notification.AbstractPrivateNotificationService.Companion.ignoreTaskComponentClasses
 import mozilla.components.support.base.android.NotificationsDelegate
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.ext.joinBlocking
@@ -39,6 +42,7 @@ import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
+import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import java.util.Locale
@@ -103,6 +107,27 @@ class AbstractPrivateNotificationServiceTest {
         verify(service.store).dispatch(TabListAction.RemoveAllPrivateTabsAction)
         verify(service).stopForegroundCompat(true)
         verify(service).stopSelf()
+    }
+
+    @Test
+    fun `WHEN task is removed with ignored intents THEN do nothing`() {
+        ignoreTaskActions.forEach { it ->
+            val service = spy(MockService())
+            service.onTaskRemoved(Intent(it))
+
+            verify(service.store, never()).dispatch(TabListAction.RemoveAllPrivateTabsAction)
+            verify(service, never()).stopForegroundCompat(true)
+            verify(service, never()).stopSelf()
+        }
+
+        ignoreTaskComponentClasses.forEach {
+            val service = spy(MockService())
+            service.onTaskRemoved(Intent().setComponent(ComponentName("", it)))
+
+            verify(service.store, never()).dispatch(TabListAction.RemoveAllPrivateTabsAction)
+            verify(service, never()).stopForegroundCompat(true)
+            verify(service, never()).stopSelf()
+        }
     }
 
     @Test


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1866617