### PR TITLE
Bug 1807295 - Fix verifyShowSearchSuggestionsToggleTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -424,6 +424,10 @@ class SettingsSearchTest {
     fun verifyShowSearchSuggestionsToggleTest() {
         homeScreen {
         }.openSearch {
+            // The Google related suggestions aren't always displayed on cold run
+            // Bugzilla ticket: https://bugzilla.mozilla.org/show_bug.cgi?id=1813587
+            clickSearchSelectorButton()
+            selectTemporarySearchMethod("DuckDuckGo")
             typeSearch("mozilla ")
             verifySearchEngineSuggestionResults(
                 activityTestRule,
@@ -438,6 +442,10 @@ class SettingsSearchTest {
         }.goBack {
         }.goBack {
         }.openSearch {
+            // The Google related suggestions aren't always displayed on cold run
+            // Bugzilla ticket: https://bugzilla.mozilla.org/show_bug.cgi?id=1813587
+            clickSearchSelectorButton()
+            selectTemporarySearchMethod("DuckDuckGo")
             typeSearch("mozilla")
             verifySuggestionsAreNotDisplayed(activityTestRule, "mozilla firefox")
         }


### PR DESCRIPTION
Summary:
In some cases the UI test was flaky because no suggestions were displayed, most likely caused by [1813587](https://bugzilla.mozilla.org/show_bug.cgi?id=1813587) which is still very easily reproducible.

While manually trying different scenarios, I've noticed that when using DuckDuckGo or Wikipedia the search suggestions are immediately displayed compared to Google.

Based on what I've discussed with @mcarare , there seems to be an app services worker that periodically retrieves the suggestions, locally saves them and afterwards get displayed.

I think there might be some delays related to the Google search suggestions, so I've added a couple of steps in the UI test to use DuckDuckGo instead. ✅  successfully passed 200x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807295