### PR TITLE
Bug 1876700 - Add more test logs to CollectionRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -49,8 +49,10 @@ object TestHelper {
 
     fun scrollToElementByText(text: String): UiScrollable {
         val appView = UiScrollable(UiSelector().scrollable(true))
+        Log.i(TAG, "scrollToElementByText: Waiting for app view")
         appView.waitForExists(waitingTime)
         appView.scrollTextIntoView(text)
+        Log.i(TAG, "scrollToElementByText: Scrolled to element with text: $text")
         return appView
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
@@ -17,10 +18,10 @@ import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.uiautomator.By
-import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemTextEquals
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectExists
@@ -46,18 +47,24 @@ class CollectionRobot {
             itemWithResId("$packageName:id/collections_list"),
         )
 
-    fun clickAddNewCollection() = addNewCollectionButton().click()
+    fun clickAddNewCollection() {
+        addNewCollectionButton().click()
+        Log.i(TAG, "clickAddNewCollection: Clicked the add new collection button")
+    }
 
     fun verifyCollectionNameTextField() = assertUIObjectExists(mainMenuEditCollectionNameField())
 
     // names a collection saved from tab drawer
     fun typeCollectionNameAndSave(collectionName: String) {
         collectionNameTextField().text = collectionName
-        addCollectionButtonPanel.waitForExists(waitingTime)
-        addCollectionOkButton.click()
+        Log.i(TAG, "typeCollectionNameAndSave: Collection name text field set to: $collectionName")
+        addCollectionButtonPanel().waitForExists(waitingTime)
+        addCollectionOkButton().click()
+        Log.i(TAG, "typeCollectionNameAndSave: Clicked \"OK\" panel button")
     }
 
     fun verifyTabsSelectedCounterText(numOfTabs: Int) {
+        Log.i(TAG, "verifyTabsSelectedCounterText: Waiting for \"Select tabs to save\" prompt to be gone")
         itemWithText("Select tabs to save").waitUntilGone(waitingTime)
 
         val tabsCounter = mDevice.findObject(UiSelector().resourceId("$packageName:id/bottom_bar_text"))
@@ -68,7 +75,8 @@ class CollectionRobot {
     }
 
     fun saveTabsSelectedForCollection() {
-        mDevice.findObject(UiSelector().resourceId("$packageName:id/save_button")).click()
+        itemWithResId("$packageName:id/save_button").click()
+        Log.i(TAG, "saveTabsSelectedForCollection: Clicked \"Save\" button")
     }
 
     fun verifyTabSavedInCollection(title: String, visible: Boolean = true) {
@@ -91,9 +99,11 @@ class CollectionRobot {
             collectionThreeDotButton(rule)
                 .assertExists()
                 .assertIsDisplayed()
+            Log.i(TAG, "verifyCollectionMenuIsVisible: Verified collection three dot button exists")
         } else {
             collectionThreeDotButton(rule)
                 .assertDoesNotExist()
+            Log.i(TAG, "verifyCollectionMenuIsVisible: Verified collection three dot button does not exist")
         }
     }
 
@@ -101,18 +111,21 @@ class CollectionRobot {
         collectionThreeDotButton(rule)
             .assertIsDisplayed()
             .performClick()
+        Log.i(TAG, "clickCollectionThreeDotButton: Clicked three dot button")
     }
 
     fun selectOpenTabs(rule: ComposeTestRule) {
         rule.onNode(hasText("Open tabs"))
             .assertIsDisplayed()
             .performClick()
+        Log.i(TAG, "selectOpenTabs: Clicked \"Open tabs\" menu option")
     }
 
     fun selectRenameCollection(rule: ComposeTestRule) {
         rule.onNode(hasText("Rename collection"))
             .assertIsDisplayed()
             .performClick()
+        Log.i(TAG, "selectRenameCollection: Clicked \"Rename collection\" menu option")
         mainMenuEditCollectionNameField().waitForExists(waitingTime)
     }
 
@@ -120,6 +133,7 @@ class CollectionRobot {
         rule.onNode(hasText("Add tab"))
             .assertIsDisplayed()
             .performClick()
+        Log.i(TAG, "selectAddTabToCollection: Clicked \"Add tab\" menu option")
 
         mDevice.waitNotNull(Until.findObject(By.text("Select Tabs")))
     }
@@ -128,35 +142,40 @@ class CollectionRobot {
         rule.onNode(hasText("Delete collection"))
             .assertIsDisplayed()
             .performClick()
+        Log.i(TAG, "selectDeleteCollection: Clicked \"Delete collection\" menu option")
     }
 
     fun verifyCollectionItemRemoveButtonIsVisible(title: String, visible: Boolean) =
         assertUIObjectExists(removeTabFromCollectionButton(title), exists = visible)
 
-    fun removeTabFromCollection(title: String) = removeTabFromCollectionButton(title).click()
+    fun removeTabFromCollection(title: String) {
+        removeTabFromCollectionButton(title).click()
+        Log.i(TAG, "removeTabFromCollection: Clicked remove button for tab: $title")
+    }
 
     fun swipeTabLeft(title: String, rule: ComposeTestRule) {
         rule.onNode(hasText(title), useUnmergedTree = true)
             .performTouchInput { swipeLeft() }
+        Log.i(TAG, "swipeTabLeft: Removed tab: $title using swipe left action")
         rule.waitForIdle()
+        Log.i(TAG, "swipeTabLeft: Waited for rule to be idle")
     }
 
     fun swipeTabRight(title: String, rule: ComposeTestRule) {
         rule.onNode(hasText(title), useUnmergedTree = true)
             .performTouchInput { swipeRight() }
+        Log.i(TAG, "swipeTabRight: Removed tab: $title using swipe right action")
         rule.waitForIdle()
+        Log.i(TAG, "swipeTabRight: Waited for rule to be idle")
     }
 
-    fun verifySnackBarText(expectedText: String) {
-        mDevice.findObject(UiSelector().text(expectedText)).waitForExists(waitingTime)
+    fun verifySnackBarText(expectedText: String) =
+        itemContainingText(expectedText).waitForExists(waitingTime)
+
+    fun goBackInCollectionFlow() {
+        backButton().click()
+        Log.i(TAG, "goBackInCollectionFlow: Clicked collection creation flow back button")
     }
-
-    fun goBackInCollectionFlow() = backButton().click()
-
-    fun swipeToBottom() =
-        UiScrollable(
-            UiSelector().resourceId("$packageName:id/sessionControlRecyclerView"),
-        ).scrollToEnd(3)
 
     class Transition {
         fun collapseCollection(
@@ -165,6 +184,7 @@ class CollectionRobot {
         ): HomeScreenRobot.Transition {
             assertUIObjectExists(itemContainingText(title))
             itemContainingText(title).clickAndWaitForNewWindow(waitingTimeShort)
+            Log.i(TAG, "collapseCollection: Clicked collection $title")
             assertUIObjectExists(itemWithDescription(getStringResource(R.string.remove_tab_from_collection)), exists = false)
 
             HomeScreenRobot().interact()
@@ -178,7 +198,9 @@ class CollectionRobot {
         ): BrowserRobot.Transition {
             mainMenuEditCollectionNameField().waitForExists(waitingTime)
             mainMenuEditCollectionNameField().text = name
+            Log.i(TAG, "typeCollectionNameAndSave: Collection name text field set to: $name")
             onView(withId(R.id.name_collection_edittext)).perform(pressImeActionButton())
+            Log.i(TAG, "typeCollectionNameAndSave: Pressed done action button")
 
             // wait for the collection creation wrapper to be dismissed
             mDevice.waitNotNull(Until.gone(By.res("$packageName:id/createCollectionWrapper")))
@@ -193,6 +215,7 @@ class CollectionRobot {
         ): BrowserRobot.Transition {
             collectionTitle(title).waitForExists(waitingTime)
             collectionTitle(title).click()
+            Log.i(TAG, "selectExistingCollection: Clicked collection with title: $title")
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
@@ -201,6 +224,7 @@ class CollectionRobot {
         fun clickShareCollectionButton(interact: ShareOverlayRobot.() -> Unit): ShareOverlayRobot.Transition {
             shareCollectionButton().waitForExists(waitingTime)
             shareCollectionButton().click()
+            Log.i(TAG, "clickShareCollectionButton: Clicked share collection button")
 
             ShareOverlayRobot().interact()
             return ShareOverlayRobot.Transition()
@@ -213,21 +237,14 @@ fun collectionRobot(interact: CollectionRobot.() -> Unit): CollectionRobot.Trans
     return CollectionRobot.Transition()
 }
 
-private fun collectionTitle(title: String) =
-    mDevice.findObject(
-        UiSelector()
-            .text(title),
-    )
+private fun collectionTitle(title: String) = itemWithText(title)
 
 private fun collectionThreeDotButton(rule: ComposeTestRule) =
     rule.onNode(hasContentDescription("Collection menu"))
 
 private fun collectionListItem(title: String) = mDevice.findObject(UiSelector().text(title))
 
-private fun shareCollectionButton() =
-    mDevice.findObject(
-        UiSelector().description("Share"),
-    )
+private fun shareCollectionButton() = itemWithDescription("Share")
 
 private fun removeTabFromCollectionButton(title: String) =
     mDevice.findObject(
@@ -245,9 +262,7 @@ private fun collectionNameTextField() =
 
 // collection name text field, when saving from the main menu option
 private fun mainMenuEditCollectionNameField() =
-    mDevice.findObject(
-        UiSelector().resourceId("$packageName:id/name_collection_edittext"),
-    )
+    itemWithResId("$packageName:id/name_collection_edittext")
 
 private fun addNewCollectionButton() =
     mDevice.findObject(UiSelector().text("Add new collection"))
@@ -256,7 +271,7 @@ private fun backButton() =
     mDevice.findObject(
         UiSelector().resourceId("$packageName:id/back_button"),
     )
-private val addCollectionButtonPanel =
+private fun addCollectionButtonPanel() =
     itemWithResId("$packageName:id/buttonPanel")
 
-private val addCollectionOkButton = onView(withId(android.R.id.button1)).inRoot(RootMatchers.isDialog())
+private fun addCollectionOkButton() = onView(withId(android.R.id.button1)).inRoot(RootMatchers.isDialog())


### PR DESCRIPTION
Summary:

- As part of the Android test hardening, to ease the debugging process, I've added test logs to the `CollectionRobot`
- Also converted the private variables to functions so they don't get initialized
- Removed unused functions
- Use where applicable the functions from the `MatcherHelper` to avoid adding unnecessary logs 
- ❗There is [this](https://github.com/mozilla-mobile/firefox-android/pull/5313/files#diff-1f0f53606bb4c1c9a89ce422b9ac691fb4b2064d76f6e90cbf3f51ed96ba5d06R173) `verifySnackBarText` function which  actually doesn't assert anything, only waits for an item containing text.
   Will do a separate refactoring related to these snackbar verifications as we have a function in `TestHelper` which is only partially used in the project and have a couple more individual functions named as `verifySnackBarText`in different robots

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1876700