### PR TITLE
Bug 1875465 - Add tab strip for tablets

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1560,6 +1560,7 @@ abstract class BaseBrowserFragment :
             (view as? SwipeGestureLayout)?.isSwipeEnabled = false
             browserToolbarView.collapse()
             browserToolbarView.view.isVisible = false
+            binding.tabStripView.isVisible = false
             val browserEngine = binding.swipeRefresh.layoutParams as CoordinatorLayout.LayoutParams
             browserEngine.bottomMargin = 0
             browserEngine.topMargin = 0
@@ -1584,6 +1585,9 @@ abstract class BaseBrowserFragment :
                 val toolbarHeight = resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
                 initializeEngineView(toolbarHeight)
                 browserToolbarView.expand()
+            }
+            if (requireContext().settings().isTabletAndTabStripEnabled) {
+                binding.tabStripView.isVisible = true
             }
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -134,6 +134,7 @@ import org.mozilla.fenix.components.toolbar.BrowserToolbarView
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarController
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarMenuController
 import org.mozilla.fenix.components.toolbar.ToolbarIntegration
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.components.toolbar.interactor.DefaultBrowserToolbarInteractor
 import org.mozilla.fenix.crashes.CrashContentIntegration
@@ -463,7 +464,7 @@ abstract class BaseBrowserFragment :
                 toolbarInfo = FindInPageIntegration.ToolbarInfo(
                     browserToolbarView.view,
                     !context.settings().shouldUseFixedTopToolbar && context.settings().isDynamicToolbarEnabled,
-                    !context.settings().shouldUseBottomToolbar,
+                    context.settings().toolbarPosition == ToolbarPosition.TOP,
                 ),
             ),
             owner = this,
@@ -820,7 +821,7 @@ abstract class BaseBrowserFragment :
                 browserStore = requireComponents.core.store,
                 appStore = requireComponents.appStore,
                 toolbar = browserToolbarView.view,
-                isToolbarPlacedAtTop = !context.settings().shouldUseBottomToolbar,
+                isToolbarPlacedAtTop = context.settings().toolbarPosition == ToolbarPosition.TOP,
                 crashReporterView = binding.crashReporterView,
                 components = requireComponents,
                 settings = context.settings(),
@@ -1155,10 +1156,9 @@ abstract class BaseBrowserFragment :
         if (!context.settings().shouldUseFixedTopToolbar && context.settings().isDynamicToolbarEnabled) {
             getEngineView().setDynamicToolbarMaxHeight(toolbarHeight)
 
-            val toolbarPosition = if (context.settings().shouldUseBottomToolbar) {
-                MozacToolbarPosition.BOTTOM
-            } else {
-                MozacToolbarPosition.TOP
+            val toolbarPosition = when (context.settings().toolbarPosition) {
+                ToolbarPosition.BOTTOM -> MozacToolbarPosition.BOTTOM
+                ToolbarPosition.TOP -> MozacToolbarPosition.TOP
             }
             (getSwipeRefreshLayout().layoutParams as CoordinatorLayout.LayoutParams).behavior =
                 EngineViewClippingBehavior(
@@ -1175,10 +1175,10 @@ abstract class BaseBrowserFragment :
             // Effectively place the engineView on top/below of the toolbar if that is not dynamic.
             val swipeRefreshParams =
                 getSwipeRefreshLayout().layoutParams as CoordinatorLayout.LayoutParams
-            if (context.settings().shouldUseBottomToolbar) {
-                swipeRefreshParams.bottomMargin = toolbarHeight
-            } else {
+            if (context.settings().toolbarPosition == ToolbarPosition.TOP) {
                 swipeRefreshParams.topMargin = toolbarHeight
+            } else {
+                swipeRefreshParams.bottomMargin = toolbarHeight
             }
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -93,9 +93,12 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
 
         val context = requireContext()
         val components = context.components
-        initTabStrip()
+        val isTabletAndTabStripEnabled = context.settings().isTabletAndTabStripEnabled
+        if (isTabletAndTabStripEnabled) {
+            initTabStrip()
+        }
 
-        if (context.settings().isSwipeToolbarToSwitchTabsEnabled) {
+        if (!isTabletAndTabStripEnabled && context.settings().isSwipeToolbarToSwitchTabsEnabled) {
             binding.gestureLayout.addGestureListener(
                 ToolbarGestureHandler(
                     activity = requireActivity(),
@@ -246,10 +249,6 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     }
 
     private fun initTabStrip() {
-        if (!resources.getBoolean(R.bool.tablet)) {
-            return
-        }
-
         binding.tabStripView.isVisible = true
         binding.tabStripView.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/TabPreview.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/TabPreview.kt
@@ -18,6 +18,7 @@ import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
 import mozilla.components.concept.base.images.ImageLoadRequest
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.databinding.TabPreviewBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
@@ -34,7 +35,7 @@ class TabPreview @JvmOverloads constructor(
     private val thumbnailLoader = ThumbnailLoader(context.components.core.thumbnailStorage)
 
     init {
-        if (!context.settings().shouldUseBottomToolbar) {
+        if (context.settings().toolbarPosition == ToolbarPosition.TOP) {
             binding.fakeToolbar.updateLayoutParams<LayoutParams> {
                 gravity = Gravity.TOP
             }
@@ -59,7 +60,7 @@ class TabPreview @JvmOverloads constructor(
             binding.tabButton.setCount(count)
         }
 
-        binding.previewThumbnail.translationY = if (!context.settings().shouldUseBottomToolbar) {
+        binding.previewThumbnail.translationY = if (context.settings().toolbarPosition == ToolbarPosition.TOP) {
             binding.fakeToolbar.height.toFloat()
         } else {
             0f

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/tabstrip/TabStrip.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/tabstrip/TabStrip.kt
@@ -1,0 +1,414 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.browser.tabstrip
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListItemInfo
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.systemGestureExclusion
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.coerceIn
+import androidx.compose.ui.unit.dp
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.lib.state.ext.observeAsState
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.components
+import org.mozilla.fenix.compose.Favicon
+import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.theme.Theme
+
+private val minTabStripItemWidth = 160.dp
+private val maxTabStripItemWidth = 280.dp
+private val tabStripIconSize = 24.dp
+private val spaceBetweenTabs = 4.dp
+private val tabStripStartPadding = 8.dp
+private val addTabIconSize = 20.dp
+
+/**
+ * Top level composable for the tabs strip.
+ *
+ * @param onHome Whether or not the tabs strip is in the home screen.
+ * @param browserStore The [BrowserStore] instance used to observe tabs state.
+ * @param appStore The [AppStore] instance used to observe browsing mode.
+ * @param tabsUseCases The [TabsUseCases] instance to perform tab actions.
+ * @param onAddTabClick Invoked when the add tab button is clicked.
+ * @param onLastTabClose Invoked when the last remaining open tab is closed.
+ * @param onSelectedTabClick Invoked when a tab is selected.
+ */
+@Composable
+fun TabStrip(
+    onHome: Boolean = false,
+    browserStore: BrowserStore = components.core.store,
+    appStore: AppStore = components.appStore,
+    tabsUseCases: TabsUseCases = components.useCases.tabsUseCases,
+    onAddTabClick: () -> Unit,
+    onLastTabClose: () -> Unit,
+    onSelectedTabClick: () -> Unit,
+) {
+    val isPrivateMode by appStore.observeAsState(false) { it.mode.isPrivate }
+    val state by browserStore.observeAsState(TabStripState.initial) {
+        it.toTabStripState(isSelectDisabled = onHome, isPrivateMode = isPrivateMode)
+    }
+
+    TabStripContent(
+        state = state,
+        onAddTabClick = onAddTabClick,
+        onCloseTabClick = {
+            if (state.tabs.size == 1) {
+                onLastTabClose()
+            }
+            tabsUseCases.removeTab(it)
+        },
+        onSelectedTabClick = {
+            tabsUseCases.selectTab(it)
+            onSelectedTabClick()
+        },
+    )
+}
+
+@Composable
+private fun TabStripContent(
+    state: TabStripState,
+    onAddTabClick: () -> Unit,
+    onCloseTabClick: (id: String) -> Unit,
+    onSelectedTabClick: (id: String) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(FirefoxTheme.colors.layer1)
+            .systemGestureExclusion(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TabsList(
+            state = state,
+            modifier = Modifier.weight(1f, fill = false),
+            onCloseTabClick = onCloseTabClick,
+            onSelectedTabClick = onSelectedTabClick,
+        )
+
+        IconButton(onClick = onAddTabClick) {
+            Icon(
+                painter = painterResource(R.drawable.mozac_ic_plus_24),
+                modifier = Modifier.size(addTabIconSize),
+                tint = FirefoxTheme.colors.iconPrimary,
+                contentDescription = stringResource(R.string.add_tab),
+            )
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
+private fun TabsList(
+    state: TabStripState,
+    modifier: Modifier = Modifier,
+    onCloseTabClick: (id: String) -> Unit,
+    onSelectedTabClick: (id: String) -> Unit,
+) {
+    BoxWithConstraints(modifier = modifier) {
+        val listState = rememberLazyListState()
+        // Calculate the width of each tab item based on available width and the number of tabs and
+        // taking into account the space between tabs.
+        val availableWidth = maxWidth - tabStripStartPadding
+        val tabWidth = (availableWidth / state.tabs.size) - spaceBetweenTabs
+
+        LazyRow(
+            modifier = Modifier,
+            state = listState,
+            contentPadding = PaddingValues(start = tabStripStartPadding),
+        ) {
+            items(
+                items = state.tabs,
+                key = { it.id },
+            ) { itemState ->
+                TabItem(
+                    state = itemState,
+                    onCloseTabClick = onCloseTabClick,
+                    onSelectedTabClick = onSelectedTabClick,
+                    modifier = Modifier
+                        .padding(end = spaceBetweenTabs)
+                        .animateItemPlacement()
+                        .width(
+                            tabWidth.coerceIn(
+                                minimumValue = minTabStripItemWidth,
+                                maximumValue = maxTabStripItemWidth,
+                            ),
+                        ),
+                )
+            }
+        }
+
+        if (state.tabs.isNotEmpty()) {
+            // When a new tab is added, scroll to the end of the list. This is done here instead of
+            // in onCloseTabClick so this acts on state change which can occur from any other
+            // place e.g. tabs tray.
+            LaunchedEffect(state.tabs.last().id) {
+                listState.scrollToItem(state.tabs.size)
+            }
+
+            // When a tab is selected, scroll to the selected tab. This is done here instead of
+            // in onSelectedTabClick so this acts on state change which can occur from any other
+            // place e.g. tabs tray.
+            val selectedTab = state.tabs.firstOrNull { it.isSelected }
+            LaunchedEffect(selectedTab?.id) {
+                if (selectedTab != null) {
+                    val selectedItemInfo =
+                        listState.layoutInfo.visibleItemsInfo.firstOrNull { it.key == selectedTab.id }
+
+                    if (listState.isItemPartiallyVisible(selectedItemInfo) || selectedItemInfo == null) {
+                        listState.animateScrollToItem(state.tabs.indexOf(selectedTab))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun LazyListState.isItemPartiallyVisible(itemInfo: LazyListItemInfo?) =
+    itemInfo != null &&
+        (itemInfo.offset + itemInfo.size > layoutInfo.viewportEndOffset || itemInfo.offset < 0)
+
+@Composable
+private fun TabItem(
+    state: TabStripItem,
+    modifier: Modifier = Modifier,
+    onCloseTabClick: (id: String) -> Unit,
+    onSelectedTabClick: (id: String) -> Unit,
+) {
+    TabStripCard(
+        modifier = modifier.fillMaxSize(),
+        backgroundColor =
+        if (state.isPrivate) {
+            if (state.isSelected) {
+                FirefoxTheme.colors.layer3
+            } else {
+                FirefoxTheme.colors.layer2
+            }
+        } else {
+            if (state.isSelected) {
+                FirefoxTheme.colors.layer2
+            } else {
+                FirefoxTheme.colors.layer3
+            }
+        },
+        elevation = if (state.isSelected) {
+            selectedTabStripCardElevation
+        } else {
+            defaultTabStripCardElevation
+        },
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable { onSelectedTabClick(state.id) },
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                modifier = Modifier.weight(1f, fill = false),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Spacer(modifier = Modifier.size(8.dp))
+
+                TabStripIcon(state.url)
+
+                Spacer(modifier = Modifier.size(8.dp))
+
+                Text(
+                    text = state.title,
+                    color = FirefoxTheme.colors.textPrimary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = FirefoxTheme.typography.subtitle2,
+                )
+            }
+
+            IconButton(onClick = { onCloseTabClick(state.id) }) {
+                Icon(
+                    painter = painterResource(R.drawable.mozac_ic_cross_20),
+                    tint = FirefoxTheme.colors.iconPrimary,
+                    contentDescription = stringResource(R.string.close_tab),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TabStripIcon(url: String) {
+    Box(
+        modifier = Modifier
+            .size(tabStripIconSize)
+            .clip(CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Favicon(
+            url = url,
+            size = tabStripIconSize,
+        )
+    }
+}
+
+private class TabUIStateParameterProvider : PreviewParameterProvider<TabStripState> {
+    override val values: Sequence<TabStripState>
+        get() = sequenceOf(
+            TabStripState(
+                listOf(
+                    TabStripItem(
+                        id = "1",
+                        title = "Tab 1",
+                        url = "https://www.mozilla.org",
+                        isPrivate = false,
+                        isSelected = false,
+                    ),
+                    TabStripItem(
+                        id = "2",
+                        title = "Tab 2 with a very long title that should be truncated",
+                        url = "https://www.mozilla.org",
+                        isPrivate = false,
+                        isSelected = false,
+                    ),
+                    TabStripItem(
+                        id = "3",
+                        title = "Selected tab",
+                        url = "https://www.mozilla.org",
+                        isPrivate = false,
+                        isSelected = true,
+                    ),
+                    TabStripItem(
+                        id = "p1",
+                        title = "Private tab 1",
+                        url = "https://www.mozilla.org",
+                        isPrivate = true,
+                        isSelected = false,
+                    ),
+                    TabStripItem(
+                        id = "p2",
+                        title = "Private selected tab",
+                        url = "https://www.mozilla.org",
+                        isPrivate = true,
+                        isSelected = true,
+                    ),
+                ),
+            ),
+        )
+}
+
+@Preview(device = Devices.TABLET)
+@Composable
+private fun TabStripPreview(
+    @PreviewParameter(TabUIStateParameterProvider::class) tabStripState: TabStripState,
+) {
+    FirefoxTheme {
+        TabStripContentPreview(tabStripState.tabs.filter { !it.isPrivate })
+    }
+}
+
+@Preview(device = Devices.TABLET)
+@Composable
+private fun TabStripPreviewDarkMode(
+    @PreviewParameter(TabUIStateParameterProvider::class) tabStripState: TabStripState,
+) {
+    FirefoxTheme(theme = Theme.Dark) {
+        TabStripContentPreview(tabStripState.tabs.filter { !it.isPrivate })
+    }
+}
+
+@Preview(device = Devices.TABLET)
+@Composable
+private fun TabStripPreviewPrivateMode(
+    @PreviewParameter(TabUIStateParameterProvider::class) tabStripState: TabStripState,
+) {
+    FirefoxTheme(theme = Theme.Private) {
+        TabStripContentPreview(tabStripState.tabs.filter { it.isPrivate })
+    }
+}
+
+@Composable
+private fun TabStripContentPreview(tabs: List<TabStripItem>) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(dimensionResource(id = R.dimen.tab_strip_height)),
+        contentAlignment = Alignment.Center,
+    ) {
+        TabStripContent(
+            state = TabStripState(
+                tabs = tabs,
+            ),
+            onAddTabClick = {},
+            onCloseTabClick = {},
+            onSelectedTabClick = {},
+        )
+    }
+}
+
+@Preview(device = Devices.TABLET)
+@Composable
+private fun TabStripPreview() {
+    val browserStore = BrowserStore()
+
+    FirefoxTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(dimensionResource(id = R.dimen.tab_strip_height)),
+            contentAlignment = Alignment.Center,
+        ) {
+            TabStrip(
+                appStore = AppStore(),
+                browserStore = browserStore,
+                tabsUseCases = TabsUseCases(browserStore),
+                onAddTabClick = {
+                    val tab = createTab(
+                        url = "www.example.com",
+                    )
+                    browserStore.dispatch(TabListAction.AddTabAction(tab))
+                },
+                onLastTabClose = {},
+                onSelectedTabClick = {},
+            )
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/tabstrip/TabStripCard.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/tabstrip/TabStripCard.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.browser.tabstrip
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.compose.annotation.LightDarkPreview
+import org.mozilla.fenix.theme.FirefoxTheme
+
+private val cardShape = RoundedCornerShape(8.dp)
+internal val defaultTabStripCardElevation = 0.dp
+internal val selectedTabStripCardElevation = 1.dp
+
+/**
+ * Card composable used in Tab Strip items.
+ *
+ * @param modifier The modifier to be applied to the card.
+ * @param backgroundColor The background color of the card.
+ * @param elevation The elevation of the card.
+ * @param content The content of the card.
+ */
+@Composable
+fun TabStripCard(
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = FirefoxTheme.colors.layer3,
+    elevation: Dp = defaultTabStripCardElevation,
+    content: @Composable () -> Unit,
+) {
+    Card(
+        shape = cardShape,
+        backgroundColor = backgroundColor,
+        elevation = elevation,
+        modifier = modifier,
+        content = content,
+    )
+}
+
+@LightDarkPreview
+@Composable
+private fun TabStripCardPreview() {
+    FirefoxTheme {
+        TabStripCard {
+            Box(
+                modifier = Modifier
+                    .height(56.dp)
+                    .width(200.dp)
+                    .padding(8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "Tab Strip Card",
+                    color = FirefoxTheme.colors.textPrimary,
+                    style = FirefoxTheme.typography.subtitle1,
+                )
+            }
+        }
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/tabstrip/TabStripState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/tabstrip/TabStripState.kt
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.browser.tabstrip
+
+import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
+import mozilla.components.browser.state.state.BrowserState
+
+/**
+ * The ui state of the tabs strip.
+ *
+ * @property tabs The list of [TabStripItem].
+ */
+data class TabStripState(
+    val tabs: List<TabStripItem>,
+) {
+    companion object {
+        val initial = TabStripState(tabs = emptyList())
+    }
+}
+
+/**
+ * The ui state of a tab.
+ *
+ * @property id The id of the tab.
+ * @property title The title of the tab.
+ * @property url The url of the tab.
+ * @property isPrivate Whether or not the tab is private.
+ * @property isSelected Whether or not the tab is selected.
+ */
+data class TabStripItem(
+    val id: String,
+    val title: String,
+    val url: String,
+    val isPrivate: Boolean,
+    val isSelected: Boolean,
+)
+
+/**
+ * Converts [BrowserState] to [TabStripState] that contains the information needed to render the
+ * tabs strip.
+ *
+ * @param isSelectDisabled When true, the tabs will show as selected.
+ * @param isPrivateMode Whether or not the browser is in private mode.
+ */
+internal fun BrowserState.toTabStripState(
+    isSelectDisabled: Boolean,
+    isPrivateMode: Boolean,
+): TabStripState {
+    return TabStripState(
+        tabs = getNormalOrPrivateTabs(isPrivateMode)
+            .map {
+                TabStripItem(
+                    id = it.id,
+                    title = it.content.title.ifBlank { it.content.url },
+                    url = it.content.url,
+                    isPrivate = it.content.private,
+                    isSelected = !isSelectDisabled && it.id == selectedTabId,
+                )
+            },
+    )
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -579,7 +579,9 @@ class HomeFragment : Fragment() {
         )
 
         toolbarView?.build()
-        initTabStrip()
+        if (requireContext().settings().isTabletAndTabStripEnabled) {
+            initTabStrip()
+        }
 
         PrivateBrowsingButtonView(binding.privateBrowsingButton, browsingModeManager) { newMode ->
             sessionControlInteractor.onPrivateModeButtonClicked(newMode)
@@ -658,10 +660,6 @@ class HomeFragment : Fragment() {
     }
 
     private fun initTabStrip() {
-        if (!resources.getBoolean(R.bool.tablet)) {
-            return
-        }
-
         binding.tabStripView.isVisible = true
         binding.tabStripView.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.semantics.testTagsAsResourceId
@@ -77,6 +78,7 @@ import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.ui.colors.PhotonColors
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.GleanMetrics.HomeScreen
 import org.mozilla.fenix.GleanMetrics.Homepage
 import org.mozilla.fenix.GleanMetrics.PrivateBrowsingShortcutCfr
@@ -84,6 +86,7 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.addons.showSnackBar
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.tabstrip.TabStrip
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.PrivateShortcutCreateManager
 import org.mozilla.fenix.components.TabCollectionStorage
@@ -576,6 +579,7 @@ class HomeFragment : Fragment() {
         )
 
         toolbarView?.build()
+        initTabStrip()
 
         PrivateBrowsingButtonView(binding.privateBrowsingButton, browsingModeManager) { newMode ->
             sessionControlInteractor.onPrivateModeButtonClicked(newMode)
@@ -651,6 +655,31 @@ class HomeFragment : Fragment() {
             profilerStartTime,
             "HomeFragment.onViewCreated",
         )
+    }
+
+    private fun initTabStrip() {
+        if (!resources.getBoolean(R.bool.tablet)) {
+            return
+        }
+
+        binding.tabStripView.isVisible = true
+        binding.tabStripView.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                FirefoxTheme {
+                    TabStrip(
+                        onHome = true,
+                        onAddTabClick = {
+                            sessionControlInteractor.onNavigateSearch()
+                        },
+                        onSelectedTabClick = {
+                            (requireActivity() as HomeActivity).openToBrowser(BrowserDirection.FromHome)
+                        },
+                        onLastTabClose = {},
+                    )
+                }
+            }
+        }
     }
 
     /**

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/ToolbarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/ToolbarView.kt
@@ -66,16 +66,27 @@ class ToolbarView(
                     gravity = Gravity.TOP
                 }
 
+                val isTabletAndTabStripEnabled = context.resources.getBoolean(R.bool.tablet)
                 ConstraintSet().apply {
                     clone(binding.toolbarLayout)
                     clear(binding.bottomBar.id, ConstraintSet.BOTTOM)
                     clear(binding.bottomBarShadow.id, ConstraintSet.BOTTOM)
-                    connect(
-                        binding.bottomBar.id,
-                        ConstraintSet.TOP,
-                        ConstraintSet.PARENT_ID,
-                        ConstraintSet.TOP,
-                    )
+
+                    if (isTabletAndTabStripEnabled) {
+                        connect(
+                            binding.bottomBar.id,
+                            ConstraintSet.TOP,
+                            binding.tabStripView.id,
+                            ConstraintSet.BOTTOM,
+                        )
+                    } else {
+                        connect(
+                            binding.bottomBar.id,
+                            ConstraintSet.TOP,
+                            ConstraintSet.PARENT_ID,
+                            ConstraintSet.TOP,
+                        )
+                    }
                     connect(
                         binding.bottomBarShadow.id,
                         ConstraintSet.TOP,
@@ -98,7 +109,12 @@ class ToolbarView(
 
                 binding.homeAppBar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                     topMargin =
-                        context.resources.getDimensionPixelSize(R.dimen.home_fragment_top_toolbar_header_margin)
+                        context.resources.getDimensionPixelSize(R.dimen.home_fragment_top_toolbar_header_margin) +
+                        if (isTabletAndTabStripEnabled) {
+                            context.resources.getDimensionPixelSize(R.dimen.tab_strip_height)
+                        } else {
+                            0
+                        }
                 }
             }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/home/ToolbarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/home/ToolbarView.kt
@@ -66,7 +66,7 @@ class ToolbarView(
                     gravity = Gravity.TOP
                 }
 
-                val isTabletAndTabStripEnabled = context.resources.getBoolean(R.bool.tablet)
+                val isTabletAndTabStripEnabled = context.settings().isTabletAndTabStripEnabled
                 ConstraintSet().apply {
                     clone(binding.toolbarLayout)
                     clear(binding.bottomBar.id, ConstraintSet.BOTTOM)

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -4,9 +4,11 @@
 
 package org.mozilla.fenix.search.toolbar
 
+import android.view.ViewGroup
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
+import androidx.core.view.updateMargins
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
@@ -123,6 +125,12 @@ class ToolbarView(
                     }
                 },
             )
+
+            if (settings.isTabletAndTabStripEnabled) {
+                (layoutParams as ViewGroup.MarginLayoutParams).updateMargins(
+                    top = context.resources.getDimensionPixelSize(R.dimen.tab_strip_height),
+                )
+            }
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -10,7 +10,9 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.AppTheme
@@ -51,8 +53,19 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         bindLightTheme()
         bindAutoBatteryTheme()
         setupRadioGroups()
-        setupToolbarCategory()
-        setupGesturesCategory()
+        val tabletAndTabStripEnabled = requireContext().settings().isTabletAndTabStripEnabled
+        if (tabletAndTabStripEnabled) {
+            val preferenceScreen: PreferenceScreen =
+                requirePreference(R.string.pref_key_customization_preference_screen)
+            val toolbarPrefCategory: PreferenceCategory =
+                requirePreference(R.string.pref_key_customization_category_toolbar)
+            preferenceScreen.removePreference(toolbarPrefCategory)
+        } else {
+            setupToolbarCategory()
+        }
+        // if tab strip is enabled, swipe toolbar to switch tabs should not be enabled so the
+        // preference is not shown
+        setupGesturesCategory(isSwipeToolbarToSwitchTabsVisible = !tabletAndTabStripEnabled)
     }
 
     private fun setupRadioGroups() {
@@ -140,7 +153,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         addToRadioGroup(topPreference, bottomPreference)
     }
 
-    private fun setupGesturesCategory() {
+    private fun setupGesturesCategory(isSwipeToolbarToSwitchTabsVisible: Boolean) {
         requirePreference<SwitchPreference>(R.string.pref_key_website_pull_to_refresh).apply {
             isVisible = FeatureFlags.pullToRefreshEnabled
             isChecked = context.settings().isPullToRefreshEnabledInBrowser
@@ -152,6 +165,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         }
         requirePreference<SwitchPreference>(R.string.pref_key_swipe_toolbar_switch_tabs).apply {
             isChecked = context.settings().isSwipeToolbarToSwitchTabsEnabled
+            isVisible = isSwipeToolbarToSwitchTabsVisible
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -122,6 +122,8 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
             }
         }
 
+        setupTabStripPreference()
+
         // for performance reasons, this is only available in Nightly or Debug builds
         requirePreference<EditTextPreference>(R.string.pref_key_custom_glean_server_url).apply {
             isVisible = Config.channel.isNightlyOrDebug && BuildConfig.GLEAN_CUSTOM_URL.isNullOrEmpty()
@@ -134,6 +136,14 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
         requirePreference<SwitchPreference>(R.string.pref_key_remote_server_prod).apply {
             isVisible = true
             isChecked = context.settings().useProductionRemoteSettingsServer
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+    }
+
+    private fun setupTabStripPreference() {
+        requirePreference<SwitchPreference>(R.string.pref_key_enable_tab_strip).apply {
+            isVisible = Config.channel.isNightlyOrDebug && context.resources.getBoolean(R.bool.tablet)
+            isChecked = context.settings().isTabStripEnabled
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -854,6 +854,9 @@ class Settings(private val appContext: Context) : PreferencesHolder {
             return touchExplorationIsEnabled || switchServiceIsEnabled
         }
 
+    private val isTablet: Boolean
+        get() = appContext.resources.getBoolean(R.bool.tablet)
+
     var lastKnownMode: BrowsingMode = BrowsingMode.Normal
         get() {
             val lastKnownModeWasPrivate = preferences.getBoolean(
@@ -922,7 +925,13 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     val toolbarPosition: ToolbarPosition
-        get() = if (shouldUseBottomToolbar) ToolbarPosition.BOTTOM else ToolbarPosition.TOP
+        get() = if (isTablet) {
+            ToolbarPosition.TOP
+        } else if (shouldUseBottomToolbar) {
+            ToolbarPosition.BOTTOM
+        } else {
+            ToolbarPosition.TOP
+        }
 
     /**
      * Check each active accessibility service to see if it can perform gestures, if any can,

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -857,6 +857,17 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     private val isTablet: Boolean
         get() = appContext.resources.getBoolean(R.bool.tablet)
 
+    /**
+     * Indicates if the user has enabled the tab strip feature.
+     */
+    val isTabStripEnabled by booleanPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_enable_tab_strip),
+        default = false,
+    )
+
+    val isTabletAndTabStripEnabled: Boolean
+        get() = isTablet && isTabStripEnabled
+
     var lastKnownMode: BrowsingMode = BrowsingMode.Normal
         get() {
             val lastKnownModeWasPrivate = preferences.getBoolean(
@@ -925,7 +936,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     val toolbarPosition: ToolbarPosition
-        get() = if (isTablet) {
+        get() = if (isTabletAndTabStripEnabled) {
             ToolbarPosition.TOP
         } else if (shouldUseBottomToolbar) {
             ToolbarPosition.BOTTOM

--- a/fenix/app/src/main/res/layout/fragment_browser.xml
+++ b/fenix/app/src/main/res/layout/fragment_browser.xml
@@ -13,6 +13,14 @@
         android:id="@+id/browserWindow"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+        
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/tabStripView"
+            app:layout_constraintBottom_toTopOf="@+id/browserLayout"
+            app:layout_constraintTop_toTopOf="parent"
+            android:layout_width="match_parent"
+            android:visibility="gone"
+            android:layout_height="@dimen/tab_strip_height" />
 
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:id="@+id/browserLayout"
@@ -20,7 +28,7 @@
             android:layout_height="0dp"
             app:layout_constraintHeight_min="1dp"
             app:layout_constraintBottom_toTopOf="@+id/addressSelectBar"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tabStripView"
             tools:context="browser.BrowserFragment">
 
             <mozilla.components.ui.widgets.VerticalSwipeRefreshLayout

--- a/fenix/app/src/main/res/layout/fragment_home.xml
+++ b/fenix/app/src/main/res/layout/fragment_home.xml
@@ -109,6 +109,14 @@
         android:layout_gravity="bottom"
         tools:context=".home.HomeFragment">
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/tabStripView"
+            android:layout_width="match_parent"
+            app:layout_constraintBottom_toTopOf="@id/bottom_bar"
+            app:layout_constraintTop_toTopOf="parent"
+            android:visibility="gone"
+            android:layout_height="@dimen/tab_strip_height" />
+
         <View
             android:id="@+id/bottom_bar"
             android:layout_width="0dp"

--- a/fenix/app/src/main/res/values-sw600dp/dimens.xml
+++ b/fenix/app/src/main/res/values-sw600dp/dimens.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <!-- Also used as toolbar top margin when tab strip is enabled to accommodate the tab strip-->
+    <dimen name="tab_strip_height">48dp</dimen>
+</resources>

--- a/fenix/app/src/main/res/values/dimens.xml
+++ b/fenix/app/src/main/res/values/dimens.xml
@@ -70,6 +70,7 @@
 
     <!-- Browser Toolbar -->
     <dimen name="browser_toolbar_height">56dp</dimen>
+    <dimen name="tab_strip_height">0dp</dimen>
 
     <!-- Bookmark Edit Fragment  -->
     <dimen name="bookmark_edit_text_height">48dp</dimen>

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -78,6 +78,7 @@
     <string name="pref_key_enable_suggest_strong_password" translatable="false">pref_key_suggest_strong_password_enabled</string>
     <string name="pref_key_enable_debug_drawer" translatable="false">pref_key_enable_debug_drawer</string>
     <string name="pref_key_show_first_time_translation" translatable="false">pref_key_show_first_time_translation</string>
+    <string name="pref_key_enable_tab_strip" translatable="false">pref_key_enable_tab_strip</string>
 
     <!-- Data Choices -->
     <string name="pref_key_telemetry" translatable="false">pref_key_telemetry</string>
@@ -155,12 +156,14 @@
     <string name="pref_key_follow_device_theme" translatable="false">pref_key_follow_device_theme</string>
 
     <!-- Customization Settings -->
+    <string name="pref_key_customization_preference_screen" translatable="false">pref_key_customization_preference_screen</string>
     <string name="pref_key_website_pull_to_refresh" translatable="false">pref_key_website_pull_to_refresh</string>
     <string name="pref_key_dynamic_toolbar" translatable="false">pref_key_dynamic_toolbar</string>
     <string name="pref_key_swipe_toolbar_switch_tabs" translatable="false">pref_key_swipe_toolbar_switch_tabs</string>
     <string name="pref_key_swipe_toolbar_show_tabs" translatable="false">pref_key_swipe_toolbar_show_tabs</string>
     <string name="pref_key_recent_tabs" translatable="false">pref_key_recent_tabs</string>
     <string name="pref_key_recent_bookmarks" translatable="false">pref_key_recent_bookmarks</string>
+    <string name="pref_key_customization_category_toolbar" translatable="false">pref_key_customization_category_toolbar</string>
 
     <!-- HTTPS Only Settings -->
     <string name="pref_key_https_only_settings" translatable="false">pref_key_https_only_settings</string>

--- a/fenix/app/src/main/res/values/static_strings.xml
+++ b/fenix/app/src/main/res/values/static_strings.xml
@@ -78,6 +78,8 @@
     <string name="preferences_debug_felt_privacy" translatable="false">Enable Felt Privacy</string>
     <!-- Label for enabling the Debug Drawer -->
     <string name="preferences_debug_settings_debug_drawer" translatable="false">Enable Debug Drawer</string>
+    <!-- Label for enabling the Tab Strip -->
+    <string name="preferences_debug_settings_tab_strip" translatable="false">Enable Tab Strip</string>
 
     <!-- A secret menu option in the tabs tray for making a tab inactive for testing. -->
     <string name="inactive_tabs_menu_item">Make inactive</string>

--- a/fenix/app/src/main/res/xml/customization_preferences.xml
+++ b/fenix/app/src/main/res/xml/customization_preferences.xml
@@ -3,7 +3,8 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:key="@string/pref_key_customization_preference_screen" >
     <androidx.preference.PreferenceCategory
         android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_theme"
@@ -34,6 +35,7 @@
     <androidx.preference.PreferenceCategory
         android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_toolbar"
+        android:key="@string/pref_key_customization_category_toolbar"
         app:iconSpaceReserved="false">
         <org.mozilla.fenix.settings.RadioButtonPreference
             android:key="@string/pref_key_toolbar_top"

--- a/fenix/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/fenix/app/src/main/res/xml/secret_settings_preferences.xml
@@ -50,6 +50,11 @@
         android:key="@string/pref_key_enable_debug_drawer"
         android:title="@string/preferences_debug_settings_debug_drawer"
         app:iconSpaceReserved="false" />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/pref_key_enable_tab_strip"
+        android:title="@string/preferences_debug_settings_tab_strip"
+        app:iconSpaceReserved="false" />
     <EditTextPreference
         android:key="@string/pref_key_custom_glean_server_url"
         android:title="@string/preferences_debug_settings_custom_glean_server_url"

--- a/fenix/app/src/test/java/org/mozilla/fenix/browser/tabstrip/TabStripStateTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/browser/tabstrip/TabStripStateTest.kt
@@ -1,0 +1,244 @@
+package org.mozilla.fenix.browser.tabstrip
+
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.createTab
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TabStripStateTest {
+
+    @Test
+    fun `WHEN browser state tabs is empty THEN tabs strip state tabs is empty`() {
+        val browserState = BrowserState(tabs = emptyList())
+        val actual = browserState.toTabStripState(isSelectDisabled = false, isPrivateMode = false)
+
+        val expected = TabStripState(tabs = emptyList())
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN private mode is off THEN tabs strip state tabs should include only non private tabs`() {
+        val browserState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    url = "https://example.com",
+                    title = "Example 1",
+                    private = false,
+                    id = "1",
+                ),
+                createTab(
+                    url = "https://example2.com",
+                    title = "Example 2",
+                    private = true,
+                    id = "2",
+                ),
+                createTab(
+                    url = "https://example3.com",
+                    title = "Example 3",
+                    private = false,
+                    id = "3",
+                ),
+            ),
+        )
+        val actual = browserState.toTabStripState(isSelectDisabled = false, isPrivateMode = false)
+
+        val expected = TabStripState(
+            tabs = listOf(
+                TabStripItem(
+                    id = "1",
+                    title = "Example 1",
+                    url = "https://example.com",
+                    isSelected = false,
+                    isPrivate = false,
+                ),
+                TabStripItem(
+                    id = "3",
+                    title = "Example 3",
+                    url = "https://example3.com",
+                    isSelected = false,
+                    isPrivate = false,
+                ),
+            ),
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN private mode is on THEN tabs strip state tabs should include only private tabs`() {
+        val browserState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    url = "https://example.com",
+                    title = "Example",
+                    private = false,
+                    id = "1",
+                ),
+                createTab(
+                    url = "https://example2.com",
+                    title = "Private Example",
+                    private = true,
+                    id = "2",
+                ),
+                createTab(
+                    url = "https://example3.com",
+                    title = "Example 3",
+                    private = true,
+                    id = "3",
+                ),
+            ),
+        )
+        val actual = browserState.toTabStripState(isSelectDisabled = false, isPrivateMode = true)
+
+        val expected = TabStripState(
+            tabs = listOf(
+                TabStripItem(
+                    id = "2",
+                    title = "Private Example",
+                    url = "https://example2.com",
+                    isSelected = false,
+                    isPrivate = true,
+                ),
+                TabStripItem(
+                    id = "3",
+                    title = "Example 3",
+                    url = "https://example3.com",
+                    isSelected = false,
+                    isPrivate = true,
+                ),
+            ),
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN isSelectDisabled is false THEN tabs strip state tabs should have a selected tab`() {
+        val browserState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    url = "https://example.com",
+                    title = "Example 1",
+                    private = false,
+                    id = "1",
+                ),
+                createTab(
+                    url = "https://example2.com",
+                    title = "Example 2",
+                    private = false,
+                    id = "2",
+                ),
+            ),
+            selectedTabId = "2",
+        )
+        val actual = browserState.toTabStripState(isSelectDisabled = false, isPrivateMode = false)
+
+        val expected = TabStripState(
+            tabs = listOf(
+                TabStripItem(
+                    id = "1",
+                    title = "Example 1",
+                    url = "https://example.com",
+                    isSelected = false,
+                    isPrivate = false,
+                ),
+                TabStripItem(
+                    id = "2",
+                    title = "Example 2",
+                    url = "https://example2.com",
+                    isSelected = true,
+                    isPrivate = false,
+                ),
+            ),
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN isSelectDisabled is true THEN tabs strip state tabs should not have a selected tab`() {
+        val browserState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    url = "https://example.com",
+                    title = "Example 1",
+                    private = false,
+                    id = "1",
+                ),
+                createTab(
+                    url = "https://example2.com",
+                    title = "Example 2",
+                    private = false,
+                    id = "2",
+                ),
+            ),
+            selectedTabId = "2",
+        )
+        val actual = browserState.toTabStripState(isSelectDisabled = true, isPrivateMode = false)
+
+        val expected = TabStripState(
+            tabs = listOf(
+                TabStripItem(
+                    id = "1",
+                    title = "Example 1",
+                    url = "https://example.com",
+                    isSelected = false,
+                    isPrivate = false,
+                ),
+                TabStripItem(
+                    id = "2",
+                    title = "Example 2",
+                    url = "https://example2.com",
+                    isSelected = false,
+                    isPrivate = false,
+                ),
+            ),
+        )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `WHEN a tab does not have a title THEN tabs strip should display the url`() {
+        val browserState = BrowserState(
+            tabs = listOf(
+                createTab(
+                    url = "https://example.com",
+                    title = "Example 1",
+                    private = false,
+                    id = "1",
+                ),
+                createTab(
+                    url = "https://example2.com",
+                    title = "",
+                    private = false,
+                    id = "2",
+                ),
+            ),
+            selectedTabId = "2",
+        )
+        val actual = browserState.toTabStripState(isSelectDisabled = false, isPrivateMode = false)
+
+        val expected = TabStripState(
+            tabs = listOf(
+                TabStripItem(
+                    id = "1",
+                    title = "Example 1",
+                    url = "https://example.com",
+                    isSelected = false,
+                    isPrivate = false,
+                ),
+                TabStripItem(
+                    id = "2",
+                    title = "https://example2.com",
+                    url = "https://example2.com",
+                    isSelected = true,
+                    isPrivate = false,
+                ),
+            ),
+        )
+
+        assertEquals(expected, actual)
+    }
+}

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
@@ -146,6 +146,7 @@ class ToolbarViewTest {
         every { context.settings().showUnifiedSearchFeature } returns true
         every { context.settings().shouldShowHistorySuggestions } returns true
         every { context.settings().shouldShowBookmarkSuggestions } returns true
+        every { context.settings().isTabletAndTabStripEnabled } returns false
         val view = buildToolbarView(false)
         mockkObject(FeatureFlags)
 
@@ -161,6 +162,7 @@ class ToolbarViewTest {
         every { context.settings().showUnifiedSearchFeature } returns true
         every { context.settings().shouldShowHistorySuggestions } returns true
         every { context.settings().shouldShowBookmarkSuggestions } returns true
+        every { context.settings().isTabletAndTabStripEnabled } returns false
         val view = buildToolbarView(false)
         mockkObject(FeatureFlags)
 
@@ -446,6 +448,7 @@ class ToolbarViewTest {
     fun `GIVEN autocomplete disabled WHEN the toolbar view is initialized THEN create an autocomplete with disabled functionality`() {
         val settings: Settings = mockk {
             every { shouldAutocompleteInAwesomebar } returns false
+            every { isTabletAndTabStripEnabled } returns false
         }
         val toolbarView = buildToolbarView(true, settings)
 
@@ -458,6 +461,7 @@ class ToolbarViewTest {
     fun `GIVEN autocomplete enabled WHEN the toolbar view is initialized THEN create an autocomplete with enabled functionality`() {
         val settings: Settings = mockk {
             every { shouldAutocompleteInAwesomebar } returns true
+            every { isTabletAndTabStripEnabled } returns false
         }
         val toolbarView = buildToolbarView(true, settings)
 


### PR DESCRIPTION
### What
– Add Secret Settiings - "Enable Tab Strip" that's visible only on tablets.
– Display open tabs in a Tab Strip above toolbar
– Add Ability to add a new tab and close tabs.

While these are not features of the Tab Strip UI, these are changes are in Settings when tab strip is enabled:
– toolbar customization in Settings is not shown as Toolbar defaults to Top.
– Swipe tab gesture to switch tabs in settings is not shown as it is disabled.


### How
– Update toolbar position based on form factor. This required replacing usages of `settings.shouldUseBottomToolbar` to `settings.toolbarPosition`. 
– `ToolbarPosition` is defaults to `TOP` when it's a tablet. This is done to simplify the implementation.
– Add dimensions to help update layouts and positioning logic
– Display TabStrip on `HomeFragment` and `BrowserFragment`. It would be ideal to join the two fragments but that's outside the scope right now.
– Add `TabStrip` composable that provides callbacks for adding a tab, selecting a tab and removal of the last tab. These are used by `BrowserFragment` and `HomeFragment` differently. 
– Create `TabUIState` model that's mapped from `TabSessionState`. This simplifies the observation and the only contains information required to render the `TabStrip`. Also helps in recompositions since only if the content in this model changes would it recompose.
– LazyRow to show `Tabs`

### Preview
[tablet-tab-strip-3.webm](https://github.com/mozilla-mobile/firefox-android/assets/38040960/fd50937d-5442-494e-b4aa-0baf75569a57)



### Known issues
–~~There's ghost padding at the bottom of `EngineView`. Keener eyes than mine could help solve this.~~

### Non exhastive list of Todos
- [x] Add secret settings feature flag
- [x] Remove customize toolbar setting for tablets
- [x] Update scroll when selecting tabs items that are partially visible.
- [ ] `TabStripState` can be marked `@Immutable` to make compose compiler aware so it doesn't need to recompose when the list doesn't change. This can also be solved by using Immutable collections from kotlinx.
- [x] Same tab width for all tabs based on number of tabs.
- [x] Display url when `content.title` is blank.
- [x] Hide tab strip when full screen.
- [ ] Tab strip should scroll up when toolbar scrolls up with content.


### Note for reviewers
This isn't pulling from a specific design but is using the usual design system tokens. 


### 26 Feb Update 
Any remaining bugs and functionality will be tracked separate as part of this [meta](https://bugzilla.mozilla.org/show_bug.cgi?id=1882105). 


------------------------------------------------------------------------------------------------------------------------

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









































### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1875465