### PR TITLE
Bug 1870677 - Fix failing task ui-test-apk-focus-arm-beta

### DIFF
--- a/focus-android/automation/taskcluster/androidTest/ui-test.sh
+++ b/focus-android/automation/taskcluster/androidTest/ui-test.sh
@@ -108,7 +108,7 @@ function failure_check() {
         echo "TEST_STATUS=${TEST_STATUS}"
         echo "PRODUCT_TYPE=${PRODUCT_TYPE}"
         echo "RELEASE_TYPE=${RELEASE_TYPE}"
-    } >> test_dashboard.env
+    } >> execution_metadata.env
 
     echo
     echo "RESULTS"


### PR DESCRIPTION

Taskcluster Task ui-test-apk-focus-arm-beta is failing because the new pipeline script , testrail.py that creates TestRail milestones is looking for the wrong .env file for the env vars - test_dashboard.env instead of execution_metadata.env, resulting in the env vars being empty when checked.

We need to update the env file to execution_metadata.env to fix this.

https://bugzilla.mozilla.org/show_bug.cgi?id=1870677