### PR TITLE
Bug 1870232 - Delegate the Activity's getNavDirections() functionality

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -33,7 +33,6 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.NavDirections
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
@@ -86,9 +85,6 @@ import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.Metrics
 import org.mozilla.fenix.GleanMetrics.SplashScreen
 import org.mozilla.fenix.GleanMetrics.StartOnHome
-import org.mozilla.fenix.addons.AddonDetailsFragmentDirections
-import org.mozilla.fenix.addons.AddonPermissionsDetailsFragmentDirections
-import org.mozilla.fenix.addons.AddonsManagementFragmentDirections
 import org.mozilla.fenix.addons.ExtensionsProcessDisabledController
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.appstate.AppAction
@@ -100,7 +96,6 @@ import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
 import org.mozilla.fenix.databinding.ActivityHomeBinding
 import org.mozilla.fenix.debugsettings.data.DefaultDebugSettingsRepository
 import org.mozilla.fenix.debugsettings.ui.FenixOverlay
-import org.mozilla.fenix.exceptions.trackingprotection.TrackingProtectionExceptionsFragmentDirections
 import org.mozilla.fenix.experiments.ResearchSurfaceDialogFragment
 import org.mozilla.fenix.ext.alreadyOnDestination
 import org.mozilla.fenix.ext.breadcrumb
@@ -108,12 +103,12 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getBreadcrumbMessage
 import org.mozilla.fenix.ext.getIntentSessionId
 import org.mozilla.fenix.ext.getIntentSource
+import org.mozilla.fenix.ext.getNavDirections
 import org.mozilla.fenix.ext.hasTopDestination
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.setNavigationIcon
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.extension.WebExtensionPromptFeature
-import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.home.intent.AssistIntentProcessor
 import org.mozilla.fenix.home.intent.CrashReporterIntentProcessor
 import org.mozilla.fenix.home.intent.HomeDeepLinkIntentProcessor
@@ -123,11 +118,7 @@ import org.mozilla.fenix.home.intent.OpenSpecificTabIntentProcessor
 import org.mozilla.fenix.home.intent.ReEngagementIntentProcessor
 import org.mozilla.fenix.home.intent.SpeechProcessingIntentProcessor
 import org.mozilla.fenix.home.intent.StartSearchIntentProcessor
-import org.mozilla.fenix.library.bookmarks.BookmarkFragmentDirections
 import org.mozilla.fenix.library.bookmarks.DesktopFolders
-import org.mozilla.fenix.library.history.HistoryFragmentDirections
-import org.mozilla.fenix.library.historymetadata.HistoryMetadataGroupFragmentDirections
-import org.mozilla.fenix.library.recentlyclosed.RecentlyClosedFragmentDirections
 import org.mozilla.fenix.messaging.FenixMessageSurfaceId
 import org.mozilla.fenix.messaging.FenixNimbusMessagingController
 import org.mozilla.fenix.messaging.MessageNotificationWorker
@@ -142,27 +133,11 @@ import org.mozilla.fenix.perf.ProfilerMarkers
 import org.mozilla.fenix.perf.StartupPathProvider
 import org.mozilla.fenix.perf.StartupTimeline
 import org.mozilla.fenix.perf.StartupTypeTelemetry
-import org.mozilla.fenix.search.SearchDialogFragmentDirections
 import org.mozilla.fenix.session.PrivateNotificationService
-import org.mozilla.fenix.settings.HttpsOnlyFragmentDirections
-import org.mozilla.fenix.settings.SettingsFragmentDirections
-import org.mozilla.fenix.settings.TrackingProtectionFragmentDirections
-import org.mozilla.fenix.settings.about.AboutFragmentDirections
-import org.mozilla.fenix.settings.logins.fragment.LoginDetailFragmentDirections
-import org.mozilla.fenix.settings.logins.fragment.SavedLoginsAuthFragmentDirections
-import org.mozilla.fenix.settings.search.SaveSearchEngineFragmentDirections
-import org.mozilla.fenix.settings.search.SearchEngineFragmentDirections
-import org.mozilla.fenix.settings.studies.StudiesFragmentDirections
-import org.mozilla.fenix.settings.wallpaper.WallpaperSettingsFragmentDirections
-import org.mozilla.fenix.share.AddNewDeviceFragmentDirections
-import org.mozilla.fenix.shopping.ReviewQualityCheckFragmentDirections
 import org.mozilla.fenix.shortcut.NewTabShortcutIntentProcessor.Companion.ACTION_OPEN_PRIVATE_TAB
 import org.mozilla.fenix.tabhistory.TabHistoryDialogFragment
 import org.mozilla.fenix.tabstray.TabsTrayFragment
-import org.mozilla.fenix.tabstray.TabsTrayFragmentDirections
 import org.mozilla.fenix.theme.DefaultThemeManager
-import org.mozilla.fenix.trackingprotection.TrackingProtectionPanelDialogFragmentDirections
-import org.mozilla.fenix.translations.TranslationsDialogFragmentDirections
 import org.mozilla.fenix.utils.Settings
 import java.lang.ref.WeakReference
 import java.util.Locale
@@ -1018,69 +993,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         if (directions != null) {
             navHost.navController.nav(fragmentId, directions)
         }
-    }
-
-    protected open fun getNavDirections(
-        from: BrowserDirection,
-        customTabSessionId: String?,
-    ): NavDirections? = when (from) {
-        BrowserDirection.FromGlobal ->
-            NavGraphDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromHome ->
-            HomeFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromWallpaper ->
-            WallpaperSettingsFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromSearchDialog ->
-            SearchDialogFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromSettings ->
-            SettingsFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromBookmarks ->
-            BookmarkFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromHistory ->
-            HistoryFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromHistoryMetadataGroup ->
-            HistoryMetadataGroupFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromTrackingProtectionExceptions ->
-            TrackingProtectionExceptionsFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromHttpsOnlyMode ->
-            HttpsOnlyFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromAbout ->
-            AboutFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromTrackingProtection ->
-            TrackingProtectionFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromTrackingProtectionDialog ->
-            TrackingProtectionPanelDialogFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromSavedLoginsFragment ->
-            SavedLoginsAuthFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromAddNewDeviceFragment ->
-            AddNewDeviceFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromSearchEngineFragment ->
-            SearchEngineFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromSaveSearchEngineFragment ->
-            SaveSearchEngineFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromAddonDetailsFragment ->
-            AddonDetailsFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromAddonPermissionsDetailsFragment ->
-            AddonPermissionsDetailsFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromLoginDetailFragment ->
-            LoginDetailFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromTabsTray ->
-            TabsTrayFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromRecentlyClosed ->
-            RecentlyClosedFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromStudiesFragment -> StudiesFragmentDirections.actionGlobalBrowser(
-            customTabSessionId,
-        )
-        BrowserDirection.FromReviewQualityCheck -> ReviewQualityCheckFragmentDirections.actionGlobalBrowser(
-            customTabSessionId,
-        )
-        BrowserDirection.FromAddonsManagementFragment -> AddonsManagementFragmentDirections.actionGlobalBrowser(
-            customTabSessionId,
-        )
-
-        BrowserDirection.FromTranslationsDialogFragment -> TranslationsDialogFragmentDirections.actionGlobalBrowser(
-            customTabSessionId,
-        )
     }
 
     /**

--- a/fenix/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
@@ -10,18 +10,12 @@ import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
-import androidx.navigation.NavDirections
 import mozilla.components.browser.state.selector.findCustomTab
 import mozilla.components.browser.state.state.SessionState
-import mozilla.components.concept.engine.manifest.WebAppManifestParser
-import mozilla.components.feature.pwa.ext.getWebAppManifest
 import mozilla.components.support.utils.SafeIntent
-import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
-import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getIntentSessionId
-import java.security.InvalidParameterException
 
 const val EXTRA_IS_SANDBOX_CUSTOM_TAB = "org.mozilla.fenix.customtabs.EXTRA_IS_SANDBOX_CUSTOM_TAB"
 
@@ -54,31 +48,6 @@ open class ExternalAppBrowserActivity : HomeActivity() {
 
     override fun handleNewIntent(intent: Intent) {
         // No-op for external app
-    }
-
-    override fun getNavDirections(
-        from: BrowserDirection,
-        customTabSessionId: String?,
-    ): NavDirections? {
-        if (customTabSessionId == null) {
-            finishAndRemoveTask()
-            return null
-        }
-
-        val manifest = intent
-            .getWebAppManifest()
-            ?.let { WebAppManifestParser().serialize(it).toString() }
-        return when (from) {
-            BrowserDirection.FromGlobal ->
-                NavGraphDirections.actionGlobalExternalAppBrowser(
-                    activeSessionId = customTabSessionId,
-                    webAppManifest = manifest,
-                    isSandboxCustomTab = intent.getBooleanExtra(EXTRA_IS_SANDBOX_CUSTOM_TAB, false),
-                )
-            else -> throw InvalidParameterException(
-                "Tried to navigate to ExternalAppBrowserFragment from $from",
-            )
-        }
     }
 
     override fun onDestroy() {

--- a/fenix/app/src/main/res/navigation/nav_graph.xml
+++ b/fenix/app/src/main/res/navigation/nav_graph.xml
@@ -284,6 +284,7 @@
         tools:layout="@layout/fragment_browser">
         <argument
             android:name="activeSessionId"
+            android:defaultValue="@null"
             app:argType="string"
             app:nullable="true" />
         <action

--- a/fenix/app/src/test/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivityTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivityTest.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.customtabs
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.navigation.NavDirections
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
@@ -29,6 +28,7 @@ import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getIntentSource
+import org.mozilla.fenix.ext.getNavDirections
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.utils.Settings
 
@@ -78,13 +78,6 @@ class ExternalAppBrowserActivityTest {
     fun `getNavDirections finishes activity if session ID is null`() {
         val activity = spyk(
             object : ExternalAppBrowserActivity() {
-                public override fun getNavDirections(
-                    from: BrowserDirection,
-                    customTabSessionId: String?,
-                ): NavDirections? {
-                    return super.getNavDirections(from, customTabSessionId)
-                }
-
                 override fun getIntent(): Intent {
                     val intent: Intent = mockk()
                     val bundle: Bundle = mockk()
@@ -109,13 +102,6 @@ class ExternalAppBrowserActivityTest {
     fun `GIVEN intent isSandboxCustomTab is true WHEN getNavDirections called THEN actionGlobalExternalAppBrowser isSandboxCustomTab is true`() {
         val activity = spyk(
             object : ExternalAppBrowserActivity() {
-                public override fun getNavDirections(
-                    from: BrowserDirection,
-                    customTabSessionId: String?,
-                ): NavDirections? {
-                    return super.getNavDirections(from, customTabSessionId)
-                }
-
                 override fun getIntent(): Intent {
                     val intent: Intent = mockk()
                     val bundle: Bundle = mockk()
@@ -144,13 +130,6 @@ class ExternalAppBrowserActivityTest {
     fun `GIVEN intent isSandboxCustomTab is false WHEN getNavDirections called THEN actionGlobalExternalAppBrowser isSandboxCustomTab is false`() {
         val activity = spyk(
             object : ExternalAppBrowserActivity() {
-                public override fun getNavDirections(
-                    from: BrowserDirection,
-                    customTabSessionId: String?,
-                ): NavDirections? {
-                    return super.getNavDirections(from, customTabSessionId)
-                }
-
                 override fun getIntent(): Intent {
                     val intent: Intent = mockk()
                     val bundle: Bundle = mockk()


### PR DESCRIPTION
Step 2 from [Bug 1865306 - RFC Custom Tabs](https://github.com/mozilla-mobile/firefox-android/pull/4732/files)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.























### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1870232