### PR TITLE
Bug 1875923 - Update max_line_length in editorconfig to match detekt

### DIFF
--- a/android-components/.editorconfig
+++ b/android-components/.editorconfig
@@ -9,6 +9,7 @@ root = True
 [*.kt]
 indent_size = 4
 indent_style = space
+max_line_length = 120 # Matches maxLineLength in detekt.yml
 
 ij_kotlin_allow_trailing_comma_on_call_site=true
 ij_kotlin_allow_trailing_comma=true

--- a/fenix/.editorconfig
+++ b/fenix/.editorconfig
@@ -1,6 +1,7 @@
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma_on_call_site=true
 ij_kotlin_allow_trailing_comma=true
+max_line_length = 120 # Matches maxLineLength in detekt.yml
 
 [*]
 insert_final_newline = true

--- a/focus-android/.editorconfig
+++ b/focus-android/.editorconfig
@@ -1,5 +1,6 @@
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma_on_call_site=true
 ij_kotlin_allow_trailing_comma=true
+max_line_length = 120 # Matches maxLineLength in detekt.yml
 
 ktlint_standard_filename = disabled


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1875923