### PR TITLE
Bug 1872170 - Fix Pull to Refresh triggered after an upward overscroll on a page

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/NestedGeckoView.kt
@@ -82,7 +82,6 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
 
             MotionEvent.ACTION_DOWN -> {
                 // A new gesture started. Ask GV if it can handle this.
-                inputResultDetail = InputResultDetail.newInstance(false)
                 parent?.requestDisallowInterceptTouchEvent(true)
                 updateInputResult(event)
 
@@ -98,6 +97,12 @@ open class NestedGeckoView(context: Context) : GeckoView(context), NestedScrolli
 
             // We don't care about other touch events
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                // inputResultDetail needs to be reset here and not in the next ACTION_DOWN, because
+                // its value is used by other features that poll for the value via
+                // `EngineView.getInputResultDetail`. Not resetting this in ACTION_CANCEL/ACTION_UP
+                // would then mean we send stale information to those features from a previous
+                // gesture's result.
+                inputResultDetail = InputResultDetail.newInstance(true)
                 stopNestedScroll()
             }
         }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1872170