### PR TITLE
Bug 1872703 - Named Translation Errors

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngine.kt
@@ -19,6 +19,7 @@ import mozilla.components.browser.engine.gecko.mediaquery.from
 import mozilla.components.browser.engine.gecko.mediaquery.toGeckoValue
 import mozilla.components.browser.engine.gecko.profiler.Profiler
 import mozilla.components.browser.engine.gecko.serviceworker.GeckoServiceWorkerDelegate
+import mozilla.components.browser.engine.gecko.translate.GeckoTranslationUtils.intoTranslationError
 import mozilla.components.browser.engine.gecko.util.SpeculativeSessionFactory
 import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtension
 import mozilla.components.browser.engine.gecko.webextension.GeckoWebExtensionException
@@ -46,6 +47,7 @@ import mozilla.components.concept.engine.translate.Language
 import mozilla.components.concept.engine.translate.LanguageModel
 import mozilla.components.concept.engine.translate.LanguageSetting
 import mozilla.components.concept.engine.translate.ModelManagementOptions
+import mozilla.components.concept.engine.translate.TranslationError
 import mozilla.components.concept.engine.translate.TranslationSupport
 import mozilla.components.concept.engine.translate.TranslationsRuntime
 import mozilla.components.concept.engine.utils.EngineVersion
@@ -669,16 +671,6 @@ class GeckoEngine(
     }
 
     /**
-     * Convenience method for handling unexpected null returns from GeckoView.
-     *
-     * @return A standard throwable for unexpected null values.
-     */
-    private fun translationsUnexpectedNull(): Throwable {
-        val errorMessage = "Unexpectedly returned a null value."
-        return IllegalStateException(errorMessage)
-    }
-
-    /**
      * See [Engine.isTranslationsEngineSupported].
      */
     override fun isTranslationsEngineSupported(
@@ -690,12 +682,12 @@ class GeckoEngine(
                 if (it != null) {
                     onSuccess(it)
                 } else {
-                    onError(translationsUnexpectedNull())
+                    onError(TranslationError.UnexpectedNull())
                 }
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -715,12 +707,12 @@ class GeckoEngine(
                 if (it != null) {
                     onSuccess(it)
                 } else {
-                    onError(translationsUnexpectedNull())
+                    onError(TranslationError.UnexpectedNull())
                 }
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -747,12 +739,12 @@ class GeckoEngine(
                     }
                     onSuccess(listOfModels)
                 } else {
-                    onError(translationsUnexpectedNull())
+                    onError(TranslationError.UnexpectedNull())
                 }
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -785,12 +777,12 @@ class GeckoEngine(
 
                     onSuccess(TranslationSupport(listOfFromLanguages, listOfToLanguages))
                 } else {
-                    onError(translationsUnexpectedNull())
+                    onError(TranslationError.UnexpectedNull())
                 }
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -817,7 +809,7 @@ class GeckoEngine(
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -835,13 +827,13 @@ class GeckoEngine(
                 if (it != null) {
                     onSuccess(it)
                 } else {
-                    onError(translationsUnexpectedNull())
+                    onError(TranslationError.UnexpectedNull())
                 }
 
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -875,16 +867,16 @@ class GeckoEngine(
                     try {
                         onSuccess(LanguageSetting.fromValue(it))
                     } catch (e: IllegalArgumentException) {
-                        onError(e)
+                        onError(e.intoTranslationError())
                     }
                 } else {
-                    onError(translationsUnexpectedNull())
+                    onError(TranslationError.UnexpectedNull())
                 }
 
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -905,7 +897,7 @@ class GeckoEngine(
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -928,15 +920,15 @@ class GeckoEngine(
                         }
                         onSuccess(result)
                     } catch (e: IllegalArgumentException) {
-                        onError(e)
+                        onError(e.intoTranslationError())
                     }
                 } else {
-                    onError(translationsUnexpectedNull())
+                    onError(TranslationError.UnexpectedNull())
                 }
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -955,15 +947,15 @@ class GeckoEngine(
                     try {
                         onSuccess(it)
                     } catch (e: IllegalArgumentException) {
-                        onError(e)
+                        onError(e.intoTranslationError())
                     }
                 } else {
-                    onError(translationsUnexpectedNull())
+                    onError(TranslationError.UnexpectedNull())
                 }
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )
@@ -984,7 +976,7 @@ class GeckoEngine(
                 GeckoResult<Void>()
             },
             { throwable ->
-                onError(throwable)
+                onError(throwable.intoTranslationError())
                 GeckoResult<Void>()
             },
         )

--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/GeckoEngineSession.kt
@@ -21,6 +21,7 @@ import mozilla.components.browser.engine.gecko.mediasession.GeckoMediaSessionDel
 import mozilla.components.browser.engine.gecko.permission.GeckoPermissionRequest
 import mozilla.components.browser.engine.gecko.prompt.GeckoPromptDelegate
 import mozilla.components.browser.engine.gecko.translate.GeckoTranslateSessionDelegate
+import mozilla.components.browser.engine.gecko.translate.GeckoTranslationUtils.intoTranslationError
 import mozilla.components.browser.engine.gecko.window.GeckoWindowRequest
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
@@ -42,6 +43,7 @@ import mozilla.components.concept.engine.shopping.Highlight
 import mozilla.components.concept.engine.shopping.ProductAnalysis
 import mozilla.components.concept.engine.shopping.ProductAnalysisStatus
 import mozilla.components.concept.engine.shopping.ProductRecommendation
+import mozilla.components.concept.engine.translate.TranslationError
 import mozilla.components.concept.engine.translate.TranslationOperation
 import mozilla.components.concept.engine.translate.TranslationOptions
 import mozilla.components.concept.engine.window.WindowRequest
@@ -916,15 +918,6 @@ class GeckoEngineSession(
     }
 
     /**
-     * Convenience method for the error when session translation is not available.
-     */
-    private fun sessionTranslationNotAvailable(): Throwable {
-        val errorMessage = "A translation session coordinator is not available."
-        logger.error(errorMessage)
-        return IllegalStateException(errorMessage)
-    }
-
-    /**
      * See [EngineSession.requestTranslate]
      */
     override fun requestTranslate(
@@ -934,7 +927,10 @@ class GeckoEngineSession(
     ) {
         if (geckoSession.sessionTranslation == null) {
             notifyObservers {
-                onTranslateException(TranslationOperation.TRANSLATE, sessionTranslationNotAvailable())
+                onTranslateException(
+                    TranslationOperation.TRANSLATE,
+                    TranslationError.MissingSessionCoordinator(),
+                )
             }
             return
         }
@@ -955,7 +951,10 @@ class GeckoEngineSession(
                 throwable ->
             logger.error("Request for translation failed: ", throwable)
             notifyObservers {
-                onTranslateException(TranslationOperation.TRANSLATE, throwable)
+                onTranslateException(
+                    TranslationOperation.TRANSLATE,
+                    throwable.intoTranslationError(),
+                )
             }
             GeckoResult()
         })
@@ -967,7 +966,10 @@ class GeckoEngineSession(
     override fun requestTranslationRestore() {
         if (geckoSession.sessionTranslation == null) {
             notifyObservers {
-                onTranslateException(TranslationOperation.RESTORE, sessionTranslationNotAvailable())
+                onTranslateException(
+                    TranslationOperation.RESTORE,
+                    TranslationError.MissingSessionCoordinator(),
+                )
             }
             return
         }
@@ -981,7 +983,7 @@ class GeckoEngineSession(
                 throwable ->
             logger.error("Request for translation failed: ", throwable)
             notifyObservers {
-                onTranslateException(TranslationOperation.RESTORE, throwable)
+                onTranslateException(TranslationOperation.RESTORE, throwable.intoTranslationError())
             }
             GeckoResult()
         })
@@ -995,17 +997,16 @@ class GeckoEngineSession(
         onException: (Throwable) -> Unit,
     ) {
         if (geckoSession.sessionTranslation == null) {
-            onException(sessionTranslationNotAvailable())
+            onException(TranslationError.MissingSessionCoordinator())
             return
         }
 
         geckoSession.sessionTranslation!!.neverTranslateSiteSetting.then({
                 response ->
             if (response == null) {
-                val errorMessage = "Did not receive a site setting response."
-                logger.error(errorMessage)
+                logger.error("Did not receive a site setting response.")
                 onException(
-                    java.lang.IllegalStateException(errorMessage),
+                    TranslationError.UnexpectedNull(),
                 )
                 return@then GeckoResult()
             }
@@ -1014,7 +1015,7 @@ class GeckoEngineSession(
         }, {
                 throwable ->
             logger.error("Request for site translation preference failed: ", throwable)
-            onException(throwable)
+            onException(throwable.intoTranslationError())
             GeckoResult()
         })
     }
@@ -1028,7 +1029,7 @@ class GeckoEngineSession(
         onException: (Throwable) -> Unit,
     ) {
         if (geckoSession.sessionTranslation == null) {
-            onException(sessionTranslationNotAvailable())
+            onException(TranslationError.MissingSessionCoordinator())
             return
         }
 
@@ -1038,7 +1039,7 @@ class GeckoEngineSession(
         }, {
                 throwable ->
             logger.error("Request for setting site translation preference failed: ", throwable)
-            onException(throwable)
+            onException(throwable.intoTranslationError())
             GeckoResult()
         })
     }

--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/translate/GeckoTranslationUtils.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/translate/GeckoTranslationUtils.kt
@@ -10,52 +10,54 @@ import org.mozilla.geckoview.TranslationsController.TranslationsException
  * Utility file for translations functions related to the Gecko implementation.
  */
 object GeckoTranslationUtils {
+
     /**
      * Convenience method for mapping a [TranslationsException] to the Android Components defined
      * error type of [TranslationError].
      *
-     * @param throwable The engine throwable that occurred during translating. Ordinarily should be
+     * Throwable is the engine throwable that occurred during translating. Ordinarily should be
      * a [TranslationsException].
      */
-    fun fromGeckoErrorToTranslationError(throwable: Throwable): TranslationError =
-        if (throwable is TranslationsException) {
-            when ((throwable).code) {
+    fun Throwable.intoTranslationError(): TranslationError {
+        return if (this is TranslationsException) {
+            when ((this).code) {
                 TranslationsException.ERROR_UNKNOWN ->
-                    TranslationError.UnknownError(throwable)
+                    TranslationError.UnknownError(this)
 
                 TranslationsException.ERROR_ENGINE_NOT_SUPPORTED ->
-                    TranslationError.EngineNotSupportedError(throwable)
+                    TranslationError.EngineNotSupportedError(this)
 
                 TranslationsException.ERROR_COULD_NOT_TRANSLATE ->
-                    TranslationError.CouldNotTranslateError(throwable)
+                    TranslationError.CouldNotTranslateError(this)
 
                 TranslationsException.ERROR_COULD_NOT_RESTORE ->
-                    TranslationError.CouldNotRestoreError(throwable)
+                    TranslationError.CouldNotRestoreError(this)
 
                 TranslationsException.ERROR_COULD_NOT_LOAD_LANGUAGES ->
-                    TranslationError.CouldNotLoadLanguagesError(throwable)
+                    TranslationError.CouldNotLoadLanguagesError(this)
 
                 TranslationsException.ERROR_LANGUAGE_NOT_SUPPORTED ->
-                    TranslationError.LanguageNotSupportedError(throwable)
+                    TranslationError.LanguageNotSupportedError(this)
 
                 TranslationsException.ERROR_MODEL_COULD_NOT_RETRIEVE ->
-                    TranslationError.ModelCouldNotRetrieveError(throwable)
+                    TranslationError.ModelCouldNotRetrieveError(this)
 
                 TranslationsException.ERROR_MODEL_COULD_NOT_DELETE ->
-                    TranslationError.ModelCouldNotDeleteError(throwable)
+                    TranslationError.ModelCouldNotDeleteError(this)
 
                 TranslationsException.ERROR_MODEL_COULD_NOT_DOWNLOAD ->
-                    TranslationError.ModelCouldNotDownloadError(throwable)
+                    TranslationError.ModelCouldNotDownloadError(this)
 
                 TranslationsException.ERROR_MODEL_LANGUAGE_REQUIRED ->
-                    TranslationError.ModelLanguageRequiredError(throwable)
+                    TranslationError.ModelLanguageRequiredError(this)
 
                 TranslationsException.ERROR_MODEL_DOWNLOAD_REQUIRED ->
-                    TranslationError.ModelDownloadRequiredError(throwable)
+                    TranslationError.ModelDownloadRequiredError(this)
 
-                else -> TranslationError.UnknownError(throwable)
+                else -> TranslationError.UnknownError(this)
             }
         } else {
-            TranslationError.UnknownError(throwable)
+            TranslationError.UnknownError(this)
         }
+    }
 }

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.engine.gecko.ext.geckoTrackingProtectionPermission
 import mozilla.components.browser.engine.gecko.ext.isExcludedForTrackingProtection
 import mozilla.components.browser.engine.gecko.permission.geckoContentPermission
-import mozilla.components.browser.engine.gecko.translate.GeckoTranslationUtils
+import mozilla.components.browser.engine.gecko.translate.GeckoTranslationUtils.intoTranslationError
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.EngineSession
@@ -3094,9 +3094,9 @@ class GeckoEngineSessionTest {
     fun `WHEN mapping a Gecko TranslationsException THEN it maps as expected to a TranslationError`() {
         // Specifically defined unknown error thrown by the translations engine
         val geckoUnknownError = TranslationsException(TranslationsException.ERROR_UNKNOWN)
-        val unknownError = GeckoTranslationUtils.fromGeckoErrorToTranslationError(geckoUnknownError)
+        val unknownError = geckoUnknownError.intoTranslationError()
         assertTrue(
-            GeckoTranslationUtils.fromGeckoErrorToTranslationError(geckoUnknownError) is TranslationError.UnknownError,
+            unknownError is TranslationError.UnknownError,
         )
         assertEquals(
             (unknownError as TranslationError.UnknownError).cause,
@@ -3117,7 +3117,7 @@ class GeckoEngineSessionTest {
 
         // Something really unexpected was thrown
         val unexpectedUnknownError = Exception("Something very unexpected")
-        val unexpectedUnknown = GeckoTranslationUtils.fromGeckoErrorToTranslationError(unexpectedUnknownError)
+        val unexpectedUnknown = unexpectedUnknownError.intoTranslationError()
         assertTrue(
             unexpectedUnknown is
             TranslationError.UnknownError,
@@ -3147,7 +3147,19 @@ class GeckoEngineSessionTest {
             false,
         )
 
-        val notSupported = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_ENGINE_NOT_SUPPORTED))
+        // For manual use as a guard for when the engine is missing a session coordinator
+        val missingCoordinator = TranslationError.MissingSessionCoordinator()
+        assertEquals(
+            missingCoordinator.errorName,
+            "missing-session-coordinator",
+        )
+        assertEquals(
+            missingCoordinator.displayError,
+            false,
+        )
+
+        val notSupported =
+            TranslationsException(TranslationsException.ERROR_ENGINE_NOT_SUPPORTED).intoTranslationError()
         assertTrue(
             notSupported is
             TranslationError.EngineNotSupportedError,
@@ -3161,7 +3173,8 @@ class GeckoEngineSessionTest {
             false,
         )
 
-        val couldNotTranslate = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_COULD_NOT_TRANSLATE))
+        val couldNotTranslate =
+            TranslationsException(TranslationsException.ERROR_COULD_NOT_TRANSLATE).intoTranslationError()
         assertTrue(
             couldNotTranslate is
             TranslationError.CouldNotTranslateError,
@@ -3175,7 +3188,8 @@ class GeckoEngineSessionTest {
             true,
         )
 
-        val couldNotRestore = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_COULD_NOT_RESTORE))
+        val couldNotRestore =
+            TranslationsException(TranslationsException.ERROR_COULD_NOT_RESTORE).intoTranslationError()
         assertTrue(
             couldNotRestore is
             TranslationError.CouldNotRestoreError,
@@ -3189,7 +3203,8 @@ class GeckoEngineSessionTest {
             false,
         )
 
-        val couldNotLoadLanguages = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_COULD_NOT_LOAD_LANGUAGES))
+        val couldNotLoadLanguages =
+            TranslationsException(TranslationsException.ERROR_COULD_NOT_LOAD_LANGUAGES).intoTranslationError()
         assertTrue(
             couldNotLoadLanguages is
             TranslationError.CouldNotLoadLanguagesError,
@@ -3203,7 +3218,8 @@ class GeckoEngineSessionTest {
             true,
         )
 
-        val languageNotSupported = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_LANGUAGE_NOT_SUPPORTED))
+        val languageNotSupported =
+            TranslationsException(TranslationsException.ERROR_LANGUAGE_NOT_SUPPORTED).intoTranslationError()
         assertTrue(
             languageNotSupported is
             TranslationError.LanguageNotSupportedError,
@@ -3217,7 +3233,8 @@ class GeckoEngineSessionTest {
             true,
         )
 
-        val couldNotRetrieve = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_MODEL_COULD_NOT_RETRIEVE))
+        val couldNotRetrieve =
+            TranslationsException(TranslationsException.ERROR_MODEL_COULD_NOT_RETRIEVE).intoTranslationError()
         assertTrue(
             couldNotRetrieve is
             TranslationError.ModelCouldNotRetrieveError,
@@ -3231,7 +3248,8 @@ class GeckoEngineSessionTest {
             false,
         )
 
-        val couldNotDelete = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_MODEL_COULD_NOT_DELETE))
+        val couldNotDelete =
+            TranslationsException(TranslationsException.ERROR_MODEL_COULD_NOT_DELETE).intoTranslationError()
         assertTrue(
             couldNotDelete is
             TranslationError.ModelCouldNotDeleteError,
@@ -3245,7 +3263,8 @@ class GeckoEngineSessionTest {
             false,
         )
 
-        val couldNotDownload = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_MODEL_COULD_NOT_DOWNLOAD))
+        val couldNotDownload =
+            TranslationsException(TranslationsException.ERROR_MODEL_COULD_NOT_DOWNLOAD).intoTranslationError()
         assertTrue(
             couldNotDownload is
             TranslationError.ModelCouldNotDownloadError,
@@ -3259,7 +3278,8 @@ class GeckoEngineSessionTest {
             false,
         )
 
-        val languageRequired = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_MODEL_LANGUAGE_REQUIRED))
+        val languageRequired =
+            TranslationsException(TranslationsException.ERROR_MODEL_LANGUAGE_REQUIRED).intoTranslationError()
         assertTrue(
             languageRequired is
             TranslationError.ModelLanguageRequiredError,
@@ -3273,7 +3293,8 @@ class GeckoEngineSessionTest {
             false,
         )
 
-        val downloadRequired = GeckoTranslationUtils.fromGeckoErrorToTranslationError(TranslationsException(TranslationsException.ERROR_MODEL_DOWNLOAD_REQUIRED))
+        val downloadRequired =
+            TranslationsException(TranslationsException.ERROR_MODEL_DOWNLOAD_REQUIRED).intoTranslationError()
         assertTrue(
             downloadRequired is
             TranslationError.ModelDownloadRequiredError,

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationError.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationError.kt
@@ -35,6 +35,12 @@ sealed class TranslationError(
         TranslationError(errorName = "unexpected-null", displayError = false, cause = null)
 
     /**
+     * Default error when a translation session coordinator is not available.
+     */
+    class MissingSessionCoordinator :
+        TranslationError(errorName = "missing-session-coordinator", displayError = false, cause = null)
+
+    /**
      * Translations engine does not work on the device architecture.
      *
      * @param cause The original throwable before it was converted into this error state.


### PR DESCRIPTION
This bug takes the named AC `TranslationError` and ensures that all translation calls to the Gecko engine translate to this type of error.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1872703