### PR TITLE
Bug 1875515 - record Nimbus is_ready event

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -45,6 +45,9 @@ permalink: /changelog/
 * **support-base**
   * Make `message` param non optional for the Logging APIs. [Bug 1867606](https://bugzilla.mozilla.org/show_bug.cgi?id=1867606)
 
+* **nimbus**
+  * Add `nimbus-is-ready` feature and call Nimbus' `recordIsReady` when the Nimbus API is ready [Bug 1875515](https://bugzilla.mozilla.org/show_bug.cgi?id=1875515).
+
 # 121.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v120..releases_v121)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/releases_v121/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)

--- a/fenix/app/nimbus.fml.yaml
+++ b/fenix/app/nimbus.fml.yaml
@@ -371,6 +371,17 @@ features:
       - channel: nightly
         value:
           enabled: true
+
+  nimbus-is-ready:
+    description: >
+      A feature that provides the number of Nimbus is_ready events to send
+      when Nimbus finishes launching.
+    variables:
+      event-count:
+        description: The number of events that should be sent.
+        type: Int
+        default: 1
+
 types:
   objects: {}
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -70,7 +70,9 @@ fun createNimbus(context: Context, urlString: String?): NimbusApi {
         onFetchCallback = {
             context.settings().nimbusExperimentsFetched = true
         }
-    }.build(appInfo)
+    }.build(appInfo).also { nimbusApi ->
+        nimbusApi.recordIsReady(FxNimbus.features.nimbusIsReady.value().eventCount)
+    }
 }
 
 private fun Context.reportError(message: String, e: Throwable) {


### PR DESCRIPTION
This PR is of O(_n_) [complexity](https://www.egorand.dev/the-big-o-of-code-reviews/).

The NimbusSetup file is mostly untested, and the Nimbus API's `recordIsReady` function records internal-to-nimbus Glean events. The `recordIsReady` function is tested [here](https://github.com/mozilla/application-services/pull/6063/files#diff-3d95777c584e63ddf89922d9a523258d2b5490f0e140db2fb3579c7dc07a6f50).

Depends on code from mozilla/application-services#6063 — should be in Nightly 01/20/24. You can build this locally before this day by checking out and using a local copy of application-services.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1875515