### PR TITLE
Bug 1709748 - Add docs about how to run Glean debugging for Fenix

### DIFF
--- a/fenix/docs/Glean-Debugging-for-Fenix.md
+++ b/fenix/docs/Glean-Debugging-for-Fenix.md
@@ -1,0 +1,77 @@
+# Glean Debugging for Fenix
+
+**Purpose:** To be able to test that pings are sending data as expected.
+
+**You need:**
+
+* An Android phone (note: this should work the same for the Android simulator)
+* A cord to plug the android phone into your computer
+* The Firefox app of your choice installed on the phone
+
+## Setup
+
+1. Plug in the Android phone to your computer (or start the Android Simulator).
+
+2. Make sure you have usb debugging enabled on your phone.
+	* Check for Settings > Developer Options
+	* If you don’t see this:
+		* Go to Settings > About Device
+		* Tap the Build Number 7 times
+		* This turns on Developer Mode
+	* Go to Settings> Developer Options
+		* Turn on the enable usb debugging option
+
+3. Check that you have adb installed on your computer.
+	* In the command line, run: `brew install android-platform-tools`
+	* If it has installed properly, you should be able to run: `adb devices`
+		* If you have the phone plugged in, you should see a device number under the List of Devices
+
+## Tag Pings
+
+In the command line, run:
+
+```
+adb shell am start -n org.mozilla.fenix/mozilla.telemetry.glean.debug.GleanDebugActivity --es debugViewTag label-for-your-pings
+```
+
+where "label-for-your-pings" is the string you want to name your pings.
+If you want to change the app that you are testing data from,
+you can replace `org.mozilla.fenix` with the appropriate string (see table below).
+This will tag the pings coming in and allow you to find them in the Glean debugger.
+This will only tag pings from the current session, so it is a good idea to run this first.
+
+| String | App Version |
+| ------ | ----------- |
+| org.mozilla.fenix | Fenix Nightly |
+| org.mozilla.firefox | Fenix |
+| org.mozilla.firefox.beta | Fenix Beta |
+
+
+Refer to the [Glean Dictionary](https://dictionary.telemetry.mozilla.org/apps/fenix?itemType=app_ids) for the application mappings.
+
+## Manually Send Pings
+
+Now we want to trigger the ping to manually send data to the Glean debugger (and not wait until the scheduled time).
+In the command line run:
+
+```
+adb shell am start -n org.mozilla.fenix/mozilla.telemetry.glean.debug.GleanDebugActivity --es sendPing metrics
+```
+
+where `metrics` is the ping type (you can substitute `baseline`, `events` etc)
+and again you can switch the app name if necessary.
+
+If you want to see only metrics updated from your current session,
+you can trigger a ping, then perform the actions you want to test,
+then trigger another ping.
+The second ping will only have data for those actions,
+while the first one sent could include any leftover data that was scheduled to be sent later in the day.
+
+## View pings
+
+Now you can see the data from your pings here:
+<https://debug-ping-preview.firebaseapp.com/>
+
+## Reference
+
+[The Glean Documentation on Debugging Android Applications](https://mozilla.github.io/glean/book/user/debugging/android.html)


### PR DESCRIPTION
A while ago Kimmy and Megan produced [a doc](https://docs.google.com/document/d/1Xyvoh6gsQDLGVMb8Tt_lRMEEl0oxRY-lQ9_l7s55uQc/edit) with detailed steps for how to actually get pings from Fenix to the debug ping viewer.
It seems fitting to put these docs in here. There's a slight overlap with `Test-telemetry-pings.md`.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1709748