### PR TITLE
Bug 1807268 - Re-enable openSponsoredShortcutsSettingsOptionTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SponsoredShortcutsTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SponsoredShortcutsTest.kt
@@ -102,7 +102,6 @@ class SponsoredShortcutsTest {
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1729336
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1807268")
     @Test
     fun openSponsoredShortcutsSettingsOptionTest() {
         homeScreen {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -26,6 +26,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.longClick
 import androidx.test.espresso.assertion.PositionAssertions.isCompletelyAbove
 import androidx.test.espresso.assertion.PositionAssertions.isPartiallyBelow
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -51,7 +52,6 @@ import org.junit.Assert
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.LISTS_MAXSWIPES
-import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
@@ -557,7 +557,8 @@ class HomeScreenRobot {
         }
 
         fun openContextMenuOnSponsoredShortcut(sponsoredShortcutTitle: String, interact: HomeScreenRobot.() -> Unit): Transition {
-            sponsoredShortcut(sponsoredShortcutTitle).click(LONG_CLICK_DURATION)
+            sponsoredShortcut(sponsoredShortcutTitle).perform(longClick())
+            Log.i(TAG, "openContextMenuOnSponsoredShortcut: Long clicked to open context menu for $sponsoredShortcutTitle sponsored shortcut")
 
             HomeScreenRobot().interact()
             return Transition()
@@ -631,8 +632,10 @@ class HomeScreenRobot {
         }
 
         fun clickSponsoredShortcutsSettingsButton(interact: SettingsSubMenuHomepageRobot.() -> Unit): SettingsSubMenuHomepageRobot.Transition {
+            Log.i(TAG, "clickSponsoredShortcutsSettingsButton: Looking for: ${sponsoredShortcutsSettingsButton.selector}")
             sponsoredShortcutsSettingsButton.waitForExists(waitingTime)
             sponsoredShortcutsSettingsButton.clickAndWaitForNewWindow(waitingTime)
+            Log.i(TAG, "clickSponsoredShortcutsSettingsButton: Clicked ${sponsoredShortcutsSettingsButton.selector} and waiting for $waitingTime for a new window")
 
             SettingsSubMenuHomepageRobot().interact()
             return SettingsSubMenuHomepageRobot.Transition()
@@ -939,10 +942,11 @@ private fun saveTabsToCollectionButton() = onView(withId(R.id.add_tabs_to_collec
 private fun tabsCounter() = onView(withId(R.id.tab_button))
 
 private fun sponsoredShortcut(sponsoredShortcutTitle: String) =
-    mDevice.findObject(
-        By
-            .res("$packageName:id/top_site_title")
-            .textContains(sponsoredShortcutTitle),
+    onView(
+        allOf(
+            withId(R.id.top_site_title),
+            withText(sponsoredShortcutTitle),
+        ),
     )
 
 private fun storyByTopicItem(composeTestRule: ComposeTestRule, position: Int) =

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
@@ -21,6 +22,7 @@ import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.Matchers
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
@@ -61,6 +63,7 @@ class SettingsSubMenuHomepageRobot {
         assertHomepageButton()
         assertLastTabButton()
         assertHomepageAfterFourHoursButton()
+        Log.i(Constants.TAG, "verifyHomePageView: Verified the home page elements")
     }
 
     fun verifySelectedOpeningScreenOption(openingScreenOption: String) =


### PR DESCRIPTION
Summary:
This UI test was disabled due to the [HomeActivity ANR](https://bugzilla.mozilla.org/show_bug.cgi?id=1807268).

Based on the logs and videos the problems seem to be occurring after performing the long click on the sponsored shortcut using BySelector.
The video shows that the long click is performed, on the other hand, the logs don't contain any info about this action.

Another worth mentioning matter would be that the java.lang.SecurityException: Calling from not trusted UID! at android.app.UiAutomationConnection.throwIfCalledByNotTrustedUidLocked(UiAutomationConnection.java:525) is constantly displayed in the logs before the test fails. (seems to be part of the UiAutomationConnection class in the Android framework. It is a method used for security checks, specifically to ensure that certain methods within the UiAutomationConnection are only called by trusted user IDs (UIDs).)

Based on all the above, I've switched to use Espresso to perform the long click action instead of anything related to UIAutomator and seem to be properly working. (Successfully passed 200x on Firebase ✅ )

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807268