### PR TITLE
Bug 1857850 - [a11y] Improve experience when accessing links in text

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContextualOnboarding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/shopping/ui/ReviewQualityCheckContextualOnboarding.kt
@@ -61,9 +61,9 @@ fun ReviewQualityCheckContextualOnboarding(
     val learnMoreText =
         stringResource(id = R.string.review_quality_check_contextual_onboarding_learn_more_link)
     val privacyPolicyText =
-        stringResource(id = R.string.review_quality_check_contextual_onboarding_privacy_policy_2)
+        stringResource(id = R.string.review_quality_check_contextual_onboarding_privacy_policy)
     val termsOfUseText =
-        stringResource(id = R.string.review_quality_check_contextual_onboarding_terms_use_2)
+        stringResource(id = R.string.review_quality_check_contextual_onboarding_terms_use)
     val titleContentDescription =
         headingResource(R.string.review_quality_check_contextual_onboarding_title)
 
@@ -111,19 +111,13 @@ fun ReviewQualityCheckContextualOnboarding(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Text(
-            text = stringResource(
-                id = R.string.review_quality_check_contextual_onboarding_caption_2,
-                stringResource(id = R.string.shopping_product_name),
-            ),
-            color = FirefoxTheme.colors.textPrimary,
-            style = FirefoxTheme.typography.caption,
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
         LinkText(
-            text = privacyPolicyText,
+            text = stringResource(
+                id = R.string.review_quality_check_contextual_onboarding_caption,
+                stringResource(id = R.string.shopping_product_name),
+                privacyPolicyText,
+                termsOfUseText,
+            ),
             linkTextStates = listOf(
                 LinkTextState(
                     text = privacyPolicyText,
@@ -132,16 +126,6 @@ fun ReviewQualityCheckContextualOnboarding(
                         onPrivacyPolicyClick()
                     },
                 ),
-            ),
-            style = FirefoxTheme.typography.body2,
-            linkTextDecoration = TextDecoration.Underline,
-        )
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        LinkText(
-            text = termsOfUseText,
-            linkTextStates = listOf(
                 LinkTextState(
                     text = termsOfUseText,
                     url = "",
@@ -150,7 +134,10 @@ fun ReviewQualityCheckContextualOnboarding(
                     },
                 ),
             ),
-            style = FirefoxTheme.typography.body2,
+            style = FirefoxTheme.typography.caption
+                .copy(
+                    color = FirefoxTheme.colors.textSecondary,
+                ),
             linkTextDecoration = TextDecoration.Underline,
         )
 

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -2179,17 +2179,17 @@
     <!-- Clickable text from the contextual onboarding card that links to review quality check support article. -->
     <string name="review_quality_check_contextual_onboarding_learn_more_link">Learn more</string>
     <!-- Caption text to be displayed in review quality check contextual onboarding card above the opt-in button. First parameter is the Fakespot product name. Following parameters are for clickable texts defined in review_quality_check_contextual_onboarding_privacy_policy and review_quality_check_contextual_onboarding_terms_use. In the phrase "Fakespot by Mozilla", "by" can be localized. Does not need to stay by. -->
-    <string name="review_quality_check_contextual_onboarding_caption" moz:RemovedIn="121" tools:ignore="UnusedResources">By selecting “Yes, try it” you agree to %1$s by Mozilla’s %2$s and %3$s.</string>
+    <string name="review_quality_check_contextual_onboarding_caption">By selecting “Yes, try it” you agree to %1$s by Mozilla’s %2$s and %3$s.</string>
     <!-- Caption text to be displayed in review quality check contextual onboarding card above the opt-in button. Parameter is the Fakespot product name. After the colon, what appears are two links, each on their own line. The first link is to a Privacy policy (review_quality_check_contextual_onboarding_privacy_policy_2). The second link is to Terms of use (review_quality_check_contextual_onboarding_terms_use_2). -->
-    <string name="review_quality_check_contextual_onboarding_caption_2">By selecting “Yes, try it” you agree to the following from %1$s:</string>
+    <string name="review_quality_check_contextual_onboarding_caption_2" moz:RemovedIn="123" tools:ignore="UnusedResources">By selecting “Yes, try it” you agree to the following from %1$s:</string>
     <!-- Clickable text from the review quality check contextual onboarding card that links to Fakespot privacy policy. -->
-    <string name="review_quality_check_contextual_onboarding_privacy_policy" moz:RemovedIn="121" tools:ignore="UnusedResources">privacy policy</string>
+    <string name="review_quality_check_contextual_onboarding_privacy_policy">privacy policy</string>
     <!-- Clickable text from the review quality check contextual onboarding card that links to Fakespot privacy policy. -->
-    <string name="review_quality_check_contextual_onboarding_privacy_policy_2">Privacy policy</string>
+    <string name="review_quality_check_contextual_onboarding_privacy_policy_2" moz:RemovedIn="123" tools:ignore="UnusedResources">Privacy policy</string>
     <!-- Clickable text from the review quality check contextual onboarding card that links to Fakespot terms of use. -->
-    <string name="review_quality_check_contextual_onboarding_terms_use" moz:RemovedIn="121" tools:ignore="UnusedResources">terms of use</string>
+    <string name="review_quality_check_contextual_onboarding_terms_use">terms of use</string>
     <!-- Clickable text from the review quality check contextual onboarding card that links to Fakespot terms of use. -->
-    <string name="review_quality_check_contextual_onboarding_terms_use_2">Terms of use</string>
+    <string name="review_quality_check_contextual_onboarding_terms_use_2" moz:RemovedIn="123" tools:ignore="UnusedResources">Terms of use</string>
     <!-- Text for opt-in button from the review quality check contextual onboarding card. -->
     <string name="review_quality_check_contextual_onboarding_primary_button_text">Yes, try it</string>
     <!-- Text for opt-out button from the review quality check contextual onboarding card. -->
@@ -2244,6 +2244,10 @@
     <string name="a11y_action_label_pocket_learn_more">open link to learn more</string>
     <!-- Content description for headings announced by accessibility service. The first parameter is the text of the heading. Talkback will announce the first parameter and then speak the word "Heading" indicating to the user that this text is a heading for a section. -->
     <string name="a11y_heading">%s, Heading</string>
+    <!-- Title for dialog displayed when trying to access links present in a text. -->
+    <string name="a11y_links_title">Links</string>
+    <!-- Additional content description for text bodies that contain urls. -->
+    <string name="a11y_links_available">Links available</string>
 
     <!-- Translations feature-->
 


### PR DESCRIPTION
This patch aims to improve a11y experience when accessing links present in bodies of text. When we have a link text element, we now indicate that there are links present in it and upon double tapping, if there is only one link, that one will be opened, if there are multiple ones, a dialog is open from where the user can access any of the links present in the text. This behavior tries to follow the default Talkback a11y one where the user can access links from a text in case they are annotated as URLs.

This solution makes all the links in a text accessible and also improves accessibility for lower version devices.

Review checker was chosen to showcase thise due the text with two links, but this solution applies to all places wher `LinkText` is used.


| Talkback | Our Solution |
| ------------- | ------------- |
| <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/e821be8e-d246-4a2c-8892-fd11ba5b07a7">  | <video src="https://github.com/mozilla-mobile/firefox-android/assets/32488956/450469fc-2db8-4b3a-a0ce-d0096e952c41">|


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1857850