### PR TITLE
Bug 1807073 - Prevent pull-to-refresh after scrolling down

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -36,6 +36,10 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
 
     private val scrollConsumed = IntArray(2)
 
+    private var didReceiveFirstTouchMove: Boolean = false
+
+    private var initialDownY: Float = 0f
+
     @VisibleForTesting
     internal var nestedOffsetY: Int = 0
 
@@ -62,6 +66,8 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
         when (action) {
             MotionEvent.ACTION_MOVE -> {
                 val allowScroll = !shouldPinOnScreen() && inputResultDetail.isTouchHandledByBrowser()
+                val isFirstTouchMove = !didReceiveFirstTouchMove
+                didReceiveFirstTouchMove = true
 
                 var deltaY = lastY - eventY
 
@@ -78,9 +84,32 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
                     event.offsetLocation(0f, scrollOffset[1].toFloat())
                     nestedOffsetY += scrollOffset[1]
                 }
+
+                // If this event is the first touch move event, there are two possible cases
+                // where we still need to wait for the reponse for this first touch move event.
+                // a) we haven't yet received the response from GeckoView because of active touch
+                //    event listners etc.
+                // b) we have received the response for the touch down event that GeckoView
+                //    consumed the event
+                // In the case of a) it's possible a touch move event listner does preventDefault()
+                // for this touch move event, then any subsequent touch events need to be directly
+                // routed to GeckoView rather than being intercepted.
+                // In the case of b) if GeckoView consumed this touch move event to scroll down the
+                // web content, any touch event interception should not be allowed since, for example
+                // SwipeRefreshLayout is supposed to trigger a refresh after the user started scroll
+                // down if the user restored the scroll position at the top.
+                if (isFirstTouchMove &&
+                    (inputResultDetail.isTouchHandlingUnknown() ||
+                     inputResultDetail.isTouchHandledByBrowser())) {
+                    updateInputResult(event)
+                    event.recycle()
+                    return true
+                }
             }
 
             MotionEvent.ACTION_DOWN -> {
+                didReceiveFirstTouchMove = false
+
                 // A new gesture started. Ask GV if it can handle this.
                 inputResultDetail = InputResultDetail.newInstance(false)
                 parent?.requestDisallowInterceptTouchEvent(true)
@@ -88,6 +117,7 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
 
                 nestedOffsetY = 0
                 lastY = eventY
+                initialDownY = event.y
 
                 // The event should be handled either by onTouchEvent,
                 // either by onTouchEventForResult, never by both.
@@ -99,6 +129,10 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
             // We don't care about other touch events
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 stopNestedScroll()
+
+                // Allow touch event interception here so that the next ACTION_DOWN event can be properly
+                // intercepted by the parent.
+                parent?.requestDisallowInterceptTouchEvent(false)
             }
         }
 
@@ -126,7 +160,38 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
                     it?.scrollableDirections(),
                     it?.overscrollDirections(),
                 )
-                parent?.requestDisallowInterceptTouchEvent(false)
+
+                when (event.action) {
+                    MotionEvent.ACTION_DOWN -> {
+                        // If the event wasn't used in GeckoView, allow touch event interception.
+                        if (inputResultDetail.isTouchUnhandled()) {
+                            parent?.requestDisallowInterceptTouchEvent(false)
+                        }
+                    }
+
+                    MotionEvent.ACTION_MOVE -> {
+                        if (initialDownY < event.y) {
+                            // In the case of scroll up gestures, allow touch event interception
+                            // only if the event wasn't consumed by the web site. I.e. even if
+                            // the event was consumed by the browser to scroll up the content.
+                            if (!inputResultDetail.isTouchHandledByWebsite()) {
+                                parent?.requestDisallowInterceptTouchEvent(false)
+                            }
+                        } else if (initialDownY > event.y) {
+                            // In the case of scroll down gestures, allow touch event interception
+                            // only if the event wasn't used in GeckoView. I.e. once after the content
+                            // started scroll down, touch event interception is never allowed.
+                            if  (inputResultDetail.isTouchUnhandled()) {
+                                parent?.requestDisallowInterceptTouchEvent(false)
+                            }
+                        } else {
+                            // Normally ACTION_MOVE should happen with moving the event position,
+                            // but if it happened allow touch event interception just in case.
+                            parent?.requestDisallowInterceptTouchEvent(false)
+                        }
+                    }
+                }
+
                 startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL)
             }
     }

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -20,6 +20,7 @@ import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.mockMotionEvent
+import mozilla.components.support.test.whenever
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -32,6 +33,10 @@ import org.mockito.Mockito.verify
 import org.mozilla.geckoview.GeckoResult
 import org.mozilla.geckoview.PanZoomController
 import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_HANDLED
+import org.mozilla.geckoview.PanZoomController.INPUT_RESULT_UNHANDLED
+import org.mozilla.geckoview.PanZoomController.SCROLLABLE_FLAG_BOTTOM
+import org.mozilla.geckoview.PanZoomController.OVERSCROLL_FLAG_VERTICAL
+import org.mozilla.geckoview.PanZoomController.OVERSCROLL_FLAG_HORIZONTAL
 import org.robolectric.Robolectric.buildActivity
 import org.robolectric.Shadows.shadowOf
 
@@ -199,6 +204,118 @@ class NestedGeckoViewTest {
 
         // Move action no longer ignores onInterceptTouchEvent calls.
         viewParent.dispatchTouchEvent(mockMotionEvent(ACTION_MOVE))
+
+        assertEquals(2, viewParentInterceptCounter)
+
+        // Complete the gesture by finishing with an up action.
+        viewParent.dispatchTouchEvent(mockMotionEvent(ACTION_UP))
+
+        assertEquals(3, viewParentInterceptCounter)
+    }
+
+    @Test
+    fun `touch events are never intercepted once after scrolled down`() {
+        var viewParentInterceptCounter = 0
+        val result: GeckoResult<PanZoomController.InputResultDetail> = GeckoResult()
+        val nestedWebView = object : NestedGeckoView(context) {
+            init {
+                // We need to make the view a non-zero size so that the touch events hit it.
+                left = 0
+                top = 0
+                right = 5
+                bottom = 5
+            }
+        }
+        val spy = spy(nestedWebView)
+        doReturn(result).`when`(spy).onTouchEventForDetailResult(any())
+
+        val viewParent = object : FrameLayout(context) {
+            override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+                viewParentInterceptCounter++
+                return super.onInterceptTouchEvent(ev)
+            }
+        }.apply {
+            addView(spy)
+        }
+
+        // Down action enables requestDisallowInterceptTouchEvent (and starts a gesture).
+        viewParent.dispatchTouchEvent(mockMotionEvent(ACTION_DOWN, y = 4f))
+
+        // `onInterceptTouchEvent` will be triggered the first time because it's the first pass.
+        assertEquals(1, viewParentInterceptCounter)
+
+        // Move action to scroll down assert that onInterceptTouchEvent calls continue to be ignored.
+        viewParent.dispatchTouchEvent(mockMotionEvent(ACTION_MOVE, y = 3f))
+
+        assertEquals(1, viewParentInterceptCounter)
+
+        // Simulate a `handled` response from the APZ GeckoEngineView API.
+        val inputResultMock = mock<PanZoomController.InputResultDetail>().apply {
+            whenever(handledResult()).thenReturn(INPUT_RESULT_HANDLED)
+            whenever(scrollableDirections()).thenReturn(SCROLLABLE_FLAG_BOTTOM)
+            whenever(overscrollDirections()).thenReturn(OVERSCROLL_FLAG_VERTICAL or OVERSCROLL_FLAG_HORIZONTAL)
+        }
+        result.complete(inputResultMock)
+        shadowOf(getMainLooper()).idle()
+
+        // Move action to scroll down further that onInterceptTouchEvent calls continue to be ignored.
+        viewParent.dispatchTouchEvent(mockMotionEvent(ACTION_MOVE, y = 2f))
+
+        assertEquals(1, viewParentInterceptCounter)
+
+        // Complete the gesture by finishing with an up action.
+        viewParent.dispatchTouchEvent(mockMotionEvent(ACTION_UP))
+
+        assertEquals(1, viewParentInterceptCounter)
+    }
+
+    @Test
+    fun `touch events are intercepted once after initially scrolled up`() {
+        var viewParentInterceptCounter = 0
+        val result: GeckoResult<PanZoomController.InputResultDetail> = GeckoResult()
+        val nestedWebView = object : NestedGeckoView(context) {
+            init {
+                // We need to make the view a non-zero size so that the touch events hit it.
+                left = 0
+                top = 0
+                right = 5
+                bottom = 5
+            }
+        }
+        val spy = spy(nestedWebView)
+        doReturn(result).`when`(spy).onTouchEventForDetailResult(any())
+
+        val viewParent = object : FrameLayout(context) {
+            override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+                viewParentInterceptCounter++
+                return super.onInterceptTouchEvent(ev)
+            }
+        }.apply {
+            addView(spy)
+        }
+
+        // Down action enables requestDisallowInterceptTouchEvent (and starts a gesture).
+        viewParent.dispatchTouchEvent(mockMotionEvent(ACTION_DOWN, y = 1f))
+
+        // `onInterceptTouchEvent` will be triggered the first time because it's the first pass.
+        assertEquals(1, viewParentInterceptCounter)
+
+        // Move action to scroll up assert that onInterceptTouchEvent calls are no longer ignored.
+        viewParent.dispatchTouchEvent(mockMotionEvent(ACTION_MOVE, y = 2f))
+
+        assertEquals(1, viewParentInterceptCounter)
+
+        // Simulate a `handled` response from the APZ GeckoEngineView API.
+        val inputResultMock = mock<PanZoomController.InputResultDetail>().apply {
+            whenever(handledResult()).thenReturn(INPUT_RESULT_HANDLED)
+            whenever(scrollableDirections()).thenReturn(SCROLLABLE_FLAG_BOTTOM)
+            whenever(overscrollDirections()).thenReturn(OVERSCROLL_FLAG_VERTICAL or OVERSCROLL_FLAG_HORIZONTAL)
+        }
+        result.complete(inputResultMock)
+        shadowOf(getMainLooper()).idle()
+
+        // Move action to scroll up further assert that onInterceptTouchEvent calls are not ignored.
+        viewParent.dispatchTouchEvent(mockMotionEvent(ACTION_MOVE, y = 3f))
 
         assertEquals(2, viewParentInterceptCounter)
 

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt
@@ -131,8 +131,8 @@ class NestedGeckoViewTest {
         assertEquals(nestedWebView.nestedOffsetY, 6)
         assertEquals(nestedWebView.lastY, 6)
 
-        // onTouchEventForResult should be called only for ACTION_DOWN
-        verify(nestedWebView, times(0)).updateInputResult(any())
+        // onTouchEventForResult should be also called for ACTION_MOVE
+        verify(nestedWebView, times(1)).updateInputResult(any())
     }
 
     @Test
@@ -154,7 +154,7 @@ class NestedGeckoViewTest {
         // ACTION_CANCEL should not change the result.
         assertTrue(nestedWebView.inputResultDetail.isTouchHandledByBrowser())
 
-        // onTouchEventForResult should be called only for ACTION_DOWN
+        // onTouchEventForResult should never be called for ACTION_UP or ACTION_CANCEL
         verify(nestedWebView, times(0)).updateInputResult(any())
     }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807073