### PR TITLE
Bug 1870149: Bump the expiration version for the font list telemetry

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -2663,7 +2663,7 @@ metrics:
     notification_emails:
       - android-probes@mozilla.com
       - tom@mozilla.com
-    expires: 122
+    expires: 124
 
 customize_home:
   most_visited_sites:

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/components/FontParserTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/components/FontParserTest.kt
@@ -13,7 +13,7 @@ class FontParserTest {
          Changing the below constant causes _all_ Nightly users to send a (large) Telemetry event containing
          their font information. Do not change this value unless you explicitly intend this.
          */
-        assertEquals(3, FontEnumerationWorker.kDesiredSubmissions)
+        assertEquals(4, FontEnumerationWorker.kDesiredSubmissions)
     }
 
     @Test

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/fonts/FontEnumerationWorker.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/fonts/FontEnumerationWorker.kt
@@ -207,6 +207,6 @@ class FontEnumerationWorker(
          * we wish to perform another data collection effort on the Nightly
          * population.
          */
-        const val kDesiredSubmissions: Int = 3
+        const val kDesiredSubmissions: Int = 4
     }
 }


### PR DESCRIPTION
We weren't getting submissions for the font telemetry list and eventually I traced it down to the metric having been expired.

We also need to bump the submission number, otherwise the work request will be skipped.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1870149