### PR TITLE
Bug 1871408 - Translations UI Add Messages Under On Toggles

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/compose/SwitchWithLabel.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/compose/SwitchWithLabel.kt
@@ -35,6 +35,7 @@ private const val DISABLED_ALPHA = 0.5f
  * UI for a switch with label that can be on or off.
  *
  * @param label Text to be displayed next to the switch.
+ * @param description An optional description text below the label.
  * @param checked Whether or not the switch is checked.
  * @param onCheckedChange Invoked when Switch is being clicked, therefore the change of checked
  * state is requested.
@@ -44,6 +45,7 @@ private const val DISABLED_ALPHA = 0.5f
 @Composable
 fun SwitchWithLabel(
     label: String,
+    description: String? = null,
     checked: Boolean,
     onCheckedChange: ((Boolean) -> Unit),
     modifier: Modifier = Modifier,
@@ -60,16 +62,28 @@ fun SwitchWithLabel(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = label,
-            color = if (enabled) {
-                FirefoxTheme.colors.textPrimary
-            } else {
-                FirefoxTheme.colors.textDisabled
-            },
-            style = FirefoxTheme.typography.subtitle1,
-            modifier = Modifier.weight(1f),
-        )
+        Column(
+            modifier = Modifier
+                .weight(1f),
+        ) {
+            Text(
+                text = label,
+                color = if (enabled) {
+                    FirefoxTheme.colors.textPrimary
+                } else {
+                    FirefoxTheme.colors.textDisabled
+                },
+                style = FirefoxTheme.typography.subtitle1,
+            )
+
+            description?.let {
+                Text(
+                    text = description,
+                    color = FirefoxTheme.colors.textSecondary,
+                    style = FirefoxTheme.typography.body2,
+                )
+            }
+        }
 
         Switch(
             modifier = Modifier.clearAndSetSemantics {},
@@ -139,6 +153,7 @@ private fun SwitchWithLabelPreview() {
             var enabledSwitchState by remember { mutableStateOf(false) }
             SwitchWithLabel(
                 label = if (enabledSwitchState) "On" else "Off",
+                description = "Description text",
                 checked = enabledSwitchState,
                 onCheckedChange = { enabledSwitchState = it },
             )

--- a/fenix/app/src/main/java/org/mozilla/fenix/translations/TranslationSettings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/translations/TranslationSettings.kt
@@ -122,6 +122,7 @@ internal fun getTranslationSettingsSwitchList(): List<TranslationSwitchItem> {
                 textLabel = stringResource(R.string.translation_settings_offer_to_translate),
                 isChecked = true,
                 hasDivider = false,
+                isEnabled = true,
                 onStateChange = {},
             ),
         )
@@ -130,6 +131,7 @@ internal fun getTranslationSettingsSwitchList(): List<TranslationSwitchItem> {
                 textLabel = stringResource(R.string.translation_settings_always_download),
                 isChecked = false,
                 hasDivider = true,
+                isEnabled = true,
                 onStateChange = {},
             ),
         )

--- a/fenix/app/src/main/java/org/mozilla/fenix/translations/TranslationSwitchItem.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/translations/TranslationSwitchItem.kt
@@ -8,14 +8,20 @@ package org.mozilla.fenix.translations
  * TranslationSwitchItem that will appear on Translation screens.
  *
  * @property textLabel The text that will appear on the switch item.
+ * @property description An optional description text below the label.
+ * @property importance Based on this, the translation switch item is enabled or disabled.
  * @property isChecked Whether the switch is checked or not.
+ * @property isEnabled Whether the switch is enabled or not.
  * @property hasDivider Whether a divider should appear under the switch item.
  * @property onStateChange Invoked when the switch item is clicked,
  * the new checked state is passed into the callback.
  */
 data class TranslationSwitchItem(
     val textLabel: String,
-    val isChecked: Boolean,
+    var description: String? = null,
+    val importance: Int = 0,
+    var isChecked: Boolean,
+    var isEnabled: Boolean = true,
     val hasDivider: Boolean,
     val onStateChange: (Boolean) -> Unit,
 )

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -2391,6 +2391,10 @@
     <string name="translation_option_bottom_sheet_never_translate_in_language">Never translate %1$s</string>
     <!-- Toggle switch label that allows a user to set the setting if they would like the browser to never translate the site the user is currently visiting. -->
     <string name="translation_option_bottom_sheet_never_translate_site">Never translate this site</string>
+    <!-- Toggle switch description that will appear under the "Never translate these sites" settings toggle switch to provide more information on how this setting interacts with other settings. -->
+    <string name="translation_option_bottom_sheet_switch_never_translate_site_description">Overrides all other settings</string>
+    <!-- Toggle switch description that will appear under the "Never translate" and "Always translate" toggle switch settings to provide more information on how these  settings interacts with other settings. -->
+    <string name="translation_option_bottom_sheet_switch_description">Overrides offers to translate</string>
     <!-- Button text for the button that will take the user to the translation settings dialog. -->
     <string name="translation_option_bottom_sheet_translation_settings">Translation settings</string>
     <!-- Button text for the button that will take the user to a website to learn more about how translations works in the given app. The first parameter is the name of the application, for example, "Fenix". -->


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1871408