### PR TITLE
Add some basic prototypes for demo

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/readermode/BrowserNavigator.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/readermode/BrowserNavigator.kt
@@ -1,0 +1,173 @@
+package org.mozilla.fenix.browser.readermode
+
+import androidx.annotation.IdRes
+import androidx.navigation.NavController
+import androidx.navigation.NavDirections
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.search.SearchEngine
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.base.profiler.Profiler
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.storage.HistoryMetadataKey
+import mozilla.components.feature.search.SearchUseCases
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.support.ktx.kotlin.isUrl
+import mozilla.components.support.ktx.kotlin.toNormalizedUrl
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.ext.alreadyOnDestination
+import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.utils.Settings
+
+class BrowserNavigator(
+    private val addTabUseCase: TabsUseCases.AddNewTabUseCase,
+    private val sessionUseCases: SessionUseCases,
+    private val searchUseCases: SearchUseCases,
+    private val appStore: AppStore,
+    private val browserStore: BrowserStore,
+    private val profiler: Profiler?,
+    private val settings: Settings,
+    private val getNavDirections: (BrowserDirection, String?) -> NavDirections?,
+    private val getNavController: () -> NavController,
+) {
+
+    constructor(
+        components: Components,
+        settings: Settings,
+        getNavDirections: (BrowserDirection, String?) -> NavDirections?,
+        getNavController: () -> NavController,
+    ) : this(
+        components.useCases.tabsUseCases.addTab,
+        components.useCases.sessionUseCases,
+        components.useCases.searchUseCases,
+        components.appStore,
+        components.core.store,
+        components.core.engine.profiler,
+        settings,
+        getNavDirections,
+        getNavController,
+    )
+
+    fun openToBrowserAndLoad(
+        searchTermOrURL: String,
+        newTab: Boolean,
+        from: BrowserDirection,
+        customTabSessionId: String? = null,
+        engine: SearchEngine? = null,
+        forceSearch: Boolean = false,
+        flags: EngineSession.LoadUrlFlags = EngineSession.LoadUrlFlags.none(),
+        requestDesktopMode: Boolean = false,
+        historyMetadata: HistoryMetadataKey? = null,
+        additionalHeaders: Map<String, String>? = null,
+    ) {
+        openToBrowser(from, customTabSessionId)
+        load(
+            searchTermOrURL = searchTermOrURL,
+            newTab = newTab,
+            engine = engine,
+            forceSearch = forceSearch,
+            flags = flags,
+            requestDesktopMode = requestDesktopMode,
+            historyMetadata = historyMetadata,
+            additionalHeaders = additionalHeaders,
+        )
+    }
+
+    fun openToBrowser(from: BrowserDirection, customTabSessionId: String? = null) {
+        if (getNavController().alreadyOnDestination(R.id.browserFragment)) return
+        @IdRes val fragmentId = if (from.fragmentId != 0) from.fragmentId else null
+        val directions = getNavDirections(from, customTabSessionId)
+        if (directions != null) {
+            getNavController().nav(fragmentId, directions)
+        }
+    }
+
+    private fun load(
+        searchTermOrURL: String,
+        newTab: Boolean,
+        engine: SearchEngine?,
+        forceSearch: Boolean,
+        flags: EngineSession.LoadUrlFlags = EngineSession.LoadUrlFlags.none(),
+        requestDesktopMode: Boolean = false,
+        historyMetadata: HistoryMetadataKey? = null,
+        additionalHeaders: Map<String, String>? = null,
+        mode: BrowsingMode? = null,
+    ) {
+        val startTime = profiler?.getProfilerTime()
+
+        val private = when (mode ?: appStore.state.mode) {
+            BrowsingMode.Private -> true
+            BrowsingMode.Normal -> false
+        }
+
+        // In situations where we want to perform a search but have no search engine (e.g. the user
+        // has removed all of them, or we couldn't load any) we will pass searchTermOrURL to Gecko
+        // and let it try to load whatever was entered.
+        if ((!forceSearch && searchTermOrURL.isUrl()) || engine == null) {
+            val tabId = if (newTab) {
+                addTabUseCase(
+                    url = searchTermOrURL.toNormalizedUrl(),
+                    flags = flags,
+                    private = private,
+                    historyMetadata = historyMetadata,
+                )
+            } else {
+                sessionUseCases.loadUrl(
+                    url = searchTermOrURL.toNormalizedUrl(),
+                    flags = flags,
+                )
+                browserStore.state.selectedTabId
+            }
+
+            if (requestDesktopMode && tabId != null) {
+                handleRequestDesktopMode(tabId)
+            }
+        } else {
+            if (newTab) {
+                val searchUseCase = if (private) {
+                    searchUseCases.newPrivateTabSearch
+                } else {
+                    searchUseCases.newTabSearch
+                }
+                searchUseCase.invoke(
+                    searchTerms = searchTermOrURL,
+                    source = SessionState.Source.Internal.UserEntered,
+                    selected = true,
+                    searchEngine = engine,
+                    flags = flags,
+                    additionalHeaders = additionalHeaders,
+                )
+            } else {
+                searchUseCases.defaultSearch.invoke(
+                    searchTerms = searchTermOrURL,
+                    searchEngine = engine,
+                    flags = flags,
+                    additionalHeaders = additionalHeaders,
+                )
+            }
+        }
+
+        if (profiler?.isProfilerActive() == true) {
+            // Wrapping the `addMarker` method with `isProfilerActive` even though it's no-op when
+            // profiler is not active. That way, `text` argument will not create a string builder all the time.
+            profiler.addMarker(
+                "HomeActivity.load",
+                startTime,
+                "newTab: $newTab",
+            )
+        }
+    }
+
+    private fun handleRequestDesktopMode(tabId: String) {
+        sessionUseCases.requestDesktopSite(true, tabId)
+        browserStore.dispatch(ContentAction.UpdateDesktopModeAction(tabId, true))
+
+        // Reset preference value after opening the tab in desktop mode
+        settings.openNextTabInDesktopMode = false
+    }
+}

--- a/fenix/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
@@ -18,8 +18,10 @@ import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import mozilla.components.concept.base.crash.Breadcrumb
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.NavHostActivity
 import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.readermode.BrowserNavigator
 import org.mozilla.fenix.components.Components
 
 /**
@@ -149,3 +151,13 @@ fun Fragment.registerForActivityResult(
         }
     }
 }
+
+fun Fragment.buildBrowserNavigator() =
+    BrowserNavigator(
+        components = requireComponents,
+        settings = requireActivity().settings(),
+        getNavDirections = { from: BrowserDirection, customTabId: String? ->
+            requireActivity().getNavDirections(from, customTabId)
+        },
+        getNavController = { findNavController() },
+    )

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -49,6 +49,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.history.DefaultPagedHistoryProvider
 import org.mozilla.fenix.databinding.FragmentHistoryBinding
+import org.mozilla.fenix.ext.buildBrowserNavigator
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.nav
@@ -60,6 +61,7 @@ import org.mozilla.fenix.library.history.state.HistoryNavigationMiddleware
 import org.mozilla.fenix.library.history.state.HistoryStorageMiddleware
 import org.mozilla.fenix.library.history.state.HistorySyncMiddleware
 import org.mozilla.fenix.library.history.state.HistoryTelemetryMiddleware
+import org.mozilla.fenix.library.history.state.HistoryUiEffectMiddleware
 import org.mozilla.fenix.library.history.state.bindings.MenuBinding
 import org.mozilla.fenix.library.history.state.bindings.PendingDeletionBinding
 import org.mozilla.fenix.tabstray.Page
@@ -112,7 +114,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler, 
                 middleware = listOf(
                     HistoryNavigationMiddleware(
                         navController = findNavController(),
-                        openToBrowser = ::openItem,
+                        browserNavigator = buildBrowserNavigator(),
                         onBackPressed = requireActivity().onBackPressedDispatcher::onBackPressed,
                     ),
                     HistoryTelemetryMiddleware(
@@ -120,8 +122,10 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler, 
                     ),
                     HistorySyncMiddleware(
                         accountManager = requireContext().components.backgroundServices.accountManager,
-                        refreshView = { historyView.historyAdapter.refresh() },
                         scope = lifecycleScope,
+                    ),
+                    HistoryUiEffectMiddleware(
+                      refreshView = { historyView.historyAdapter.refresh() }
                     ),
                     HistoryStorageMiddleware(
                         appStore = requireContext().components.appStore,

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistoryNavigationMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistoryNavigationMiddleware.kt
@@ -11,7 +11,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.readermode.BrowserNavigator
 import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.library.history.History
 import org.mozilla.fenix.library.history.HistoryFragmentAction
@@ -30,7 +32,7 @@ import org.mozilla.fenix.library.history.HistoryFragmentStore
  */
 class HistoryNavigationMiddleware(
     private val navController: NavController,
-    private val openToBrowser: (item: History.Regular) -> Unit,
+    private val browserNavigator: BrowserNavigator,
     private val onBackPressed: () -> Unit,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.Main),
 ) : Middleware<HistoryFragmentState, HistoryFragmentAction> {
@@ -85,5 +87,13 @@ class HistoryNavigationMiddleware(
                 else -> Unit
             }
         }
+    }
+
+    private fun openToBrowser(item: History.Regular) {
+        browserNavigator.openToBrowserAndLoad(
+            searchTermOrURL = item.url,
+            newTab = true,
+            from = BrowserDirection.FromHistory,
+        )
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistorySyncMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistorySyncMiddleware.kt
@@ -24,7 +24,6 @@ import org.mozilla.fenix.library.history.HistoryFragmentState
  */
 class HistorySyncMiddleware(
     private val accountManager: FxaAccountManager,
-    private val refreshView: () -> Unit,
     private val scope: CoroutineScope,
 ) : Middleware<HistoryFragmentState, HistoryFragmentAction> {
     override fun invoke(
@@ -41,7 +40,6 @@ class HistorySyncMiddleware(
                         debounce = true,
                         customEngineSubset = listOf(SyncEngine.History),
                     )
-                    refreshView()
                     context.store.dispatch(HistoryFragmentAction.FinishSync)
                 }
             }

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistoryUiEffectMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistoryUiEffectMiddleware.kt
@@ -1,0 +1,35 @@
+package org.mozilla.fenix.library.history.state
+
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+import org.mozilla.fenix.library.history.HistoryFragmentAction
+import org.mozilla.fenix.library.history.HistoryFragmentState
+
+class HistoryUiEffectMiddleware(
+    private val refreshView: () -> Unit,
+) : Middleware<HistoryFragmentState, HistoryFragmentAction> {
+    override fun invoke(
+        context: MiddlewareContext<HistoryFragmentState, HistoryFragmentAction>,
+        next: (HistoryFragmentAction) -> Unit,
+        action: HistoryFragmentAction,
+    ) {
+        when (action) {
+            is HistoryFragmentAction.FinishSync -> refreshView()
+            is HistoryFragmentAction.AddItemForRemoval, 
+            HistoryFragmentAction.BackPressed, 
+            is HistoryFragmentAction.ChangeEmptyState, 
+            is HistoryFragmentAction.DeleteItems, 
+            is HistoryFragmentAction.DeleteTimeRange, 
+            HistoryFragmentAction.EnterDeletionMode, 
+            HistoryFragmentAction.EnterRecentlyClosed, 
+            HistoryFragmentAction.ExitDeletionMode, 
+            HistoryFragmentAction.ExitEditMode, 
+            is HistoryFragmentAction.HistoryItemClicked, 
+            is HistoryFragmentAction.HistoryItemLongClicked, 
+            is HistoryFragmentAction.RemoveItemForRemoval, 
+            HistoryFragmentAction.SearchClicked, 
+            HistoryFragmentAction.StartSync, 
+            is HistoryFragmentAction.UpdatePendingDeletionItems -> Unit
+        }
+    }
+}


### PR DESCRIPTION
This PR is meant to demonstrate some of the concepts discussed in the proposal for [RFC 0010](https://github.com/mozilla-mobile/firefox-android/pull/4126/files).

Namely, this shows:
1. A `BrowserNavigator` abstraction for middlewares to have a common use case for handling navigation to the browser and opening a tab.
2. A slight refactor of how the view gets refreshed when the History fragment is finished syncing.

For transient effects such as the view refresh shown in this prototype, I do think the code may be determined by the effect. For example, the [undo snackbar](https://searchfox.org/mozilla-mobile/rev/2655756f8d424489c4dda3486c7cec3bd408f347/firefox-android/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistoryStorageMiddleware.kt#62) for history needs to be an atomic sequence of work (barring more refactoring).

Finally, this prototype does not include navigation between screens using a `NavController` as there are existing examples in the app like the [HistoryNavigationMiddleware](https://searchfox.org/mozilla-mobile/rev/2655756f8d424489c4dda3486c7cec3bd408f347/firefox-android/fenix/app/src/main/java/org/mozilla/fenix/library/history/state/HistoryNavigationMiddleware.kt#32) and the [DebugDrawerNavigationMiddleware](https://searchfox.org/mozilla-mobile/rev/2655756f8d424489c4dda3486c7cec3bd408f347/firefox-android/fenix/app/src/main/java/org/mozilla/fenix/debugsettings/store/DebugDrawerNavigationMiddleware.kt#21).

I do also believe that `BrowserNavigator` has plenty of room for improvement, but this would be the first simple step in decoupling the implementation from `HomeActivity` and moving it into the `lib-state` world.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
