### PR TITLE
Bug 1838580 - [a11y] Increase tap area for search engine icon

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/ext/View.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ext/View.kt
@@ -30,6 +30,23 @@ fun View.increaseTapArea(@Dimension(unit = DP) extraDps: Int) {
     }
 }
 
+/**
+ * Increase tap area only vertically.
+ *
+ * @param extraDps the extra dps that's wanted to be added on top and bottom of the view
+ */
+fun View.increaseTapAreaVertically(@Dimension(unit = DP) extraDps: Int) {
+    val dips = extraDps.dpToPx(resources.displayMetrics)
+    val parent = this.parent as View
+    parent.post {
+        val touchArea = Rect()
+        getHitRect(touchArea)
+        touchArea.top -= dips
+        touchArea.bottom += dips
+        parent.touchDelegate = TouchDelegate(touchArea, this)
+    }
+}
+
 fun View.removeTouchDelegate() {
     val parent = this.parent as View
     parent.post {

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/toolbar/SearchSelectorBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/toolbar/SearchSelectorBinding.kt
@@ -20,6 +20,7 @@ import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.GleanMetrics.UnifiedSearch
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.FragmentHomeBinding
+import org.mozilla.fenix.ext.increaseTapAreaVertically
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
 
@@ -51,6 +52,8 @@ class SearchSelectorBinding(
                     orientation = orientation,
                 )
             }
+
+            increaseTapAreaVertically(SEARCH_SELECTOR_INCREASE_HEIGHT_DPS)
         }
     }
 
@@ -75,5 +78,9 @@ class SearchSelectorBinding(
 
                 binding.searchSelectorButton.setIcon(icon, name)
             }
+    }
+
+    companion object {
+        const val SEARCH_SELECTOR_INCREASE_HEIGHT_DPS = 10
     }
 }


### PR DESCRIPTION
The touching area for search engine icon (Google by default) from the search bar was only 28dp.
To Increase tap area to reach the minimum accessibility touch target size of 48dp, it was used TouchDelegate. This way there are no visual changes.

Other notes:
For Android 9 and earlier versions, Accessibility Scanner will not detect that we used TouchDelegate to enlarge touch targets to an appropriate size. So the changes can be seen with Accessibility Scanner on devices with android 10 +. 
More on [support.google.com](https://support.google.com/accessibility/android/answer/7101858?hl=en#zippy=%2Ccompose%2Cview:~:text=Accessibility%20Scanner%20can%20detect%20and%20account%20for%20the%20use%20of%C2%A0TouchDelegate%C2%A0only%20when%20running%20on%20Android%2010%20and%20later.%20On%20earlier%20Android%20versions%2C%20touch%20target%20size%20results%20may%20appear%20even%20when%20this%20API%20is%20used%20to%20enlarge%20touch%20targets%20to%20an%20appropriate%20size.).

Before
![searchengine_before](https://github.com/mozilla-mobile/firefox-android/assets/122524342/44880d36-a100-4070-ab4c-c81e89621629)

After
![seearchengine_after](https://github.com/mozilla-mobile/firefox-android/assets/122524342/59423f01-af22-448e-b454-fd91c39db16e)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1838580