### PR TITLE
Bug 1874124 - Add foregroundServiceType for DownloadService and FOREGROUND_SERVICE_DATA_SYNC permission.

### DIFF
--- a/android-components/components/feature/downloads/README.md
+++ b/android-components/components/feature/downloads/README.md
@@ -12,6 +12,14 @@ Use Gradle to download the library from [maven.mozilla.org](https://maven.mozill
 implementation "org.mozilla.components:feature-downloads:{latest-version}"
 ```
 
+The `AbstractFetchDownloadService` also requires extra permissions needed to post notifications and to start downloads
+- `android.permission.POST_NOTIFICATIONS`
+- `android.permission.FOREGROUND_SERVICE`
+- `android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK`
+
+The implementing service in the client app also needs to declare `dataSync` as `foregroundServiceType` in the manifest for
+Android 14 compatibility. Adding the `FOREGROUND_SERVICE_DATA_SYNC` permission in the app manifest is not needed since it is declared in feature-downloads module. 
+
 ### DownloadsFeature
 Feature implementation for proving download functionality for the selected session.
 

--- a/android-components/components/feature/downloads/src/main/AndroidManifest.xml
+++ b/android-components/components/feature/downloads/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         tools:ignore="ScopedStorage"

--- a/android-components/samples/browser/src/main/AndroidManifest.xml
+++ b/android-components/samples/browser/src/main/AndroidManifest.xml
@@ -164,7 +164,9 @@
             </intent-filter>
         </service>
 
-        <service android:name=".downloads.DownloadService" />
+        <service
+            android:name=".downloads.DownloadService"
+            android:foregroundServiceType="dataSync" />
 
         <service android:name=".media.MediaSessionService"
             android:foregroundServiceType="mediaPlayback"

--- a/fenix/app/src/main/AndroidManifest.xml
+++ b/fenix/app/src/main/AndroidManifest.xml
@@ -340,6 +340,7 @@
 
         <service
             android:name=".downloads.DownloadService"
+            android:foregroundServiceType="dataSync"
             android:exported="false" />
 
         <receiver

--- a/focus-android/app/src/main/AndroidManifest.xml
+++ b/focus-android/app/src/main/AndroidManifest.xml
@@ -176,8 +176,10 @@
             </intent-filter>
         </service>
 
-        <service android:name=".downloads.DownloadService"
-            android:exported="false" />
+        <service
+            android:name=".downloads.DownloadService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
 
         <service android:name=".media.MediaSessionService"
             android:foregroundServiceType="mediaPlayback"


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1874124