### PR TITLE
Bug 1874804 - Replace ClearFlags with Engine.BrowsingData

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoSitePermissionsStorage.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/permission/GeckoSitePermissionsStorage.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import mozilla.components.browser.engine.gecko.await
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.Engine.BrowsingData.Companion.PERMISSIONS
 import mozilla.components.concept.engine.permission.PermissionRequest
 import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.concept.engine.permission.SitePermissions.AutoplayStatus
@@ -34,7 +36,6 @@ import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_PERSISTE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_STORAGE_ACCESS
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_TRACKING
 import org.mozilla.geckoview.StorageController
-import org.mozilla.geckoview.StorageController.ClearFlags
 
 /**
  * A storage to save [SitePermissions] using GeckoView APIs.
@@ -340,13 +341,16 @@ class GeckoSitePermissionsStorage(
     @VisibleForTesting
     internal suspend fun clearGeckoCacheFor(origin: String) {
         withContext(mainScope.coroutineContext) {
-            geckoStorage.clearDataFromHost(origin, ClearFlags.PERMISSIONS).await()
+            geckoStorage.clearDataFromHost(
+                origin,
+                Engine.BrowsingData.select(PERMISSIONS).types.toLong(),
+            ).await()
         }
     }
 
     @VisibleForTesting
     internal fun clearAllPermissionsGeckoCache() {
-        geckoStorage.clearData(ClearFlags.PERMISSIONS)
+        geckoStorage.clearData(Engine.BrowsingData.select(PERMISSIONS).types.toLong())
     }
 
     @VisibleForTesting

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoSitePermissionsStorageTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoSitePermissionsStorageTest.kt
@@ -6,6 +6,8 @@ package mozilla.components.browser.engine.gecko.permission
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.Engine.BrowsingData.Companion.PERMISSIONS
 import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.concept.engine.permission.SitePermissions.AutoplayStatus
 import mozilla.components.concept.engine.permission.SitePermissions.Status.ALLOWED
@@ -42,7 +44,6 @@ import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_PERSISTE
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_STORAGE_ACCESS
 import org.mozilla.geckoview.GeckoSession.PermissionDelegate.PERMISSION_TRACKING
 import org.mozilla.geckoview.StorageController
-import org.mozilla.geckoview.StorageController.ClearFlags
 
 @ExperimentalCoroutinesApi
 class GeckoSitePermissionsStorageTest {
@@ -603,7 +604,7 @@ class GeckoSitePermissionsStorageTest {
         geckoPermissions.forEach {
             verify(geckoStorage).removeGeckoContentPermission(it)
         }
-        verify(storageController).clearData(ClearFlags.PERMISSIONS)
+        verify(storageController).clearData(Engine.BrowsingData.select(PERMISSIONS).types.toLong())
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1874804