### PR TITLE
Bug 1854936 - Update notification reminder delay to 5 min instead of 5 sec

### DIFF
--- a/android-components/components/feature/media/src/main/java/mozilla/components/feature/media/middleware/RecordingDevicesMiddleware.kt
+++ b/android-components/components/feature/media/src/main/java/mozilla/components/feature/media/middleware/RecordingDevicesMiddleware.kt
@@ -36,7 +36,7 @@ private const val NOTIFICATION_ID = 1
 private const val PENDING_INTENT_TAG = "mozac.feature.media.pendingintent"
 private const val ACTION_RECORDING_DEVICES_NOTIFICATION_DISMISSED =
     "mozac.feature.media.recordingDevices.notificationDismissed"
-private const val NOTIFICATION_REMINDER_DELAY_MS = 5 * 1000L
+private const val NOTIFICATION_REMINDER_DELAY_MS = 5 * 60 * 1000L // 5 minutes
 
 /**
  * Middleware for displaying an ongoing notification while recording devices (camera, microphone)


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1854936#c3


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1854936