### PR TITLE
Bug 1874771 - Only run 'github-push' Taskcluster tasks against main a…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -147,7 +147,7 @@ tasks:
                   $if: >
                       tasks_for in ["action", "cron"]
                       || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
-                      || (tasks_for == "github-push" && head_ref[:10] != "refs/tags/" && short_head_ref != "staging.tmp" && short_head_ref != "trying.tmp" && short_head_ref[:8] != "mergify/")
+                      || (tasks_for == "github-push" && (short_head_ref == "main" || short_head_ref[:9] == "releases_"))
                   then:
                       $mergeDeep:
                           - $if: 'tasks_for != "action"'


### PR DESCRIPTION
…nd release branches



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1874771