### PR TITLE
Bug 1812359 - 'suspend' should also be applied to CustomTabs

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/SuspendMiddleware.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/SuspendMiddleware.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.EngineAction
-import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.selector.findTabOrCustomTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.EngineState
 import mozilla.components.concept.engine.EngineSession
@@ -43,7 +43,7 @@ internal class SuspendMiddleware(
         context: MiddlewareContext<BrowserState, BrowserAction>,
         sessionId: String,
     ) {
-        val tab = context.state.findTab(sessionId) ?: return
+        val tab = context.state.findTabOrCustomTab(sessionId) ?: return
 
         // First we unlink (which clearsEngineSession and state)
         context.dispatch(

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TrimMemoryMiddlewareTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TrimMemoryMiddlewareTest.kt
@@ -234,8 +234,8 @@ class TrimMemoryMiddlewareTest {
         }
 
         store.state.findCustomTab("twitch")!!.engineState.apply {
-            assertNotNull(engineSession)
-            assertNotNull(engineObserver)
+            assertNull(engineSession)
+            assertNull(engineObserver)
             assertNotNull(engineSessionState)
         }
 
@@ -247,9 +247,9 @@ class TrimMemoryMiddlewareTest {
 
         verify(engineSessionTheVerge).close()
         verify(engineSessionYouTube).close()
+        verify(engineSessionTwitch).close()
 
         verify(engineSessionReddit, never()).close()
-        verify(engineSessionTwitch, never()).close()
         verify(engineSessionGoogleNews, never()).close()
         verify(engineSessionFacebook, never()).close()
         verify(engineSessionAmazon, never()).close()


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1812359