### PR TITLE
Bug 1871168 - add debug secret setting for adding tabs

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/DebugAddTabsSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/DebugAddTabsSettingsFragment.kt
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.lib.state.ext.observeAsState
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.components
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Adds tabs for debug purposes
+ */
+class DebugAddTabsSettingsFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                FirefoxTheme {
+                    DebugAddTabsScreen()
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun DebugAddTabsScreen() {
+        val currentTabCount by components.core.store.observeAsState(
+            initialValue = 0,
+            map = { it.tabs.size },
+        )
+
+        Column(modifier = Modifier
+            .padding(8.dp),
+        ) {
+            CurrentTabCount(currentTabCount)
+            Spacer(modifier = Modifier.size(8.dp))
+            AddTabsButton(store = components.core.store)
+        }
+
+    }
+    
+    @Composable
+    private fun CurrentTabCount(count: Int) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.debug_add_tabs_count),
+                color = FirefoxTheme.colors.textPrimary,
+                style = FirefoxTheme.typography.headline7,
+                modifier = Modifier.padding(4.dp)
+            )
+
+            Text(
+                text = count.toString(),
+                color = FirefoxTheme.colors.textPrimary,
+                modifier = Modifier.padding(4.dp)
+            )
+        }
+    }
+
+    @Composable
+    private fun AddTabsButton(store: BrowserStore) {
+        Button(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp),
+            onClick = {
+                store.dispatch(TabListAction.AddMultipleTabsAction(
+                    tabs = listOf(
+                        createTab("https://www.mozilla.org", private = false),
+                        createTab("https://www.wikipedia.org", private = false),
+                        createTab("https://www.amazon.com", private = false),
+                        createTab("https://www.reddit.com", private = false),
+                        createTab("https://androiddev.reddit.com", private = false),
+                        createTab("https://www.google.com", private = false),
+                        createTab("https://www.facebook.com", private = false),
+                        createTab("https://www.whatsapp.com", private = false),
+                        createTab("https://www.instagram.com", private = false),
+                        createTab("https://www.linkedin.com", private = false),
+                        createTab("https://www.tiktok.com", private = false),
+                        createTab("https://www.twitter.com", private = false),
+                        createTab("https://www.youtube.com", private = false),
+                        createTab("https://www.twitch.tv", private = false),
+                        createTab("https://www.ebay.com", private = false),
+                        createTab("https://www.shopify.com", private = false),
+                        createTab("https://www.square.com", private = false),
+                        createTab("https://www.ign.com", private = false),
+                        createTab("https://www.gamespot.com", private = false),
+                        createTab("https://www.pcgamer.com", private = false),
+                        createTab("https://www.cnet.com", private = false),
+                        createTab("https://www.theverge.com", private = false),
+                        createTab("https://www.androidcentral.com", private = false),
+                        createTab("https://developers.googleblog.com", private = false),
+                        createTab("https://developer.android.com", private = false),
+                        createTab("https://www.oracle.com", private = false),
+                        createTab("https://www.reddit.com/r/androiddev/comments/14skdld/threads_is_written_almost_completely_in_jetpack/", private = false),
+                        createTab("https://www.apple.com", private = false),
+                        createTab("https://www.google.com", private = false),
+                        createTab("https://www.samsung.com", private = false),
+                        createTab("https://www.microsoft.com", private = false),
+                        createTab("https://www.expedia.com", private = false),
+                        createTab("https://www.united.com", private = false),
+                        createTab("https://www.southwest.com", private = false),
+                        createTab("https://www.jetblue.com", private = false),
+                        createTab("https://www.aa.com", private = false),
+                        createTab("https://www.spirit.com", private = false),
+                        createTab("https://www.kayak.com", private = false),
+                        createTab("https://www.vrbo.com", private = false),
+                        createTab("https://www.airbnb.com", private = false),
+                        createTab("https://www.zillow.com", private = false),
+                        createTab("https://www.redfin.com", private = false),
+                        createTab("https://www.realtor.com", private = false),
+                        createTab("https://www.apartments.com", private = false),
+                        createTab("https://www.autotrader.com", private = false),
+                        createTab("https://www.cars.com", private = false),
+                        createTab("https://www.carvana.com", private = false),
+                        createTab("https://www.carmax.com", private = false),
+                        createTab("https://www.honda.com", private = false),
+                        createTab("https://www.ford.com", private = false),
+                        createTab("https://www.chevy.com", private = false),
+                        createTab("https://www.bmw.com", private = false),
+                        createTab("https://www.porsche.com", private = false),
+                        createTab("https://www.tesla.com", private = false),
+                        createTab("https://www.audi.com", private = false),
+                        createTab("https://www.subaru.com", private = false),
+                        createTab("https://www.adidas.com", private = false),
+                        createTab("https://www.nike.com", private = false),
+                        createTab("https://www.reebok.com", private = false),
+                        createTab("https://www.dsw.com", private = false),
+                        createTab("https://www.zappos.com", private = false),
+                        createTab("https://www.famousfootwear.com", private = false),
+                        createTab("https://www.nordstrom.com", private = false),
+                        createTab("https://www.macys.com", private = false),
+                        createTab("https://www.bestbuy.com", private = false),
+                        createTab("https://www.razer.com", private = false),
+                        createTab("https://www.netflix.com", private = false),
+                        createTab("https://www.disneyplus.com", private = false),
+                        createTab("https://www.hulu.com", private = false),
+                        createTab("https://www.espn.com", private = false),
+                        createTab("https://tv.apple.com", private = false),
+                        createTab("https://www.paramountplus.com/", private = false),
+                        createTab("https://www.marvel.com", private = false),
+                        createTab("https://www.dc.com", private = false),
+                        createTab("https://www.imagecomics.com", private = false),
+                        createTab("https://www.asus.com", private = false),
+                        createTab("https://www.verizon.com", private = false),
+                        createTab("https://www.att.com", private = false),
+                        createTab("https://www.t-mobile.com", private = false),
+                        createTab("https://www.boostmobile.com", private = false),
+                        createTab("https://fi.google.com", private = false),
+                        createTab("https://www.ups.com", private = false),
+                        createTab("https://www.dhl.com", private = false),
+                        createTab("https://www.figma.com", private = false),
+                        createTab("https://www.metmuseum.org", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170000", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170001", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170002", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170003", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170004", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170005", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170006", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170007", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170008", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170009", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170010", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170011", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170012", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170013", private = false),
+                        createTab("https://bugzilla.mozilla.org/show_bug.cgi?id=170014", private = false),
+                    )
+                ))
+            }
+        ) {
+            Text(
+                textAlign = TextAlign.Center,
+                text = "Add 100 tabs",
+                color = FirefoxTheme.colors.textOnColorPrimary
+            )
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -128,6 +128,10 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
         requirePreference<Preference>(R.string.pref_key_custom_sponsored_stories_parameters).apply {
             isVisible = Config.channel.isNightlyOrDebug
         }
+
+        requirePreference<Preference>(R.string.pref_key_debug_add_tabs).apply {
+            isVisible = Config.channel.isDebug
+        }
     }
 
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
@@ -136,6 +140,11 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
                 findNavController().nav(
                     R.id.secretSettingsPreference,
                     SecretSettingsFragmentDirections.actionSecretSettingsFragmentToSponsoredStoriesSettings(),
+                )
+            getString(R.string.pref_key_debug_add_tabs) ->
+                findNavController().nav(
+                    R.id.secretSettingsPreference,
+                    SecretSettingsFragmentDirections.actionSecretSettingsFragmentToDebugAddTabs()
                 )
         }
         return super.onPreferenceTreeClick(preference)

--- a/fenix/app/src/main/res/navigation/nav_graph.xml
+++ b/fenix/app/src/main/res/navigation/nav_graph.xml
@@ -794,6 +794,14 @@
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
+
+        <action
+            android:id="@+id/action_secretSettingsFragment_to_debugAddTabs"
+            app:destination="@id/debugAddTabSettings"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
     </fragment>
     <fragment
         android:id="@+id/secretInfoSettingsFragment"
@@ -819,6 +827,10 @@
         android:id="@+id/sponsoredStoriesSettings"
         android:name="org.mozilla.fenix.settings.SponsoredStoriesSettingsFragment"
         android:label="@string/preferences_debug_settings_custom_sponsored_stories_parameters" />
+    <fragment
+        android:id="@+id/debugAddTabSettings"
+        android:name="org.mozilla.fenix.settings.DebugAddTabsSettingsFragment"
+        android:label="@string/preferences_debug_settings_add_tabs" />
     <fragment
         android:id="@+id/trackingProtectionFragment"
         android:name="org.mozilla.fenix.settings.TrackingProtectionFragment">

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -364,6 +364,7 @@
     <string name="pref_key_custom_sponsored_stories_city" translatable="false">pref_key_custom_sponsored_stories_city</string>
     <string name="pref_key_enable_compose_top_sites" translatable="false">pref_key_enable_compose_top_sites</string>
     <string name="pref_key_enable_translations" translatable="false">pref_key_enable_translations</string>
+    <string name="pref_key_debug_add_tabs" translatable="false">pref_key_debug_add_tabs</string>
 
     <!-- Growth Data -->
     <string name="pref_key_growth_set_as_default" translatable="false">pref_key_growth_set_as_default</string>

--- a/fenix/app/src/main/res/values/static_strings.xml
+++ b/fenix/app/src/main/res/values/static_strings.xml
@@ -46,6 +46,8 @@
     <string name="preferences_debug_settings_custom_glean_server_url" translatable="false">Custom Glean server URL (requires restart)</string>
     <!-- Label for custom Pocket sponsored stories settings -->
     <string name="preferences_debug_settings_custom_sponsored_stories_parameters" translatable="false">Pocket sponsored stories</string>
+    <!-- Label for debug add tabs settings -->
+    <string name="preferences_debug_settings_add_tabs" translatable="false">Add Tabs</string>
     <!-- Label for custom Pocket sponsored stories site enabled setting -->
     <string name="preferences_debug_settings_custom_sponsored_stories_parameters_enabled" translatable="false">Enable custom Pocket sponsored stories parameters (requires restart)</string>
     <!-- Label for custom Pocket sponsored stories site id setting -->
@@ -86,6 +88,9 @@
     <!-- Secret debug info strings -->
     <string name="debug_info_region_home" translatable="false">Home region</string>
     <string name="debug_info_region_current" translatable="false">Current region</string>
+
+    <!-- Secret debug tabs strings -->
+    <string name="debug_add_tabs_count" translatable="false">Current Tab Count</string>   //FIXME: placement
 
     <!-- Profiler settings -->
     <string name="preferences_start_profiler">Start Profiler</string>

--- a/fenix/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/fenix/app/src/main/res/xml/secret_settings_preferences.xml
@@ -61,4 +61,8 @@
         app:iconSpaceReserved="false"
         android:title="@string/preferences_debug_settings_custom_sponsored_stories_parameters"
         />
+    <Preference
+        android:key="@string/pref_key_debug_add_tabs"
+        app:iconSpaceReserved="false"
+        android:title="@string/preferences_debug_settings_add_tabs" />
 </PreferenceScreen>


### PR DESCRIPTION
This allows for creating large amounts of tabs quickly when in debug builds of the app from within the Secret Settings.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1871168