### PR TITLE
Bug 1872777 - Update LeakCanary to version 2.13

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -41,7 +41,7 @@ object Versions {
     const val zxing = "3.5.2"
 
     const val disklrucache = "2.0.2"
-    const val leakcanary = "2.12"
+    const val leakcanary = "2.13"
 
     // DO NOT MODIFY MANUALLY. This is auto-updated along with GeckoView.
     const val mozilla_glean = "56.0.0"


### PR DESCRIPTION


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1872777