### PR TITLE
Bug 1873511 - New `supportedLanguages` and `translationError` on TranslationsState, with `TranslateExceptionAction` Refactor

### DIFF
--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt
@@ -2880,7 +2880,7 @@ class GeckoEngineSessionTest {
 
             override fun onTranslateException(
                 operation: TranslationOperation,
-                throwable: Throwable,
+                translationError: TranslationError,
             ) {
                 assert(false) { "We should not notify of a failure." }
             }
@@ -2911,7 +2911,7 @@ class GeckoEngineSessionTest {
             }
             override fun onTranslateException(
                 operation: TranslationOperation,
-                throwable: Throwable,
+                translationError: TranslationError,
             ) {
                 assert(false) { "We should not notify of a failure." }
             }
@@ -2943,7 +2943,7 @@ class GeckoEngineSessionTest {
 
             override fun onTranslateException(
                 operation: TranslationOperation,
-                throwable: Throwable,
+                translationError: TranslationError,
             ) {
                 assert(true) { "We should notify of a failure." }
             }
@@ -2974,7 +2974,7 @@ class GeckoEngineSessionTest {
             }
             override fun onTranslateException(
                 operation: TranslationOperation,
-                throwable: Throwable,
+                translationError: TranslationError,
             ) {
                 assert(true) { "We should notify of a failure." }
             }

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -46,8 +46,10 @@ import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.search.SearchRequest
 import mozilla.components.concept.engine.translate.TranslationEngineState
+import mozilla.components.concept.engine.translate.TranslationError
 import mozilla.components.concept.engine.translate.TranslationOperation
 import mozilla.components.concept.engine.translate.TranslationOptions
+import mozilla.components.concept.engine.translate.TranslationSupport
 import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
 import mozilla.components.concept.engine.webextension.WebExtensionPageAction
 import mozilla.components.concept.engine.window.WindowRequest
@@ -909,7 +911,8 @@ sealed class TranslationsAction : BrowserAction() {
     ) : TranslationsAction(), ActionWithTab
 
     /**
-     * Indicates the given [tabId] was successful in translating or restoring the page.
+     * Indicates the given [tabId] was successful in translating or restoring the page
+     * or acquiring a necessary resource.
      *
      * @property tabId The ID of the tab the [EngineSession] should be linked to.
      * @property operation The translation operation that was successful.
@@ -920,16 +923,28 @@ sealed class TranslationsAction : BrowserAction() {
     ) : TranslationsAction(), ActionWithTab
 
     /**
-     * Indicates the given [tabId] was unable to translate or restore the page.
+     * Indicates the given [tabId] was unable to translate or restore the page or acquire a
+     * necessary resource.
      *
      * @property tabId The ID of the tab the [EngineSession] should be linked to.
      * @property operation The translation operation that failed.
-     * @property throwable The throwable for error handling.
+     * @property translationError The error that occurred.
      */
     data class TranslateExceptionAction(
         override val tabId: String,
         val operation: TranslationOperation,
-        val throwable: Throwable,
+        val translationError: TranslationError,
+    ) : TranslationsAction(), ActionWithTab
+
+    /**
+     * Sets the languages that are supported by the translations engine.
+     *
+     * @property tabId The ID of the tab the [EngineSession] that requested the list.
+     * @property supportedLanguages The languages the engine supports for translation.
+     */
+    data class TranslateSetLanguagesAction(
+        override val tabId: String,
+        val supportedLanguages: TranslationSupport?,
     ) : TranslationsAction(), ActionWithTab
 }
 

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineMiddleware.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineMiddleware.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.state.engine.middleware.ExtensionsProcessMiddl
 import mozilla.components.browser.state.engine.middleware.LinkingMiddleware
 import mozilla.components.browser.state.engine.middleware.SuspendMiddleware
 import mozilla.components.browser.state.engine.middleware.TabsRemovedMiddleware
+import mozilla.components.browser.state.engine.middleware.TranslationsMiddleware
 import mozilla.components.browser.state.engine.middleware.TrimMemoryMiddleware
 import mozilla.components.browser.state.engine.middleware.WebExtensionMiddleware
 import mozilla.components.browser.state.state.BrowserState
@@ -50,6 +51,7 @@ object EngineMiddleware {
             WebExtensionMiddleware(),
             CrashMiddleware(),
             ExtensionsProcessMiddleware(engine),
+            TranslationsMiddleware(engine, scope),
         ) + if (trimMemoryAutomatically) {
             listOf(TrimMemoryMiddleware())
         } else {

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/EngineObserver.kt
@@ -34,6 +34,7 @@ import mozilla.components.concept.engine.mediasession.MediaSession
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.translate.TranslationEngineState
+import mozilla.components.concept.engine.translate.TranslationError
 import mozilla.components.concept.engine.translate.TranslationOperation
 import mozilla.components.concept.engine.window.WindowRequest
 import mozilla.components.concept.fetch.Response
@@ -484,7 +485,7 @@ internal class EngineObserver(
         store.dispatch(TranslationsAction.TranslateSuccessAction(tabId, operation))
     }
 
-    override fun onTranslateException(operation: TranslationOperation, throwable: Throwable) {
-        store.dispatch(TranslationsAction.TranslateExceptionAction(tabId, operation, throwable))
+    override fun onTranslateException(operation: TranslationOperation, translationError: TranslationError) {
+        store.dispatch(TranslationsAction.TranslateExceptionAction(tabId, operation, translationError))
     }
 }

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/TranslationsMiddleware.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/TranslationsMiddleware.kt
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.engine.middleware
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.TranslationsAction
+import mozilla.components.browser.state.action.TranslationsAction.TranslateExpectedAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.translate.TranslationError
+import mozilla.components.concept.engine.translate.TranslationOperation
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * This middleware is for use with managing any states or resources required for translating a
+ * webpage.
+ */
+class TranslationsMiddleware(
+    private val engine: Engine,
+    private val scope: CoroutineScope,
+) : Middleware<BrowserState, BrowserAction> {
+    private val logger = Logger("TranslationsMiddleware")
+
+    override fun invoke(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        next: (BrowserAction) -> Unit,
+        action: BrowserAction,
+    ) {
+        // Pre process actions
+        when (action) {
+            is TranslateExpectedAction -> {
+                scope.launch {
+                    requestSupportedLanguages(context, action.tabId)
+                }
+            }
+            else -> {
+                // no-op
+            }
+        }
+
+        // Continue to post process actions
+        next(action)
+    }
+
+    /**
+     * Retrieves the list of supported languages using [scope] and dispatches the result to the
+     * store via [TranslationsAction.TranslateSetLanguagesAction] or else dispatches the failure
+     * [TranslationsAction.TranslateExceptionAction].
+     *
+     * @param context Context to use to dispatch to the store.
+     * @param tabId Tab ID associated with the request.
+     */
+    private suspend fun requestSupportedLanguages(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        tabId: String,
+    ) = withContext(Dispatchers.IO) {
+        scope.launch {
+            engine.getSupportedTranslationLanguages(
+
+                onSuccess = {
+                    context.store.dispatch(
+                        TranslationsAction.TranslateSetLanguagesAction(
+                            tabId = tabId,
+                            supportedLanguages = it,
+                        ),
+                    )
+                    logger.info("Success requesting supported languages.")
+                },
+
+                onError = {
+                    context.store.dispatch(
+                        TranslationsAction.TranslateExceptionAction(
+                            tabId = tabId,
+                            operation = TranslationOperation.FETCH_LANGUAGES,
+                            translationError = TranslationError.CouldNotLoadLanguagesError(it),
+                        ),
+                    )
+                    logger.error("Error requesting supported languages: ", it)
+                },
+            )
+        }
+    }
+}

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/TranslationsState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/TranslationsState.kt
@@ -5,6 +5,8 @@
 package mozilla.components.browser.state.state
 
 import mozilla.components.concept.engine.translate.TranslationEngineState
+import mozilla.components.concept.engine.translate.TranslationError
+import mozilla.components.concept.engine.translate.TranslationSupport
 
 /**
  * Value type that represents the state of a translation within a [SessionState].
@@ -16,6 +18,9 @@ import mozilla.components.concept.engine.translate.TranslationEngineState
  * @property isTranslated The page is currently translated.
  * @property isTranslateProcessing The page is currently attempting a translation.
  * @property isRestoreProcessing The page is currently attempting a restoration.
+ * @property supportedLanguages Set of languages the translation engine supports.
+ * @property translationError Type of error that occurred when acquiring resources, translating, or
+ * restoring a translation.
  */
 data class TranslationsState(
     val isExpectedTranslate: Boolean = false,
@@ -24,4 +29,6 @@ data class TranslationsState(
     val isTranslated: Boolean = false,
     val isTranslateProcessing: Boolean = false,
     val isRestoreProcessing: Boolean = false,
+    val supportedLanguages: TranslationSupport? = null,
+    val translationError: TranslationError? = null,
 )

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt
@@ -41,6 +41,7 @@ import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.concept.engine.shopping.ProductAnalysis
 import mozilla.components.concept.engine.shopping.ProductAnalysisStatus
 import mozilla.components.concept.engine.shopping.ProductRecommendation
+import mozilla.components.concept.engine.translate.TranslationError
 import mozilla.components.concept.engine.translate.TranslationOperation
 import mozilla.components.concept.engine.translate.TranslationOptions
 import mozilla.components.concept.engine.window.WindowRequest
@@ -449,7 +450,7 @@ class EngineObserverTest {
     fun `WHEN onTranslateException is called THEN dispatch a TranslationsAction TranslateExceptionAction`() {
         val store: BrowserStore = mock()
         val observer = EngineObserver("mozilla", store)
-        val exception = Exception()
+        val exception = TranslationError.UnknownError(Exception())
 
         observer.onTranslateException(operation = TranslationOperation.TRANSLATE, exception)
 

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TranslationsMiddlewareTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TranslationsMiddlewareTest.kt
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.browser.state.engine.middleware
+
+import kotlinx.coroutines.launch
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.TranslationsAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.translate.TranslationError
+import mozilla.components.concept.engine.translate.TranslationOperation
+import mozilla.components.concept.engine.translate.TranslationSupport
+import mozilla.components.lib.state.MiddlewareContext
+import mozilla.components.support.test.any
+import mozilla.components.support.test.argumentCaptor
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.mock
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.whenever
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.verify
+
+class TranslationsMiddlewareTest {
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+    private val scope = coroutinesTestRule.scope
+    private lateinit var engine: Engine
+    private lateinit var engineSession: EngineSession
+    private lateinit var tab: TabSessionState
+    private lateinit var store: BrowserStore
+    private lateinit var translationsMiddleware: TranslationsMiddleware
+
+    @Before
+    fun setUp() {
+        engine = mock()
+        engineSession = mock()
+        tab = createTab("https://www.mozilla.org", id = "test-tab", engineSession = engineSession)
+        translationsMiddleware = TranslationsMiddleware(engine = engine, scope = scope)
+        store = spy(
+            BrowserStore(
+                middleware = listOf(translationsMiddleware),
+                initialState = BrowserState(
+                    tabs = listOf(tab),
+                ),
+            ),
+        )
+    }
+
+    private fun waitForIdle() {
+        scope.testScheduler.advanceUntilIdle()
+        coroutinesTestRule.testDispatcher.scheduler.advanceUntilIdle()
+        store.waitUntilIdle()
+    }
+
+    @Test
+    fun `WHEN TranslateExpectedAction is dispatched AND fetching languages is successful THEN TranslateSetLanguagesAction is dispatched`() {
+        val supportedLanguages = TranslationSupport(null, null)
+        val callbackCaptor = argumentCaptor<((TranslationSupport) -> Unit)>()
+        val action = TranslationsAction.TranslateExpectedAction(tabId = tab.id)
+        val middlewareContext = mock<MiddlewareContext<BrowserState, BrowserAction>>()
+
+        // Important for ensuring that the tests verify on the same store
+        whenever(middlewareContext.store).thenReturn(store)
+        whenever(engine.getSupportedTranslationLanguages(callbackCaptor.capture(), any()))
+            .thenAnswer { callbackCaptor.value(supportedLanguages) }
+
+        translationsMiddleware.invoke(middlewareContext, {}, action)
+
+        waitForIdle()
+
+        scope.launch {
+            verify(store).dispatch(
+                TranslationsAction.TranslateSetLanguagesAction(
+                    tabId = tab.id,
+                    supportedLanguages = supportedLanguages,
+                ),
+            )
+        }
+
+        waitForIdle()
+    }
+
+    @Test
+    fun `WHEN TranslateExpectedAction is dispatched AND fetching languages fails THEN TranslateExceptionAction is dispatched`() {
+        store.dispatch(TranslationsAction.TranslateExpectedAction(tabId = tab.id)).joinBlocking()
+
+        waitForIdle()
+
+        verify(store).dispatch(
+            TranslationsAction.TranslateExceptionAction(
+                tabId = tab.id,
+                operation = TranslationOperation.FETCH_LANGUAGES,
+                translationError = TranslationError.CouldNotLoadLanguagesError(any()),
+            ),
+        )
+
+        waitForIdle()
+    }
+}

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt
@@ -19,6 +19,7 @@ import mozilla.components.concept.engine.shopping.ProductAnalysis
 import mozilla.components.concept.engine.shopping.ProductAnalysisStatus
 import mozilla.components.concept.engine.shopping.ProductRecommendation
 import mozilla.components.concept.engine.translate.TranslationEngineState
+import mozilla.components.concept.engine.translate.TranslationError
 import mozilla.components.concept.engine.translate.TranslationOperation
 import mozilla.components.concept.engine.translate.TranslationOptions
 import mozilla.components.concept.engine.window.WindowRequest
@@ -369,9 +370,12 @@ abstract class EngineSession(
          * Event to indicate that the translation operation was unsuccessful.
          *
          * @param operation The operation that the translation engine attempted.
-         * @param throwable The exception that occurred during the operation.
+         * @param translationError The exception that occurred during the operation.
          */
-        fun onTranslateException(operation: TranslationOperation, throwable: Throwable) = Unit
+        fun onTranslateException(
+            operation: TranslationOperation,
+            translationError: TranslationError,
+        ) = Unit
     }
 
     /**

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationOperation.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationOperation.kt
@@ -17,4 +17,11 @@ enum class TranslationOperation {
      * A translated page should be restored.
      */
     RESTORE,
+
+    /**
+     * The list of languages that the translation engine should fetch. This includes
+     * the languages supported for translating both "to" and "from" with their BCP-47 language tag
+     * and localized name.
+     */
+    FETCH_LANGUAGES,
 }


### PR DESCRIPTION
This patch adds the additional state information of `supportedLanguages` and `translationError` to `TranslationsState`. The `supportedLanguages` are the languages the translation engine supports for translating for use in UI dropdowns. `translationError` is any error that occurred relating to translating.

`supportedLanguages` is currently set via an action that indicates the intention to translate on the new `EngineMiddleware` addition of `TranslationsMiddleware`. This patch also adds a new `TranslationOperation` of `FETCH_TO_AND_FROM_LANGUAGES` to indicate the process of getting `supportedLanguages`.

`translationError` is added to the `TranslationsState` to store errors as they arise. `TranslateExceptionAction` is also refactored from using the generic `Throwable` to the new `TranslationError` to accommodate `supportedLanguages` and better general error handling. 



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










































### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1873511