### PR TITLE
Bug 1870668 - Remove the `mozac_feature_addons_authors` string

### DIFF
--- a/android-components/samples/browser/src/main/res/layout/activity_add_on_details.xml
+++ b/android-components/samples/browser/src/main/res/layout/activity_add_on_details.xml
@@ -29,7 +29,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@+id/details"
-            android:text="@string/mozac_feature_addons_authors" />
+            android:text="@string/mozac_feature_addons_author" />
 
         <TextView
             android:id="@+id/author_text"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues. **See:** https://github.com/mozilla-mobile/reference-browser/pull/2625

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1870668