### PR TITLE
Bug 1874743 - Add network profile coverage on physical devices on Firebase Test Lab

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NetworkTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NetworkTest.kt
@@ -1,0 +1,26 @@
+package org.mozilla.fenix.ui
+
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.ext.toUri
+import org.mozilla.fenix.ui.robots.navigationToolbar
+
+class NetworkTest {
+    @get:Rule
+    val activityTestRule =
+        HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
+
+    @Test
+    fun urlBarTest() {
+        // Note: This test may fail in GSM/GPRS
+        // Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1868469
+        val urls = listOf("indianexpress.com", "nzherald.co.nz")
+        urls.mapNotNull { it.toUri() }.forEach { uri ->
+            navigationToolbar {}.enterURLAndEnterToBrowser(uri) {
+                println("Entered URL: $uri")
+                verifyUrl(uri.toString())
+            }
+        }
+    }
+}

--- a/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/fenix/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -22,15 +22,18 @@ gcloud:
     - notPackage org.mozilla.fenix.screenshots
     - notPackage org.mozilla.fenix.syncintegration
     - notPackage org.mozilla.fenix.experimentintegration
+    - class org.mozilla.fenix.ui.NetworkTest#urlBarTest
 
   device:
-    - model: Pixel2.arm
+    - model: q2q
       version: 30
       locale: en_US
 
+  network-profile: GSM-poor
+
 flank:
   project: GOOGLE_PROJECT
-  max-test-shards: 100
+  max-test-shards: 1
   num-test-runs: 1
   output-style: compact
   full-junit-result: true

--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -256,7 +256,7 @@ tasks:
             commands:
                 - [wget, {artifact-reference: '<signed-apk-debug-apk/public/build/target.arm64-v8a.apk>'}, '-O', app.apk]
                 - [wget, {artifact-reference: '<signed-apk-android-test/public/build/target.noarch.apk>'}, '-O', android-test.apk]
-                - [automation/taskcluster/androidTest/ui-test.sh, arm64-v8a, app.apk, android-test.apk, '100']
+                - [automation/taskcluster/androidTest/ui-test.sh, arm64-v8a, app.apk, android-test.apk, '1']
         treeherder:
             platform: 'fenix-ui-test/opt'
             symbol: fenix-debug(ui-test-arm)


### PR DESCRIPTION
POC test https://bugzilla.mozilla.org/show_bug.cgi?id=1874743 using https://bugzilla.mozilla.org/show_bug.cgi?id=1874743 as an example test case. 

Network profiles require a physical device 
https://cloud.google.com/sdk/gcloud/reference/firebase/test/network-profiles

```
┌────────────┐
│ PROFILE_ID │
├────────────┤
│ LTE        │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.040s │ 0.001      │                   │ 16000.0   │       │
    │ down │ 0.040s │ 0.001      │                   │ 16000.0   │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ LTE-poor   │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.060s │ 0.0015     │                   │ 4000.0    │       │
    │ down │ 0.060s │ 0.0015     │                   │ 4000.0    │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ HSPA       │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.060s │ 0.001      │                   │ 2000.0    │       │
    │ down │ 0.060s │ 0.001      │                   │ 4000.0    │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ HSPA-poor  │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.100s │ 0.0015     │                   │ 500.0     │       │
    │ down │ 0.100s │ 0.0015     │                   │ 1000.0    │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ UMTS       │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.060s │ 0.02       │                   │ 2000.0    │       │
    │ down │ 0.060s │ 0.02       │                   │ 2000.0    │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ UMTS-poor  │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.090s │ 0.04       │                   │ 384.0     │       │
    │ down │ 0.090s │ 0.04       │                   │ 384.0     │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ EDGE       │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.150s │ 0.04       │                   │ 384.0     │       │
    │ down │ 0.150s │ 0.04       │                   │ 384.0     │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ EDGE-poor  │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.200s │ 0.08       │                   │ 96.0      │       │
    │ down │ 0.200s │ 0.08       │                   │ 96.0      │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ GPRS       │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.300s │ 0.08       │                   │ 172.0     │       │
    │ down │ 0.300s │ 0.08       │                   │ 172.0     │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ GPRS-poor  │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.500s │ 0.1        │                   │ 48.0      │       │
    │ down │ 0.500s │ 0.1        │                   │ 48.0      │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ GSM        │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.500s │ 0.08       │                   │ 9.6       │       │
    │ down │ 0.500s │ 0.08       │                   │ 9.6       │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ GSM-poor   │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.600s │ 0.1        │                   │ 2.4       │       │
    │ down │ 0.600s │ 0.1        │                   │ 2.4       │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
aaronmt@Pegasus Desktop % gcloud firebase test network-profiles list
┌────────────┐
│ PROFILE_ID │
├────────────┤
│ LTE        │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.040s │ 0.001      │                   │ 16000.0   │       │
    │ down │ 0.040s │ 0.001      │                   │ 16000.0   │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ LTE-poor   │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.060s │ 0.0015     │                   │ 4000.0    │       │
    │ down │ 0.060s │ 0.0015     │                   │ 4000.0    │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ HSPA       │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.060s │ 0.001      │                   │ 2000.0    │       │
    │ down │ 0.060s │ 0.001      │                   │ 4000.0    │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ HSPA-poor  │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.100s │ 0.0015     │                   │ 500.0     │       │
    │ down │ 0.100s │ 0.0015     │                   │ 1000.0    │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ UMTS       │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.060s │ 0.02       │                   │ 2000.0    │       │
    │ down │ 0.060s │ 0.02       │                   │ 2000.0    │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ UMTS-poor  │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.090s │ 0.04       │                   │ 384.0     │       │
    │ down │ 0.090s │ 0.04       │                   │ 384.0     │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ EDGE       │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.150s │ 0.04       │                   │ 384.0     │       │
    │ down │ 0.150s │ 0.04       │                   │ 384.0     │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ EDGE-poor  │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.200s │ 0.08       │                   │ 96.0      │       │
    │ down │ 0.200s │ 0.08       │                   │ 96.0      │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ GPRS       │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.300s │ 0.08       │                   │ 172.0     │       │
    │ down │ 0.300s │ 0.08       │                   │ 172.0     │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ GPRS-poor  │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.500s │ 0.1        │                   │ 48.0      │       │
    │ down │ 0.500s │ 0.1        │                   │ 48.0      │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ GSM        │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.500s │ 0.08       │                   │ 9.6       │       │
    │ down │ 0.500s │ 0.08       │                   │ 9.6       │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
┌────────────┐
│ GSM-poor   │
└────────────┘
    ┌──────┬────────┬────────────┬───────────────────┬───────────┬───────┐
    │ RULE │ DELAY  │ LOSS_RATIO │ DUPLICATION_RATIO │ BANDWIDTH │ BURST │
    ├──────┼────────┼────────────┼───────────────────┼───────────┼───────┤
    │ up   │ 0.600s │ 0.1        │                   │ 2.4       │       │
    │ down │ 0.600s │ 0.1        │                   │ 2.4       │       │
    └──────┴────────┴────────────┴───────────────────┴───────────┴───────┘
```
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743
https://bugzilla.mozilla.org/show_bug.cgi?id=1874743