### PR TITLE
Bug 1862263 - Translations Error Support

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/translate/GeckoTranslationUtils.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/translate/GeckoTranslationUtils.kt
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package mozilla.components.browser.engine.gecko.translate
+
+import mozilla.components.concept.engine.translate.TranslationError
+import org.mozilla.geckoview.TranslationsController.TranslationsException
+
+/**
+ * Utility file for translations functions related to the Gecko implementation.
+ */
+object GeckoTranslationUtils {
+    /**
+     * Convenience method for mapping a [TranslationsException] to the Android Components defined
+     * error type of [TranslationError].
+     *
+     * @param throwable The engine throwable that occurred during translating. Ordinarily should be
+     * a [TranslationsException].
+     */
+    fun fromGeckoErrorToTranslationError(throwable: Throwable): TranslationError =
+        if (throwable is TranslationsException) {
+            when ((throwable).code) {
+                TranslationsException.ERROR_UNKNOWN ->
+                    TranslationError.UnknownError(throwable)
+
+                TranslationsException.ERROR_ENGINE_NOT_SUPPORTED ->
+                    TranslationError.EngineNotSupportedError(throwable)
+
+                TranslationsException.ERROR_COULD_NOT_TRANSLATE ->
+                    TranslationError.CouldNotTranslateError(throwable)
+
+                TranslationsException.ERROR_COULD_NOT_RESTORE ->
+                    TranslationError.CouldNotRestoreError(throwable)
+
+                TranslationsException.ERROR_COULD_NOT_LOAD_LANGUAGES ->
+                    TranslationError.CouldNotLoadLanguagesError(throwable)
+
+                TranslationsException.ERROR_LANGUAGE_NOT_SUPPORTED ->
+                    TranslationError.LanguageNotSupportedError(throwable)
+
+                TranslationsException.ERROR_MODEL_COULD_NOT_RETRIEVE ->
+                    TranslationError.ModelCouldNotRetrieveError(throwable)
+
+                TranslationsException.ERROR_MODEL_COULD_NOT_DELETE ->
+                    TranslationError.ModelCouldNotDeleteError(throwable)
+
+                TranslationsException.ERROR_MODEL_COULD_NOT_DOWNLOAD ->
+                    TranslationError.ModelCouldNotDownloadError(throwable)
+
+                TranslationsException.ERROR_MODEL_LANGUAGE_REQUIRED ->
+                    TranslationError.ModelLanguageRequiredError(throwable)
+
+                TranslationsException.ERROR_MODEL_DOWNLOAD_REQUIRED ->
+                    TranslationError.ModelDownloadRequiredError(throwable)
+
+                else -> TranslationError.UnknownError(throwable)
+            }
+        } else {
+            TranslationError.UnknownError(throwable)
+        }
+}

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationError.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationError.kt
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.translate
+
+/**
+ * The types of translation errors that can occur. Has features for determining telemetry error
+ * names and determining if an error needs to be displayed.
+ *
+ * @param errorName The translation error name. The expected use is for telemetry.
+ * @param displayError Signal to determine if we need to specifically display an error for
+ * this given issue. (Some errors should only silently report telemetry or simply revert to the
+ * prior UI state.)
+ * @param cause The original throwable before it was converted into this error state.
+ */
+sealed class TranslationError(
+    val errorName: String,
+    val displayError: Boolean,
+    override val cause: Throwable?,
+) : Throwable(cause = cause) {
+
+    /**
+     * Default error for unexpected issues.
+     *
+     * @param cause The original throwable that lead us to the unknown error state.
+     */
+    class UnknownError(override val cause: Throwable) :
+        TranslationError(errorName = "unknown", displayError = false, cause = cause)
+
+    /**
+     * Default error for unexpected null value received on a non-null translations call.
+     */
+    class UnexpectedNull :
+        TranslationError(errorName = "unexpected-null", displayError = false, cause = null)
+
+    /**
+     * Translations engine does not work on the device architecture.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class EngineNotSupportedError(override val cause: Throwable?) :
+        TranslationError(errorName = "engine-not-supported", displayError = false, cause = cause)
+
+    /**
+     * Generic could not compete a translation error.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class CouldNotTranslateError(override val cause: Throwable?) :
+        TranslationError(errorName = "could-not-translate", displayError = true, cause = cause)
+
+    /**
+     * Generic could not restore the page after a translation error.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class CouldNotRestoreError(override val cause: Throwable?) :
+        TranslationError(errorName = "could-not-restore", displayError = false, cause = cause)
+
+    /**
+     * Could not load language options error.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class CouldNotLoadLanguagesError(override val cause: Throwable?) :
+        TranslationError(errorName = "could-not-load-languages", displayError = true, cause = cause)
+
+    /**
+     * The language is not supported for translation.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class LanguageNotSupportedError(override val cause: Throwable?) :
+        TranslationError(errorName = "language-not-supported", displayError = true, cause = cause)
+
+    /**
+     * Could not retrieve information on the language model.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class ModelCouldNotRetrieveError(override val cause: Throwable?) :
+        TranslationError(
+            errorName = "model-could-not-retrieve",
+            displayError = false,
+            cause = cause,
+        )
+
+    /**
+     * Could not delete the language model.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class ModelCouldNotDeleteError(override val cause: Throwable?) :
+        TranslationError(errorName = "model-could-not-delete", displayError = false, cause = cause)
+
+    /**
+     * Could not download the language model.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class ModelCouldNotDownloadError(override val cause: Throwable?) :
+        TranslationError(
+            errorName = "model-could-not-download",
+            displayError = false,
+            cause = cause,
+        )
+
+    /**
+     * A language is required for language scoped requests.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class ModelLanguageRequiredError(override val cause: Throwable?) :
+        TranslationError(errorName = "model-language-required", displayError = false, cause = cause)
+
+    /**
+     * A download is required and the translate request specified do not download.
+     *
+     * @param cause The original throwable before it was converted into this error state.
+     */
+    class ModelDownloadRequiredError(override val cause: Throwable?) :
+        TranslationError(errorName = "model-download-required", displayError = false, cause = cause)
+}


### PR DESCRIPTION
This patch defines different possible translation errors, how they map from GeckoView, and how they map to errors we display.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1862263