### PR TITLE
Bug 1830005 - Re-enable addPrivateBrowsingShortcutFromHomeScreenCFRTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -10,7 +10,6 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -172,7 +171,6 @@ class HomeScreenTest {
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/414970
-    @Ignore("Failure, more details at: https://bugzilla.mozilla.org/show_bug.cgi?id=1830005")
     @SmokeTest
     @Test
     fun addPrivateBrowsingShortcutFromHomeScreenCFRTest() {


### PR DESCRIPTION
Summary:
This UI test was refactored to use Compose in #1162 but it was disabled because it was failing afterwards (not sure what the cause was, don't have any Firebase runs to check)

Decided to do a status check and it seems that the test is now working properly, successfully passed 100x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1830005