### PR TITLE
Bug 1806838 - Update extension icon when invalidate is called.

### DIFF
--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/item/WebExtensionBrowserMenuItemTest.kt
@@ -13,7 +13,6 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import mozilla.components.browser.menu.R
 import mozilla.components.browser.menu.WebExtensionBrowserMenu
@@ -36,7 +35,6 @@ import org.mockito.Mockito.verify
 import androidx.appcompat.R as appcompatR
 
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class)
 class WebExtensionBrowserMenuItemTest {
 
     @get:Rule
@@ -317,6 +315,41 @@ class WebExtensionBrowserMenuItemTest {
         assertEquals(view, viewCaptor.value)
         assertEquals(imageView, imageViewCaptor.value)
 
+        assertEquals(testIconTintColorResource, webExtMenuItem.iconTintColorResource)
+    }
+
+    @Test
+    fun `WHEN invalidate is called THEN setupIcon is called`() = runTest {
+        val webExtMenuItem = spy(WebExtensionBrowserMenuItem(mock(), mock()))
+        val imageView: ImageView = mock()
+        val badgeView: TextView = mock()
+        val labelView: TextView = mock()
+        val container = View(testContext)
+        val testIconTintColorResource = appcompatR.color.accent_material_dark
+        val view: View = mock()
+
+        whenever(view.findViewById<ImageView>(R.id.action_image)).thenReturn(imageView)
+        whenever(view.findViewById<TextView>(R.id.badge_text)).thenReturn(badgeView)
+        whenever(view.findViewById<TextView>(R.id.action_label)).thenReturn(labelView)
+        whenever(view.findViewById<View>(R.id.container)).thenReturn(container)
+        whenever(view.context).thenReturn(mock())
+        whenever(imageView.measuredHeight).thenReturn(2)
+
+        webExtMenuItem.setIconTint(testIconTintColorResource)
+        webExtMenuItem.invalidate(view)
+
+        val viewCaptor = argumentCaptor<View>()
+        val imageViewCaptor = argumentCaptor<ImageView>()
+        val tintCaptor = argumentCaptor<Int>()
+
+        verify(webExtMenuItem).setupIcon(
+            viewCaptor.capture(),
+            imageViewCaptor.capture(),
+            tintCaptor.capture(),
+        )
+
+        assertEquals(view, viewCaptor.value)
+        assertEquals(imageView, imageViewCaptor.value)
         assertEquals(testIconTintColorResource, webExtMenuItem.iconTintColorResource)
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1806838