### PR TITLE
Bug 1807350 - Baseline profiles for nightly

### DIFF
--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -206,7 +206,14 @@ android {
 
             reset()
 
-            include "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
+            // As gradle is unable to pick the right apk to install when multiple apks are generated
+            // while running benchmark tests or generating baseline profiles. To circumvent this,
+            // this flag is passed to make sure only one apk is generated so gradle can pick that one.
+            if (project.hasProperty("benchmarkTest")) {
+                include "arm64-v8a"
+            } else {
+                include "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
+            }
         }
     }
 

--- a/fenix/benchmark/build.gradle
+++ b/fenix/benchmark/build.gradle
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id 'com.android.test'
     id 'org.jetbrains.kotlin.android'
@@ -39,6 +41,18 @@ android {
 
     targetProjectPath = ":app"
     experimentalProperties["android.experimental.self-instrumenting"] = true
+
+    testOptions {
+        managedDevices {
+            devices {
+                pixel6Api34(ManagedVirtualDevice) {
+                    device = "Pixel 6"
+                    apiLevel = 34
+                    systemImageSource = "google"
+                }
+            }
+        }
+    }
 }
 
 /**

--- a/fenix/benchmark/src/main/java/org/mozilla/fenix/benchmark/BaselineProfilesStartupBenchmark.kt
+++ b/fenix/benchmark/src/main/java/org/mozilla/fenix/benchmark/BaselineProfilesStartupBenchmark.kt
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.benchmark
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.benchmark.macro.BaselineProfileMode
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.benchmark.utils.measureRepeatedDefault
+
+/**
+ * This test class benchmarks the speed of app startup. Run this benchmark to verify how effective
+ * a Baseline Profile is. It does this by comparing [CompilationMode.None], which represents the
+ * app with no Baseline Profiles optimizations, and [CompilationMode.Partial], which uses Baseline Profiles.
+ *
+ * Before running make sure `autosignReleaseWithDebugKey=true` is present in local.properties.
+ *
+ * Run this benchmark to see startup measurements and captured system traces for verifying
+ * the effectiveness of your Baseline Profiles. You can run it directly from Android
+ * Studio as an instrumentation test that logs the benchmark metrics with links to the Perfetto traces,
+ *
+ * or using the gradle command:
+ *
+ * ```
+ * ./gradlew :benchmark:connectedBenchmarkAndroidTest -P android.testInstrumentationRunnerArguments.class=org.mozilla.fenix.benchmark.BaselineProfilesStartupBenchmark -P benchmarkTest
+ * ```
+ *
+ * The metric results will be in `benchmark/build/outputs/connected_android_test_additional_output` folder.
+ *
+ * Run the benchmarks on a physical device, not an emulator because the emulator doesn't represent
+ * real world performance and shares system resources with its host.
+ *
+ * For more information, see the [Macrobenchmark documentation](https://d.android.com/macrobenchmark#create-macrobenchmark)
+ * and the [instrumentation arguments documentation](https://d.android.com/topic/performance/benchmarking/macrobenchmark-instrumentation-args).
+ **/
+@RunWith(AndroidJUnit4::class)
+@RequiresApi(Build.VERSION_CODES.N)
+class BaselineProfilesStartupBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun startupNone() = startupBenchmark(CompilationMode.None())
+
+    @Test
+    fun startupPartialWithBaselineProfiles() =
+        startupBenchmark(CompilationMode.Partial(baselineProfileMode = BaselineProfileMode.Require))
+
+    private fun startupBenchmark(compilationMode: CompilationMode) =
+        benchmarkRule.measureRepeatedDefault(
+            metrics = listOf(StartupTimingMetric()),
+            startupMode = StartupMode.COLD,
+            compilationMode = compilationMode,
+            setupBlock = {
+                pressHome()
+            },
+        ) {
+            startActivityAndWait()
+        }
+}

--- a/fenix/benchmark/src/main/java/org/mozilla/fenix/benchmark/baselineprofile/StartupOnlyBaselineProfileGenerator.kt
+++ b/fenix/benchmark/src/main/java/org/mozilla/fenix/benchmark/baselineprofile/StartupOnlyBaselineProfileGenerator.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.benchmark.baselineprofile
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.benchmark.macro.junit4.BaselineProfileRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.benchmark.utils.TARGET_PACKAGE
+
+/**
+ * This test class generates a basic startup baseline profile for the target package.
+ *
+ * Refer to the [baseline profile documentation](https://d.android.com/topic/performance/baselineprofiles)
+ * for more information.
+ *
+ * Make sure `autosignReleaseWithDebugKey=true` is present in local.properties.
+ *
+ * Generate the baseline profile using this gradle task:
+ * ```
+ *  ./gradlew :benchmark:pixel6Api34BenchmarkAndroidTest -P android.testInstrumentationRunnerArguments.class=org.mozilla.fenix.benchmark.baselineprofile.StartupOnlyBaselineProfileGenerator -P benchmarkTest -P disableOptimization
+ * ```
+ *
+ * Check [documentation](https://d.android.com/topic/performance/benchmarking/macrobenchmark-instrumentation-args)
+ * for more information about available instrumentation arguments.
+ *
+ * As the experiment is only for nightly, run
+ * ```
+ * ./gradlew copyBaselineProfile
+ * ```
+ * This will copy the baseline profiles to the nightly folder. These are the profiles that will be compiled with the nightly build.
+ *
+ * Then, copy the profiles to app/src/benchmark/baselineProfiles to verify the improvements by running
+ * the [org.mozilla.fenix.benchmark.BaselineProfilesStartupBenchmark] benchmark.
+ * Notice that when we run the benchmark, we run the benchmark variant and not the nightly so copying the profiles here is important.
+ * These shouldn't be pushed to version control.
+ *
+ * When using this class to generate a baseline profile, only API 33+ or rooted API 28+ are supported.
+ **/
+@RequiresApi(Build.VERSION_CODES.P)
+@RunWith(AndroidJUnit4::class)
+class StartupOnlyBaselineProfileGenerator {
+
+    @get:Rule
+    val rule = BaselineProfileRule()
+
+    @Test
+    fun generateBaselineProfile() {
+        rule.collect(
+            packageName = TARGET_PACKAGE,
+        ) {
+            startActivityAndWait()
+        }
+    }
+}

--- a/fenix/build.gradle
+++ b/fenix/build.gradle
@@ -1,8 +1,11 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 
 buildscript {
     // This logic is duplicated in the allprojects block: I don't know how to fix that.
@@ -282,4 +285,19 @@ tasks.register("githubLintDetektDetails", GithubDetailsTask) {
 
 tasks.register("githubLintAndroidDetails", GithubDetailsTask) {
     text = "### [Android Lint Results Fenix]({reportsUrl}/lint-results-debug.html)"
+}
+
+// Task to copy generated baseline profile to the app module nightly variant.
+tasks.register("copyBaselineProfile", DefaultTask) {
+    doLast {
+        File profileFile = fileTree('benchmark/build/outputs') {
+            include '**/*baseline-prof.txt'
+        }.getSingleFile()
+        def destinationPath = Paths.get("app", "src", "nightly", "baselineProfiles", "baseline-prof.txt")
+        File destinationDir = destinationPath.toFile().parentFile
+        if (!destinationDir.exists()) {
+            destinationDir.mkdirs()
+        }
+        Files.copy(profileFile.toPath(), destinationPath, StandardCopyOption.REPLACE_EXISTING)
+    }
 }


### PR DESCRIPTION
### What
This PR adds baseline profiles generator, startup metric benchmark to see the difference between startup timings with/out baseline profiles. The goal is to test the change in startup timings in nightly. 

The metrics to consider:
– [Google Play Vitals - Nightly - Slow Cold Start](https://play.google.com/console/u/0/developers/7083182635971239206/app/4975374341268119750/vitals/metrics/details?peersetKey=1%3A37fd48e7&metric=COLD_STARTUP_TIME&days=28)
– [Glean - cold_x_app_to_first_frame](https://dictionary.telemetry.mozilla.org/apps/fenix?page=1&search=perf.startup) - I think it's interesting to monitor other first frame metrics along with `cold_main_app_to_first_frame` as the benefits can be in other metrics as well since the startup path has common elements.


### Local test data 
#### Using BaselineProfilesStartupBenchmark on Pixel 7 - Android 14

| Benchmark                                        | Time to Initial Display (ms) |
| ------------------------------------------------ | ---------------------------- |
| BaselineProfilesStartupBenchmark_startupPartialWithBaselineProfiles | min: 590.2, median: 642.9, max: 673.4 |
| BaselineProfilesStartupBenchmark_startupNone     | min: 732.4, median: 759.1, max: 790.2 |

#### Using BaselineProfilesStartupBenchmark on Samsung Galaxy A50 - Android 11
| Benchmark                                                        | Time to Initial Display (ms)               |
| ---------------------------------------------------------------- | ----------------------------------------- |
| BaselineProfilesStartupBenchmark_startupPartialWithBaselineProfiles | min: 917.3, median: 1,036.5, max: 1,089.5 |
| BaselineProfilesStartupBenchmark_startupNone                     | min: 1,388.7, median: 1,447.2, max: 1,479.9 |


#### Using ColdStartupDurationTelemetry on Pixel 7 - Android 14

| Type                              | Measurements                                  |
| --------------------------------- | --------------------------------------------- |
| Without Baseline Profiles | 635 ms, 594 ms, 440 ms, 427 ms, 420 ms |
| With Baseline Profiles)   | 548 ms, 451 ms, 431 ms, 367 ms, 368 ms |


Note: many times `startupStateProvider.isColdStartForStartedActivity()` returns false even though the conditions for cold start are present. So I removed that check to get the data. Between each run, the app was removed from recents and then force closed.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807350