### PR TITLE
Bug 1868260 – Sync navbar position with toolbar

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -121,14 +121,15 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.FindInPageIntegration
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.metrics.MetricsUtils
+import org.mozilla.fenix.components.toolbar.BottomToolbarContainerView
 import org.mozilla.fenix.components.toolbar.BrowserFragmentState
 import org.mozilla.fenix.components.toolbar.BrowserFragmentStore
 import org.mozilla.fenix.components.toolbar.BrowserToolbarView
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarController
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarMenuController
 import org.mozilla.fenix.components.toolbar.IncompleteRedesignToolbarFeature
-import org.mozilla.fenix.components.toolbar.NavigationBarView
 import org.mozilla.fenix.components.toolbar.ToolbarIntegration
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.components.toolbar.interactor.DefaultBrowserToolbarInteractor
 import org.mozilla.fenix.crashes.CrashContentIntegration
@@ -439,9 +440,19 @@ abstract class BaseBrowserFragment :
         )
 
         if (IncompleteRedesignToolbarFeature(context.settings()).isEnabled) {
-            NavigationBarView(
+            val toolbarView = if (context.components.settings.toolbarPosition == ToolbarPosition.BOTTOM) {
+                // Should refactor this so there is no added view to remove to begin with
+                // https://bugzilla.mozilla.org/show_bug.cgi?id=1870976
+                binding.browserLayout.removeView(browserToolbarView.view)
+                browserToolbarView.view
+            } else {
+                null
+            }
+
+            BottomToolbarContainerView(
                 context = context,
                 container = binding.browserLayout,
+                androidToolbarView = toolbarView,
             )
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BottomToolbarContainerView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BottomToolbarContainerView.kt
@@ -6,9 +6,13 @@ package org.mozilla.fenix.components.toolbar
 
 import android.content.Context
 import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import org.mozilla.fenix.compose.Divider
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -17,19 +21,29 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * @param context The Context the view is running in.
  * @param container The ViewGroup into which the NavigationBar composable will be added.
  * @param navigationItems A list of [ActionItem] objects representing the items to be displayed in the navigation bar.
+ * @param androidToolbarView An option toolbar view that will be added atop of the navigation bar.
  * Defaults to [NavigationItems.defaultItems] which provides a standard set of navigation items.
  */
-class NavigationBarView(
+class BottomToolbarContainerView(
     context: Context,
     container: ViewGroup,
     navigationItems: List<ActionItem> = NavigationItems.defaultItems,
+    androidToolbarView: View? = null,
 ) {
 
     init {
         val composeView = ComposeView(context).apply {
             setContent {
                 FirefoxTheme {
-                    NavigationBar(navigationItems)
+                    Column {
+                        if (androidToolbarView != null) {
+                            AndroidView(factory = { _ -> androidToolbarView })
+                        } else {
+                            Divider()
+                        }
+
+                        NavigationBar(actionItems = navigationItems)
+                    }
                 }
             }
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -53,8 +53,7 @@ class BrowserToolbarView(
     private val layout = LayoutInflater.from(context)
         .inflate(toolbarLayout, container, true)
 
-    @VisibleForTesting
-    internal var view: BrowserToolbar = layout
+    var view: BrowserToolbar = layout
         .findViewById(R.id.toolbar)
 
     val toolbarIntegration: ToolbarIntegration

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.mozilla.fenix.R
-import org.mozilla.fenix.compose.Divider
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
@@ -43,8 +42,6 @@ fun NavigationBar(actionItems: List<ActionItem>) {
             .height(48.dp)
             .fillMaxWidth(),
     ) {
-        Divider()
-
         Row(
             modifier = Modifier
                 .align(Alignment.Center)

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -86,8 +86,8 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.PrivateShortcutCreateManager
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.components.toolbar.BottomToolbarContainerView
 import org.mozilla.fenix.components.toolbar.IncompleteRedesignToolbarFeature
-import org.mozilla.fenix.components.toolbar.NavigationBarView
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.databinding.FragmentHomeBinding
 import org.mozilla.fenix.ext.components
@@ -427,9 +427,20 @@ class HomeFragment : Fragment() {
         )
 
         if (IncompleteRedesignToolbarFeature(requireContext().settings()).isEnabled) {
-            NavigationBarView(
+            val toolbarView = if (requireContext().components.settings.toolbarPosition == ToolbarPosition.BOTTOM) {
+                val toolbar = binding.toolbarLayout
+                // Should refactor this so there is no added view to remove to begin with
+                // https://bugzilla.mozilla.org/show_bug.cgi?id=1870976
+                binding.root.removeView(toolbar)
+                toolbar
+            } else {
+                null
+            }
+
+            BottomToolbarContainerView(
                 context = requireContext(),
                 container = binding.homeLayout,
+                androidToolbarView = toolbarView,
             )
         }
 


### PR DESCRIPTION
### Screenshots
 Top | Bottom
 --- | --- 
<img src="https://github.com/mozilla-mobile/firefox-android/assets/92760693/c7c288f8-65f0-4287-89b2-067434d22b4c" width="300"> |  <img src="https://github.com/mozilla-mobile/firefox-android/assets/92760693/08d38f6b-ee48-4acd-9ee2-3ba75a35d847" width="300">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1868260
