### PR TITLE
Bug 1875187 - Avoid race condition setting mode before opening a tab

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -227,7 +227,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             OpenBrowserIntentProcessor(this, ::getIntentSessionId),
             OpenSpecificTabIntentProcessor(this),
             OpenPasswordManagerIntentProcessor(),
-            ReEngagementIntentProcessor(this, settings(), components.appStore),
+            ReEngagementIntentProcessor(this, settings()),
         )
     }
 
@@ -999,6 +999,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
      * @param historyMetadata The [HistoryMetadataKey] of the new tab in case this tab
      * was opened from history.
      * @param additionalHeaders The extra headers to use when loading the URL.
+     * @param mode Optional [BrowsingMode] to open the tab in. If not provided,
+     * the current mode of [AppStore] will be used.
      */
     @Suppress("LongParameterList")
     fun openToBrowserAndLoad(
@@ -1012,6 +1014,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         requestDesktopMode: Boolean = false,
         historyMetadata: HistoryMetadataKey? = null,
         additionalHeaders: Map<String, String>? = null,
+        mode: BrowsingMode? = null,
     ) {
         openToBrowser(from, customTabSessionId)
         load(
@@ -1023,6 +1026,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             requestDesktopMode = requestDesktopMode,
             historyMetadata = historyMetadata,
             additionalHeaders = additionalHeaders,
+            mode = mode,
         )
     }
 
@@ -1110,6 +1114,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
      * @param historyMetadata The [HistoryMetadataKey] of the new tab in case this tab
      * was opened from history.
      * @param additionalHeaders The extra headers to use when loading the URL.
+     * @param mode Optional [BrowsingMode] to open the tab in. If not provided,
+     * the current mode of [AppStore] will be used.
      */
     private fun load(
         searchTermOrURL: String,
@@ -1120,11 +1126,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         requestDesktopMode: Boolean = false,
         historyMetadata: HistoryMetadataKey? = null,
         additionalHeaders: Map<String, String>? = null,
+        mode: BrowsingMode? = null,
     ) {
         val startTime = components.core.engine.profiler?.getProfilerTime()
-        val mode = components.appStore.state.mode
 
-        val private = when (mode) {
+        val private = when (mode ?: components.appStore.state.mode) {
             BrowsingMode.Private -> true
             BrowsingMode.Normal -> false
         }
@@ -1153,7 +1159,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             }
         } else {
             if (newTab) {
-                val searchUseCase = if (mode.isPrivate) {
+                val searchUseCase = if (private) {
                     components.useCases.searchUseCases.newPrivateTabSearch
                 } else {
                     components.useCases.searchUseCases.newTabSearch

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -41,15 +41,6 @@ sealed class AppAction : Action {
     object Init : AppAction()
 
     /**
-     * NOTE: This action is not yet functional and will require https://bugzilla.mozilla.org/show_bug.cgi?id=1845409
-     * to be resolved. This is part of an ongoing lib-state refactor.
-     * Open a tab in the browser.
-     *
-     * @property mode Which [BrowsingMode] the tab should be opened in.
-     */
-    data class OpenTabInBrowser(val mode: BrowsingMode) : AppAction()
-
-    /**
      * The browsing [mode] has been loaded from a persistence layer.
      */
     data class BrowsingModeLoaded(val mode: BrowsingMode) : AppAction()

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -30,7 +30,6 @@ internal object AppStoreReducer {
     @Suppress("LongMethod")
     fun reduce(state: AppState, action: AppAction): AppState = when (action) {
         is AppAction.Init -> state
-        is AppAction.OpenTabInBrowser -> state.copy(mode = action.mode)
         is AppAction.BrowsingModeLoaded -> state.copy(mode = action.mode)
         is AppAction.UpdateInactiveExpanded ->
             state.copy(inactiveTabsExpanded = action.expanded)

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/intent/ReEngagementIntentProcessor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/intent/ReEngagementIntentProcessor.kt
@@ -15,8 +15,6 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
-import org.mozilla.fenix.components.AppStore
-import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.onboarding.ReEngagementNotificationWorker
 import org.mozilla.fenix.onboarding.ReEngagementNotificationWorker.Companion.isReEngagementNotificationIntent
@@ -32,7 +30,6 @@ import org.mozilla.fenix.utils.Settings
 class ReEngagementIntentProcessor(
     private val activity: HomeActivity,
     private val settings: Settings,
-    private val appStore: AppStore,
 ) : HomeIntentProcessor {
 
     override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
@@ -49,12 +46,12 @@ class ReEngagementIntentProcessor(
                         navController.nav(null, directions, options)
                     }
                     else -> {
-                        appStore.dispatch(AppAction.OpenTabInBrowser(BrowsingMode.Private))
                         activity.openToBrowserAndLoad(
                             ReEngagementNotificationWorker.NOTIFICATION_TARGET_URL,
                             newTab = true,
                             from = BrowserDirection.FromGlobal,
                             flags = EngineSession.LoadUrlFlags.external(),
+                            mode = BrowsingMode.Private,
                         )
                     }
                 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -276,11 +276,11 @@ class DefaultSessionControlController(
             TopSites.openInPrivateTab.record(NoExtras())
         }
         with(activity) {
-            appStore.dispatch(AppAction.ModeChange(BrowsingMode.Private))
             openToBrowserAndLoad(
                 searchTermOrURL = topSite.url,
                 newTab = true,
                 from = BrowserDirection.FromHome,
+                mode = BrowsingMode.Private,
             )
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragment.kt
@@ -29,7 +29,6 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.StoreProvider
-import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.databinding.FragmentRecentlyClosedTabsBinding
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.setTextColor
@@ -139,12 +138,11 @@ class RecentlyClosedFragment :
     }
 
     private fun openItem(url: String, mode: BrowsingMode? = null) {
-        mode?.let { requireComponents.appStore.dispatch(AppAction.OpenTabInBrowser(it)) }
-
         (activity as HomeActivity).openToBrowserAndLoad(
             searchTermOrURL = url,
             newTab = true,
             from = BrowserDirection.FromRecentlyClosed,
+            mode = mode,
         )
     }
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/home/intent/ReEngagementIntentProcessorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/home/intent/ReEngagementIntentProcessorTest.kt
@@ -42,7 +42,7 @@ class ReEngagementIntentProcessorTest {
         val navController: NavController = mockk()
         val out: Intent = mockk()
         val settings: Settings = mockk()
-        val result = ReEngagementIntentProcessor(mockk(), settings, mockk())
+        val result = ReEngagementIntentProcessor(mockk(), settings)
             .process(Intent(), navController, out)
 
         assertFalse(result)
@@ -56,18 +56,16 @@ class ReEngagementIntentProcessorTest {
         val out: Intent = mockk()
         val activity: HomeActivity = mockk(relaxed = true)
         val settings: Settings = mockk(relaxed = true)
-        val appStore: AppStore = mockk(relaxed = true)
 
         val intent = Intent().apply {
             putExtra("org.mozilla.fenix.re-engagement.intent", true)
         }
         every { activity.applicationContext } returns testContext
         every { settings.reEngagementNotificationType } returns ReEngagementNotificationWorker.NOTIFICATION_TYPE_A
-        every { appStore.dispatch(any()) } returns Job()
 
         assertNull(Events.reEngagementNotifTapped.testGetValue())
 
-        val result = ReEngagementIntentProcessor(activity, settings, appStore)
+        val result = ReEngagementIntentProcessor(activity, settings)
             .process(intent, navController, out)
 
         assert(result)
@@ -84,9 +82,9 @@ class ReEngagementIntentProcessorTest {
                 flags = EngineSession.LoadUrlFlags.external(),
                 requestDesktopMode = false,
                 historyMetadata = null,
+                mode = BrowsingMode.Private,
             )
         }
-        verify { appStore.dispatch(AppAction.OpenTabInBrowser(BrowsingMode.Private)) }
         verify { navController wasNot Called }
         verify { out wasNot Called }
     }
@@ -106,7 +104,7 @@ class ReEngagementIntentProcessorTest {
 
         assertNull(Events.reEngagementNotifTapped.testGetValue())
 
-        val result = ReEngagementIntentProcessor(activity, settings, mockk())
+        val result = ReEngagementIntentProcessor(activity, settings)
             .process(intent, navController, out)
 
         assert(result)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1875187