### PR TITLE
Revert "Bug 1812843 - Increased the width for a CustomTabsToolbarFeature action button"

### DIFF
--- a/android-components/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
+++ b/android-components/components/browser/toolbar/src/main/res/layout/mozac_browser_toolbar_displaytoolbar.xml
@@ -29,12 +29,10 @@
         android:layout_width="0dp"
         android:layout_height="40dp"
         android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
         android:importantForAccessibility="no"
         app:layout_constraintEnd_toStartOf="@+id/mozac_browser_toolbar_browser_actions"
         app:layout_constraintStart_toEndOf="@+id/mozac_browser_toolbar_navigation_actions"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_goneMarginEnd="0dp" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <!-- URL indicators (lock, tracking protection, ..) -->
 

--- a/android-components/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
+++ b/android-components/components/feature/customtabs/src/main/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeature.kt
@@ -299,7 +299,7 @@ class CustomTabsToolbarFeature(
     }
 
     companion object {
-        private const val ACTION_BUTTON_DRAWABLE_WIDTH_DP = 48
+        private const val ACTION_BUTTON_DRAWABLE_WIDTH_DP = 24
         private const val ACTION_BUTTON_DRAWABLE_HEIGHT_DP = 24
     }
 }

--- a/android-components/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/android-components/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -404,10 +404,9 @@ class CustomTabsToolbarFeatureTest {
     }
 
     @Test
-    fun `action button is scaled to 48 width and 24 height`() {
+    fun `action button is scaled to 24 width and 24 height`() {
         val captor = argumentCaptor<Toolbar.ActionButton>()
-        val originalWidth = 86
-        val originalHeight = 48
+        val size = 48
         val pendingIntent: PendingIntent = mock()
         val tab = createCustomTab(
             "https://www.mozilla.org",
@@ -415,7 +414,7 @@ class CustomTabsToolbarFeatureTest {
             config = CustomTabConfig(
                 actionButtonConfig = CustomTabActionButtonConfig(
                     description = "Button",
-                    icon = Bitmap.createBitmap(IntArray(originalWidth * originalHeight), originalWidth, originalHeight, Bitmap.Config.ARGB_8888),
+                    icon = Bitmap.createBitmap(IntArray(size * size), size, size, Bitmap.Config.ARGB_8888),
                     pendingIntent = pendingIntent,
                 ),
             ),
@@ -439,7 +438,7 @@ class CustomTabsToolbarFeatureTest {
 
         val button = captor.value.createView(FrameLayout(testContext))
         assertEquals(24, (button as ImageButton).drawable.intrinsicHeight)
-        assertEquals(48, button.drawable.intrinsicWidth)
+        assertEquals(24, button.drawable.intrinsicWidth)
     }
 
     @Test
@@ -1070,7 +1069,10 @@ class CustomTabsToolbarFeatureTest {
         assertEquals("", toolbar.title)
 
         store.dispatch(
-            ContentAction.UpdateTitleAction("mozilla", "Firefox - Protect your life online with privacy-first products"),
+            ContentAction.UpdateTitleAction(
+                "mozilla",
+                "Firefox - Protect your life online with privacy-first products",
+            ),
         ).joinBlocking()
 
         assertEquals("Firefox - Protect your life online with privacy-first products", toolbar.title)
@@ -1100,7 +1102,10 @@ class CustomTabsToolbarFeatureTest {
         assertEquals("https://github.com/mozilla-mobile/fenix", toolbar.title)
 
         store.dispatch(
-            ContentAction.UpdateTitleAction("mozilla", "A collection of Android libraries to build browsers or browser-like applications."),
+            ContentAction.UpdateTitleAction(
+                "mozilla",
+                "A collection of Android libraries to build browsers or browser-like applications.",
+            ),
         ).joinBlocking()
 
         assertEquals("A collection of Android libraries to build browsers or browser-like applications.", toolbar.title)


### PR DESCRIPTION
Reverting mozilla-mobile/firefox-android#5141 as this patch has created more bugs, see: 

- https://bugzilla.mozilla.org/show_bug.cgi?id=1875933, 
- https://bugzilla.mozilla.org/show_bug.cgi?id=1875788

https://bugzilla.mozilla.org/show_bug.cgi?id=1812843
https://bugzilla.mozilla.org/show_bug.cgi?id=1812843
https://bugzilla.mozilla.org/show_bug.cgi?id=1812843
https://bugzilla.mozilla.org/show_bug.cgi?id=1812843
https://bugzilla.mozilla.org/show_bug.cgi?id=1812843