### PR TITLE
Bug 1869225 - Catch `SuggestApiException`s.

### DIFF
--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestIngestionWorker.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestIngestionWorker.kt
@@ -7,7 +7,6 @@ package mozilla.components.feature.fxsuggest
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import mozilla.appservices.suggest.SuggestApiException
 import mozilla.components.support.base.log.logger.Logger
 
 /**
@@ -25,12 +24,12 @@ internal class FxSuggestIngestionWorker(
     override suspend fun doWork(): Result {
         logger.info("Ingesting new suggestions")
         val storage = GlobalFxSuggestDependencyProvider.requireStorage()
-        return try {
-            storage.ingest()
+        val success = storage.ingest()
+        return if (success) {
             logger.info("Successfully ingested new suggestions")
             Result.success()
-        } catch (suggestError: SuggestApiException) {
-            logger.error("Failed to ingest new suggestions", suggestError)
+        } else {
+            logger.error("Failed to ingest new suggestions")
             Result.retry()
         }
     }

--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestStorage.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestStorage.kt
@@ -5,27 +5,35 @@
 package mozilla.components.feature.fxsuggest
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.withContext
+import mozilla.appservices.suggest.SuggestApiException
 import mozilla.appservices.suggest.SuggestIngestionConstraints
 import mozilla.appservices.suggest.SuggestStore
 import mozilla.appservices.suggest.Suggestion
 import mozilla.appservices.suggest.SuggestionQuery
+import mozilla.components.concept.base.crash.CrashReporting
+import mozilla.components.support.base.log.logger.Logger
 import java.io.File
 
 /**
  * A coroutine-aware wrapper around the synchronous [SuggestStore] interface.
  *
- * @property context The Android application context.
+ * @param context The Android application context.
+ * @param crashReporter An optional [CrashReporting] instance for reporting unexpected caught
+ * exceptions.
  */
 class FxSuggestStorage(
     context: Context,
+    private val crashReporter: CrashReporting? = null,
 ) {
     // Lazily initializes the store on first use. `cacheDir` and using the `File` constructor
     // does I/O, so `store.value` should only be accessed from the read or write scope.
-    private val store: Lazy<SuggestStore> = lazy {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val store: Lazy<SuggestStore> = lazy {
         SuggestStore(File(context.cacheDir, DATABASE_NAME).absolutePath)
     }
 
@@ -35,6 +43,8 @@ class FxSuggestStorage(
     private val readScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
     private val writeScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
+    private val logger = Logger("FxSuggestStorage")
+
     /**
      * Queries the store for suggestions.
      *
@@ -43,17 +53,23 @@ class FxSuggestStorage(
      */
     suspend fun query(query: SuggestionQuery): List<Suggestion> =
         withContext(readScope.coroutineContext) {
-            store.value.query(query)
+            handleSuggestExceptions("query", emptyList()) {
+                store.value.query(query)
+            }
         }
 
     /**
      * Downloads and persists new Firefox Suggest search suggestions.
      *
      * @param constraints Optional limits on suggestions to ingest.
+     * @return `true` if ingestion succeeded; `false` if ingestion failed and should be retried.
      */
-    suspend fun ingest(constraints: SuggestIngestionConstraints = SuggestIngestionConstraints()) =
+    suspend fun ingest(constraints: SuggestIngestionConstraints = SuggestIngestionConstraints()): Boolean =
         withContext(writeScope.coroutineContext) {
-            store.value.ingest(constraints)
+            handleSuggestExceptions("ingest", false) {
+                store.value.ingest(constraints)
+                true
+            }
         }
 
     /**
@@ -63,6 +79,29 @@ class FxSuggestStorage(
         if (store.isInitialized()) {
             store.value.interrupt()
             readScope.coroutineContext.cancelChildren()
+        }
+    }
+
+    /**
+     * Runs an [operation] with the given [name], ignoring and logging any non-fatal exceptions.
+     * Returns either the result of the [operation], or the provided [default] value if the
+     * [operation] throws an exception.
+     *
+     * @param name The name of the operation to run.
+     * @param default The default value to return if the operation fails.
+     * @param operation The operation to run.
+     */
+    private inline fun <T> handleSuggestExceptions(
+        name: String,
+        default: T,
+        operation: () -> T,
+    ): T {
+        return try {
+            operation()
+        } catch (e: SuggestApiException) {
+            crashReporter?.submitCaughtException(e)
+            logger.warn("Ignoring exception from `$name`", e)
+            default
         }
     }
 

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestStorageTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestStorageTest.kt
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.feature.fxsuggest
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import mozilla.appservices.suggest.SuggestApiException
+import mozilla.appservices.suggest.SuggestStore
+import mozilla.appservices.suggest.Suggestion
+import mozilla.appservices.suggest.SuggestionQuery
+import mozilla.components.concept.base.crash.CrashReporting
+import mozilla.components.support.test.any
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.never
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+@RunWith(AndroidJUnit4::class)
+class FxSuggestStorageTest {
+    @Test
+    fun `GIVEN an exception is thrown WHEN querying the store THEN the exception should be reported`() = runTest {
+        val store: SuggestStore = mock()
+        whenever(store.query(any())).then {
+            throw SuggestApiException.Other("Mercury in retrograde")
+        }
+
+        val crashReporter: CrashReporting = mock()
+        val storage = spy(FxSuggestStorage(testContext, crashReporter))
+        whenever(storage.store).thenReturn(lazy { store })
+
+        val suggestions = storage.query(SuggestionQuery("la", providers = emptyList()))
+        assertTrue(suggestions.isEmpty())
+        verify(crashReporter).submitCaughtException(any())
+    }
+
+    @Test
+    fun `GIVEN an exception is not thrown WHEN querying the store THEN nothing should be reported`() = runTest {
+        val store: SuggestStore = mock()
+        whenever(store.query(any())).thenReturn(
+            listOf(
+                Suggestion.Wikipedia(
+                    title = "Las Vegas",
+                    url = "https://wikipedia.org/wiki/Las_Vegas",
+                    icon = null,
+                    fullKeyword = "las",
+                ),
+            ),
+        )
+
+        val crashReporter: CrashReporting = mock()
+        val storage = spy(FxSuggestStorage(testContext, crashReporter))
+        whenever(storage.store).thenReturn(lazy { store })
+
+        val suggestions = storage.query(SuggestionQuery("la", providers = emptyList()))
+        assertEquals(1, suggestions.size)
+        verify(crashReporter, never()).submitCaughtException(any())
+    }
+
+    @Test
+    fun `GIVEN an exception is thrown WHEN ingesting THEN the exception should be reported`() = runTest {
+        val crashReporter: CrashReporting = mock()
+        val store: SuggestStore = mock()
+        whenever(store.ingest(any())).then {
+            throw SuggestApiException.Other("Mercury in retrograde")
+        }
+
+        val storage = spy(FxSuggestStorage(testContext, crashReporter))
+        whenever(storage.store).thenReturn(lazy { store })
+
+        val success = storage.ingest()
+        assertFalse(success)
+        verify(crashReporter).submitCaughtException(any())
+    }
+
+    @Test
+    fun `GIVEN an exception is not thrown WHEN ingesting THEN nothing should be reported`() = runTest {
+        val crashReporter: CrashReporting = mock()
+        val store: SuggestStore = mock()
+        doNothing().`when`(store).ingest(any())
+
+        val storage = spy(FxSuggestStorage(testContext, crashReporter))
+        whenever(storage.store).thenReturn(lazy { store })
+
+        val success = storage.ingest()
+        assertTrue(success)
+        verify(crashReporter, never()).submitCaughtException(any())
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -227,7 +227,7 @@ class Components(private val context: Context) {
         )
     }
 
-    val fxSuggest by lazyMonitored { FxSuggest(context) }
+    val fxSuggest by lazyMonitored { FxSuggest(context, analytics.crashReporter) }
 }
 
 /**

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/FxSuggest.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/FxSuggest.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.components
 
 import android.content.Context
+import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.feature.fxsuggest.FxSuggestIngestionScheduler
 import mozilla.components.feature.fxsuggest.FxSuggestStorage
 import org.mozilla.fenix.perf.lazyMonitored
@@ -13,10 +14,12 @@ import org.mozilla.fenix.perf.lazyMonitored
  * Component group for Firefox Suggest.
  *
  * @param context The Android application context.
+ * @param crashReporter An optional [CrashReporting] instance for reporting unexpected caught
+ * exceptions.
  */
-class FxSuggest(context: Context) {
+class FxSuggest(context: Context, crashReporter: CrashReporting? = null) {
     val storage by lazyMonitored {
-        FxSuggestStorage(context)
+        FxSuggestStorage(context, crashReporter)
     }
 
     val ingestionScheduler by lazyMonitored {


### PR DESCRIPTION
This commit adds a `handleSuggestExceptions` helper to `FxSuggestStorage` that catches and reports `SuggestApiException`s from the Suggest Rust component. `handleSuggestExceptions` works like the existing `handle{Fxa, Places}Exceptions` helpers.

`FxSuggestIngestionWorker`'s retry behavior is unchanged: if ingestion fails, the exception will now be reported, but the operation will still be rescheduled using `WorkManager`'s retry mechanism, as before.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1869225