### PR TITLE
Bug 1875479 - Change URL for documentation on configuring java from Mozilla shared-docs to Fenix repo in Fenix README.md's build instructions

### DIFF
--- a/fenix/README.md
+++ b/fenix/README.md
@@ -70,7 +70,7 @@ Please keep in mind that even though a feature you have in mind may seem like a 
 
 Pre-requisites:
 * Android SDK
-* To run command line tools, you'll need to configure Java: see [our how-to guide](https://github.com/mozilla-mobile/shared-docs/blob/master/android/configure_java.md).
+* To run command line tools, you'll need to configure Java: see [our how-to guide](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/configure_java.md).
 
 1. Clone or Download the repository:
 


### PR DESCRIPTION
I noticed one of the URL's was going to the archived shared-docs when there is a more up to date version in this repo. This pull request fixes that in the Fenix README.md

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1875479