### PR TITLE
Bug 1864073 - Stand up debug drawer Store and State

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -102,6 +102,7 @@ import org.mozilla.fenix.components.metrics.GrowthDataWorker
 import org.mozilla.fenix.components.metrics.fonts.FontEnumerationWorker
 import org.mozilla.fenix.databinding.ActivityHomeBinding
 import org.mozilla.fenix.debugsettings.data.DefaultDebugSettingsRepository
+import org.mozilla.fenix.debugsettings.store.DebugDrawerStore
 import org.mozilla.fenix.debugsettings.ui.DebugOverlay
 import org.mozilla.fenix.exceptions.trackingprotection.TrackingProtectionExceptionsFragmentDirections
 import org.mozilla.fenix.experiments.ResearchSurfaceDialogFragment
@@ -301,7 +302,9 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
 
                                 setContent {
                                     FirefoxTheme(theme = Theme.getTheme(allowPrivateTheme = false)) {
-                                        DebugOverlay()
+                                        DebugOverlay(
+                                            debugDrawerStore = DebugDrawerStore(),
+                                        )
                                     }
                                 }
                             } else {

--- a/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/store/DebugDrawerAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/store/DebugDrawerAction.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.debugsettings.store
+
+import mozilla.components.lib.state.Action
+
+/**
+ * [Action] implementation related to [DebugDrawerStore].
+ */
+sealed class DebugDrawerAction : Action {
+
+    /**
+     * [DebugDrawerAction] fired when the user opens the drawer.
+     */
+    object DrawerOpened : DebugDrawerAction()
+
+    /**
+     * [DebugDrawerAction] fired when the user closes the drawer.
+     */
+    object DrawerClosed : DebugDrawerAction()
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/store/DebugDrawerState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/store/DebugDrawerState.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.debugsettings.store
+
+import mozilla.components.lib.state.State
+
+/**
+ * UI state of the debug drawer feature.
+ *
+ * @property drawerStatus The [DrawerStatus] indicating the physical state of the drawer.
+ */
+data class DebugDrawerState(
+    val drawerStatus: DrawerStatus = DrawerStatus.Closed,
+) : State {
+
+    /**
+     * Possible values of [DebugDrawerState.drawerStatus].
+     */
+    enum class DrawerStatus {
+        /**
+         * The state of the drawer when it is closed.
+         */
+        Closed,
+
+        /**
+         * The state of the drawer when it is open.
+         */
+        Open,
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/store/DebugDrawerStore.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/store/DebugDrawerStore.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.debugsettings.store
+
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.Store
+
+/**
+ * A [Store] that holds the [DebugDrawerState] for the Debug Drawer and reduces [DebugDrawerAction]s
+ * dispatched to the store.
+ */
+class DebugDrawerStore(
+    initialState: DebugDrawerState = DebugDrawerState(),
+    middlewares: List<Middleware<DebugDrawerState, DebugDrawerAction>> = emptyList(),
+) : Store<DebugDrawerState, DebugDrawerAction>(
+    initialState,
+    ::reduce,
+    middlewares,
+)
+
+private fun reduce(state: DebugDrawerState, action: DebugDrawerAction): DebugDrawerState {
+    return when (action) {
+        is DebugDrawerAction.DrawerOpened -> state.copy(drawerStatus = DebugDrawerState.DrawerStatus.Open)
+        is DebugDrawerAction.DrawerClosed -> state.copy(drawerStatus = DebugDrawerState.DrawerStatus.Closed)
+    }
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/debugsettings/DebugDrawerStoreTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/debugsettings/DebugDrawerStoreTest.kt
@@ -1,0 +1,41 @@
+package org.mozilla.fenix.debugsettings
+
+import mozilla.components.support.test.ext.joinBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mozilla.fenix.debugsettings.store.DebugDrawerAction
+import org.mozilla.fenix.debugsettings.store.DebugDrawerState
+import org.mozilla.fenix.debugsettings.store.DebugDrawerStore
+
+class DebugDrawerStoreTest {
+
+    @Test
+    fun `GIVEN the drawer is closed WHEN the drawer is opened THEN the state should be set to open`() {
+        val expected = DebugDrawerState.DrawerStatus.Open
+        val store = createStore()
+
+        store.dispatch(DebugDrawerAction.DrawerOpened).joinBlocking()
+
+        assertEquals(expected, store.state.drawerStatus)
+    }
+
+    @Test
+    fun `GIVEN the drawer is opened WHEN the drawer is closed THEN the state should be set to closed`() {
+        val expected = DebugDrawerState.DrawerStatus.Closed
+        val store = createStore(
+            drawerStatus = DebugDrawerState.DrawerStatus.Open,
+        )
+
+        store.dispatch(DebugDrawerAction.DrawerClosed).joinBlocking()
+
+        assertEquals(expected, store.state.drawerStatus)
+    }
+
+    private fun createStore(
+        drawerStatus: DebugDrawerState.DrawerStatus = DebugDrawerState.DrawerStatus.Closed,
+    ) = DebugDrawerStore(
+        initialState = DebugDrawerState(
+            drawerStatus = drawerStatus,
+        ),
+    )
+}


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1864073