### PR TITLE
DRAFT Navigation bar compose concept

### DIFF
--- a/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehavior.kt
+++ b/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehavior.kt
@@ -39,7 +39,7 @@ class BrowserToolbarBehavior(
     attrs: AttributeSet?,
     private val toolbarPosition: ToolbarPosition,
     private val crashReporting: CrashReporting? = null,
-) : CoordinatorLayout.Behavior<BrowserToolbar>(context, attrs) {
+) : CoordinatorLayout.Behavior<View>(context, attrs) {
     // This implementation is heavily based on this blog article:
     // https://android.jlelse.eu/scroll-your-bottom-navigation-view-away-with-10-lines-of-code-346f1ed40e9e
 
@@ -62,7 +62,7 @@ class BrowserToolbarBehavior(
      * Reference to the actual [BrowserToolbar] that we'll animate.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal var browserToolbar: BrowserToolbar? = null
+    internal var browserToolbar: View? = null
 
     /**
      * Depending on how user's touch was consumed by EngineView / current website,
@@ -90,7 +90,7 @@ class BrowserToolbarBehavior(
 
     override fun onStartNestedScroll(
         coordinatorLayout: CoordinatorLayout,
-        child: BrowserToolbar,
+        child: View,
         directTargetChild: View,
         target: View,
         axes: Int,
@@ -105,7 +105,7 @@ class BrowserToolbarBehavior(
 
     override fun onStopNestedScroll(
         coordinatorLayout: CoordinatorLayout,
-        child: BrowserToolbar,
+        child: View,
         target: View,
         type: Int,
     ) {
@@ -116,7 +116,7 @@ class BrowserToolbarBehavior(
 
     override fun onInterceptTouchEvent(
         parent: CoordinatorLayout,
-        child: BrowserToolbar,
+        child: View,
         ev: MotionEvent,
     ): Boolean {
         if (browserToolbar != null) {
@@ -127,7 +127,7 @@ class BrowserToolbarBehavior(
 
     override fun onLayoutChild(
         parent: CoordinatorLayout,
-        child: BrowserToolbar,
+        child: View,
         layoutDirection: Int,
     ): Boolean {
         browserToolbar = child
@@ -211,7 +211,7 @@ class BrowserToolbarBehavior(
         )
 
     @VisibleForTesting
-    internal fun startNestedScroll(axes: Int, type: Int, toolbar: BrowserToolbar): Boolean {
+    internal fun startNestedScroll(axes: Int, type: Int, toolbar: View): Boolean {
         return if (shouldScroll && axes == ViewCompat.SCROLL_AXIS_VERTICAL) {
             startedScroll = true
             shouldSnapAfterScroll = type == ViewCompat.TYPE_TOUCH
@@ -229,7 +229,7 @@ class BrowserToolbarBehavior(
     }
 
     @VisibleForTesting
-    internal fun stopNestedScroll(type: Int, toolbar: BrowserToolbar) {
+    internal fun stopNestedScroll(type: Int, toolbar: View) {
         startedScroll = false
         if (shouldSnapAfterScroll || type == ViewCompat.TYPE_NON_TOUCH) {
             yTranslator.snapWithAnimation(toolbar)

--- a/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarYTranslationStrategy.kt
+++ b/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarYTranslationStrategy.kt
@@ -5,9 +5,10 @@
 package mozilla.components.browser.toolbar.behavior
 
 import android.animation.ValueAnimator
+import android.view.View
 import android.view.animation.DecelerateInterpolator
 import androidx.annotation.VisibleForTesting
-import mozilla.components.browser.toolbar.BrowserToolbar
+//import mozilla.components.browser.toolbar.BrowserToolbar
 import kotlin.math.max
 import kotlin.math.min
 
@@ -28,38 +29,38 @@ internal abstract class BrowserToolbarYTranslationStrategy {
      * Snap the [BrowserToolbar] to be collapsed or expanded, depending on whatever state is closer
      * over a short amount of time.
      */
-    abstract fun snapWithAnimation(toolbar: BrowserToolbar)
+    abstract fun snapWithAnimation(toolbar: View)
 
     /**
      * Snap the [BrowserToolbar] to be collapsed or expanded, depending on whatever state is closer immediately.
      */
-    abstract fun snapImmediately(toolbar: BrowserToolbar?)
+    abstract fun snapImmediately(toolbar: View?)
 
     /**
      * Translate the [BrowserToolbar] to it's full visible height.
      */
-    abstract fun expandWithAnimation(toolbar: BrowserToolbar)
+    abstract fun expandWithAnimation(toolbar: View)
 
     /**
      * Force expanding the [BrowserToolbar] depending on the [distance] value that should be translated
      * cancelling any other translation already in progress.
      */
-    abstract fun forceExpandWithAnimation(toolbar: BrowserToolbar, distance: Float)
+    abstract fun forceExpandWithAnimation(toolbar: View, distance: Float)
 
     /**
      * Translate the [BrowserToolbar] to it's full 0 visible height.
      */
-    abstract fun collapseWithAnimation(toolbar: BrowserToolbar)
+    abstract fun collapseWithAnimation(toolbar: View)
 
     /**
      * Translate [toolbar] immediately to the specified [distance] amount (positive or negative).
      */
-    abstract fun translate(toolbar: BrowserToolbar, distance: Float)
+    abstract fun translate(toolbar: View, distance: Float)
 
     /**
      * Translate [toolbar] to the indicated [targetTranslationY] vaue over a short amount of time.
      */
-    open fun animateToTranslationY(toolbar: BrowserToolbar, targetTranslationY: Float) = with(animator) {
+    open fun animateToTranslationY(toolbar: View, targetTranslationY: Float) = with(animator) {
         addUpdateListener { toolbar.translationY = it.animatedValue as Float }
         setFloatValues(toolbar.translationY, targetTranslationY)
         start()
@@ -79,7 +80,7 @@ internal class BottomToolbarBehaviorStrategy : BrowserToolbarYTranslationStrateg
     @VisibleForTesting
     internal var wasLastExpanding = false
 
-    override fun snapWithAnimation(toolbar: BrowserToolbar) {
+    override fun snapWithAnimation(toolbar: View) {
         if (toolbar.translationY >= (toolbar.height / 2f)) {
             collapseWithAnimation(toolbar)
         } else {
@@ -87,7 +88,7 @@ internal class BottomToolbarBehaviorStrategy : BrowserToolbarYTranslationStrateg
         }
     }
 
-    override fun snapImmediately(toolbar: BrowserToolbar?) {
+    override fun snapImmediately(toolbar: View?) {
         if (animator.isStarted) {
             animator.end()
         } else {
@@ -101,11 +102,11 @@ internal class BottomToolbarBehaviorStrategy : BrowserToolbarYTranslationStrateg
         }
     }
 
-    override fun expandWithAnimation(toolbar: BrowserToolbar) {
+    override fun expandWithAnimation(toolbar: View) {
         animateToTranslationY(toolbar, 0f)
     }
 
-    override fun forceExpandWithAnimation(toolbar: BrowserToolbar, distance: Float) {
+    override fun forceExpandWithAnimation(toolbar: View, distance: Float) {
         val shouldExpandToolbar = distance < 0
         val isToolbarExpanded = toolbar.translationY == 0f
         if (shouldExpandToolbar && !isToolbarExpanded && !wasLastExpanding) {
@@ -114,16 +115,16 @@ internal class BottomToolbarBehaviorStrategy : BrowserToolbarYTranslationStrateg
         }
     }
 
-    override fun collapseWithAnimation(toolbar: BrowserToolbar) {
+    override fun collapseWithAnimation(toolbar: View) {
         animateToTranslationY(toolbar, toolbar.height.toFloat())
     }
 
-    override fun translate(toolbar: BrowserToolbar, distance: Float) {
+    override fun translate(toolbar: View, distance: Float) {
         toolbar.translationY =
             max(0f, min(toolbar.height.toFloat(), toolbar.translationY + distance))
     }
 
-    override fun animateToTranslationY(toolbar: BrowserToolbar, targetTranslationY: Float) {
+    override fun animateToTranslationY(toolbar: View, targetTranslationY: Float) {
         wasLastExpanding = targetTranslationY <= toolbar.translationY
         super.animateToTranslationY(toolbar, targetTranslationY)
     }
@@ -137,7 +138,7 @@ internal class TopToolbarBehaviorStrategy : BrowserToolbarYTranslationStrategy()
     @VisibleForTesting
     internal var wasLastExpanding = false
 
-    override fun snapWithAnimation(toolbar: BrowserToolbar) {
+    override fun snapWithAnimation(toolbar: View) {
         if (toolbar.translationY >= -(toolbar.height / 2f)) {
             expandWithAnimation(toolbar)
         } else {
@@ -145,7 +146,7 @@ internal class TopToolbarBehaviorStrategy : BrowserToolbarYTranslationStrategy()
         }
     }
 
-    override fun snapImmediately(toolbar: BrowserToolbar?) {
+    override fun snapImmediately(toolbar: View?) {
         if (animator.isStarted) {
             animator.end()
         } else {
@@ -159,11 +160,11 @@ internal class TopToolbarBehaviorStrategy : BrowserToolbarYTranslationStrategy()
         }
     }
 
-    override fun expandWithAnimation(toolbar: BrowserToolbar) {
+    override fun expandWithAnimation(toolbar: View) {
         animateToTranslationY(toolbar, 0f)
     }
 
-    override fun forceExpandWithAnimation(toolbar: BrowserToolbar, distance: Float) {
+    override fun forceExpandWithAnimation(toolbar: View, distance: Float) {
         val isExpandingInProgress = animator.isStarted && wasLastExpanding
         val shouldExpandToolbar = distance < 0
         val isToolbarExpanded = toolbar.translationY == 0f
@@ -173,16 +174,16 @@ internal class TopToolbarBehaviorStrategy : BrowserToolbarYTranslationStrategy()
         }
     }
 
-    override fun collapseWithAnimation(toolbar: BrowserToolbar) {
+    override fun collapseWithAnimation(toolbar: View) {
         animateToTranslationY(toolbar, -toolbar.height.toFloat())
     }
 
-    override fun translate(toolbar: BrowserToolbar, distance: Float) {
+    override fun translate(toolbar: View, distance: Float) {
         toolbar.translationY =
             min(0f, max(-toolbar.height.toFloat(), toolbar.translationY - distance))
     }
 
-    override fun animateToTranslationY(toolbar: BrowserToolbar, targetTranslationY: Float) {
+    override fun animateToTranslationY(toolbar: View, targetTranslationY: Float) {
         wasLastExpanding = targetTranslationY >= toolbar.translationY
         super.animateToTranslationY(toolbar, targetTranslationY)
     }

--- a/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarYTranslator.kt
+++ b/android-components/components/browser/toolbar/src/main/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarYTranslator.kt
@@ -4,8 +4,9 @@
 
 package mozilla.components.browser.toolbar.behavior
 
+import android.view.View
 import androidx.annotation.VisibleForTesting
-import mozilla.components.browser.toolbar.BrowserToolbar
+//import mozilla.components.browser.toolbar.BrowserToolbar
 
 /**
  * Helper class with methods for translating on the Y axis a top / bottom [BottomToolbar].
@@ -23,28 +24,28 @@ class BrowserToolbarYTranslator(toolbarPosition: ToolbarPosition) {
      * Snap the [BrowserToolbar] to be collapsed or expanded, depending on whatever state is closer
      * over a short amount of time.
      */
-    internal fun snapWithAnimation(toolbar: BrowserToolbar) {
+    internal fun snapWithAnimation(toolbar: View) {
         strategy.snapWithAnimation(toolbar)
     }
 
     /**
      * Snap the [BrowserToolbar] to be collapsed or expanded, depending on whatever state is closer immediately.
      */
-    fun snapImmediately(toolbar: BrowserToolbar?) {
+    fun snapImmediately(toolbar: View?) {
         strategy.snapImmediately(toolbar)
     }
 
     /**
      * Translate the [BrowserToolbar] to it's full visible height over a short amount of time.
      */
-    internal fun expandWithAnimation(toolbar: BrowserToolbar) {
+    internal fun expandWithAnimation(toolbar: View) {
         strategy.expandWithAnimation(toolbar)
     }
 
     /**
      * Translate the [BrowserToolbar] to be hidden from view over a short amount of time.
      */
-    internal fun collapseWithAnimation(toolbar: BrowserToolbar) {
+    internal fun collapseWithAnimation(toolbar: View) {
         strategy.collapseWithAnimation(toolbar)
     }
 
@@ -52,14 +53,14 @@ class BrowserToolbarYTranslator(toolbarPosition: ToolbarPosition) {
      * Force expanding the [BrowserToolbar] depending on the [distance] value that should be translated
      * cancelling any other translation already in progress.
      */
-    fun forceExpandIfNotAlready(toolbar: BrowserToolbar, distance: Float) {
+    fun forceExpandIfNotAlready(toolbar: View, distance: Float) {
         strategy.forceExpandWithAnimation(toolbar, distance)
     }
 
     /**
      * Translate [toolbar] immediately to the specified [distance] amount (positive or negative).
      */
-    fun translate(toolbar: BrowserToolbar, distance: Float) {
+    fun translate(toolbar: View, distance: Float) {
         strategy.translate(toolbar, distance)
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -130,6 +130,7 @@ import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarMenuController
 import org.mozilla.fenix.components.toolbar.IncompleteRedesignToolbarFeature
 import org.mozilla.fenix.components.toolbar.NavigationBarView
 import org.mozilla.fenix.components.toolbar.ToolbarIntegration
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.components.toolbar.interactor.DefaultBrowserToolbarInteractor
 import org.mozilla.fenix.crashes.CrashContentIntegration
@@ -450,10 +451,18 @@ abstract class BaseBrowserFragment :
                 menuButton = WeakReference(MenuButton(view.context)),
             )
 
+            val toolbarView = if (context.components.settings.toolbarPosition == ToolbarPosition.BOTTOM) {
+                binding.browserLayout.removeView(browserToolbarView.getToolbarView())
+                browserToolbarView.getToolbarView()
+            } else {
+                null
+            }
+
             NavigationBarView(
                 context = context,
                 container = binding.browserLayout,
                 menuView = homeMenuView,
+                toolbarView = toolbarView
             )
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.appservices.places.uniffi.PlacesApiException
+import mozilla.components.browser.menu.view.MenuButton
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.selector.findCustomTab
 import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
@@ -150,6 +151,7 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.secure
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.home.HomeMenuView
 import org.mozilla.fenix.home.HomeScreenViewModel
 import org.mozilla.fenix.home.SharedViewModel
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
@@ -439,9 +441,19 @@ abstract class BaseBrowserFragment :
         )
 
         if (IncompleteRedesignToolbarFeature(context.settings()).isEnabled) {
+            val homeMenuView = HomeMenuView(
+                view = view,
+                context = view.context,
+                lifecycleOwner = viewLifecycleOwner,
+                homeActivity = activity,
+                navController = findNavController(),
+                menuButton = WeakReference(MenuButton(view.context)),
+            )
+
             NavigationBarView(
                 context = context,
                 container = binding.browserLayout,
+                menuView = homeMenuView,
             )
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -449,6 +449,7 @@ abstract class BaseBrowserFragment :
                 homeActivity = activity,
                 navController = findNavController(),
                 menuButton = WeakReference(MenuButton(view.context)),
+                fragmentNavId = R.id.browserFragment,
             )
 
             val toolbarView = if (context.components.settings.toolbarPosition == ToolbarPosition.BOTTOM) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -126,6 +126,8 @@ import org.mozilla.fenix.components.toolbar.BrowserFragmentStore
 import org.mozilla.fenix.components.toolbar.BrowserToolbarView
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarController
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarMenuController
+import org.mozilla.fenix.components.toolbar.IncompleteRedesignToolbarFeature
+import org.mozilla.fenix.components.toolbar.NavigationBarView
 import org.mozilla.fenix.components.toolbar.ToolbarIntegration
 import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.components.toolbar.interactor.DefaultBrowserToolbarInteractor
@@ -435,6 +437,13 @@ abstract class BaseBrowserFragment :
             customTabSession = customTabSessionId?.let { store.state.findCustomTab(it) },
             lifecycleOwner = viewLifecycleOwner,
         )
+
+        if (IncompleteRedesignToolbarFeature(context.settings()).isEnabled) {
+            NavigationBarView(
+                context = context,
+                container = binding.browserLayout,
+            )
+        }
 
         toolbarIntegration.set(
             feature = browserToolbarView.toolbarIntegration,

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -268,4 +268,8 @@ class BrowserToolbarView(
             view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
         }
     }
+
+    fun getToolbarView() : View {
+        return view
+    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -40,7 +39,7 @@ import org.mozilla.fenix.theme.Theme
 @Composable
 fun NavigationBar(
     actionItems: List<ActionItem>,
-    menuView: HomeMenuView? = null
+    menuView: HomeMenuView? = null,
 ) {
     Box(
         modifier = Modifier
@@ -48,8 +47,6 @@ fun NavigationBar(
             .height(48.dp)
             .fillMaxWidth(),
     ) {
-        Divider(color = FirefoxTheme.colors.borderPrimary)
-
         Row(
             modifier = Modifier
                 .align(Alignment.Center)

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.mozilla.fenix.R
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.theme.Theme
+
+/**
+ * Top-level UI for displaying the navigation bar.
+ *
+ * @param actionItems A list of [ActionItem] used to populate the bar.
+ */
+@Composable
+fun NavigationBar(actionItems: List<ActionItem>) {
+    Box(
+        modifier = Modifier
+            .background(FirefoxTheme.colors.layer1)
+            .height(48.dp)
+            .fillMaxWidth(),
+    ) {
+        Divider(color = FirefoxTheme.colors.borderPrimary)
+
+        Row(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            actionItems.forEach {
+                when (it.type) {
+                    ItemType.STANDARD -> {
+                        IconButton(onClick = {}) {
+                            Icon(
+                                painter = painterResource(it.iconId),
+                                stringResource(id = it.descriptionResourceId),
+                                tint = FirefoxTheme.colors.iconPrimary,
+                            )
+                        }
+                    }
+                    ItemType.TAB_COUNTER -> {
+                        IconButton(onClick = {}) {
+                            TabsIcon(item = it, tabsCount = 0)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TabsIcon(item: ActionItem, tabsCount: Int) {
+    Box(contentAlignment = Alignment.Center) {
+        Icon(
+            painter = painterResource(id = item.iconId),
+            contentDescription = stringResource(id = item.descriptionResourceId),
+            tint = FirefoxTheme.colors.iconPrimary,
+        )
+
+        Text(
+            text = tabsCount.toString(),
+            color = FirefoxTheme.colors.iconPrimary,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.W700,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+/**
+ * Represents a navigation bar element.
+ *
+ * @property iconId Resource ID of the icon that item should display.
+ * @property descriptionResourceId Text used as a content description by accessibility services.
+ * @property type Type of the item, defaults to [ItemType.STANDARD].
+ */
+data class ActionItem(
+    val iconId: Int,
+    val descriptionResourceId: Int,
+    val type: ItemType = ItemType.STANDARD,
+)
+
+/**
+ * Enumerates the types of items that can be used in a navigation bar.
+ *
+ * [STANDARD] - Represents a regular navigation item. Used for most navigation actions.
+ * [TAB_COUNTER] - Represents a specialized item used to display a count, such as the number of open tabs in a browser.
+ */
+enum class ItemType {
+    STANDARD, TAB_COUNTER
+}
+
+/**
+ * Provides a collection of standard navigation items used in the application's navigation bar.
+ */
+object StandardNavigationItems {
+    val home = ActionItem(
+        iconId = R.drawable.mozac_ic_home_24,
+        descriptionResourceId = R.string.browser_toolbar_home,
+    )
+
+    val settings = ActionItem(
+        iconId = R.drawable.mozac_ic_ellipsis_vertical_24,
+        descriptionResourceId = R.string.mozac_browser_menu_button,
+    )
+
+    val back = ActionItem(
+        iconId = R.drawable.mozac_ic_back_24,
+        descriptionResourceId = R.string.browser_menu_back,
+    )
+
+    val forward = ActionItem(
+        iconId = R.drawable.mozac_ic_forward_24,
+        descriptionResourceId = R.string.browser_menu_forward,
+    )
+
+    val tabs = ActionItem(
+        iconId = R.drawable.mozac_ui_tabcounter_box,
+        descriptionResourceId = R.string.mozac_tab_counter_content_description,
+        type = ItemType.TAB_COUNTER,
+    )
+
+    val defaultItems = listOf(back, forward, home, tabs, settings)
+}
+
+@LightDarkPreview
+@Composable
+private fun NavigationBarPreview() {
+    FirefoxTheme {
+        NavigationBar(StandardNavigationItems.defaultItems)
+    }
+}
+
+@Preview
+@Composable
+private fun NavigationBarPrivatePreview() {
+    FirefoxTheme(theme = Theme.Private) {
+        NavigationBar(StandardNavigationItems.defaultItems)
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
@@ -25,8 +25,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.home.HomeMenuView
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
 
@@ -36,7 +38,10 @@ import org.mozilla.fenix.theme.Theme
  * @param actionItems A list of [ActionItem] used to populate the bar.
  */
 @Composable
-fun NavigationBar(actionItems: List<ActionItem>) {
+fun NavigationBar(
+    actionItems: List<ActionItem>,
+    menuView: HomeMenuView? = null
+) {
     Box(
         modifier = Modifier
             .background(FirefoxTheme.colors.layer1)
@@ -66,6 +71,27 @@ fun NavigationBar(actionItems: List<ActionItem>) {
                     ItemType.TAB_COUNTER -> {
                         IconButton(onClick = {}) {
                             TabsIcon(item = it, tabsCount = 0)
+                        }
+                    }
+
+                    ItemType.MENU -> {
+                        menuView?.let {
+                            IconButton(onClick = {}) {
+                                AndroidView(
+                                    factory = { _ ->
+                                        menuView.build()
+                                        menuView.getMenuButton()!!
+                                    },
+                                )
+                            }
+                        } ?: run {
+                            IconButton(onClick = {}) {
+                                Icon(
+                                    painter = painterResource(it.iconId),
+                                    stringResource(id = it.descriptionResourceId),
+                                    tint = FirefoxTheme.colors.iconPrimary,
+                                )
+                            }
                         }
                     }
                 }
@@ -113,7 +139,7 @@ data class ActionItem(
  * [TAB_COUNTER] - Represents a specialized item used to display a count, such as the number of open tabs in a browser.
  */
 enum class ItemType {
-    STANDARD, TAB_COUNTER
+    STANDARD, TAB_COUNTER, MENU
 }
 
 /**
@@ -125,9 +151,10 @@ object StandardNavigationItems {
         descriptionResourceId = R.string.browser_toolbar_home,
     )
 
-    val settings = ActionItem(
+    val menu = ActionItem(
         iconId = R.drawable.mozac_ic_ellipsis_vertical_24,
         descriptionResourceId = R.string.mozac_browser_menu_button,
+        type = ItemType.MENU
     )
 
     val back = ActionItem(
@@ -146,7 +173,7 @@ object StandardNavigationItems {
         type = ItemType.TAB_COUNTER,
     )
 
-    val defaultItems = listOf(back, forward, home, tabs, settings)
+    val defaultItems = listOf(back, forward, home, tabs, menu)
 }
 
 @LightDarkPreview

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBarView.kt
@@ -6,8 +6,12 @@ package org.mozilla.fenix.components.toolbar
 
 import android.content.Context
 import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Divider
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import mozilla.components.browser.toolbar.behavior.BrowserToolbarBehavior
 import mozilla.components.browser.toolbar.behavior.ToolbarPosition
@@ -26,6 +30,7 @@ class NavigationBarView(
     context: Context,
     container: ViewGroup,
     menuView: HomeMenuView,
+    toolbarView: View? = null,
     navigationItems: List<ActionItem> = StandardNavigationItems.defaultItems,
 ) {
 
@@ -33,10 +38,18 @@ class NavigationBarView(
         val composeView = ComposeView(context).apply {
             setContent {
                 FirefoxTheme {
-                    NavigationBar(
-                        actionItems = navigationItems,
-                        menuView = menuView,
-                    )
+                    Column {
+                        if (toolbarView != null) {
+                            AndroidView(factory = { _ -> toolbarView })
+                        } else {
+                            Divider(color = FirefoxTheme.colors.borderPrimary)
+                        }
+
+                        NavigationBar(
+                            actionItems = navigationItems,
+                            menuView = menuView,
+                        )
+                    }
                 }
             }
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBarView.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import android.content.Context
+import android.view.Gravity
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ *  A helper class to add NavigationBar composable to a [ViewGroup].
+ *
+ * @param context The Context the view is running in.
+ * @param container The ViewGroup into which the NavigationBar composable will be added.
+ * @param navigationItems A list of [ActionItem] objects representing the items to be displayed in the navigation bar.
+ * Defaults to [StandardNavigationItems.defaultItems] which provides a standard set of navigation items.
+ */
+class NavigationBarView(
+    context: Context,
+    container: ViewGroup,
+    navigationItems: List<ActionItem> = StandardNavigationItems.defaultItems,
+) {
+
+    init {
+        val composeView = ComposeView(context).apply {
+            setContent {
+                FirefoxTheme {
+                    NavigationBar(navigationItems)
+                }
+            }
+        }
+
+        val layoutParams = CoordinatorLayout.LayoutParams(
+            CoordinatorLayout.LayoutParams.MATCH_PARENT,
+            CoordinatorLayout.LayoutParams.WRAP_CONTENT,
+        ).apply {
+            gravity = Gravity.BOTTOM
+        }
+
+        composeView.layoutParams = layoutParams
+        container.addView(composeView)
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBarView.kt
@@ -9,6 +9,8 @@ import android.view.Gravity
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import mozilla.components.browser.toolbar.behavior.BrowserToolbarBehavior
+import mozilla.components.browser.toolbar.behavior.ToolbarPosition
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -39,9 +41,14 @@ class NavigationBarView(
             CoordinatorLayout.LayoutParams.WRAP_CONTENT,
         ).apply {
             gravity = Gravity.BOTTOM
+
+            behavior = BrowserToolbarBehavior(container.context, null, ToolbarPosition.BOTTOM).apply {
+                enableScrolling()
+            }
         }
 
         composeView.layoutParams = layoutParams
         container.addView(composeView)
     }
+
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBarView.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import mozilla.components.browser.toolbar.behavior.BrowserToolbarBehavior
 import mozilla.components.browser.toolbar.behavior.ToolbarPosition
+import org.mozilla.fenix.home.HomeMenuView
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -24,6 +25,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
 class NavigationBarView(
     context: Context,
     container: ViewGroup,
+    menuView: HomeMenuView,
     navigationItems: List<ActionItem> = StandardNavigationItems.defaultItems,
 ) {
 
@@ -31,7 +33,10 @@ class NavigationBarView(
         val composeView = ComposeView(context).apply {
             setContent {
                 FirefoxTheme {
-                    NavigationBar(navigationItems)
+                    NavigationBar(
+                        actionItems = navigationItems,
+                        menuView = menuView,
+                    )
                 }
             }
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -86,6 +86,8 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.PrivateShortcutCreateManager
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.toolbar.IncompleteRedesignToolbarFeature
+import org.mozilla.fenix.components.toolbar.NavigationBarView
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.databinding.FragmentHomeBinding
 import org.mozilla.fenix.ext.components
@@ -423,6 +425,13 @@ class HomeFragment : Fragment() {
             context = requireContext(),
             interactor = sessionControlInteractor,
         )
+
+        if (IncompleteRedesignToolbarFeature(requireContext().settings()).isEnabled) {
+            NavigationBarView(
+                context = requireContext(),
+                container = binding.homeLayout,
+            )
+        }
 
         sessionControlView = SessionControlView(
             containerView = binding.sessionControlRecyclerView,

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -435,6 +435,7 @@ class HomeFragment : Fragment() {
                 homeActivity = activity,
                 navController = findNavController(),
                 menuButton = WeakReference(MenuButton(requireContext())),
+                fragmentNavId = R.id.homeFragment,
             )
 
             val toolbarView = if (requireContext().components.settings.toolbarPosition == ToolbarPosition.BOTTOM) {
@@ -587,6 +588,7 @@ class HomeFragment : Fragment() {
             homeActivity = activity as HomeActivity,
             navController = findNavController(),
             menuButton = WeakReference(binding.menuButton),
+            fragmentNavId = R.id.homeFragment,
         ).also { it.build() }
 
         tabCounterView = TabCounterView(

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -437,11 +437,19 @@ class HomeFragment : Fragment() {
                 menuButton = WeakReference(MenuButton(requireContext())),
             )
 
+            val toolbarView = if (requireContext().components.settings.toolbarPosition == ToolbarPosition.BOTTOM) {
+                val toolbar = binding.toolbarLayout
+                binding.root.removeView(toolbar)
+                toolbar
+            } else {
+                null
+            }
 
             NavigationBarView(
                 context = requireContext(),
                 container = binding.homeLayout,
                 menuView = homeMenuView,
+                toolbarView = toolbarView,
             )
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -51,6 +51,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import mozilla.components.browser.menu.view.MenuButton
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.selector.privateTabs
@@ -427,9 +428,20 @@ class HomeFragment : Fragment() {
         )
 
         if (IncompleteRedesignToolbarFeature(requireContext().settings()).isEnabled) {
+            val homeMenuView = HomeMenuView(
+                view = binding.root,
+                context = requireContext(),
+                lifecycleOwner = viewLifecycleOwner,
+                homeActivity = activity,
+                navController = findNavController(),
+                menuButton = WeakReference(MenuButton(requireContext())),
+            )
+
+
             NavigationBarView(
                 context = requireContext(),
                 container = binding.homeLayout,
+                menuView = homeMenuView,
             )
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
@@ -56,6 +56,7 @@ class HomeMenuView(
     private val navController: NavController,
     private val menuButton: WeakReference<MenuButton>,
     private val fxaEntrypoint: FxAEntryPoint = FenixFxAEntryPoint.HomeMenu,
+    private val fragmentNavId: Int,
 ) {
 
     /**
@@ -100,7 +101,7 @@ class HomeMenuView(
                 HomeMenuMetrics.settingsItemClicked.record(NoExtras())
 
                 navController.nav(
-                    R.id.homeFragment,
+                    fragmentNavId,
                     HomeFragmentDirections.actionGlobalSettingsFragment(),
                 )
             }
@@ -108,13 +109,13 @@ class HomeMenuView(
                 HomeScreen.customizeHomeClicked.record(NoExtras())
 
                 navController.nav(
-                    R.id.homeFragment,
+                    fragmentNavId,
                     HomeFragmentDirections.actionGlobalHomeSettingsFragment(),
                 )
             }
             is HomeMenu.Item.SyncAccount -> {
                 navController.nav(
-                    R.id.homeFragment,
+                    fragmentNavId,
                     when (item.accountState) {
                         AccountState.AUTHENTICATED ->
                             HomeFragmentDirections.actionGlobalAccountSettingsFragment()
@@ -143,19 +144,19 @@ class HomeMenuView(
             }
             HomeMenu.Item.Bookmarks -> {
                 navController.nav(
-                    R.id.homeFragment,
+                    fragmentNavId,
                     HomeFragmentDirections.actionGlobalBookmarkFragment(BookmarkRoot.Mobile.id),
                 )
             }
             HomeMenu.Item.History -> {
                 navController.nav(
-                    R.id.homeFragment,
+                    fragmentNavId,
                     HomeFragmentDirections.actionGlobalHistoryFragment(),
                 )
             }
             HomeMenu.Item.Downloads -> {
                 navController.nav(
-                    R.id.homeFragment,
+                    fragmentNavId,
                     HomeFragmentDirections.actionGlobalDownloadsFragment(),
                 )
             }
@@ -195,7 +196,7 @@ class HomeMenuView(
             }
             HomeMenu.Item.ReconnectSync -> {
                 navController.nav(
-                    R.id.homeFragment,
+                    fragmentNavId,
                     HomeFragmentDirections.actionGlobalAccountProblemFragment(
                         entrypoint = fxaEntrypoint as FenixFxAEntryPoint,
                     ),
@@ -203,7 +204,7 @@ class HomeMenuView(
             }
             HomeMenu.Item.Extensions -> {
                 navController.nav(
-                    R.id.homeFragment,
+                    fragmentNavId,
                     HomeFragmentDirections.actionGlobalAddonsManagementFragment(),
                 )
             }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeMenuView.kt
@@ -78,6 +78,10 @@ class HomeMenuView(
         )
     }
 
+    fun getMenuButton() : MenuButton? {
+        return menuButton.get()
+    }
+
     /**
      * Dismisses the menu.
      */


### PR DESCRIPTION
This is a continuation of a conversation happening [here](https://github.com/mozilla-mobile/firefox-android/pull/4699) and will be closed once the discussion has been resolved. It's a (very hackish) demonstration of integrating existing toolbar elements into a compose nav bar. 

On a very high level, the strategy is to use a container for combination of Toolbar + Navbar that will handle scrolling behaviour, and inject the android view toolbar into Compose. Even if we were to implement Navbar in Android view, the approach of combining it with the toolbar in some form of a container probably makes the most sense.

Menu item is added as an AndroidView composable as well. I will have to look into positioning properly, but I do not expect it to be a blocker. Menu positioning got simpler in the new [design](https://www.figma.com/file/8fsCvtnweBkWGZ9NfL907l/Toolbar-Redesign?type=design&node-id=5320-13971&mode=design&t=QExVXWG6kdt4g0FG-0), when the keyboard is shown there is no option to show the menu.

I didn't implement the tab menu, it's implemented in compose in tabs tray. Not decided if I should use AndroidView or go for Compose implementation, probably will look into reusing the tabs tray compose element first.

https://github.com/mozilla-mobile/firefox-android/assets/92760693/97023150-2336-4b22-bfd5-8a3798b03a57




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1867698