### PR TITLE
Bug 1874943 - Add a tab counter UI element

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -470,6 +470,7 @@ abstract class BaseBrowserFragment :
                 menuButton = MenuButton(requireContext()).apply {
                     menuBuilder = browserToolbarView.menuToolbar.menuBuilder
                 },
+                browsingModeManager = activity.browsingModeManager,
             )
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BottomToolbarContainerView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/BottomToolbarContainerView.kt
@@ -13,7 +13,13 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import mozilla.components.browser.menu.view.MenuButton
+import mozilla.components.browser.state.selector.normalTabs
+import mozilla.components.browser.state.selector.privateTabs
+import mozilla.components.lib.state.ext.observeAsState
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.compose.Divider
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -23,7 +29,8 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * @param container The ViewGroup into which the NavigationBar composable will be added.
  * @param navigationItems A list of [ActionItem] objects representing the items to be displayed in the navigation bar.
  * @param androidToolbarView An option toolbar view that will be added atop of the navigation bar.
- * @param menuButton A [MenuButton] to be used for [ItemType.MENU]
+ * @param menuButton A [MenuButton] to be used for [ItemType.MENU].
+ * @param browsingModeManager A helper class that provides access to the current [BrowsingMode].
  *
  * Defaults to [NavigationItems.defaultItems] which provides a standard set of navigation items.
  */
@@ -33,11 +40,21 @@ class BottomToolbarContainerView(
     navigationItems: List<ActionItem> = NavigationItems.defaultItems,
     androidToolbarView: View? = null,
     menuButton: MenuButton,
+    browsingModeManager: BrowsingModeManager,
 ) {
 
     init {
         val composeView = ComposeView(context).apply {
             setContent {
+                val isPrivate = browsingModeManager.mode.isPrivate
+                val tabCount = context.components.core.store.observeAsState(initialValue = 0) { browserState ->
+                    if (isPrivate) {
+                        browserState.privateTabs.size
+                    } else {
+                        browserState.normalTabs.size
+                    }
+                }.value
+
                 FirefoxTheme {
                     Column {
                         if (androidToolbarView != null) {
@@ -48,6 +65,7 @@ class BottomToolbarContainerView(
 
                         NavigationBar(
                             actionItems = navigationItems,
+                            tabCount = tabCount,
                             menuButton = menuButton,
                         )
                     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/NavigationBar.kt
@@ -11,23 +11,24 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
-import androidx.compose.material.Text
+import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import mozilla.components.browser.menu.view.MenuButton
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.toolbar.ItemType.STANDARD
+import org.mozilla.fenix.components.toolbar.ItemType.TAB_COUNTER
+import org.mozilla.fenix.compose.TabCounter
 import org.mozilla.fenix.compose.annotation.LightDarkPreview
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
@@ -36,11 +37,13 @@ import org.mozilla.fenix.theme.Theme
  * Top-level UI for displaying the navigation bar.
  *
  * @param actionItems A list of [ActionItem] used to populate the bar.
- * @param menuButton A [MenuButton] to be used for [ItemType.MENU]
+ * @param tabCount The number of opened tabs.
+ * @param menuButton A [MenuButton] to be used for [ItemType.MENU].
  */
 @Composable
 fun NavigationBar(
     actionItems: List<ActionItem>,
+    tabCount: Int,
     menuButton: MenuButton? = null,
 ) {
     Box(
@@ -68,8 +71,10 @@ fun NavigationBar(
                         }
                     }
                     ItemType.TAB_COUNTER -> {
-                        IconButton(onClick = {}) {
-                            TabsIcon(item = it, tabsCount = 0)
+                        CompositionLocalProvider(LocalContentColor provides FirefoxTheme.colors.iconPrimary) {
+                            IconButton(onClick = {}) {
+                                TabCounter(tabCount = tabCount)
+                            }
                         }
                     }
 
@@ -79,10 +84,8 @@ fun NavigationBar(
                         // will revisit it when doing tab counter and navigation buttons.
                         if (menuButton != null) {
                             AndroidView(
-                                modifier = Modifier.height(48.dp).width(48.dp),
-                                factory = { _ ->
-                                    menuButton
-                                },
+                                modifier = Modifier.size(48.dp),
+                                factory = { _ -> menuButton },
                             )
                         } else {
                             IconButton(onClick = {}) {
@@ -97,25 +100,6 @@ fun NavigationBar(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun TabsIcon(item: ActionItem, tabsCount: Int) {
-    Box(contentAlignment = Alignment.Center) {
-        Icon(
-            painter = painterResource(id = item.iconId),
-            contentDescription = stringResource(id = item.descriptionResourceId),
-            tint = FirefoxTheme.colors.iconPrimary,
-        )
-
-        Text(
-            text = tabsCount.toString(),
-            color = FirefoxTheme.colors.iconPrimary,
-            fontSize = 10.sp,
-            fontWeight = FontWeight.W700,
-            textAlign = TextAlign.Center,
-        )
     }
 }
 
@@ -180,7 +164,10 @@ object NavigationItems {
 @Composable
 private fun NavigationBarPreview() {
     FirefoxTheme {
-        NavigationBar(NavigationItems.defaultItems)
+        NavigationBar(
+            actionItems = NavigationItems.defaultItems,
+            tabCount = 0,
+        )
     }
 }
 
@@ -188,6 +175,9 @@ private fun NavigationBarPreview() {
 @Composable
 private fun NavigationBarPrivatePreview() {
     FirefoxTheme(theme = Theme.Private) {
-        NavigationBar(NavigationItems.defaultItems)
+        NavigationBar(
+            actionItems = NavigationItems.defaultItems,
+            tabCount = 0,
+        )
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -454,6 +454,7 @@ class HomeFragment : Fragment() {
                 container = binding.homeLayout,
                 androidToolbarView = toolbarView,
                 menuButton = menuButton,
+                browsingModeManager = browsingModeManager,
             )
         }
 


### PR DESCRIPTION
I reused some of the classes already masterfully crafted by @MozillaNoah  for the nav bar as well :)

### Screenshots
 Old | New
 --- | --- 
<img src="https://github.com/mozilla-mobile/firefox-android/assets/92760693/066f48f7-93d2-43ea-b624-6671b2538d60" width="300"> |  <img src="https://github.com/mozilla-mobile/firefox-android/assets/92760693/fdb9acef-6492-4d25-a644-6a8ef717486e" width="300">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1874943