### PR TITLE
DO NOT MERGE - Bug 1873601 - UA override for Google Search' index page.

### DIFF
--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/data/ua_overrides.js
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/data/ua_overrides.js
@@ -1414,6 +1414,34 @@ const AVAILABLE_UA_OVERRIDES = [
       },
     },
   },
+  {
+    /*
+     * Bug 1873601 - UA override for Google Search' index page
+     * WebCompat issue #131916 - https://webcompat.com/issues/131916
+     *
+     * Ongoing incident, where the index page of Google Search is empty for
+     * any Firefox for Android UA string with Version >= 65. Search result
+     * pages work fine, so this only overrides the UA for the index page.
+     */
+    id: "bug1873601",
+    platform: "android",
+    domain: "google.com",
+    bug: "1873601",
+    config: {
+      matches: [
+        InterventionHelpers.matchPatternsForGoogle(
+          "*://www.google.",
+          "/webhp*"
+        ),
+        InterventionHelpers.matchPatternsForGoogle("*://www.google.", "/?*"),
+        InterventionHelpers.matchPatternsForGoogle("*://www.google.", "/"),
+        InterventionHelpers.matchPatternsForGoogle("*://www.google.", "/#*"),
+      ].flat(),
+      uaTransformer: originalUA => {
+        return "User-Agent: Mozilla/5.0 (Android 10; Mobile; rv:64.0) Gecko/64.0 Firefox/64.0";
+      },
+    },
+  },
 ];
 
 module.exports = AVAILABLE_UA_OVERRIDES;

--- a/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
+++ b/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Mozilla Android Components - Web Compatibility Interventions",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "121.0.0",
+  "version": "121.0.1",
   "browser_specific_settings": {
     "gecko": {
       "id": "webcompat@mozilla.org",


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1873601