### PR TITLE
Bug 1868539 - Add method of changing remote server url

### DIFF
--- a/android-components/components/feature/search/src/main/java/mozilla/components/feature/search/telemetry/SerpTelemetryRepository.kt
+++ b/android-components/components/feature/search/src/main/java/mozilla/components/feature/search/telemetry/SerpTelemetryRepository.kt
@@ -16,7 +16,7 @@ import org.json.JSONException
 import org.json.JSONObject
 import java.io.File
 
-internal const val REMOTE_ENDPOINT_URL = "https://firefox.settings.services.mozilla.com"
+internal const val REMOTE_PROD_ENDPOINT_URL = "https://firefox.settings.services.mozilla.com"
 internal const val REMOTE_ENDPOINT_BUCKET_NAME = "main"
 
 /**
@@ -26,7 +26,7 @@ class SerpTelemetryRepository(
     rootStorageDirectory: File,
     private val readJson: () -> JSONObject,
     collectionName: String,
-    serverUrl: String = REMOTE_ENDPOINT_URL,
+    serverUrl: String = REMOTE_PROD_ENDPOINT_URL,
     bucketName: String = REMOTE_ENDPOINT_BUCKET_NAME,
 ) {
     val logger = Logger("SerpTelemetryRepository")

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -329,6 +329,11 @@ class Core(
                         rootStorageDirectory = context.filesDir,
                         readJson = readJson,
                         collectionName = COLLECTION_NAME,
+                        serverUrl = if (context.settings().useProductionRemoteSettingsServer) {
+                            REMOTE_PROD_ENDPOINT_URL
+                        } else {
+                            REMOTE_STAGE_ENDPOINT_URL
+                        },
                     ).updateProviderList()
                 }
                 // Install the "ads" WebExtension to get the links in an partner page.
@@ -623,5 +628,7 @@ class Core(
 
         // collection name to fetch from server for SERP telemetry
         const val COLLECTION_NAME = "search-telemetry-v2"
+        internal const val REMOTE_PROD_ENDPOINT_URL = "https://firefox.settings.services.mozilla.com"
+        internal const val REMOTE_STAGE_ENDPOINT_URL = "https://firefox.settings.services.allizom.org"
     }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -88,7 +88,8 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
             onPreferenceChangeListener = object : Preference.OnPreferenceChangeListener {
                 override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                     val newBooleanValue = newValue as? Boolean ?: return false
-                    val ingestionScheduler = requireContext().components.fxSuggest.ingestionScheduler
+                    val ingestionScheduler =
+                        requireContext().components.fxSuggest.ingestionScheduler
                     if (newBooleanValue) {
                         ingestionScheduler.startPeriodicIngestion()
                     } else {
@@ -128,6 +129,12 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
 
         requirePreference<Preference>(R.string.pref_key_custom_sponsored_stories_parameters).apply {
             isVisible = Config.channel.isNightlyOrDebug
+        }
+
+        requirePreference<SwitchPreference>(R.string.pref_key_remote_server_prod).apply {
+            isVisible = true
+            isChecked = context.settings().useProductionRemoteSettingsServer
+            onPreferenceChangeListener = SharedPreferenceUpdater()
         }
     }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -767,6 +767,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         true,
     )
 
+    val useProductionRemoteSettingsServer by booleanPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_remote_server_prod),
+        default = true,
+    )
+
     val enabledTotalCookieProtection: Boolean
         get() = mr2022Sections[Mr2022Section.TCP_FEATURE] == true
 

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -145,6 +145,9 @@
     <!-- Privacy Pop Window -->
     <string name="pref_key_privacy_pop_window" translatable="false">pref_key_privacy_pop_window</string>
 
+    <!-- Remote Server Settings -->
+    <string name="pref_key_remote_server_prod" translatable="false">pref_key_remote_server_prod</string>
+
     <!-- Theme Settings -->
     <string name="pref_key_light_theme" translatable="false">pref_key_light_theme</string>
     <string name="pref_key_dark_theme" translatable="false">pref_key_dark_theme</string>

--- a/fenix/app/src/main/res/values/static_strings.xml
+++ b/fenix/app/src/main/res/values/static_strings.xml
@@ -34,6 +34,8 @@
     <string name="preferences_debug_settings">Secret Settings</string>
     <!-- Label for the secret settings preference -->
     <string name="preferences_debug_info" translatable="false">Secret Debug Info</string>
+    <!-- Label for using remote settings server url -->
+    <string name="preferences_debug_settings_remote_settings_server" translatable="false">Use Remote Settings Production server \n(Staging will be used when disabled) \n(requires restart)</string>
     <!-- Label for allowing third party root certificates from the Android OS CA store preference -->
     <string name="preferences_debug_settings_allow_third_party_root_certs">Use third party CA certificates</string>
     <!-- Label for a longer description of allowing third party root certificates from the Android OS CA store preference -->

--- a/fenix/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/fenix/app/src/main/res/xml/secret_settings_preferences.xml
@@ -61,4 +61,9 @@
         app:iconSpaceReserved="false"
         android:title="@string/preferences_debug_settings_custom_sponsored_stories_parameters"
         />
+    <SwitchPreference
+        android:key="@string/pref_key_remote_server_prod"
+        app:iconSpaceReserved="false"
+        android:title="@string/preferences_debug_settings_remote_settings_server"
+        />
 </PreferenceScreen>

--- a/focus-android/app/src/main/java/org/mozilla/focus/settings/advanced/SecretSettingsFragment.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/settings/advanced/SecretSettingsFragment.kt
@@ -10,6 +10,8 @@ import androidx.preference.SwitchPreferenceCompat
 import org.mozilla.focus.R
 import org.mozilla.focus.ext.getPreferenceKey
 import org.mozilla.focus.ext.requireComponents
+import org.mozilla.focus.ext.requirePreference
+import org.mozilla.focus.ext.settings
 import org.mozilla.focus.ext.showToolbar
 import org.mozilla.focus.settings.BaseSettingsFragment
 import kotlin.system.exitProcess
@@ -26,6 +28,12 @@ class SecretSettingsFragment :
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.secret_settings)
+
+        requirePreference<SwitchPreferenceCompat>(R.string.pref_key_remote_server_prod).apply {
+            isVisible = true
+            isChecked = context.settings.useProductionRemoteSettingsServer
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {

--- a/focus-android/app/src/main/java/org/mozilla/focus/settings/advanced/SharedPreferenceUpdater.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/settings/advanced/SharedPreferenceUpdater.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.settings.advanced
+
+import androidx.core.content.edit
+import androidx.preference.Preference
+import org.mozilla.focus.ext.settings
+
+/**
+ * Updates the corresponding [android.content.SharedPreferences] when the boolean [Preference] is changed.
+ * The preference key is used as the shared preference key.
+ */
+open class SharedPreferenceUpdater : Preference.OnPreferenceChangeListener {
+
+    override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
+        val newBooleanValue = newValue as? Boolean ?: return false
+        preference.context.settings.preferences.edit {
+            putBoolean(preference.key, newBooleanValue)
+        }
+        return true
+    }
+}

--- a/focus-android/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt
@@ -60,6 +60,11 @@ class GleanMetricsService(context: Context) : MetricsService {
     companion object {
         // collection name to fetch from server for SERP telemetry
         const val COLLECTION_NAME = "search-telemetry-v2"
+
+        // urls for prod and stage remote settings server
+        internal const val REMOTE_PROD_ENDPOINT_URL = "https://firefox.settings.services.mozilla.com"
+        internal const val REMOTE_STAGE_ENDPOINT_URL = "https://firefox.settings.services.allizom.org"
+
         private val isEnabledByDefault: Boolean
             get() = !AppConstants.isKlarBuild
 
@@ -122,6 +127,11 @@ class GleanMetricsService(context: Context) : MetricsService {
                         rootStorageDirectory = context.filesDir,
                         readJson = readJson,
                         collectionName = COLLECTION_NAME,
+                        serverUrl = if (context.settings.useProductionRemoteSettingsServer) {
+                            REMOTE_PROD_ENDPOINT_URL
+                        } else {
+                            REMOTE_STAGE_ENDPOINT_URL
+                        },
                     ).updateProviderList()
                 }
                 installSearchTelemetryExtensions(components, providerList)

--- a/focus-android/app/src/main/java/org/mozilla/focus/utils/Settings.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/utils/Settings.kt
@@ -412,6 +412,14 @@ class Settings(
                 .commit()
         }
 
+    var useProductionRemoteSettingsServer: Boolean
+        get() = preferences.getBoolean(getPreferenceKey(R.string.pref_key_remote_server_prod), true)
+        set(value) {
+            preferences.edit()
+                .putBoolean(getPreferenceKey(R.string.pref_key_remote_server_prod), value)
+                .commit()
+        }
+
     fun addSearchWidgetInstalled(count: Int) {
         val key = getPreferenceKey(R.string.pref_key_search_widget_installed)
         val newValue = preferences.getInt(key, 0) + count

--- a/focus-android/app/src/main/res/values/preference_keys.xml
+++ b/focus-android/app/src/main/res/values/preference_keys.xml
@@ -10,6 +10,8 @@
     <string name="pref_key_radio_search_engine_list" translatable="false">pref_radio_search_engine_list</string>
     <string name="pref_key_multiselect_search_engine_list" translatable="false">pref_multiselect_search_engine_list</string>
 
+    <string name="pref_key_remote_server_prod" translatable="false">pref_key_remote_server_prod</string>
+
     <string name="pref_key_privacy_block_ads" translatable="false"><xliff:g id="preference_key">pref_privacy_block_ads</xliff:g></string>
     <string name="pref_key_privacy_block_analytics" translatable="false"><xliff:g id="preference_key">pref_privacy_block_analytics</xliff:g></string>
     <string name="pref_key_privacy_block_social" translatable="false"><xliff:g id="preference_key">pref_privacy_block_social</xliff:g></string>

--- a/focus-android/app/src/main/res/values/static_strings.xml
+++ b/focus-android/app/src/main/res/values/static_strings.xml
@@ -20,4 +20,7 @@
 
     <!-- Application Services abbreviation used in AboutFragment -->
     <string name="services_abbreviation" translatable="false">AS</string>
+
+    <!-- Label for using remote settings server url -->
+    <string name="preferences_debug_settings_remote_settings_server" translatable="false">Use Remote Settings Production server \n(Staging will be used when disabled) \n(requires restart)</string>
 </resources>

--- a/focus-android/app/src/main/res/xml/secret_settings.xml
+++ b/focus-android/app/src/main/res/xml/secret_settings.xml
@@ -8,4 +8,10 @@
         android:key="@string/pref_key_use_nimbus_preview"
         android:layout="@layout/focus_preference_no_icon"
         android:title="@string/preference_use_nimbus_preview" />
+
+    <androidx.preference.SwitchPreferenceCompat
+        android:key="@string/pref_key_remote_server_prod"
+        android:layout="@layout/focus_preference_no_icon"
+        android:title="@string/preferences_debug_settings_remote_settings_server"
+        />
 </PreferenceScreen>


### PR DESCRIPTION
| Fenix  | Focus |
| ------------- | ------------- |
| <img src="https://github.com/mozilla-mobile/firefox-android/assets/29518411/504d1bfa-152a-4cea-a4b0-492bba968cd4" width="400" height="800">  |  <img src="https://github.com/mozilla-mobile/firefox-android/assets/29518411/143ef205-ed03-42b8-924c-d2d5d3b3bf1b" width="400" height="800"> |


### Pull Request checklist

<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1868539