### PR TITLE
Bug 1858874 - Fix goToSettingsFromOpenLinksInAppCFRTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -327,7 +327,7 @@ class SettingsAdvancedTest {
         }
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(youTubePage) {
+        }.enterURLAndEnterToBrowser("https://m.youtube.com/".toUri()) {
             waitForPageToLoad()
             verifyOpenLinksInAppsCFRExists(true)
         }.clickOpenLinksInAppsGoToSettingsCFRButton {

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -1154,6 +1154,7 @@ class BrowserRobot {
                 "$packageName:id/action",
                 getStringResource(R.string.open_in_app_cfr_positive_button_text),
             ).clickAndWaitForNewWindow(waitingTime)
+            Log.i(TAG, "clickOpenLinksInAppsGoToSettingsCFRButton: Clicked \"Go to settings\" open links in apps CFR button")
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -604,6 +604,7 @@ private fun assertOpenLinksInAppsButton() {
     scrollToElementByText("Open links in apps")
     openLinksInAppsButton()
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    Log.i(TAG, "clickOpenLinksInAppsGoToSettingsCFRButton: Verified \"Open links in apps\" setting option")
 }
 
 // ADVANCED SECTION


### PR DESCRIPTION
Summary:
In #3602 the Youtube related links were changed to the Android Youtube Scheme URL because in some cases the UI tests ran on non US located devices which led to the cookie banners being displayed, causing failures.

This UI test was flaky because the "Open links in apps" banner  wasn't displayed sometimes.
From my point of view, the Android Youtube Scheme URL `vnd.youtube` wasn't always properly recognized, so I've switched the link in this particular case to `m.youtube.com`

Even though it might display the cookie banner (if the UI test runs on a non US device) it will not have any impact in this case, the "Open links in apps"  banner will be properly displayed, as it will display Youtube's cookie banner not the Google's banner (the later being displayed when trying to access directly a YT channel or video) 

Successfully passed 200x on Firebase. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1858874