### PR TITLE
Bug 1876419 - Move comment from editorconfig files

### DIFF
--- a/android-components/.editorconfig
+++ b/android-components/.editorconfig
@@ -9,7 +9,9 @@ root = True
 [*.kt]
 indent_size = 4
 indent_style = space
-max_line_length = 120 # Matches maxLineLength in detekt.yml
+
+# Matches maxLineLength in detekt.yml
+max_line_length = 120
 
 ij_kotlin_allow_trailing_comma_on_call_site=true
 ij_kotlin_allow_trailing_comma=true

--- a/android-components/ktlint-baseline.xml
+++ b/android-components/ktlint-baseline.xml
@@ -2,24 +2,4624 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-
 <baseline version="1.0">
+    <file name="components/browser/domains/src/test/java/mozilla/components/browser/domains/BaseDomainAutocompleteProviderTest.kt">
+        <error line="72" column="1" source="standard:max-line-length" />
+        <error line="72" column="26" source="standard:argument-list-wrapping" />
+        <error line="72" column="36" source="standard:argument-list-wrapping" />
+        <error line="72" column="42" source="standard:argument-list-wrapping" />
+        <error line="72" column="56" source="standard:argument-list-wrapping" />
+        <error line="72" column="68" source="standard:argument-list-wrapping" />
+        <error line="72" column="80" source="standard:argument-list-wrapping" />
+        <error line="72" column="100" source="standard:argument-list-wrapping" />
+        <error line="72" column="121" source="standard:argument-list-wrapping" />
+        <error line="76" column="1" source="standard:max-line-length" />
+        <error line="76" column="26" source="standard:argument-list-wrapping" />
+        <error line="76" column="36" source="standard:argument-list-wrapping" />
+        <error line="76" column="42" source="standard:argument-list-wrapping" />
+        <error line="76" column="56" source="standard:argument-list-wrapping" />
+        <error line="76" column="71" source="standard:argument-list-wrapping" />
+        <error line="76" column="86" source="standard:argument-list-wrapping" />
+        <error line="76" column="104" source="standard:argument-list-wrapping" />
+        <error line="76" column="123" source="standard:argument-list-wrapping" />
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="77" column="26" source="standard:argument-list-wrapping" />
+        <error line="77" column="36" source="standard:argument-list-wrapping" />
+        <error line="77" column="42" source="standard:argument-list-wrapping" />
+        <error line="77" column="56" source="standard:argument-list-wrapping" />
+        <error line="77" column="76" source="standard:argument-list-wrapping" />
+        <error line="77" column="96" source="standard:argument-list-wrapping" />
+        <error line="77" column="116" source="standard:argument-list-wrapping" />
+        <error line="77" column="137" source="standard:argument-list-wrapping" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="78" column="26" source="standard:argument-list-wrapping" />
+        <error line="78" column="36" source="standard:argument-list-wrapping" />
+        <error line="78" column="42" source="standard:argument-list-wrapping" />
+        <error line="78" column="56" source="standard:argument-list-wrapping" />
+        <error line="78" column="72" source="standard:argument-list-wrapping" />
+        <error line="78" column="88" source="standard:argument-list-wrapping" />
+        <error line="78" column="104" source="standard:argument-list-wrapping" />
+        <error line="78" column="125" source="standard:argument-list-wrapping" />
+        <error line="96" column="1" source="standard:max-line-length" />
+        <error line="96" column="26" source="standard:argument-list-wrapping" />
+        <error line="96" column="36" source="standard:argument-list-wrapping" />
+        <error line="96" column="42" source="standard:argument-list-wrapping" />
+        <error line="96" column="56" source="standard:argument-list-wrapping" />
+        <error line="96" column="68" source="standard:argument-list-wrapping" />
+        <error line="96" column="80" source="standard:argument-list-wrapping" />
+        <error line="96" column="100" source="standard:argument-list-wrapping" />
+        <error line="96" column="121" source="standard:argument-list-wrapping" />
+        <error line="100" column="1" source="standard:max-line-length" />
+        <error line="100" column="26" source="standard:argument-list-wrapping" />
+        <error line="100" column="36" source="standard:argument-list-wrapping" />
+        <error line="100" column="42" source="standard:argument-list-wrapping" />
+        <error line="100" column="56" source="standard:argument-list-wrapping" />
+        <error line="100" column="71" source="standard:argument-list-wrapping" />
+        <error line="100" column="86" source="standard:argument-list-wrapping" />
+        <error line="100" column="104" source="standard:argument-list-wrapping" />
+        <error line="100" column="123" source="standard:argument-list-wrapping" />
+        <error line="101" column="1" source="standard:max-line-length" />
+        <error line="101" column="26" source="standard:argument-list-wrapping" />
+        <error line="101" column="36" source="standard:argument-list-wrapping" />
+        <error line="101" column="42" source="standard:argument-list-wrapping" />
+        <error line="101" column="56" source="standard:argument-list-wrapping" />
+        <error line="101" column="76" source="standard:argument-list-wrapping" />
+        <error line="101" column="96" source="standard:argument-list-wrapping" />
+        <error line="101" column="116" source="standard:argument-list-wrapping" />
+        <error line="101" column="137" source="standard:argument-list-wrapping" />
+        <error line="102" column="1" source="standard:max-line-length" />
+        <error line="102" column="26" source="standard:argument-list-wrapping" />
+        <error line="102" column="36" source="standard:argument-list-wrapping" />
+        <error line="102" column="42" source="standard:argument-list-wrapping" />
+        <error line="102" column="56" source="standard:argument-list-wrapping" />
+        <error line="102" column="72" source="standard:argument-list-wrapping" />
+        <error line="102" column="88" source="standard:argument-list-wrapping" />
+        <error line="102" column="104" source="standard:argument-list-wrapping" />
+        <error line="102" column="125" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/domains/src/test/java/mozilla/components/browser/domains/ProvidersTest.kt">
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="32" column="26" source="standard:argument-list-wrapping" />
+        <error line="32" column="36" source="standard:argument-list-wrapping" />
+        <error line="32" column="56" source="standard:argument-list-wrapping" />
+        <error line="32" column="76" source="standard:argument-list-wrapping" />
+        <error line="32" column="82" source="standard:argument-list-wrapping" />
+        <error line="32" column="102" source="standard:argument-list-wrapping" />
+        <error line="32" column="123" source="standard:argument-list-wrapping" />
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="46" column="26" source="standard:argument-list-wrapping" />
+        <error line="46" column="36" source="standard:argument-list-wrapping" />
+        <error line="46" column="41" source="standard:argument-list-wrapping" />
+        <error line="46" column="60" source="standard:argument-list-wrapping" />
+        <error line="46" column="80" source="standard:argument-list-wrapping" />
+        <error line="46" column="98" source="standard:argument-list-wrapping" />
+        <error line="46" column="125" source="standard:argument-list-wrapping" />
+        <error line="47" column="1" source="standard:max-line-length" />
+        <error line="47" column="26" source="standard:argument-list-wrapping" />
+        <error line="47" column="36" source="standard:argument-list-wrapping" />
+        <error line="47" column="42" source="standard:argument-list-wrapping" />
+        <error line="47" column="61" source="standard:argument-list-wrapping" />
+        <error line="47" column="81" source="standard:argument-list-wrapping" />
+        <error line="47" column="99" source="standard:argument-list-wrapping" />
+        <error line="47" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineSessionTest.kt">
+        <error line="230" column="1" source="standard:max-line-length" />
+        <error line="1024" column="1" source="standard:max-line-length" />
+        <error line="1123" column="1" source="standard:max-line-length" />
+        <error line="1193" column="1" source="standard:max-line-length" />
+        <error line="1193" column="41" source="standard:argument-list-wrapping" />
+        <error line="1193" column="55" source="standard:argument-list-wrapping" />
+        <error line="1193" column="82" source="standard:argument-list-wrapping" />
+        <error line="1193" column="88" source="standard:argument-list-wrapping" />
+        <error line="1193" column="132" source="standard:argument-list-wrapping" />
+        <error line="1212" column="1" source="standard:max-line-length" />
+        <error line="1212" column="41" source="standard:argument-list-wrapping" />
+        <error line="1212" column="55" source="standard:argument-list-wrapping" />
+        <error line="1212" column="82" source="standard:argument-list-wrapping" />
+        <error line="1212" column="109" source="standard:argument-list-wrapping" />
+        <error line="1212" column="153" source="standard:argument-list-wrapping" />
+        <error line="1232" column="1" source="standard:max-line-length" />
+        <error line="1232" column="41" source="standard:argument-list-wrapping" />
+        <error line="1232" column="55" source="standard:argument-list-wrapping" />
+        <error line="1232" column="90" source="standard:argument-list-wrapping" />
+        <error line="1232" column="96" source="standard:argument-list-wrapping" />
+        <error line="1232" column="140" source="standard:argument-list-wrapping" />
+        <error line="1238" column="1" source="standard:max-line-length" />
+        <error line="1238" column="41" source="standard:argument-list-wrapping" />
+        <error line="1238" column="55" source="standard:argument-list-wrapping" />
+        <error line="1238" column="94" source="standard:argument-list-wrapping" />
+        <error line="1238" column="100" source="standard:argument-list-wrapping" />
+        <error line="1238" column="144" source="standard:argument-list-wrapping" />
+        <error line="1269" column="1" source="standard:max-line-length" />
+        <error line="1269" column="51" source="standard:argument-list-wrapping" />
+        <error line="1269" column="95" source="standard:argument-list-wrapping" />
+        <error line="1269" column="98" source="standard:argument-list-wrapping" />
+        <error line="1269" column="108" source="standard:argument-list-wrapping" />
+        <error line="1269" column="138" source="standard:argument-list-wrapping" />
+        <error line="1269" column="162" source="standard:argument-list-wrapping" />
+        <error line="1269" column="163" source="standard:argument-list-wrapping" />
+        <error line="1269" column="164" source="standard:argument-list-wrapping" />
+        <error line="1280" column="1" source="standard:max-line-length" />
+        <error line="1280" column="51" source="standard:argument-list-wrapping" />
+        <error line="1280" column="95" source="standard:argument-list-wrapping" />
+        <error line="1280" column="98" source="standard:argument-list-wrapping" />
+        <error line="1280" column="108" source="standard:argument-list-wrapping" />
+        <error line="1280" column="138" source="standard:argument-list-wrapping" />
+        <error line="1280" column="162" source="standard:argument-list-wrapping" />
+        <error line="1280" column="163" source="standard:argument-list-wrapping" />
+        <error line="1280" column="164" source="standard:argument-list-wrapping" />
+        <error line="1293" column="1" source="standard:max-line-length" />
+        <error line="1293" column="51" source="standard:argument-list-wrapping" />
+        <error line="1293" column="93" source="standard:argument-list-wrapping" />
+        <error line="1293" column="96" source="standard:argument-list-wrapping" />
+        <error line="1293" column="121" source="standard:argument-list-wrapping" />
+        <error line="1293" column="122" source="standard:argument-list-wrapping" />
+        <error line="1304" column="1" source="standard:max-line-length" />
+        <error line="1304" column="51" source="standard:argument-list-wrapping" />
+        <error line="1304" column="93" source="standard:argument-list-wrapping" />
+        <error line="1304" column="96" source="standard:argument-list-wrapping" />
+        <error line="1304" column="121" source="standard:argument-list-wrapping" />
+        <error line="1304" column="122" source="standard:argument-list-wrapping" />
+        <error line="1321" column="1" source="standard:max-line-length" />
+        <error line="1321" column="41" source="standard:argument-list-wrapping" />
+        <error line="1321" column="55" source="standard:argument-list-wrapping" />
+        <error line="1321" column="82" source="standard:argument-list-wrapping" />
+        <error line="1321" column="109" source="standard:argument-list-wrapping" />
+        <error line="1321" column="153" source="standard:argument-list-wrapping" />
+        <error line="1592" column="1" source="standard:max-line-length" />
+        <error line="1608" column="1" source="standard:max-line-length" />
+        <error line="1608" column="54" source="standard:argument-list-wrapping" />
+        <error line="1608" column="83" source="standard:argument-list-wrapping" />
+        <error line="1608" column="125" source="standard:argument-list-wrapping" />
+        <error line="1608" column="126" source="standard:argument-list-wrapping" />
+        <error line="1616" column="1" source="standard:max-line-length" />
+        <error line="1632" column="1" source="standard:max-line-length" />
+        <error line="1632" column="54" source="standard:argument-list-wrapping" />
+        <error line="1632" column="83" source="standard:argument-list-wrapping" />
+        <error line="1632" column="125" source="standard:argument-list-wrapping" />
+        <error line="1632" column="126" source="standard:argument-list-wrapping" />
+        <error line="1640" column="1" source="standard:max-line-length" />
+        <error line="1959" column="1" source="standard:max-line-length" />
+        <error line="1959" column="48" source="standard:argument-list-wrapping" />
+        <error line="1959" column="62" source="standard:argument-list-wrapping" />
+        <error line="1959" column="121" source="standard:argument-list-wrapping" />
+        <error line="2446" column="1" source="standard:max-line-length" />
+        <error line="2446" column="54" source="standard:argument-list-wrapping" />
+        <error line="2446" column="68" source="standard:argument-list-wrapping" />
+        <error line="2446" column="74" source="standard:argument-list-wrapping" />
+        <error line="2446" column="94" source="standard:argument-list-wrapping" />
+        <error line="2446" column="133" source="standard:argument-list-wrapping" />
+        <error line="2446" column="136" source="standard:argument-list-wrapping" />
+        <error line="2446" column="140" source="standard:argument-list-wrapping" />
+        <error line="2838" column="1" source="standard:max-line-length" />
+        <error line="4475" column="1" source="standard:max-line-length" />
+        <error line="4605" column="1" source="standard:max-line-length" />
+        <error line="4829" column="1" source="standard:max-line-length" />
+        <error line="4829" column="30" source="standard:argument-list-wrapping" />
+        <error line="4829" column="65" source="standard:argument-list-wrapping" />
+        <error line="4829" column="109" source="standard:argument-list-wrapping" />
+        <error line="4829" column="148" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/GeckoEngineTest.kt">
+        <error line="340" column="1" source="standard:max-line-length" />
+        <error line="340" column="22" source="standard:argument-list-wrapping" />
+        <error line="340" column="79" source="standard:argument-list-wrapping" />
+        <error line="340" column="131" source="standard:argument-list-wrapping" />
+        <error line="341" column="1" source="standard:max-line-length" />
+        <error line="341" column="22" source="standard:argument-list-wrapping" />
+        <error line="341" column="74" source="standard:argument-list-wrapping" />
+        <error line="341" column="124" source="standard:argument-list-wrapping" />
+        <error line="342" column="1" source="standard:max-line-length" />
+        <error line="342" column="22" source="standard:argument-list-wrapping" />
+        <error line="342" column="78" source="standard:argument-list-wrapping" />
+        <error line="342" column="125" source="standard:argument-list-wrapping" />
+        <error line="343" column="1" source="standard:max-line-length" />
+        <error line="343" column="22" source="standard:argument-list-wrapping" />
+        <error line="343" column="87" source="standard:argument-list-wrapping" />
+        <error line="343" column="143" source="standard:argument-list-wrapping" />
+        <error line="345" column="1" source="standard:max-line-length" />
+        <error line="345" column="22" source="standard:argument-list-wrapping" />
+        <error line="345" column="93" source="standard:argument-list-wrapping" />
+        <error line="345" column="147" source="standard:argument-list-wrapping" />
+        <error line="346" column="1" source="standard:max-line-length" />
+        <error line="346" column="22" source="standard:argument-list-wrapping" />
+        <error line="346" column="83" source="standard:argument-list-wrapping" />
+        <error line="346" column="131" source="standard:argument-list-wrapping" />
+        <error line="347" column="1" source="standard:max-line-length" />
+        <error line="347" column="22" source="standard:argument-list-wrapping" />
+        <error line="347" column="83" source="standard:argument-list-wrapping" />
+        <error line="347" column="131" source="standard:argument-list-wrapping" />
+        <error line="349" column="1" source="standard:max-line-length" />
+        <error line="349" column="22" source="standard:argument-list-wrapping" />
+        <error line="349" column="90" source="standard:argument-list-wrapping" />
+        <error line="349" column="141" source="standard:argument-list-wrapping" />
+        <error line="700" column="1" source="standard:max-line-length" />
+        <error line="700" column="22" source="standard:argument-list-wrapping" />
+        <error line="700" column="84" source="standard:argument-list-wrapping" />
+        <error line="700" column="136" source="standard:argument-list-wrapping" />
+        <error line="701" column="1" source="standard:max-line-length" />
+        <error line="701" column="22" source="standard:argument-list-wrapping" />
+        <error line="701" column="82" source="standard:argument-list-wrapping" />
+        <error line="701" column="136" source="standard:argument-list-wrapping" />
+        <error line="702" column="1" source="standard:max-line-length" />
+        <error line="702" column="22" source="standard:argument-list-wrapping" />
+        <error line="702" column="92" source="standard:argument-list-wrapping" />
+        <error line="702" column="156" source="standard:argument-list-wrapping" />
+        <error line="706" column="1" source="standard:max-line-length" />
+        <error line="888" column="1" source="standard:max-line-length" />
+        <error line="888" column="22" source="standard:argument-list-wrapping" />
+        <error line="888" column="76" source="standard:argument-list-wrapping" />
+        <error line="888" column="131" source="standard:argument-list-wrapping" />
+        <error line="2043" column="1" source="standard:max-line-length" />
+        <error line="2043" column="99" source="standard:argument-list-wrapping" />
+        <error line="2043" column="138" source="standard:argument-list-wrapping" />
+        <error line="2078" column="1" source="standard:max-line-length" />
+        <error line="2078" column="99" source="standard:argument-list-wrapping" />
+        <error line="2078" column="138" source="standard:argument-list-wrapping" />
+        <error line="2844" column="1" source="standard:max-line-length" />
+        <error line="2923" column="1" source="standard:max-line-length" />
+        <error line="2923" column="93" source="standard:argument-list-wrapping" />
+        <error line="2923" column="110" source="standard:argument-list-wrapping" />
+        <error line="2923" column="122" source="standard:argument-list-wrapping" />
+        <error line="2923" column="125" source="standard:argument-list-wrapping" />
+        <error line="2923" column="142" source="standard:argument-list-wrapping" />
+        <error line="2923" column="152" source="standard:argument-list-wrapping" />
+        <error line="2923" column="153" source="standard:argument-list-wrapping" />
+        <error line="2926" column="1" source="standard:max-line-length" />
+        <error line="2958" column="1" source="standard:max-line-length" />
+        <error line="3464" column="1" source="standard:max-line-length" />
+        <error line="3464" column="34" source="standard:argument-list-wrapping" />
+        <error line="3464" column="51" source="standard:argument-list-wrapping" />
+        <error line="3464" column="67" source="standard:argument-list-wrapping" />
+        <error line="3464" column="74" source="standard:argument-list-wrapping" />
+        <error line="3464" column="96" source="standard:argument-list-wrapping" />
+        <error line="3464" column="122" source="standard:argument-list-wrapping" />
+        <error line="3464" column="123" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/NestedGeckoViewTest.kt">
+        <error line="289" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/activity/GeckoScreenOrientationDelegateTest.kt">
+        <error line="30" column="1" source="standard:max-line-length" />
+        <error line="42" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/cookiebanners/GeckoCookieBannersStorageTest.kt">
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="130" column="1" source="standard:max-line-length" />
+        <error line="143" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/cookiebanners/ReportSiteDomainsRepositoryTest.kt">
+        <error line="63" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/fetch/GeckoViewFetchUnitTestCases.kt">
+        <error line="283" column="1" source="standard:max-line-length" />
+        <error line="283" column="128" source="standard:argument-list-wrapping" />
+        <error line="283" column="129" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/mediasession/GeckoMediaSessionDelegateTest.kt">
+        <error line="207" column="1" source="standard:max-line-length" />
+        <error line="207" column="72" source="standard:argument-list-wrapping" />
+        <error line="207" column="80" source="standard:argument-list-wrapping" />
+        <error line="207" column="103" source="standard:argument-list-wrapping" />
+        <error line="207" column="109" source="standard:argument-list-wrapping" />
+        <error line="207" column="124" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoPermissionRequestTest.kt">
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="38" column="50" source="standard:argument-list-wrapping" />
+        <error line="38" column="55" source="standard:argument-list-wrapping" />
+        <error line="38" column="116" source="standard:argument-list-wrapping" />
+        <error line="38" column="124" source="standard:argument-list-wrapping" />
+        <error line="38" column="130" source="standard:argument-list-wrapping" />
+        <error line="42" column="1" source="standard:max-line-length" />
+        <error line="42" column="50" source="standard:argument-list-wrapping" />
+        <error line="42" column="55" source="standard:argument-list-wrapping" />
+        <error line="42" column="118" source="standard:argument-list-wrapping" />
+        <error line="42" column="126" source="standard:argument-list-wrapping" />
+        <error line="42" column="132" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/permission/GeckoSitePermissionsStorageTest.kt">
+        <error line="66" column="1" source="standard:max-line-length" />
+        <error line="69" column="1" source="standard:max-line-length" />
+        <error line="69" column="59" source="standard:argument-list-wrapping" />
+        <error line="69" column="74" source="standard:argument-list-wrapping" />
+        <error line="69" column="98" source="standard:argument-list-wrapping" />
+        <error line="69" column="116" source="standard:argument-list-wrapping" />
+        <error line="69" column="122" source="standard:argument-list-wrapping" />
+        <error line="83" column="1" source="standard:max-line-length" />
+        <error line="86" column="1" source="standard:max-line-length" />
+        <error line="86" column="59" source="standard:argument-list-wrapping" />
+        <error line="86" column="74" source="standard:argument-list-wrapping" />
+        <error line="86" column="107" source="standard:argument-list-wrapping" />
+        <error line="86" column="125" source="standard:argument-list-wrapping" />
+        <error line="86" column="131" source="standard:argument-list-wrapping" />
+        <error line="100" column="1" source="standard:max-line-length" />
+        <error line="103" column="1" source="standard:max-line-length" />
+        <error line="103" column="59" source="standard:argument-list-wrapping" />
+        <error line="103" column="74" source="standard:argument-list-wrapping" />
+        <error line="103" column="105" source="standard:argument-list-wrapping" />
+        <error line="103" column="123" source="standard:argument-list-wrapping" />
+        <error line="103" column="129" source="standard:argument-list-wrapping" />
+        <error line="117" column="1" source="standard:max-line-length" />
+        <error line="120" column="1" source="standard:max-line-length" />
+        <error line="120" column="59" source="standard:argument-list-wrapping" />
+        <error line="120" column="74" source="standard:argument-list-wrapping" />
+        <error line="120" column="101" source="standard:argument-list-wrapping" />
+        <error line="120" column="119" source="standard:argument-list-wrapping" />
+        <error line="120" column="125" source="standard:argument-list-wrapping" />
+        <error line="134" column="1" source="standard:max-line-length" />
+        <error line="137" column="1" source="standard:max-line-length" />
+        <error line="137" column="59" source="standard:argument-list-wrapping" />
+        <error line="137" column="74" source="standard:argument-list-wrapping" />
+        <error line="137" column="110" source="standard:argument-list-wrapping" />
+        <error line="137" column="128" source="standard:argument-list-wrapping" />
+        <error line="137" column="134" source="standard:argument-list-wrapping" />
+        <error line="151" column="1" source="standard:max-line-length" />
+        <error line="154" column="1" source="standard:max-line-length" />
+        <error line="154" column="59" source="standard:argument-list-wrapping" />
+        <error line="154" column="74" source="standard:argument-list-wrapping" />
+        <error line="154" column="105" source="standard:argument-list-wrapping" />
+        <error line="154" column="123" source="standard:argument-list-wrapping" />
+        <error line="154" column="129" source="standard:argument-list-wrapping" />
+        <error line="168" column="1" source="standard:max-line-length" />
+        <error line="171" column="1" source="standard:max-line-length" />
+        <error line="171" column="59" source="standard:argument-list-wrapping" />
+        <error line="171" column="74" source="standard:argument-list-wrapping" />
+        <error line="171" column="103" source="standard:argument-list-wrapping" />
+        <error line="171" column="121" source="standard:argument-list-wrapping" />
+        <error line="171" column="127" source="standard:argument-list-wrapping" />
+        <error line="185" column="1" source="standard:max-line-length" />
+        <error line="188" column="1" source="standard:max-line-length" />
+        <error line="188" column="59" source="standard:argument-list-wrapping" />
+        <error line="188" column="74" source="standard:argument-list-wrapping" />
+        <error line="188" column="103" source="standard:argument-list-wrapping" />
+        <error line="188" column="121" source="standard:argument-list-wrapping" />
+        <error line="188" column="127" source="standard:argument-list-wrapping" />
+        <error line="205" column="1" source="standard:max-line-length" />
+        <error line="205" column="59" source="standard:argument-list-wrapping" />
+        <error line="205" column="74" source="standard:argument-list-wrapping" />
+        <error line="205" column="103" source="standard:argument-list-wrapping" />
+        <error line="205" column="121" source="standard:argument-list-wrapping" />
+        <error line="205" column="127" source="standard:argument-list-wrapping" />
+        <error line="224" column="1" source="standard:max-line-length" />
+        <error line="228" column="1" source="standard:max-line-length" />
+        <error line="228" column="59" source="standard:argument-list-wrapping" />
+        <error line="228" column="74" source="standard:argument-list-wrapping" />
+        <error line="228" column="103" source="standard:argument-list-wrapping" />
+        <error line="228" column="129" source="standard:argument-list-wrapping" />
+        <error line="228" column="135" source="standard:argument-list-wrapping" />
+        <error line="254" column="1" source="standard:max-line-length" />
+        <error line="257" column="1" source="standard:max-line-length" />
+        <error line="257" column="59" source="standard:argument-list-wrapping" />
+        <error line="257" column="74" source="standard:argument-list-wrapping" />
+        <error line="257" column="103" source="standard:argument-list-wrapping" />
+        <error line="257" column="121" source="standard:argument-list-wrapping" />
+        <error line="257" column="127" source="standard:argument-list-wrapping" />
+        <error line="272" column="1" source="standard:max-line-length" />
+        <error line="285" column="1" source="standard:max-line-length" />
+        <error line="333" column="1" source="standard:max-line-length" />
+        <error line="428" column="1" source="standard:max-line-length" />
+        <error line="461" column="1" source="standard:max-line-length" />
+        <error line="501" column="1" source="standard:max-line-length" />
+        <error line="519" column="1" source="standard:max-line-length" />
+        <error line="586" column="1" source="standard:max-line-length" />
+        <error line="610" column="1" source="standard:max-line-length" />
+        <error line="673" column="1" source="standard:max-line-length" />
+        <error line="677" column="1" source="standard:max-line-length" />
+        <error line="677" column="34" source="standard:property-wrapping" />
+        <error line="677" column="58" source="standard:argument-list-wrapping" />
+        <error line="677" column="79" source="standard:argument-list-wrapping" />
+        <error line="677" column="119" source="standard:argument-list-wrapping" />
+        <error line="677" column="137" source="standard:argument-list-wrapping" />
+        <error line="685" column="1" source="standard:max-line-length" />
+        <error line="692" column="1" source="standard:max-line-length" />
+        <error line="699" column="1" source="standard:max-line-length" />
+        <error line="706" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/GeckoPromptDelegateTest.kt">
+        <error line="1186" column="1" source="standard:max-line-length" />
+        <error line="1228" column="1" source="standard:max-line-length" />
+        <error line="1228" column="73" source="standard:argument-list-wrapping" />
+        <error line="1228" column="81" source="standard:argument-list-wrapping" />
+        <error line="1228" column="109" source="standard:argument-list-wrapping" />
+        <error line="1228" column="116" source="standard:argument-list-wrapping" />
+        <error line="1228" column="129" source="standard:argument-list-wrapping" />
+        <error line="1228" column="130" source="standard:argument-list-wrapping" />
+        <error line="1228" column="131" source="standard:argument-list-wrapping" />
+        <error line="1239" column="1" source="standard:max-line-length" />
+        <error line="1282" column="1" source="standard:max-line-length" />
+        <error line="1282" column="72" source="standard:argument-list-wrapping" />
+        <error line="1282" column="80" source="standard:argument-list-wrapping" />
+        <error line="1282" column="107" source="standard:argument-list-wrapping" />
+        <error line="1282" column="114" source="standard:argument-list-wrapping" />
+        <error line="1282" column="126" source="standard:argument-list-wrapping" />
+        <error line="1282" column="129" source="standard:argument-list-wrapping" />
+        <error line="1282" column="137" source="standard:argument-list-wrapping" />
+        <error line="1282" column="138" source="standard:argument-list-wrapping" />
+        <error line="1293" column="1" source="standard:max-line-length" />
+        <error line="1835" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/prompt/PromptInstanceDismissDelegateTest.kt">
+        <error line="21" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/serviceworker/GeckoServiceWorkerDelegateTest.kt">
+        <error line="20" column="1" source="standard:max-line-length" />
+        <error line="31" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/translate/GeckoTranslateSessionDelegateTest.kt">
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="96" column="1" source="standard:max-line-length" />
+        <error line="96" column="97" source="standard:argument-list-wrapping" />
+        <error line="96" column="110" source="standard:argument-list-wrapping" />
+        <error line="96" column="133" source="standard:argument-list-wrapping" />
+        <error line="96" column="143" source="standard:argument-list-wrapping" />
+        <error line="98" column="1" source="standard:max-line-length" />
+        <error line="98" column="89" source="standard:argument-list-wrapping" />
+        <error line="98" column="111" source="standard:argument-list-wrapping" />
+        <error line="98" column="118" source="standard:argument-list-wrapping" />
+        <error line="98" column="141" source="standard:argument-list-wrapping" />
+        <error line="98" column="154" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt">
+        <error line="125" column="1" source="standard:max-line-length" />
+        <error line="125" column="66" source="standard:argument-list-wrapping" />
+        <error line="125" column="89" source="standard:argument-list-wrapping" />
+        <error line="125" column="122" source="standard:argument-list-wrapping" />
+        <error line="125" column="125" source="standard:argument-list-wrapping" />
+        <error line="125" column="136" source="standard:argument-list-wrapping" />
+        <error line="125" column="137" source="standard:argument-list-wrapping" />
+        <error line="191" column="1" source="standard:max-line-length" />
+        <error line="191" column="66" source="standard:argument-list-wrapping" />
+        <error line="191" column="89" source="standard:argument-list-wrapping" />
+        <error line="191" column="122" source="standard:argument-list-wrapping" />
+        <error line="191" column="125" source="standard:argument-list-wrapping" />
+        <error line="191" column="136" source="standard:argument-list-wrapping" />
+        <error line="191" column="137" source="standard:argument-list-wrapping" />
+        <error line="294" column="1" source="standard:max-line-length" />
+        <error line="294" column="97" source="standard:argument-list-wrapping" />
+        <error line="294" column="123" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-gecko/src/test/java/mozilla/components/browser/experiment/NimbusExperimentDelegateTest.kt">
+        <error line="34" column="1" source="standard:max-line-length" />
+        <error line="34" column="20" source="standard:argument-list-wrapping" />
+        <error line="34" column="65" source="standard:argument-list-wrapping" />
+        <error line="34" column="102" source="standard:argument-list-wrapping" />
+        <error line="34" column="110" source="standard:argument-list-wrapping" />
+        <error line="34" column="132" source="standard:argument-list-wrapping" />
+        <error line="34" column="133" source="standard:argument-list-wrapping" />
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="43" column="1" source="standard:max-line-length" />
+        <error line="43" column="28" source="standard:argument-list-wrapping" />
+        <error line="43" column="68" source="standard:argument-list-wrapping" />
+        <error line="43" column="146" source="standard:argument-list-wrapping" />
+        <error line="50" column="1" source="standard:max-line-length" />
+        <error line="50" column="28" source="standard:argument-list-wrapping" />
+        <error line="50" column="68" source="standard:argument-list-wrapping" />
+        <error line="50" column="146" source="standard:argument-list-wrapping" />
+        <error line="56" column="1" source="standard:max-line-length" />
+        <error line="56" column="28" source="standard:argument-list-wrapping" />
+        <error line="56" column="68" source="standard:argument-list-wrapping" />
+        <error line="56" column="146" source="standard:argument-list-wrapping" />
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="62" column="28" source="standard:argument-list-wrapping" />
+        <error line="62" column="68" source="standard:argument-list-wrapping" />
+        <error line="62" column="146" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/NestedWebViewTest.kt">
+        <error line="141" column="1" source="standard:max-line-length" />
+        <error line="154" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionStateTest.kt">
+        <error line="131" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineSessionTest.kt">
+        <error line="266" column="1" source="standard:max-line-length" />
+        <error line="1217" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineTest.kt">
+        <error line="88" column="1" source="standard:max-line-length" />
+        <error line="88" column="22" source="standard:argument-list-wrapping" />
+        <error line="88" column="29" source="standard:argument-list-wrapping" />
+        <error line="88" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/engine-system/src/test/java/mozilla/components/browser/engine/system/SystemEngineViewTest.kt">
+        <error line="338" column="1" source="standard:max-line-length" />
+        <error line="338" column="68" source="standard:argument-list-wrapping" />
+        <error line="338" column="77" source="standard:argument-list-wrapping" />
+        <error line="338" column="116" source="standard:argument-list-wrapping" />
+        <error line="338" column="121" source="standard:argument-list-wrapping" />
+        <error line="1633" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/errorpages/src/test/java/mozilla/components/browser/errorpages/ErrorPagesTest.kt">
+        <error line="100" column="1" source="standard:max-line-length" />
+        <error line="100" column="20" source="standard:argument-list-wrapping" />
+        <error line="100" column="39" source="standard:argument-list-wrapping" />
+        <error line="100" column="123" source="standard:argument-list-wrapping" />
+        <error line="100" column="124" source="standard:argument-list-wrapping" />
+        <error line="102" column="1" source="standard:max-line-length" />
+        <error line="102" column="94" source="standard:argument-list-wrapping" />
+        <error line="102" column="102" source="standard:argument-list-wrapping" />
+        <error line="102" column="130" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/icons/src/test/java/mozilla/components/browser/icons/BrowserIconsTest.kt">
+        <error line="173" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/icons/src/test/java/mozilla/components/browser/icons/extension/IconMessageHandlerTest.kt">
+        <error line="170" column="1" source="standard:max-line-length" />
+        <error line="170" column="30" source="standard:argument-list-wrapping" />
+        <error line="170" column="120" source="standard:argument-list-wrapping" />
+        <error line="170" column="123" source="standard:argument-list-wrapping" />
+        <error line="207" column="1" source="standard:max-line-length" />
+        <error line="207" column="30" source="standard:argument-list-wrapping" />
+        <error line="207" column="134" source="standard:argument-list-wrapping" />
+        <error line="207" column="137" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/icons/src/test/java/mozilla/components/browser/icons/loader/NonBlockingHttpIconLoaderTest.kt">
+        <error line="50" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/icons/src/test/java/mozilla/components/browser/icons/pipeline/IconResourceComparatorTest.kt">
+        <error line="303" column="1" source="standard:max-line-length" />
+    </file>
     <file name="components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuPositioning.kt">
         <error line="1" column="1" source="standard:filename" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuAdapterTest.kt">
+        <error line="150" column="1" source="standard:max-line-length" />
+        <error line="163" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuPositioningTest.kt">
+        <error line="23" column="1" source="standard:max-line-length" />
+        <error line="45" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuTest.kt">
+        <error line="107" column="1" source="standard:max-line-length" />
+        <error line="107" column="85" source="standard:argument-list-wrapping" />
+        <error line="107" column="121" source="standard:argument-list-wrapping" />
+        <error line="359" column="1" source="standard:max-line-length" />
+        <error line="377" column="1" source="standard:max-line-length" />
+        <error line="455" column="1" source="standard:max-line-length" />
+        <error line="471" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilderTest.kt">
+        <error line="192" column="1" source="standard:max-line-length" />
+        <error line="200" column="1" source="standard:max-line-length" />
+        <error line="259" column="1" source="standard:max-line-length" />
+        <error line="259" column="47" source="standard:property-wrapping" />
+        <error line="259" column="74" source="standard:argument-list-wrapping" />
+        <error line="259" column="103" source="standard:argument-list-wrapping" />
+        <error line="259" column="109" source="standard:argument-list-wrapping" />
+        <error line="259" column="117" source="standard:argument-list-wrapping" />
+        <error line="259" column="121" source="standard:argument-list-wrapping" />
+        <error line="259" column="124" source="standard:argument-list-wrapping" />
+        <error line="259" column="125" source="standard:argument-list-wrapping" />
+        <error line="343" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/WebExtensionBrowserMenuTest.kt">
+        <error line="478" column="1" source="standard:max-line-length" />
+        <error line="478" column="31" source="standard:argument-list-wrapping" />
+        <error line="478" column="41" source="standard:argument-list-wrapping" />
+        <error line="478" column="74" source="standard:argument-list-wrapping" />
+        <error line="478" column="95" source="standard:argument-list-wrapping" />
+        <error line="478" column="121" source="standard:argument-list-wrapping" />
+        <error line="480" column="1" source="standard:max-line-length" />
+        <error line="480" column="50" source="standard:property-wrapping" />
+        <error line="480" column="84" source="standard:argument-list-wrapping" />
+        <error line="480" column="122" source="standard:argument-list-wrapping" />
+        <error line="480" column="137" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCategoryTest.kt">
+        <error line="72" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuCompoundButtonTest.kt">
+        <error line="139" column="1" source="standard:max-line-length" />
+        <error line="152" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableItemTest.kt">
+        <error line="129" column="1" source="standard:max-line-length" />
+        <error line="129" column="22" source="standard:argument-list-wrapping" />
+        <error line="129" column="63" source="standard:argument-list-wrapping" />
+        <error line="129" column="126" source="standard:argument-list-wrapping" />
+        <error line="138" column="1" source="standard:max-line-length" />
+        <error line="138" column="22" source="standard:argument-list-wrapping" />
+        <error line="138" column="63" source="standard:argument-list-wrapping" />
+        <error line="138" column="126" source="standard:argument-list-wrapping" />
+        <error line="168" column="1" source="standard:max-line-length" />
+        <error line="168" column="22" source="standard:argument-list-wrapping" />
+        <error line="168" column="63" source="standard:argument-list-wrapping" />
+        <error line="168" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/item/BrowserMenuHighlightableSwitchTest.kt">
+        <error line="87" column="1" source="standard:max-line-length" />
+        <error line="87" column="22" source="standard:argument-list-wrapping" />
+        <error line="87" column="63" source="standard:argument-list-wrapping" />
+        <error line="87" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/view/DynamicWidthRecyclerViewTest.kt">
+        <error line="120" column="1" source="standard:max-line-length" />
+        <error line="120" column="76" source="standard:argument-list-wrapping" />
+        <error line="120" column="126" source="standard:argument-list-wrapping" />
+        <error line="135" column="1" source="standard:max-line-length" />
+        <error line="147" column="1" source="standard:max-line-length" />
+        <error line="147" column="76" source="standard:argument-list-wrapping" />
+        <error line="147" column="126" source="standard:argument-list-wrapping" />
+        <error line="163" column="1" source="standard:max-line-length" />
+        <error line="163" column="82" source="standard:argument-list-wrapping" />
+        <error line="163" column="130" source="standard:argument-list-wrapping" />
+        <error line="178" column="1" source="standard:max-line-length" />
+        <error line="178" column="82" source="standard:argument-list-wrapping" />
+        <error line="178" column="130" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/view/ExpandableLayoutTest.kt">
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="98" column="1" source="standard:max-line-length" />
+        <error line="115" column="1" source="standard:max-line-length" />
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="140" column="1" source="standard:max-line-length" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="158" column="1" source="standard:max-line-length" />
+        <error line="158" column="120" source="standard:argument-list-wrapping" />
+        <error line="158" column="128" source="standard:argument-list-wrapping" />
+        <error line="186" column="1" source="standard:max-line-length" />
+        <error line="207" column="1" source="standard:max-line-length" />
+        <error line="227" column="1" source="standard:max-line-length" />
+        <error line="245" column="1" source="standard:max-line-length" />
+        <error line="261" column="1" source="standard:max-line-length" />
+        <error line="277" column="1" source="standard:max-line-length" />
+        <error line="296" column="1" source="standard:max-line-length" />
+        <error line="315" column="1" source="standard:max-line-length" />
+        <error line="331" column="1" source="standard:max-line-length" />
+        <error line="348" column="1" source="standard:max-line-length" />
+        <error line="365" column="1" source="standard:max-line-length" />
+        <error line="382" column="1" source="standard:max-line-length" />
+        <error line="398" column="1" source="standard:max-line-length" />
+        <error line="448" column="1" source="standard:max-line-length" />
+        <error line="481" column="1" source="standard:max-line-length" />
+        <error line="506" column="1" source="standard:max-line-length" />
+        <error line="522" column="1" source="standard:max-line-length" />
+        <error line="538" column="1" source="standard:max-line-length" />
+        <error line="557" column="1" source="standard:max-line-length" />
+        <error line="573" column="1" source="standard:max-line-length" />
+        <error line="590" column="1" source="standard:max-line-length" />
+        <error line="600" column="1" source="standard:max-line-length" />
+        <error line="600" column="68" source="standard:argument-list-wrapping" />
+        <error line="600" column="101" source="standard:argument-list-wrapping" />
+        <error line="600" column="106" source="standard:argument-list-wrapping" />
+        <error line="600" column="130" source="standard:argument-list-wrapping" />
+        <error line="600" column="131" source="standard:argument-list-wrapping" />
+        <error line="608" column="1" source="standard:max-line-length" />
+        <error line="608" column="64" source="standard:argument-list-wrapping" />
+        <error line="608" column="97" source="standard:argument-list-wrapping" />
+        <error line="608" column="102" source="standard:argument-list-wrapping" />
+        <error line="608" column="126" source="standard:argument-list-wrapping" />
+        <error line="608" column="127" source="standard:argument-list-wrapping" />
+        <error line="635" column="1" source="standard:max-line-length" />
+        <error line="666" column="1" source="standard:max-line-length" />
+        <error line="695" column="1" source="standard:max-line-length" />
+        <error line="702" column="1" source="standard:max-line-length" />
+        <error line="732" column="1" source="standard:max-line-length" />
+        <error line="740" column="1" source="standard:max-line-length" />
+        <error line="769" column="1" source="standard:max-line-length" />
+        <error line="776" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/view/StickyFooterLinearLayoutManagerTest.kt">
+        <error line="29" column="1" source="standard:max-line-length" />
+        <error line="48" column="1" source="standard:max-line-length" />
+        <error line="69" column="1" source="standard:max-line-length" />
+        <error line="84" column="1" source="standard:max-line-length" />
+        <error line="108" column="1" source="standard:max-line-length" />
+        <error line="115" column="1" source="standard:max-line-length" />
+        <error line="127" column="1" source="standard:max-line-length" />
+        <error line="138" column="1" source="standard:max-line-length" />
+        <error line="147" column="1" source="standard:max-line-length" />
+        <error line="159" column="1" source="standard:max-line-length" />
+        <error line="171" column="1" source="standard:max-line-length" />
+        <error line="181" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/view/StickyHeaderLinearLayoutManagerTest.kt">
+        <error line="27" column="1" source="standard:max-line-length" />
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="61" column="1" source="standard:max-line-length" />
+        <error line="85" column="1" source="standard:max-line-length" />
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="101" column="1" source="standard:max-line-length" />
+        <error line="113" column="1" source="standard:max-line-length" />
+        <error line="128" column="1" source="standard:max-line-length" />
+        <error line="137" column="1" source="standard:max-line-length" />
+        <error line="147" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu/src/test/java/mozilla/components/browser/menu/view/StickyItemsLinearLayoutManagerTest.kt">
+        <error line="72" column="1" source="standard:max-line-length" />
+        <error line="86" column="1" source="standard:max-line-length" />
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="106" column="1" source="standard:max-line-length" />
+        <error line="121" column="1" source="standard:max-line-length" />
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="141" column="1" source="standard:max-line-length" />
+        <error line="150" column="1" source="standard:max-line-length" />
+        <error line="159" column="1" source="standard:max-line-length" />
+        <error line="168" column="1" source="standard:max-line-length" />
+        <error line="177" column="1" source="standard:max-line-length" />
+        <error line="186" column="1" source="standard:max-line-length" />
+        <error line="195" column="1" source="standard:max-line-length" />
+        <error line="213" column="1" source="standard:max-line-length" />
+        <error line="223" column="1" source="standard:max-line-length" />
+        <error line="235" column="1" source="standard:max-line-length" />
+        <error line="244" column="1" source="standard:max-line-length" />
+        <error line="249" column="1" source="standard:max-line-length" />
+        <error line="261" column="1" source="standard:max-line-length" />
+        <error line="288" column="1" source="standard:max-line-length" />
+        <error line="317" column="1" source="standard:max-line-length" />
+        <error line="332" column="1" source="standard:max-line-length" />
+        <error line="349" column="1" source="standard:max-line-length" />
+        <error line="365" column="1" source="standard:max-line-length" />
+        <error line="381" column="1" source="standard:max-line-length" />
+        <error line="495" column="1" source="standard:max-line-length" />
+        <error line="513" column="1" source="standard:max-line-length" />
+        <error line="523" column="1" source="standard:max-line-length" />
+        <error line="561" column="1" source="standard:max-line-length" />
+        <error line="573" column="1" source="standard:max-line-length" />
+        <error line="585" column="1" source="standard:max-line-length" />
+        <error line="597" column="1" source="standard:max-line-length" />
+        <error line="609" column="1" source="standard:max-line-length" />
+        <error line="621" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu2/src/test/java/mozilla/components/browser/menu2/BrowserMenuControllerTest.kt">
+        <error line="104" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/menu2/src/test/java/mozilla/components/browser/menu2/adapter/icons/DrawableMenuIconViewHoldersTest.kt">
+        <error line="59" column="1" source="standard:max-line-length" />
+        <error line="59" column="60" source="standard:argument-list-wrapping" />
+        <error line="59" column="108" source="standard:argument-list-wrapping" />
+        <error line="59" column="116" source="standard:argument-list-wrapping" />
+        <error line="59" column="121" source="standard:argument-list-wrapping" />
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="60" column="62" source="standard:argument-list-wrapping" />
+        <error line="60" column="111" source="standard:argument-list-wrapping" />
+        <error line="60" column="119" source="standard:argument-list-wrapping" />
+        <error line="60" column="124" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/menu2/src/test/java/mozilla/components/browser/menu2/ext/BrowserMenuPositioningTest.kt">
+        <error line="108" column="1" source="standard:max-line-length" />
+        <error line="129" column="1" source="standard:max-line-length" />
+        <error line="150" column="1" source="standard:max-line-length" />
+        <error line="171" column="1" source="standard:max-line-length" />
+        <error line="193" column="1" source="standard:max-line-length" />
+        <error line="202" column="1" source="standard:max-line-length" />
+        <error line="202" column="55" source="standard:argument-list-wrapping" />
+        <error line="202" column="58" source="standard:argument-list-wrapping" />
+        <error line="202" column="61" source="standard:argument-list-wrapping" />
+        <error line="202" column="76" source="standard:argument-list-wrapping" />
+        <error line="202" column="84" source="standard:argument-list-wrapping" />
+        <error line="202" column="108" source="standard:argument-list-wrapping" />
+        <error line="202" column="127" source="standard:argument-list-wrapping" />
+        <error line="215" column="1" source="standard:max-line-length" />
+        <error line="236" column="1" source="standard:max-line-length" />
+        <error line="244" column="1" source="standard:max-line-length" />
+        <error line="244" column="55" source="standard:argument-list-wrapping" />
+        <error line="244" column="58" source="standard:argument-list-wrapping" />
+        <error line="244" column="61" source="standard:argument-list-wrapping" />
+        <error line="244" column="76" source="standard:argument-list-wrapping" />
+        <error line="244" column="84" source="standard:argument-list-wrapping" />
+        <error line="244" column="108" source="standard:argument-list-wrapping" />
+        <error line="244" column="127" source="standard:argument-list-wrapping" />
+        <error line="275" column="1" source="standard:max-line-length" />
+        <error line="296" column="1" source="standard:max-line-length" />
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="304" column="55" source="standard:argument-list-wrapping" />
+        <error line="304" column="58" source="standard:argument-list-wrapping" />
+        <error line="304" column="61" source="standard:argument-list-wrapping" />
+        <error line="304" column="76" source="standard:argument-list-wrapping" />
+        <error line="304" column="84" source="standard:argument-list-wrapping" />
+        <error line="304" column="108" source="standard:argument-list-wrapping" />
+        <error line="304" column="127" source="standard:argument-list-wrapping" />
+        <error line="317" column="1" source="standard:max-line-length" />
+        <error line="338" column="1" source="standard:max-line-length" />
+        <error line="359" column="1" source="standard:max-line-length" />
+        <error line="380" column="1" source="standard:max-line-length" />
+        <error line="388" column="1" source="standard:max-line-length" />
+        <error line="388" column="55" source="standard:argument-list-wrapping" />
+        <error line="388" column="58" source="standard:argument-list-wrapping" />
+        <error line="388" column="61" source="standard:argument-list-wrapping" />
+        <error line="388" column="76" source="standard:argument-list-wrapping" />
+        <error line="388" column="84" source="standard:argument-list-wrapping" />
+        <error line="388" column="98" source="standard:argument-list-wrapping" />
+        <error line="388" column="119" source="standard:argument-list-wrapping" />
+        <error line="388" column="141" source="standard:argument-list-wrapping" />
+        <error line="401" column="1" source="standard:max-line-length" />
+        <error line="422" column="1" source="standard:max-line-length" />
+        <error line="444" column="1" source="standard:max-line-length" />
+        <error line="465" column="1" source="standard:max-line-length" />
+        <error line="486" column="1" source="standard:max-line-length" />
+        <error line="507" column="1" source="standard:max-line-length" />
+        <error line="515" column="1" source="standard:max-line-length" />
+        <error line="515" column="55" source="standard:argument-list-wrapping" />
+        <error line="515" column="58" source="standard:argument-list-wrapping" />
+        <error line="515" column="61" source="standard:argument-list-wrapping" />
+        <error line="515" column="76" source="standard:argument-list-wrapping" />
+        <error line="515" column="84" source="standard:argument-list-wrapping" />
+        <error line="515" column="97" source="standard:argument-list-wrapping" />
+        <error line="515" column="118" source="standard:argument-list-wrapping" />
+        <error line="515" column="140" source="standard:argument-list-wrapping" />
+        <error line="528" column="1" source="standard:max-line-length" />
+        <error line="549" column="1" source="standard:max-line-length" />
+        <error line="571" column="1" source="standard:max-line-length" />
+        <error line="592" column="1" source="standard:max-line-length" />
+        <error line="600" column="1" source="standard:max-line-length" />
+        <error line="600" column="55" source="standard:argument-list-wrapping" />
+        <error line="600" column="58" source="standard:argument-list-wrapping" />
+        <error line="600" column="61" source="standard:argument-list-wrapping" />
+        <error line="600" column="76" source="standard:argument-list-wrapping" />
+        <error line="600" column="84" source="standard:argument-list-wrapping" />
+        <error line="600" column="104" source="standard:argument-list-wrapping" />
+        <error line="600" column="126" source="standard:argument-list-wrapping" />
+        <error line="613" column="1" source="standard:max-line-length" />
+        <error line="621" column="1" source="standard:max-line-length" />
+        <error line="621" column="55" source="standard:argument-list-wrapping" />
+        <error line="621" column="58" source="standard:argument-list-wrapping" />
+        <error line="621" column="61" source="standard:argument-list-wrapping" />
+        <error line="621" column="76" source="standard:argument-list-wrapping" />
+        <error line="621" column="84" source="standard:argument-list-wrapping" />
+        <error line="621" column="104" source="standard:argument-list-wrapping" />
+        <error line="621" column="123" source="standard:argument-list-wrapping" />
+        <error line="634" column="1" source="standard:max-line-length" />
+        <error line="642" column="1" source="standard:max-line-length" />
+        <error line="642" column="55" source="standard:argument-list-wrapping" />
+        <error line="642" column="58" source="standard:argument-list-wrapping" />
+        <error line="642" column="61" source="standard:argument-list-wrapping" />
+        <error line="642" column="76" source="standard:argument-list-wrapping" />
+        <error line="642" column="84" source="standard:argument-list-wrapping" />
+        <error line="642" column="104" source="standard:argument-list-wrapping" />
+        <error line="642" column="125" source="standard:argument-list-wrapping" />
+        <error line="642" column="147" source="standard:argument-list-wrapping" />
+        <error line="655" column="1" source="standard:max-line-length" />
+        <error line="663" column="1" source="standard:max-line-length" />
+        <error line="663" column="55" source="standard:argument-list-wrapping" />
+        <error line="663" column="58" source="standard:argument-list-wrapping" />
+        <error line="663" column="61" source="standard:argument-list-wrapping" />
+        <error line="663" column="76" source="standard:argument-list-wrapping" />
+        <error line="663" column="84" source="standard:argument-list-wrapping" />
+        <error line="663" column="104" source="standard:argument-list-wrapping" />
+        <error line="663" column="123" source="standard:argument-list-wrapping" />
+        <error line="676" column="1" source="standard:max-line-length" />
+        <error line="685" column="1" source="standard:max-line-length" />
+        <error line="685" column="55" source="standard:argument-list-wrapping" />
+        <error line="685" column="58" source="standard:argument-list-wrapping" />
+        <error line="685" column="61" source="standard:argument-list-wrapping" />
+        <error line="685" column="76" source="standard:argument-list-wrapping" />
+        <error line="685" column="84" source="standard:argument-list-wrapping" />
+        <error line="685" column="104" source="standard:argument-list-wrapping" />
+        <error line="685" column="123" source="standard:argument-list-wrapping" />
+        <error line="825" column="1" source="standard:max-line-length" />
+        <error line="845" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/session-storage/src/androidTest/java/mozilla/components/browser/session/storage/RestoringBrowsingSessionsTest.kt">
+        <error line="121" column="1" source="standard:max-line-length" />
+        <error line="121" column="30" source="standard:argument-list-wrapping" />
+        <error line="121" column="133" source="standard:argument-list-wrapping" />
+        <error line="121" column="136" source="standard:argument-list-wrapping" />
+        <error line="145" column="1" source="standard:max-line-length" />
+        <error line="145" column="30" source="standard:argument-list-wrapping" />
+        <error line="145" column="221" source="standard:argument-list-wrapping" />
+        <error line="145" column="224" source="standard:argument-list-wrapping" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="149" column="30" source="standard:argument-list-wrapping" />
+        <error line="149" column="114" source="standard:argument-list-wrapping" />
+        <error line="149" column="135" source="standard:argument-list-wrapping" />
+        <error line="196" column="1" source="standard:max-line-length" />
+        <error line="196" column="30" source="standard:argument-list-wrapping" />
+        <error line="196" column="137" source="standard:argument-list-wrapping" />
+        <error line="196" column="140" source="standard:argument-list-wrapping" />
+        <error line="200" column="1" source="standard:max-line-length" />
+        <error line="200" column="30" source="standard:argument-list-wrapping" />
+        <error line="200" column="137" source="standard:argument-list-wrapping" />
+        <error line="200" column="158" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/action/AwesomeBarActionTest.kt">
+        <error line="40" column="1" source="standard:max-line-length" />
+        <error line="40" column="22" source="standard:argument-list-wrapping" />
+        <error line="40" column="48" source="standard:argument-list-wrapping" />
+        <error line="40" column="128" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/action/DownloadActionTest.kt">
+        <error line="49" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/action/SearchActionTest.kt">
+        <error line="226" column="1" source="standard:max-line-length" />
+        <error line="235" column="1" source="standard:max-line-length" />
+        <error line="235" column="38" source="standard:argument-list-wrapping" />
+        <error line="235" column="57" source="standard:argument-list-wrapping" />
+        <error line="235" column="78" source="standard:argument-list-wrapping" />
+        <error line="235" column="93" source="standard:argument-list-wrapping" />
+        <error line="235" column="125" source="standard:argument-list-wrapping" />
+        <error line="268" column="1" source="standard:max-line-length" />
+        <error line="268" column="38" source="standard:argument-list-wrapping" />
+        <error line="268" column="57" source="standard:argument-list-wrapping" />
+        <error line="268" column="78" source="standard:argument-list-wrapping" />
+        <error line="268" column="93" source="standard:argument-list-wrapping" />
+        <error line="268" column="125" source="standard:argument-list-wrapping" />
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="304" column="38" source="standard:argument-list-wrapping" />
+        <error line="304" column="57" source="standard:argument-list-wrapping" />
+        <error line="304" column="78" source="standard:argument-list-wrapping" />
+        <error line="304" column="93" source="standard:argument-list-wrapping" />
+        <error line="304" column="125" source="standard:argument-list-wrapping" />
+        <error line="332" column="1" source="standard:max-line-length" />
+        <error line="332" column="38" source="standard:argument-list-wrapping" />
+        <error line="332" column="57" source="standard:argument-list-wrapping" />
+        <error line="332" column="78" source="standard:argument-list-wrapping" />
+        <error line="332" column="93" source="standard:argument-list-wrapping" />
+        <error line="332" column="125" source="standard:argument-list-wrapping" />
+        <error line="361" column="1" source="standard:max-line-length" />
+        <error line="361" column="38" source="standard:argument-list-wrapping" />
+        <error line="361" column="57" source="standard:argument-list-wrapping" />
+        <error line="361" column="78" source="standard:argument-list-wrapping" />
+        <error line="361" column="93" source="standard:argument-list-wrapping" />
+        <error line="361" column="125" source="standard:argument-list-wrapping" />
+        <error line="364" column="1" source="standard:max-line-length" />
+        <error line="364" column="38" source="standard:argument-list-wrapping" />
+        <error line="364" column="53" source="standard:argument-list-wrapping" />
+        <error line="364" column="77" source="standard:argument-list-wrapping" />
+        <error line="364" column="92" source="standard:argument-list-wrapping" />
+        <error line="364" column="123" source="standard:argument-list-wrapping" />
+        <error line="399" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/action/TabListActionTest.kt">
+        <error line="285" column="1" source="standard:max-line-length" />
+        <error line="285" column="33" source="standard:argument-list-wrapping" />
+        <error line="285" column="43" source="standard:argument-list-wrapping" />
+        <error line="285" column="82" source="standard:argument-list-wrapping" />
+        <error line="285" column="130" source="standard:argument-list-wrapping" />
+        <error line="285" column="136" source="standard:argument-list-wrapping" />
+        <error line="285" column="137" source="standard:argument-list-wrapping" />
+        <error line="343" column="1" source="standard:max-line-length" />
+        <error line="343" column="33" source="standard:argument-list-wrapping" />
+        <error line="343" column="44" source="standard:argument-list-wrapping" />
+        <error line="343" column="78" source="standard:argument-list-wrapping" />
+        <error line="343" column="126" source="standard:argument-list-wrapping" />
+        <error line="343" column="132" source="standard:argument-list-wrapping" />
+        <error line="343" column="133" source="standard:argument-list-wrapping" />
+        <error line="376" column="1" source="standard:max-line-length" />
+        <error line="376" column="33" source="standard:argument-list-wrapping" />
+        <error line="376" column="44" source="standard:argument-list-wrapping" />
+        <error line="376" column="78" source="standard:argument-list-wrapping" />
+        <error line="376" column="126" source="standard:argument-list-wrapping" />
+        <error line="376" column="132" source="standard:argument-list-wrapping" />
+        <error line="376" column="133" source="standard:argument-list-wrapping" />
+        <error line="716" column="1" source="standard:max-line-length" />
+        <error line="716" column="36" source="standard:argument-list-wrapping" />
+        <error line="716" column="63" source="standard:argument-list-wrapping" />
+        <error line="716" column="80" source="standard:argument-list-wrapping" />
+        <error line="716" column="90" source="standard:argument-list-wrapping" />
+        <error line="716" column="123" source="standard:argument-list-wrapping" />
+        <error line="716" column="137" source="standard:argument-list-wrapping" />
+        <error line="716" column="138" source="standard:argument-list-wrapping" />
+        <error line="717" column="1" source="standard:max-line-length" />
+        <error line="717" column="36" source="standard:argument-list-wrapping" />
+        <error line="717" column="63" source="standard:argument-list-wrapping" />
+        <error line="717" column="80" source="standard:argument-list-wrapping" />
+        <error line="717" column="90" source="standard:argument-list-wrapping" />
+        <error line="717" column="121" source="standard:argument-list-wrapping" />
+        <error line="717" column="136" source="standard:argument-list-wrapping" />
+        <error line="717" column="137" source="standard:argument-list-wrapping" />
+        <error line="748" column="1" source="standard:max-line-length" />
+        <error line="748" column="36" source="standard:argument-list-wrapping" />
+        <error line="748" column="63" source="standard:argument-list-wrapping" />
+        <error line="748" column="80" source="standard:argument-list-wrapping" />
+        <error line="748" column="90" source="standard:argument-list-wrapping" />
+        <error line="748" column="123" source="standard:argument-list-wrapping" />
+        <error line="748" column="132" source="standard:argument-list-wrapping" />
+        <error line="748" column="133" source="standard:argument-list-wrapping" />
+        <error line="777" column="1" source="standard:max-line-length" />
+        <error line="777" column="36" source="standard:argument-list-wrapping" />
+        <error line="777" column="63" source="standard:argument-list-wrapping" />
+        <error line="777" column="80" source="standard:argument-list-wrapping" />
+        <error line="777" column="90" source="standard:argument-list-wrapping" />
+        <error line="777" column="123" source="standard:argument-list-wrapping" />
+        <error line="777" column="132" source="standard:argument-list-wrapping" />
+        <error line="777" column="133" source="standard:argument-list-wrapping" />
+        <error line="806" column="1" source="standard:max-line-length" />
+        <error line="806" column="36" source="standard:argument-list-wrapping" />
+        <error line="806" column="63" source="standard:argument-list-wrapping" />
+        <error line="806" column="80" source="standard:argument-list-wrapping" />
+        <error line="806" column="90" source="standard:argument-list-wrapping" />
+        <error line="806" column="123" source="standard:argument-list-wrapping" />
+        <error line="806" column="132" source="standard:argument-list-wrapping" />
+        <error line="806" column="133" source="standard:argument-list-wrapping" />
+        <error line="835" column="1" source="standard:max-line-length" />
+        <error line="835" column="36" source="standard:argument-list-wrapping" />
+        <error line="835" column="63" source="standard:argument-list-wrapping" />
+        <error line="835" column="80" source="standard:argument-list-wrapping" />
+        <error line="835" column="90" source="standard:argument-list-wrapping" />
+        <error line="835" column="123" source="standard:argument-list-wrapping" />
+        <error line="835" column="132" source="standard:argument-list-wrapping" />
+        <error line="835" column="133" source="standard:argument-list-wrapping" />
+        <error line="864" column="1" source="standard:max-line-length" />
+        <error line="864" column="36" source="standard:argument-list-wrapping" />
+        <error line="864" column="63" source="standard:argument-list-wrapping" />
+        <error line="864" column="80" source="standard:argument-list-wrapping" />
+        <error line="864" column="90" source="standard:argument-list-wrapping" />
+        <error line="864" column="123" source="standard:argument-list-wrapping" />
+        <error line="864" column="132" source="standard:argument-list-wrapping" />
+        <error line="864" column="133" source="standard:argument-list-wrapping" />
+        <error line="865" column="1" source="standard:max-line-length" />
+        <error line="865" column="36" source="standard:argument-list-wrapping" />
+        <error line="865" column="63" source="standard:argument-list-wrapping" />
+        <error line="865" column="80" source="standard:argument-list-wrapping" />
+        <error line="865" column="90" source="standard:argument-list-wrapping" />
+        <error line="865" column="123" source="standard:argument-list-wrapping" />
+        <error line="865" column="132" source="standard:argument-list-wrapping" />
+        <error line="865" column="133" source="standard:argument-list-wrapping" />
+        <error line="895" column="1" source="standard:max-line-length" />
+        <error line="895" column="36" source="standard:argument-list-wrapping" />
+        <error line="895" column="63" source="standard:argument-list-wrapping" />
+        <error line="895" column="80" source="standard:argument-list-wrapping" />
+        <error line="895" column="90" source="standard:argument-list-wrapping" />
+        <error line="895" column="123" source="standard:argument-list-wrapping" />
+        <error line="895" column="132" source="standard:argument-list-wrapping" />
+        <error line="895" column="133" source="standard:argument-list-wrapping" />
+        <error line="896" column="1" source="standard:max-line-length" />
+        <error line="896" column="36" source="standard:argument-list-wrapping" />
+        <error line="896" column="63" source="standard:argument-list-wrapping" />
+        <error line="896" column="80" source="standard:argument-list-wrapping" />
+        <error line="896" column="90" source="standard:argument-list-wrapping" />
+        <error line="896" column="123" source="standard:argument-list-wrapping" />
+        <error line="896" column="132" source="standard:argument-list-wrapping" />
+        <error line="896" column="133" source="standard:argument-list-wrapping" />
+        <error line="926" column="1" source="standard:max-line-length" />
+        <error line="926" column="36" source="standard:argument-list-wrapping" />
+        <error line="926" column="63" source="standard:argument-list-wrapping" />
+        <error line="926" column="80" source="standard:argument-list-wrapping" />
+        <error line="926" column="90" source="standard:argument-list-wrapping" />
+        <error line="926" column="123" source="standard:argument-list-wrapping" />
+        <error line="926" column="133" source="standard:argument-list-wrapping" />
+        <error line="926" column="134" source="standard:argument-list-wrapping" />
+        <error line="927" column="1" source="standard:max-line-length" />
+        <error line="927" column="36" source="standard:argument-list-wrapping" />
+        <error line="927" column="63" source="standard:argument-list-wrapping" />
+        <error line="927" column="80" source="standard:argument-list-wrapping" />
+        <error line="927" column="90" source="standard:argument-list-wrapping" />
+        <error line="927" column="121" source="standard:argument-list-wrapping" />
+        <error line="927" column="122" source="standard:argument-list-wrapping" />
+        <error line="950" column="1" source="standard:max-line-length" />
+        <error line="950" column="33" source="standard:argument-list-wrapping" />
+        <error line="950" column="44" source="standard:argument-list-wrapping" />
+        <error line="950" column="83" source="standard:argument-list-wrapping" />
+        <error line="950" column="131" source="standard:argument-list-wrapping" />
+        <error line="950" column="137" source="standard:argument-list-wrapping" />
+        <error line="950" column="138" source="standard:argument-list-wrapping" />
+        <error line="1332" column="1" source="standard:max-line-length" />
+        <error line="1332" column="40" source="standard:parameter-list-wrapping" />
+        <error line="1332" column="61" source="standard:parameter-list-wrapping" />
+        <error line="1332" column="83" source="standard:parameter-list-wrapping" />
+        <error line="1332" column="104" source="standard:parameter-list-wrapping" />
+        <error line="1332" column="123" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/action/TranslationsActionTest.kt">
+        <error line="81" column="1" source="standard:max-line-length" />
+        <error line="81" column="24" source="standard:argument-list-wrapping" />
+        <error line="81" column="66" source="standard:argument-list-wrapping" />
+        <error line="81" column="82" source="standard:argument-list-wrapping" />
+        <error line="81" column="124" source="standard:argument-list-wrapping" />
+        <error line="81" column="125" source="standard:argument-list-wrapping" />
+        <error line="100" column="1" source="standard:max-line-length" />
+        <error line="100" column="24" source="standard:argument-list-wrapping" />
+        <error line="100" column="68" source="standard:argument-list-wrapping" />
+        <error line="100" column="84" source="standard:argument-list-wrapping" />
+        <error line="100" column="128" source="standard:argument-list-wrapping" />
+        <error line="100" column="133" source="standard:argument-list-wrapping" />
+        <error line="100" column="134" source="standard:argument-list-wrapping" />
+        <error line="118" column="1" source="standard:max-line-length" />
+        <error line="118" column="24" source="standard:argument-list-wrapping" />
+        <error line="118" column="66" source="standard:argument-list-wrapping" />
+        <error line="118" column="82" source="standard:argument-list-wrapping" />
+        <error line="118" column="122" source="standard:argument-list-wrapping" />
+        <error line="118" column="123" source="standard:argument-list-wrapping" />
+        <error line="137" column="1" source="standard:max-line-length" />
+        <error line="137" column="24" source="standard:argument-list-wrapping" />
+        <error line="137" column="68" source="standard:argument-list-wrapping" />
+        <error line="137" column="84" source="standard:argument-list-wrapping" />
+        <error line="137" column="126" source="standard:argument-list-wrapping" />
+        <error line="137" column="131" source="standard:argument-list-wrapping" />
+        <error line="137" column="132" source="standard:argument-list-wrapping" />
+        <error line="166" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/action/WebExtensionActionTest.kt">
+        <error line="127" column="1" source="standard:max-line-length" />
+        <error line="128" column="1" source="standard:max-line-length" />
+        <error line="312" column="1" source="standard:max-line-length" />
+        <error line="357" column="1" source="standard:max-line-length" />
+        <error line="364" column="1" source="standard:max-line-length" />
+        <error line="367" column="1" source="standard:max-line-length" />
+        <error line="390" column="1" source="standard:max-line-length" />
+        <error line="404" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/engine/EngineObserverTest.kt">
+        <error line="473" column="1" source="standard:max-line-length" />
+        <error line="473" column="57" source="standard:argument-list-wrapping" />
+        <error line="473" column="68" source="standard:argument-list-wrapping" />
+        <error line="473" column="112" source="standard:argument-list-wrapping" />
+        <error line="473" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddlewareTest.kt">
+        <error line="204" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/SessionPrioritizationMiddlewareTest.kt">
+        <error line="54" column="1" source="standard:max-line-length" />
+        <error line="55" column="1" source="standard:max-line-length" />
+        <error line="55" column="25" source="standard:property-wrapping" />
+        <error line="55" column="58" source="standard:argument-list-wrapping" />
+        <error line="55" column="89" source="standard:argument-list-wrapping" />
+        <error line="55" column="125" source="standard:argument-list-wrapping" />
+        <error line="81" column="1" source="standard:max-line-length" />
+        <error line="104" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TranslationsMiddlewareTest.kt">
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="95" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/reducer/BrowserStateReducerKtTest.kt">
+        <error line="20" column="1" source="standard:max-line-length" />
+        <error line="42" column="1" source="standard:max-line-length" />
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="72" column="1" source="standard:max-line-length" />
+        <error line="87" column="1" source="standard:max-line-length" />
+        <error line="110" column="1" source="standard:max-line-length" />
+        <error line="162" column="1" source="standard:max-line-length" />
+        <error line="184" column="1" source="standard:max-line-length" />
+        <error line="206" column="1" source="standard:max-line-length" />
+        <error line="221" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/reducer/LastAccessReducerTest.kt">
+        <error line="37" column="1" source="standard:max-line-length" />
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="80" column="1" source="standard:max-line-length" />
+        <error line="103" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/selector/SelectorsKtTest.kt">
+        <error line="293" column="1" source="standard:max-line-length" />
+        <error line="293" column="19" source="standard:property-wrapping" />
+        <error line="293" column="30" source="standard:argument-list-wrapping" />
+        <error line="293" column="115" source="standard:argument-list-wrapping" />
+        <error line="293" column="130" source="standard:argument-list-wrapping" />
+        <error line="298" column="1" source="standard:max-line-length" />
+        <error line="298" column="22" source="standard:argument-list-wrapping" />
+        <error line="298" column="28" source="standard:argument-list-wrapping" />
+        <error line="298" column="78" source="standard:argument-list-wrapping" />
+        <error line="298" column="125" source="standard:argument-list-wrapping" />
+        <error line="298" column="140" source="standard:argument-list-wrapping" />
+        <error line="298" column="141" source="standard:argument-list-wrapping" />
+        <error line="299" column="1" source="standard:max-line-length" />
+        <error line="299" column="22" source="standard:argument-list-wrapping" />
+        <error line="299" column="28" source="standard:argument-list-wrapping" />
+        <error line="299" column="78" source="standard:argument-list-wrapping" />
+        <error line="299" column="129" source="standard:argument-list-wrapping" />
+        <error line="299" column="144" source="standard:argument-list-wrapping" />
+        <error line="299" column="145" source="standard:argument-list-wrapping" />
+        <error line="300" column="1" source="standard:max-line-length" />
+        <error line="300" column="22" source="standard:argument-list-wrapping" />
+        <error line="300" column="28" source="standard:argument-list-wrapping" />
+        <error line="300" column="78" source="standard:argument-list-wrapping" />
+        <error line="300" column="149" source="standard:argument-list-wrapping" />
+        <error line="300" column="164" source="standard:argument-list-wrapping" />
+        <error line="300" column="165" source="standard:argument-list-wrapping" />
+        <error line="301" column="1" source="standard:max-line-length" />
+        <error line="301" column="22" source="standard:argument-list-wrapping" />
+        <error line="301" column="35" source="standard:argument-list-wrapping" />
+        <error line="301" column="85" source="standard:argument-list-wrapping" />
+        <error line="301" column="109" source="standard:argument-list-wrapping" />
+        <error line="301" column="123" source="standard:argument-list-wrapping" />
+        <error line="301" column="124" source="standard:argument-list-wrapping" />
+        <error line="302" column="1" source="standard:max-line-length" />
+        <error line="302" column="20" source="standard:argument-list-wrapping" />
+        <error line="302" column="70" source="standard:argument-list-wrapping" />
+        <error line="302" column="113" source="standard:argument-list-wrapping" />
+        <error line="302" column="128" source="standard:argument-list-wrapping" />
+        <error line="302" column="129" source="standard:argument-list-wrapping" />
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="304" column="20" source="standard:argument-list-wrapping" />
+        <error line="304" column="70" source="standard:argument-list-wrapping" />
+        <error line="304" column="109" source="standard:argument-list-wrapping" />
+        <error line="304" column="123" source="standard:argument-list-wrapping" />
+        <error line="304" column="124" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/state/src/test/java/mozilla/components/browser/state/store/BrowserStoreExceptionTest.kt">
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="57" column="28" source="standard:argument-list-wrapping" />
+        <error line="57" column="56" source="standard:argument-list-wrapping" />
+        <error line="57" column="89" source="standard:argument-list-wrapping" />
+        <error line="57" column="160" source="standard:argument-list-wrapping" />
+        <error line="57" column="161" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesBookmarksStorageTest.kt">
+        <error line="210" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageTest.kt">
+        <error line="144" column="1" source="standard:max-line-length" />
+        <error line="144" column="55" source="standard:argument-list-wrapping" />
+        <error line="144" column="58" source="standard:argument-list-wrapping" />
+        <error line="144" column="62" source="standard:argument-list-wrapping" />
+        <error line="144" column="69" source="standard:argument-list-wrapping" />
+        <error line="144" column="99" source="standard:argument-list-wrapping" />
+        <error line="144" column="127" source="standard:argument-list-wrapping" />
+        <error line="144" column="128" source="standard:argument-list-wrapping" />
+        <error line="177" column="1" source="standard:max-line-length" />
+        <error line="177" column="35" source="standard:argument-list-wrapping" />
+        <error line="177" column="61" source="standard:argument-list-wrapping" />
+        <error line="177" column="77" source="standard:argument-list-wrapping" />
+        <error line="177" column="126" source="standard:argument-list-wrapping" />
+        <error line="177" column="127" source="standard:argument-list-wrapping" />
+        <error line="316" column="1" source="standard:max-line-length" />
+        <error line="316" column="22" source="standard:argument-list-wrapping" />
+        <error line="316" column="42" source="standard:argument-list-wrapping" />
+        <error line="316" column="61" source="standard:argument-list-wrapping" />
+        <error line="316" column="121" source="standard:argument-list-wrapping" />
+        <error line="316" column="122" source="standard:argument-list-wrapping" />
+        <error line="319" column="1" source="standard:max-line-length" />
+        <error line="319" column="22" source="standard:argument-list-wrapping" />
+        <error line="319" column="43" source="standard:argument-list-wrapping" />
+        <error line="319" column="62" source="standard:argument-list-wrapping" />
+        <error line="319" column="69" source="standard:argument-list-wrapping" />
+        <error line="319" column="96" source="standard:argument-list-wrapping" />
+        <error line="319" column="121" source="standard:argument-list-wrapping" />
+        <error line="319" column="122" source="standard:argument-list-wrapping" />
+        <error line="319" column="123" source="standard:argument-list-wrapping" />
+        <error line="321" column="1" source="standard:max-line-length" />
+        <error line="321" column="22" source="standard:argument-list-wrapping" />
+        <error line="321" column="43" source="standard:argument-list-wrapping" />
+        <error line="321" column="62" source="standard:argument-list-wrapping" />
+        <error line="321" column="69" source="standard:argument-list-wrapping" />
+        <error line="321" column="96" source="standard:argument-list-wrapping" />
+        <error line="321" column="121" source="standard:argument-list-wrapping" />
+        <error line="321" column="122" source="standard:argument-list-wrapping" />
+        <error line="321" column="123" source="standard:argument-list-wrapping" />
+        <error line="327" column="1" source="standard:max-line-length" />
+        <error line="327" column="22" source="standard:argument-list-wrapping" />
+        <error line="327" column="55" source="standard:argument-list-wrapping" />
+        <error line="327" column="74" source="standard:argument-list-wrapping" />
+        <error line="327" column="81" source="standard:argument-list-wrapping" />
+        <error line="327" column="108" source="standard:argument-list-wrapping" />
+        <error line="327" column="137" source="standard:argument-list-wrapping" />
+        <error line="327" column="164" source="standard:argument-list-wrapping" />
+        <error line="327" column="189" source="standard:argument-list-wrapping" />
+        <error line="327" column="190" source="standard:argument-list-wrapping" />
+        <error line="327" column="191" source="standard:argument-list-wrapping" />
+        <error line="446" column="1" source="standard:max-line-length" />
+        <error line="446" column="29" source="standard:argument-list-wrapping" />
+        <error line="446" column="118" source="standard:argument-list-wrapping" />
+        <error line="446" column="128" source="standard:argument-list-wrapping" />
+        <error line="446" column="142" source="standard:argument-list-wrapping" />
+        <error line="446" column="143" source="standard:argument-list-wrapping" />
+        <error line="618" column="1" source="standard:max-line-length" />
+        <error line="618" column="22" source="standard:argument-list-wrapping" />
+        <error line="618" column="57" source="standard:argument-list-wrapping" />
+        <error line="618" column="81" source="standard:argument-list-wrapping" />
+        <error line="618" column="128" source="standard:argument-list-wrapping" />
+        <error line="618" column="129" source="standard:argument-list-wrapping" />
+        <error line="871" column="1" source="standard:max-line-length" />
+        <error line="871" column="48" source="standard:argument-list-wrapping" />
+        <error line="871" column="57" source="standard:argument-list-wrapping" />
+        <error line="871" column="108" source="standard:argument-list-wrapping" />
+        <error line="871" column="128" source="standard:argument-list-wrapping" />
+        <error line="871" column="129" source="standard:argument-list-wrapping" />
+        <error line="888" column="1" source="standard:max-line-length" />
+        <error line="888" column="48" source="standard:argument-list-wrapping" />
+        <error line="888" column="58" source="standard:argument-list-wrapping" />
+        <error line="888" column="109" source="standard:argument-list-wrapping" />
+        <error line="888" column="129" source="standard:argument-list-wrapping" />
+        <error line="888" column="130" source="standard:argument-list-wrapping" />
+        <error line="896" column="1" source="standard:max-line-length" />
+        <error line="896" column="48" source="standard:argument-list-wrapping" />
+        <error line="896" column="58" source="standard:argument-list-wrapping" />
+        <error line="896" column="109" source="standard:argument-list-wrapping" />
+        <error line="896" column="127" source="standard:argument-list-wrapping" />
+        <error line="896" column="128" source="standard:argument-list-wrapping" />
+        <error line="908" column="1" source="standard:max-line-length" />
+        <error line="912" column="1" source="standard:max-line-length" />
+        <error line="912" column="48" source="standard:argument-list-wrapping" />
+        <error line="912" column="58" source="standard:argument-list-wrapping" />
+        <error line="912" column="109" source="standard:argument-list-wrapping" />
+        <error line="912" column="129" source="standard:argument-list-wrapping" />
+        <error line="912" column="130" source="standard:argument-list-wrapping" />
+        <error line="920" column="1" source="standard:max-line-length" />
+        <error line="920" column="48" source="standard:argument-list-wrapping" />
+        <error line="920" column="58" source="standard:argument-list-wrapping" />
+        <error line="920" column="109" source="standard:argument-list-wrapping" />
+        <error line="920" column="127" source="standard:argument-list-wrapping" />
+        <error line="920" column="128" source="standard:argument-list-wrapping" />
+        <error line="971" column="1" source="standard:max-line-length" />
+        <error line="971" column="48" source="standard:argument-list-wrapping" />
+        <error line="971" column="58" source="standard:argument-list-wrapping" />
+        <error line="971" column="109" source="standard:argument-list-wrapping" />
+        <error line="971" column="127" source="standard:argument-list-wrapping" />
+        <error line="971" column="128" source="standard:argument-list-wrapping" />
+        <error line="980" column="1" source="standard:max-line-length" />
+        <error line="980" column="48" source="standard:argument-list-wrapping" />
+        <error line="980" column="58" source="standard:argument-list-wrapping" />
+        <error line="980" column="109" source="standard:argument-list-wrapping" />
+        <error line="980" column="127" source="standard:argument-list-wrapping" />
+        <error line="980" column="128" source="standard:argument-list-wrapping" />
+        <error line="989" column="1" source="standard:max-line-length" />
+        <error line="989" column="48" source="standard:argument-list-wrapping" />
+        <error line="989" column="58" source="standard:argument-list-wrapping" />
+        <error line="989" column="109" source="standard:argument-list-wrapping" />
+        <error line="989" column="129" source="standard:argument-list-wrapping" />
+        <error line="989" column="130" source="standard:argument-list-wrapping" />
+        <error line="1025" column="1" source="standard:max-line-length" />
+        <error line="1025" column="48" source="standard:argument-list-wrapping" />
+        <error line="1025" column="58" source="standard:argument-list-wrapping" />
+        <error line="1025" column="109" source="standard:argument-list-wrapping" />
+        <error line="1025" column="127" source="standard:argument-list-wrapping" />
+        <error line="1025" column="128" source="standard:argument-list-wrapping" />
+        <error line="1035" column="1" source="standard:max-line-length" />
+        <error line="1035" column="48" source="standard:argument-list-wrapping" />
+        <error line="1035" column="58" source="standard:argument-list-wrapping" />
+        <error line="1035" column="109" source="standard:argument-list-wrapping" />
+        <error line="1035" column="129" source="standard:argument-list-wrapping" />
+        <error line="1035" column="130" source="standard:argument-list-wrapping" />
+        <error line="1046" column="1" source="standard:max-line-length" />
+        <error line="1046" column="48" source="standard:argument-list-wrapping" />
+        <error line="1046" column="58" source="standard:argument-list-wrapping" />
+        <error line="1046" column="109" source="standard:argument-list-wrapping" />
+        <error line="1046" column="127" source="standard:argument-list-wrapping" />
+        <error line="1046" column="128" source="standard:argument-list-wrapping" />
+        <error line="1210" column="1" source="standard:max-line-length" />
+        <error line="1210" column="20" source="standard:argument-list-wrapping" />
+        <error line="1210" column="38" source="standard:argument-list-wrapping" />
+        <error line="1210" column="125" source="standard:argument-list-wrapping" />
+        <error line="1210" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesHistoryStorageWorkerTest.kt">
+        <error line="76" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/PlacesStorageTest.kt">
+        <error line="70" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/RemoteTabsStorageTest.kt">
+        <error line="101" column="1" source="standard:max-line-length" />
+        <error line="101" column="35" source="standard:argument-list-wrapping" />
+        <error line="101" column="42" source="standard:argument-list-wrapping" />
+        <error line="101" column="101" source="standard:argument-list-wrapping" />
+        <error line="101" column="121" source="standard:argument-list-wrapping" />
+        <error line="101" column="134" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/BrowserToolbarTest.kt">
+        <error line="129" column="1" source="standard:max-line-length" />
+        <error line="129" column="41" source="standard:argument-list-wrapping" />
+        <error line="129" column="71" source="standard:argument-list-wrapping" />
+        <error line="129" column="102" source="standard:argument-list-wrapping" />
+        <error line="129" column="133" source="standard:argument-list-wrapping" />
+        <error line="129" column="162" source="standard:argument-list-wrapping" />
+        <error line="208" column="1" source="standard:max-line-length" />
+        <error line="208" column="41" source="standard:property-wrapping" />
+        <error line="208" column="51" source="standard:argument-list-wrapping" />
+        <error line="208" column="134" source="standard:argument-list-wrapping" />
+        <error line="224" column="1" source="standard:max-line-length" />
+        <error line="224" column="22" source="standard:argument-list-wrapping" />
+        <error line="224" column="94" source="standard:argument-list-wrapping" />
+        <error line="224" column="121" source="standard:argument-list-wrapping" />
+        <error line="250" column="1" source="standard:max-line-length" />
+        <error line="250" column="41" source="standard:property-wrapping" />
+        <error line="250" column="51" source="standard:argument-list-wrapping" />
+        <error line="250" column="134" source="standard:argument-list-wrapping" />
+        <error line="266" column="1" source="standard:max-line-length" />
+        <error line="266" column="22" source="standard:argument-list-wrapping" />
+        <error line="266" column="94" source="standard:argument-list-wrapping" />
+        <error line="266" column="121" source="standard:argument-list-wrapping" />
+        <error line="963" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarBehaviorTest.kt">
+        <error line="107" column="1" source="standard:max-line-length" />
+        <error line="344" column="1" source="standard:max-line-length" />
+        <error line="366" column="1" source="standard:max-line-length" />
+        <error line="378" column="1" source="standard:max-line-length" />
+        <error line="502" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/behavior/BrowserToolbarYTranslationStrategyTest.kt">
+        <error line="28" column="1" source="standard:max-line-length" />
+        <error line="196" column="1" source="standard:max-line-length" />
+        <error line="224" column="1" source="standard:max-line-length" />
+        <error line="252" column="1" source="standard:max-line-length" />
+        <error line="280" column="1" source="standard:max-line-length" />
+        <error line="308" column="1" source="standard:max-line-length" />
+        <error line="375" column="1" source="standard:max-line-length" />
+        <error line="407" column="1" source="standard:max-line-length" />
+        <error line="442" column="1" source="standard:max-line-length" />
+        <error line="474" column="1" source="standard:max-line-length" />
+        <error line="490" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/display/DisplayToolbarTest.kt">
+        <error line="124" column="1" source="standard:max-line-length" />
+        <error line="667" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/browser/toolbar/src/test/java/mozilla/components/browser/toolbar/edit/EditToolbarTest.kt">
+        <error line="68" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/compose/awesomebar/src/test/java/mozilla/components/compose/browser/awesomebar/internal/SuggestionFetcherTest.kt">
+        <error line="45" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/compose/awesomebar/src/test/java/mozilla/components/compose/browser/awesomebar/internal/SuggestionsTest.kt">
+        <error line="31" column="1" source="standard:max-line-length" />
+        <error line="55" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="103" column="1" source="standard:max-line-length" />
+        <error line="136" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/compose/cfr/src/test/java/mozilla/components/compose/cfr/CFRPopupFullscreenLayoutTest.kt">
+        <error line="160" column="1" source="standard:max-line-length" />
+        <error line="182" column="1" source="standard:max-line-length" />
+        <error line="225" column="1" source="standard:max-line-length" />
+        <error line="247" column="1" source="standard:max-line-length" />
+        <error line="292" column="1" source="standard:max-line-length" />
+        <error line="338" column="1" source="standard:max-line-length" />
+        <error line="384" column="1" source="standard:max-line-length" />
+        <error line="430" column="1" source="standard:max-line-length" />
+        <error line="453" column="1" source="standard:max-line-length" />
+        <error line="476" column="1" source="standard:max-line-length" />
+        <error line="497" column="1" source="standard:max-line-length" />
+        <error line="520" column="1" source="standard:max-line-length" />
+        <error line="542" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/compose/cfr/src/test/java/mozilla/components/compose/cfr/helper/DisplayOrientationListenerTest.kt">
+        <error line="105" column="1" source="standard:max-line-length" />
+        <error line="120" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/concept/engine/src/test/java/mozilla/components/concept/engine/EngineSessionTest.kt">
+        <error line="816" column="1" source="standard:max-line-length" />
+        <error line="816" column="20" source="standard:argument-list-wrapping" />
+        <error line="816" column="48" source="standard:argument-list-wrapping" />
+        <error line="816" column="123" source="standard:argument-list-wrapping" />
+        <error line="816" column="124" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/concept/engine/src/test/java/mozilla/components/concept/engine/InputResultDetailTest.kt">
+        <error line="36" column="1" source="standard:max-line-length" />
+        <error line="43" column="1" source="standard:max-line-length" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="75" column="1" source="standard:max-line-length" />
+        <error line="83" column="1" source="standard:max-line-length" />
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="109" column="1" source="standard:max-line-length" />
+        <error line="131" column="1" source="standard:max-line-length" />
+        <error line="166" column="1" source="standard:max-line-length" />
+        <error line="186" column="1" source="standard:max-line-length" />
+        <error line="206" column="1" source="standard:max-line-length" />
+        <error line="218" column="1" source="standard:max-line-length" />
+        <error line="240" column="1" source="standard:max-line-length" />
+        <error line="258" column="1" source="standard:max-line-length" />
+        <error line="272" column="1" source="standard:max-line-length" />
+        <error line="283" column="1" source="standard:max-line-length" />
+        <error line="294" column="1" source="standard:max-line-length" />
+        <error line="308" column="1" source="standard:max-line-length" />
+        <error line="325" column="1" source="standard:max-line-length" />
+        <error line="342" column="1" source="standard:max-line-length" />
+        <error line="359" column="1" source="standard:max-line-length" />
+        <error line="376" column="1" source="standard:max-line-length" />
+        <error line="384" column="1" source="standard:max-line-length" />
+        <error line="384" column="52" source="standard:argument-list-wrapping" />
+        <error line="384" column="67" source="standard:argument-list-wrapping" />
+        <error line="384" column="93" source="standard:argument-list-wrapping" />
+        <error line="384" column="125" source="standard:argument-list-wrapping" />
+        <error line="393" column="1" source="standard:max-line-length" />
+        <error line="393" column="52" source="standard:argument-list-wrapping" />
+        <error line="393" column="94" source="standard:argument-list-wrapping" />
+        <error line="393" column="149" source="standard:argument-list-wrapping" />
+        <error line="396" column="1" source="standard:max-line-length" />
+        <error line="396" column="52" source="standard:argument-list-wrapping" />
+        <error line="396" column="67" source="standard:argument-list-wrapping" />
+        <error line="396" column="92" source="standard:argument-list-wrapping" />
+        <error line="396" column="122" source="standard:argument-list-wrapping" />
+        <error line="401" column="1" source="standard:max-line-length" />
+        <error line="415" column="1" source="standard:max-line-length" />
+        <error line="415" column="52" source="standard:argument-list-wrapping" />
+        <error line="415" column="75" source="standard:argument-list-wrapping" />
+        <error line="415" column="98" source="standard:argument-list-wrapping" />
+        <error line="415" column="128" source="standard:argument-list-wrapping" />
+        <error line="418" column="1" source="standard:max-line-length" />
+        <error line="418" column="52" source="standard:argument-list-wrapping" />
+        <error line="418" column="69" source="standard:argument-list-wrapping" />
+        <error line="418" column="93" source="standard:argument-list-wrapping" />
+        <error line="418" column="123" source="standard:argument-list-wrapping" />
+        <error line="426" column="1" source="standard:max-line-length" />
+        <error line="434" column="1" source="standard:max-line-length" />
+        <error line="434" column="52" source="standard:argument-list-wrapping" />
+        <error line="434" column="67" source="standard:argument-list-wrapping" />
+        <error line="434" column="93" source="standard:argument-list-wrapping" />
+        <error line="434" column="125" source="standard:argument-list-wrapping" />
+        <error line="443" column="1" source="standard:max-line-length" />
+        <error line="443" column="52" source="standard:argument-list-wrapping" />
+        <error line="443" column="94" source="standard:argument-list-wrapping" />
+        <error line="443" column="149" source="standard:argument-list-wrapping" />
+        <error line="446" column="1" source="standard:max-line-length" />
+        <error line="446" column="52" source="standard:argument-list-wrapping" />
+        <error line="446" column="67" source="standard:argument-list-wrapping" />
+        <error line="446" column="91" source="standard:argument-list-wrapping" />
+        <error line="446" column="121" source="standard:argument-list-wrapping" />
+        <error line="451" column="1" source="standard:max-line-length" />
+        <error line="465" column="1" source="standard:max-line-length" />
+        <error line="465" column="52" source="standard:argument-list-wrapping" />
+        <error line="465" column="75" source="standard:argument-list-wrapping" />
+        <error line="465" column="101" source="standard:argument-list-wrapping" />
+        <error line="465" column="131" source="standard:argument-list-wrapping" />
+        <error line="468" column="1" source="standard:max-line-length" />
+        <error line="468" column="52" source="standard:argument-list-wrapping" />
+        <error line="468" column="69" source="standard:argument-list-wrapping" />
+        <error line="468" column="93" source="standard:argument-list-wrapping" />
+        <error line="468" column="123" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/concept/engine/src/test/java/mozilla/components/concept/engine/SettingsTest.kt">
+        <error line="221" column="1" source="standard:max-line-length" />
+        <error line="221" column="22" source="standard:argument-list-wrapping" />
+        <error line="221" column="73" source="standard:argument-list-wrapping" />
+        <error line="221" column="128" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/concept/engine/src/test/java/mozilla/components/concept/engine/prompt/PromptRequestTest.kt">
+        <error line="279" column="1" source="standard:max-line-length" />
+        <error line="322" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/concept/engine/src/test/java/mozilla/components/concept/engine/utils/EngineVersionTest.kt">
+        <error line="145" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/concept/fetch/src/test/java/mozilla/components/concept/fetch/HeadersTest.kt">
+        <error line="41" column="1" source="standard:max-line-length" />
+        <error line="41" column="22" source="standard:argument-list-wrapping" />
+        <error line="41" column="108" source="standard:argument-list-wrapping" />
+        <error line="41" column="124" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/concept/fetch/src/test/java/mozilla/components/concept/fetch/RequestTest.kt">
+        <error line="104" column="1" source="standard:max-line-length" />
+        <error line="116" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/concept/storage/src/test/java/mozilla/components/concept/storage/BookmarkNodeTest.kt">
+        <error line="27" column="1" source="standard:max-line-length" />
+        <error line="36" column="1" source="standard:max-line-length" />
+        <error line="59" column="1" source="standard:max-line-length" />
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="74" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/concept/storage/src/test/java/mozilla/components/concept/storage/CreditCardEntryTest.kt">
+        <error line="43" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/AutoPushObserverTest.kt">
+        <error line="107" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/accounts-push/src/test/java/mozilla/components/feature/accounts/push/EventsObserverTest.kt">
+        <error line="23" column="1" source="standard:max-line-length" />
+        <error line="23" column="21" source="standard:property-wrapping" />
+        <error line="23" column="29" source="standard:argument-list-wrapping" />
+        <error line="23" column="64" source="standard:argument-list-wrapping" />
+        <error line="23" column="108" source="standard:argument-list-wrapping" />
+        <error line="23" column="116" source="standard:argument-list-wrapping" />
+        <error line="23" column="122" source="standard:argument-list-wrapping" />
+        <error line="23" column="123" source="standard:argument-list-wrapping" />
+        <error line="23" column="124" source="standard:argument-list-wrapping" />
+        <error line="29" column="1" source="standard:max-line-length" />
+        <error line="29" column="27" source="standard:argument-list-wrapping" />
+        <error line="29" column="34" source="standard:argument-list-wrapping" />
+        <error line="29" column="69" source="standard:argument-list-wrapping" />
+        <error line="29" column="113" source="standard:argument-list-wrapping" />
+        <error line="29" column="119" source="standard:argument-list-wrapping" />
+        <error line="29" column="125" source="standard:argument-list-wrapping" />
+        <error line="29" column="126" source="standard:argument-list-wrapping" />
+        <error line="29" column="127" source="standard:argument-list-wrapping" />
+        <error line="29" column="128" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FirefoxAccountsAuthFeatureTest.kt">
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="65" column="23" source="standard:argument-list-wrapping" />
+        <error line="65" column="32" source="standard:argument-list-wrapping" />
+        <error line="65" column="40" source="standard:argument-list-wrapping" />
+        <error line="65" column="90" source="standard:argument-list-wrapping" />
+        <error line="65" column="96" source="standard:argument-list-wrapping" />
+        <error line="65" column="104" source="standard:argument-list-wrapping" />
+        <error line="65" column="110" source="standard:argument-list-wrapping" />
+        <error line="65" column="126" source="standard:argument-list-wrapping" />
+        <error line="168" column="1" source="standard:max-line-length" />
+        <error line="168" column="20" source="standard:argument-list-wrapping" />
+        <error line="168" column="54" source="standard:argument-list-wrapping" />
+        <error line="168" column="62" source="standard:argument-list-wrapping" />
+        <error line="168" column="112" source="standard:argument-list-wrapping" />
+        <error line="168" column="118" source="standard:argument-list-wrapping" />
+        <error line="168" column="125" source="standard:argument-list-wrapping" />
+        <error line="168" column="132" source="standard:argument-list-wrapping" />
+        <error line="168" column="139" source="standard:argument-list-wrapping" />
+        <error line="168" column="146" source="standard:argument-list-wrapping" />
+        <error line="168" column="151" source="standard:argument-list-wrapping" />
+        <error line="168" column="152" source="standard:argument-list-wrapping" />
+        <error line="172" column="1" source="standard:max-line-length" />
+        <error line="172" column="20" source="standard:argument-list-wrapping" />
+        <error line="172" column="54" source="standard:argument-list-wrapping" />
+        <error line="172" column="62" source="standard:argument-list-wrapping" />
+        <error line="172" column="91" source="standard:argument-list-wrapping" />
+        <error line="172" column="97" source="standard:argument-list-wrapping" />
+        <error line="172" column="104" source="standard:argument-list-wrapping" />
+        <error line="172" column="111" source="standard:argument-list-wrapping" />
+        <error line="172" column="118" source="standard:argument-list-wrapping" />
+        <error line="172" column="125" source="standard:argument-list-wrapping" />
+        <error line="172" column="130" source="standard:argument-list-wrapping" />
+        <error line="172" column="131" source="standard:argument-list-wrapping" />
+        <error line="176" column="1" source="standard:max-line-length" />
+        <error line="176" column="20" source="standard:argument-list-wrapping" />
+        <error line="176" column="54" source="standard:argument-list-wrapping" />
+        <error line="176" column="62" source="standard:argument-list-wrapping" />
+        <error line="176" column="113" source="standard:argument-list-wrapping" />
+        <error line="176" column="119" source="standard:argument-list-wrapping" />
+        <error line="176" column="126" source="standard:argument-list-wrapping" />
+        <error line="176" column="133" source="standard:argument-list-wrapping" />
+        <error line="176" column="140" source="standard:argument-list-wrapping" />
+        <error line="176" column="147" source="standard:argument-list-wrapping" />
+        <error line="176" column="152" source="standard:argument-list-wrapping" />
+        <error line="176" column="153" source="standard:argument-list-wrapping" />
+        <error line="180" column="1" source="standard:max-line-length" />
+        <error line="180" column="20" source="standard:argument-list-wrapping" />
+        <error line="180" column="54" source="standard:argument-list-wrapping" />
+        <error line="180" column="62" source="standard:argument-list-wrapping" />
+        <error line="180" column="117" source="standard:argument-list-wrapping" />
+        <error line="180" column="123" source="standard:argument-list-wrapping" />
+        <error line="180" column="130" source="standard:argument-list-wrapping" />
+        <error line="180" column="137" source="standard:argument-list-wrapping" />
+        <error line="180" column="144" source="standard:argument-list-wrapping" />
+        <error line="180" column="151" source="standard:argument-list-wrapping" />
+        <error line="180" column="156" source="standard:argument-list-wrapping" />
+        <error line="180" column="157" source="standard:argument-list-wrapping" />
+        <error line="186" column="1" source="standard:max-line-length" />
+        <error line="186" column="47" source="standard:argument-list-wrapping" />
+        <error line="186" column="55" source="standard:argument-list-wrapping" />
+        <error line="186" column="138" source="standard:argument-list-wrapping" />
+        <error line="186" column="144" source="standard:argument-list-wrapping" />
+        <error line="186" column="151" source="standard:argument-list-wrapping" />
+        <error line="186" column="158" source="standard:argument-list-wrapping" />
+        <error line="186" column="165" source="standard:argument-list-wrapping" />
+        <error line="186" column="172" source="standard:argument-list-wrapping" />
+        <error line="186" column="177" source="standard:argument-list-wrapping" />
+        <error line="198" column="1" source="standard:max-line-length" />
+        <error line="198" column="47" source="standard:argument-list-wrapping" />
+        <error line="198" column="55" source="standard:argument-list-wrapping" />
+        <error line="198" column="152" source="standard:argument-list-wrapping" />
+        <error line="198" column="158" source="standard:argument-list-wrapping" />
+        <error line="198" column="165" source="standard:argument-list-wrapping" />
+        <error line="198" column="172" source="standard:argument-list-wrapping" />
+        <error line="198" column="179" source="standard:argument-list-wrapping" />
+        <error line="198" column="186" source="standard:argument-list-wrapping" />
+        <error line="198" column="191" source="standard:argument-list-wrapping" />
+        <error line="210" column="1" source="standard:max-line-length" />
+        <error line="210" column="47" source="standard:argument-list-wrapping" />
+        <error line="210" column="55" source="standard:argument-list-wrapping" />
+        <error line="210" column="152" source="standard:argument-list-wrapping" />
+        <error line="210" column="158" source="standard:argument-list-wrapping" />
+        <error line="210" column="165" source="standard:argument-list-wrapping" />
+        <error line="210" column="172" source="standard:argument-list-wrapping" />
+        <error line="210" column="179" source="standard:argument-list-wrapping" />
+        <error line="210" column="186" source="standard:argument-list-wrapping" />
+        <error line="210" column="191" source="standard:argument-list-wrapping" />
+        <error line="222" column="1" source="standard:max-line-length" />
+        <error line="222" column="47" source="standard:argument-list-wrapping" />
+        <error line="222" column="55" source="standard:argument-list-wrapping" />
+        <error line="222" column="153" source="standard:argument-list-wrapping" />
+        <error line="222" column="159" source="standard:argument-list-wrapping" />
+        <error line="222" column="166" source="standard:argument-list-wrapping" />
+        <error line="222" column="173" source="standard:argument-list-wrapping" />
+        <error line="222" column="180" source="standard:argument-list-wrapping" />
+        <error line="222" column="187" source="standard:argument-list-wrapping" />
+        <error line="222" column="192" source="standard:argument-list-wrapping" />
+        <error line="234" column="1" source="standard:max-line-length" />
+        <error line="234" column="47" source="standard:argument-list-wrapping" />
+        <error line="234" column="55" source="standard:argument-list-wrapping" />
+        <error line="234" column="163" source="standard:argument-list-wrapping" />
+        <error line="234" column="169" source="standard:argument-list-wrapping" />
+        <error line="234" column="176" source="standard:argument-list-wrapping" />
+        <error line="234" column="183" source="standard:argument-list-wrapping" />
+        <error line="234" column="190" source="standard:argument-list-wrapping" />
+        <error line="234" column="197" source="standard:argument-list-wrapping" />
+        <error line="234" column="202" source="standard:argument-list-wrapping" />
+        <error line="240" column="1" source="standard:max-line-length" />
+        <error line="240" column="25" source="standard:argument-list-wrapping" />
+        <error line="240" column="81" source="standard:argument-list-wrapping" />
+        <error line="240" column="101" source="standard:argument-list-wrapping" />
+        <error line="240" column="121" source="standard:argument-list-wrapping" />
+        <error line="255" column="1" source="standard:max-line-length" />
+        <error line="255" column="84" source="standard:argument-list-wrapping" />
+        <error line="255" column="96" source="standard:argument-list-wrapping" />
+        <error line="255" column="109" source="standard:argument-list-wrapping" />
+        <error line="255" column="121" source="standard:argument-list-wrapping" />
+        <error line="255" column="122" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/accounts/src/test/java/mozilla/components/feature/accounts/FxaWebChannelFeatureTest.kt">
+        <error line="348" column="1" source="standard:max-line-length" />
+        <error line="348" column="32" source="standard:property-wrapping" />
+        <error line="348" column="55" source="standard:argument-list-wrapping" />
+        <error line="348" column="60" source="standard:argument-list-wrapping" />
+        <error line="348" column="66" source="standard:argument-list-wrapping" />
+        <error line="348" column="81" source="standard:argument-list-wrapping" />
+        <error line="348" column="98" source="standard:argument-list-wrapping" />
+        <error line="348" column="110" source="standard:argument-list-wrapping" />
+        <error line="348" column="124" source="standard:argument-list-wrapping" />
+        <error line="404" column="1" source="standard:max-line-length" />
+        <error line="404" column="32" source="standard:property-wrapping" />
+        <error line="404" column="55" source="standard:argument-list-wrapping" />
+        <error line="404" column="60" source="standard:argument-list-wrapping" />
+        <error line="404" column="66" source="standard:argument-list-wrapping" />
+        <error line="404" column="81" source="standard:argument-list-wrapping" />
+        <error line="404" column="98" source="standard:argument-list-wrapping" />
+        <error line="404" column="110" source="standard:argument-list-wrapping" />
+        <error line="404" column="124" source="standard:argument-list-wrapping" />
+        <error line="459" column="1" source="standard:max-line-length" />
+        <error line="459" column="32" source="standard:property-wrapping" />
+        <error line="459" column="55" source="standard:argument-list-wrapping" />
+        <error line="459" column="60" source="standard:argument-list-wrapping" />
+        <error line="459" column="66" source="standard:argument-list-wrapping" />
+        <error line="459" column="81" source="standard:argument-list-wrapping" />
+        <error line="459" column="98" source="standard:argument-list-wrapping" />
+        <error line="459" column="110" source="standard:argument-list-wrapping" />
+        <error line="459" column="124" source="standard:argument-list-wrapping" />
+        <error line="507" column="1" source="standard:max-line-length" />
+        <error line="507" column="32" source="standard:property-wrapping" />
+        <error line="507" column="55" source="standard:argument-list-wrapping" />
+        <error line="507" column="60" source="standard:argument-list-wrapping" />
+        <error line="507" column="66" source="standard:argument-list-wrapping" />
+        <error line="507" column="81" source="standard:argument-list-wrapping" />
+        <error line="507" column="98" source="standard:argument-list-wrapping" />
+        <error line="507" column="110" source="standard:argument-list-wrapping" />
+        <error line="507" column="124" source="standard:argument-list-wrapping" />
+        <error line="585" column="1" source="standard:max-line-length" />
+        <error line="608" column="1" source="standard:max-line-length" />
+        <error line="608" column="26" source="standard:argument-list-wrapping" />
+        <error line="608" column="36" source="standard:argument-list-wrapping" />
+        <error line="608" column="53" source="standard:argument-list-wrapping" />
+        <error line="608" column="69" source="standard:argument-list-wrapping" />
+        <error line="608" column="86" source="standard:argument-list-wrapping" />
+        <error line="608" column="115" source="standard:argument-list-wrapping" />
+        <error line="608" column="137" source="standard:argument-list-wrapping" />
+        <error line="608" column="151" source="standard:argument-list-wrapping" />
+        <error line="610" column="1" source="standard:max-line-length" />
+        <error line="610" column="26" source="standard:argument-list-wrapping" />
+        <error line="610" column="37" source="standard:argument-list-wrapping" />
+        <error line="610" column="55" source="standard:argument-list-wrapping" />
+        <error line="610" column="71" source="standard:argument-list-wrapping" />
+        <error line="610" column="88" source="standard:argument-list-wrapping" />
+        <error line="610" column="94" source="standard:argument-list-wrapping" />
+        <error line="610" column="116" source="standard:argument-list-wrapping" />
+        <error line="610" column="130" source="standard:argument-list-wrapping" />
+        <error line="612" column="1" source="standard:max-line-length" />
+        <error line="612" column="26" source="standard:argument-list-wrapping" />
+        <error line="612" column="39" source="standard:argument-list-wrapping" />
+        <error line="612" column="76" source="standard:argument-list-wrapping" />
+        <error line="612" column="92" source="standard:argument-list-wrapping" />
+        <error line="612" column="109" source="standard:argument-list-wrapping" />
+        <error line="612" column="115" source="standard:argument-list-wrapping" />
+        <error line="612" column="137" source="standard:argument-list-wrapping" />
+        <error line="612" column="151" source="standard:argument-list-wrapping" />
+        <error line="638" column="1" source="standard:max-line-length" />
+        <error line="638" column="26" source="standard:argument-list-wrapping" />
+        <error line="638" column="36" source="standard:argument-list-wrapping" />
+        <error line="638" column="53" source="standard:argument-list-wrapping" />
+        <error line="638" column="61" source="standard:argument-list-wrapping" />
+        <error line="638" column="71" source="standard:argument-list-wrapping" />
+        <error line="638" column="122" source="standard:argument-list-wrapping" />
+        <error line="638" column="144" source="standard:argument-list-wrapping" />
+        <error line="638" column="158" source="standard:argument-list-wrapping" />
+        <error line="640" column="1" source="standard:max-line-length" />
+        <error line="640" column="26" source="standard:argument-list-wrapping" />
+        <error line="640" column="36" source="standard:argument-list-wrapping" />
+        <error line="640" column="53" source="standard:argument-list-wrapping" />
+        <error line="640" column="69" source="standard:argument-list-wrapping" />
+        <error line="640" column="86" source="standard:argument-list-wrapping" />
+        <error line="640" column="92" source="standard:argument-list-wrapping" />
+        <error line="640" column="114" source="standard:argument-list-wrapping" />
+        <error line="640" column="128" source="standard:argument-list-wrapping" />
+        <error line="642" column="1" source="standard:max-line-length" />
+        <error line="642" column="26" source="standard:argument-list-wrapping" />
+        <error line="642" column="37" source="standard:argument-list-wrapping" />
+        <error line="642" column="55" source="standard:argument-list-wrapping" />
+        <error line="642" column="71" source="standard:argument-list-wrapping" />
+        <error line="642" column="88" source="standard:argument-list-wrapping" />
+        <error line="642" column="94" source="standard:argument-list-wrapping" />
+        <error line="642" column="116" source="standard:argument-list-wrapping" />
+        <error line="642" column="130" source="standard:argument-list-wrapping" />
+        <error line="644" column="1" source="standard:max-line-length" />
+        <error line="644" column="26" source="standard:argument-list-wrapping" />
+        <error line="644" column="39" source="standard:argument-list-wrapping" />
+        <error line="644" column="76" source="standard:argument-list-wrapping" />
+        <error line="644" column="92" source="standard:argument-list-wrapping" />
+        <error line="644" column="109" source="standard:argument-list-wrapping" />
+        <error line="644" column="115" source="standard:argument-list-wrapping" />
+        <error line="644" column="137" source="standard:argument-list-wrapping" />
+        <error line="644" column="151" source="standard:argument-list-wrapping" />
+        <error line="661" column="1" source="standard:max-line-length" />
+        <error line="661" column="32" source="standard:property-wrapping" />
+        <error line="661" column="55" source="standard:argument-list-wrapping" />
+        <error line="661" column="60" source="standard:argument-list-wrapping" />
+        <error line="661" column="66" source="standard:argument-list-wrapping" />
+        <error line="661" column="81" source="standard:argument-list-wrapping" />
+        <error line="661" column="98" source="standard:argument-list-wrapping" />
+        <error line="661" column="110" source="standard:argument-list-wrapping" />
+        <error line="661" column="124" source="standard:argument-list-wrapping" />
+        <error line="765" column="1" source="standard:max-line-length" />
+        <error line="765" column="42" source="standard:parameter-list-wrapping" />
+        <error line="765" column="58" source="standard:parameter-list-wrapping" />
+        <error line="765" column="86" source="standard:parameter-list-wrapping" />
+        <error line="765" column="100" source="standard:parameter-list-wrapping" />
+        <error line="765" column="115" source="standard:parameter-list-wrapping" />
+        <error line="765" column="143" source="standard:parameter-list-wrapping" />
+        <error line="765" column="175" source="standard:parameter-list-wrapping" />
+        <error line="765" column="208" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt">
+        <error line="254" column="1" source="standard:max-line-length" />
+        <error line="384" column="1" source="standard:max-line-length" />
+        <error line="384" column="52" source="standard:argument-list-wrapping" />
+        <error line="384" column="70" source="standard:argument-list-wrapping" />
+        <error line="384" column="132" source="standard:argument-list-wrapping" />
+        <error line="384" column="133" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/addons/src/main/java/mozilla/components/feature/addons/update/AddonUpdater.kt">
+        <error line="611" column="1" source="standard:max-line-length" />
+        <error line="611" column="42" source="standard:argument-list-wrapping" />
+        <error line="611" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/addons/src/test/java/AddonManagerTest.kt">
+        <error line="90" column="1" source="standard:max-line-length" />
+        <error line="90" column="111" source="standard:argument-list-wrapping" />
+        <error line="90" column="118" source="standard:argument-list-wrapping" />
+        <error line="90" column="124" source="standard:argument-list-wrapping" />
+        <error line="90" column="135" source="standard:argument-list-wrapping" />
+        <error line="90" column="138" source="standard:argument-list-wrapping" />
+        <error line="90" column="144" source="standard:argument-list-wrapping" />
+        <error line="90" column="155" source="standard:argument-list-wrapping" />
+        <error line="90" column="158" source="standard:argument-list-wrapping" />
+        <error line="90" column="164" source="standard:argument-list-wrapping" />
+        <error line="90" column="175" source="standard:argument-list-wrapping" />
+        <error line="90" column="176" source="standard:argument-list-wrapping" />
+        <error line="90" column="177" source="standard:argument-list-wrapping" />
+        <error line="272" column="1" source="standard:max-line-length" />
+        <error line="272" column="45" source="standard:argument-list-wrapping" />
+        <error line="272" column="84" source="standard:argument-list-wrapping" />
+        <error line="272" column="114" source="standard:argument-list-wrapping" />
+        <error line="272" column="141" source="standard:argument-list-wrapping" />
+        <error line="273" column="1" source="standard:max-line-length" />
+        <error line="273" column="41" source="standard:argument-list-wrapping" />
+        <error line="273" column="76" source="standard:argument-list-wrapping" />
+        <error line="273" column="105" source="standard:argument-list-wrapping" />
+        <error line="273" column="128" source="standard:argument-list-wrapping" />
+        <error line="285" column="1" source="standard:max-line-length" />
+        <error line="285" column="111" source="standard:argument-list-wrapping" />
+        <error line="285" column="118" source="standard:argument-list-wrapping" />
+        <error line="285" column="123" source="standard:argument-list-wrapping" />
+        <error line="285" column="124" source="standard:argument-list-wrapping" />
+        <error line="302" column="1" source="standard:max-line-length" />
+        <error line="302" column="45" source="standard:argument-list-wrapping" />
+        <error line="302" column="84" source="standard:argument-list-wrapping" />
+        <error line="302" column="114" source="standard:argument-list-wrapping" />
+        <error line="302" column="141" source="standard:argument-list-wrapping" />
+        <error line="303" column="1" source="standard:max-line-length" />
+        <error line="303" column="41" source="standard:argument-list-wrapping" />
+        <error line="303" column="76" source="standard:argument-list-wrapping" />
+        <error line="303" column="105" source="standard:argument-list-wrapping" />
+        <error line="303" column="128" source="standard:argument-list-wrapping" />
+        <error line="315" column="1" source="standard:max-line-length" />
+        <error line="315" column="111" source="standard:argument-list-wrapping" />
+        <error line="315" column="122" source="standard:argument-list-wrapping" />
+        <error line="351" column="1" source="standard:max-line-length" />
+        <error line="351" column="111" source="standard:argument-list-wrapping" />
+        <error line="351" column="118" source="standard:argument-list-wrapping" />
+        <error line="351" column="123" source="standard:argument-list-wrapping" />
+        <error line="351" column="124" source="standard:argument-list-wrapping" />
+        <error line="393" column="1" source="standard:max-line-length" />
+        <error line="393" column="111" source="standard:argument-list-wrapping" />
+        <error line="393" column="122" source="standard:argument-list-wrapping" />
+        <error line="746" column="1" source="standard:max-line-length" />
+        <error line="746" column="44" source="standard:argument-list-wrapping" />
+        <error line="746" column="59" source="standard:argument-list-wrapping" />
+        <error line="746" column="89" source="standard:argument-list-wrapping" />
+        <error line="746" column="116" source="standard:argument-list-wrapping" />
+        <error line="746" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/addons/src/test/java/AddonTest.kt">
+        <error line="138" column="1" source="standard:max-line-length" />
+        <error line="138" column="45" source="standard:argument-list-wrapping" />
+        <error line="138" column="84" source="standard:argument-list-wrapping" />
+        <error line="138" column="108" source="standard:argument-list-wrapping" />
+        <error line="138" column="129" source="standard:argument-list-wrapping" />
+        <error line="430" column="1" source="standard:max-line-length" />
+        <error line="446" column="1" source="standard:max-line-length" />
+        <error line="462" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/addons/src/test/java/mozilla/components/feature/addons/amo/AMOAddonsProviderTest.kt">
+        <error line="81" column="1" source="standard:max-line-length" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="167" column="1" source="standard:max-line-length" />
+        <error line="359" column="1" source="standard:max-line-length" />
+        <error line="359" column="103" source="standard:argument-list-wrapping" />
+        <error line="359" column="134" source="standard:argument-list-wrapping" />
+        <error line="362" column="1" source="standard:max-line-length" />
+        <error line="362" column="103" source="standard:argument-list-wrapping" />
+        <error line="362" column="134" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonInstallationDialogFragmentTest.kt">
+        <error line="59" column="1" source="standard:max-line-length" />
+        <error line="59" column="20" source="standard:argument-list-wrapping" />
+        <error line="59" column="46" source="standard:argument-list-wrapping" />
+        <error line="59" column="68" source="standard:argument-list-wrapping" />
+        <error line="59" column="126" source="standard:argument-list-wrapping" />
+        <error line="59" column="127" source="standard:argument-list-wrapping" />
+        <error line="59" column="128" source="standard:argument-list-wrapping" />
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="60" column="20" source="standard:argument-list-wrapping" />
+        <error line="60" column="59" source="standard:argument-list-wrapping" />
+        <error line="60" column="81" source="standard:argument-list-wrapping" />
+        <error line="60" column="145" source="standard:argument-list-wrapping" />
+        <error line="60" column="146" source="standard:argument-list-wrapping" />
+        <error line="60" column="147" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/AddonsManagerAdapterTest.kt">
+        <error line="155" column="1" source="standard:max-line-length" />
+        <error line="155" column="45" source="standard:argument-list-wrapping" />
+        <error line="155" column="84" source="standard:argument-list-wrapping" />
+        <error line="155" column="108" source="standard:argument-list-wrapping" />
+        <error line="155" column="129" source="standard:argument-list-wrapping" />
+        <error line="754" column="1" source="standard:max-line-length" />
+        <error line="795" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/ExtensionsTest.kt">
+        <error line="83" column="1" source="standard:max-line-length" />
+        <error line="83" column="57" source="standard:argument-list-wrapping" />
+        <error line="83" column="108" source="standard:argument-list-wrapping" />
+        <error line="83" column="114" source="standard:argument-list-wrapping" />
+        <error line="83" column="133" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/addons/src/test/java/mozilla/components/feature/addons/ui/PermissionsDialogFragmentTest.kt">
+        <error line="50" column="1" source="standard:max-line-length" />
+        <error line="50" column="20" source="standard:argument-list-wrapping" />
+        <error line="50" column="44" source="standard:argument-list-wrapping" />
+        <error line="50" column="66" source="standard:argument-list-wrapping" />
+        <error line="50" column="123" source="standard:argument-list-wrapping" />
+        <error line="50" column="124" source="standard:argument-list-wrapping" />
+        <error line="50" column="125" source="standard:argument-list-wrapping" />
+        <error line="51" column="1" source="standard:max-line-length" />
+        <error line="51" column="20" source="standard:argument-list-wrapping" />
+        <error line="51" column="44" source="standard:argument-list-wrapping" />
+        <error line="51" column="66" source="standard:argument-list-wrapping" />
+        <error line="51" column="127" source="standard:argument-list-wrapping" />
+        <error line="51" column="128" source="standard:argument-list-wrapping" />
+        <error line="51" column="129" source="standard:argument-list-wrapping" />
+        <error line="52" column="1" source="standard:max-line-length" />
+        <error line="52" column="20" source="standard:argument-list-wrapping" />
+        <error line="52" column="44" source="standard:argument-list-wrapping" />
+        <error line="52" column="66" source="standard:argument-list-wrapping" />
+        <error line="52" column="128" source="standard:argument-list-wrapping" />
+        <error line="52" column="129" source="standard:argument-list-wrapping" />
+        <error line="52" column="130" source="standard:argument-list-wrapping" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="53" column="20" source="standard:argument-list-wrapping" />
+        <error line="53" column="44" source="standard:argument-list-wrapping" />
+        <error line="53" column="66" source="standard:argument-list-wrapping" />
+        <error line="53" column="124" source="standard:argument-list-wrapping" />
+        <error line="53" column="125" source="standard:argument-list-wrapping" />
+        <error line="53" column="126" source="standard:argument-list-wrapping" />
+        <error line="55" column="1" source="standard:max-line-length" />
+        <error line="55" column="20" source="standard:argument-list-wrapping" />
+        <error line="55" column="53" source="standard:argument-list-wrapping" />
+        <error line="55" column="75" source="standard:argument-list-wrapping" />
+        <error line="55" column="132" source="standard:argument-list-wrapping" />
+        <error line="55" column="133" source="standard:argument-list-wrapping" />
+        <error line="55" column="134" source="standard:argument-list-wrapping" />
+        <error line="56" column="1" source="standard:max-line-length" />
+        <error line="56" column="20" source="standard:argument-list-wrapping" />
+        <error line="56" column="53" source="standard:argument-list-wrapping" />
+        <error line="56" column="75" source="standard:argument-list-wrapping" />
+        <error line="56" column="136" source="standard:argument-list-wrapping" />
+        <error line="56" column="137" source="standard:argument-list-wrapping" />
+        <error line="56" column="138" source="standard:argument-list-wrapping" />
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="57" column="20" source="standard:argument-list-wrapping" />
+        <error line="57" column="53" source="standard:argument-list-wrapping" />
+        <error line="57" column="75" source="standard:argument-list-wrapping" />
+        <error line="57" column="137" source="standard:argument-list-wrapping" />
+        <error line="57" column="138" source="standard:argument-list-wrapping" />
+        <error line="57" column="139" source="standard:argument-list-wrapping" />
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="58" column="20" source="standard:argument-list-wrapping" />
+        <error line="58" column="53" source="standard:argument-list-wrapping" />
+        <error line="58" column="75" source="standard:argument-list-wrapping" />
+        <error line="58" column="133" source="standard:argument-list-wrapping" />
+        <error line="58" column="134" source="standard:argument-list-wrapping" />
+        <error line="58" column="135" source="standard:argument-list-wrapping" />
+        <error line="150" column="1" source="standard:max-line-length" />
+        <error line="150" column="21" source="standard:argument-list-wrapping" />
+        <error line="150" column="45" source="standard:argument-list-wrapping" />
+        <error line="150" column="67" source="standard:argument-list-wrapping" />
+        <error line="150" column="124" source="standard:argument-list-wrapping" />
+        <error line="150" column="125" source="standard:argument-list-wrapping" />
+        <error line="150" column="126" source="standard:argument-list-wrapping" />
+        <error line="151" column="1" source="standard:max-line-length" />
+        <error line="151" column="21" source="standard:argument-list-wrapping" />
+        <error line="151" column="54" source="standard:argument-list-wrapping" />
+        <error line="151" column="76" source="standard:argument-list-wrapping" />
+        <error line="151" column="133" source="standard:argument-list-wrapping" />
+        <error line="151" column="134" source="standard:argument-list-wrapping" />
+        <error line="151" column="135" source="standard:argument-list-wrapping" />
+        <error line="161" column="1" source="standard:max-line-length" />
+        <error line="161" column="23" source="standard:property-wrapping" />
+        <error line="161" column="56" source="standard:argument-list-wrapping" />
+        <error line="161" column="63" source="standard:argument-list-wrapping" />
+        <error line="161" column="94" source="standard:argument-list-wrapping" />
+        <error line="161" column="133" source="standard:argument-list-wrapping" />
+        <error line="179" column="1" source="standard:max-line-length" />
+        <error line="179" column="20" source="standard:argument-list-wrapping" />
+        <error line="179" column="44" source="standard:argument-list-wrapping" />
+        <error line="179" column="66" source="standard:argument-list-wrapping" />
+        <error line="179" column="132" source="standard:argument-list-wrapping" />
+        <error line="179" column="133" source="standard:argument-list-wrapping" />
+        <error line="179" column="134" source="standard:argument-list-wrapping" />
+        <error line="180" column="1" source="standard:max-line-length" />
+        <error line="180" column="20" source="standard:argument-list-wrapping" />
+        <error line="180" column="44" source="standard:argument-list-wrapping" />
+        <error line="180" column="66" source="standard:argument-list-wrapping" />
+        <error line="180" column="127" source="standard:argument-list-wrapping" />
+        <error line="180" column="128" source="standard:argument-list-wrapping" />
+        <error line="180" column="129" source="standard:argument-list-wrapping" />
+        <error line="189" column="1" source="standard:max-line-length" />
+        <error line="189" column="20" source="standard:argument-list-wrapping" />
+        <error line="189" column="44" source="standard:argument-list-wrapping" />
+        <error line="189" column="66" source="standard:argument-list-wrapping" />
+        <error line="189" column="124" source="standard:argument-list-wrapping" />
+        <error line="189" column="125" source="standard:argument-list-wrapping" />
+        <error line="189" column="126" source="standard:argument-list-wrapping" />
+        <error line="191" column="1" source="standard:max-line-length" />
+        <error line="191" column="20" source="standard:argument-list-wrapping" />
+        <error line="191" column="53" source="standard:argument-list-wrapping" />
+        <error line="191" column="75" source="standard:argument-list-wrapping" />
+        <error line="191" column="141" source="standard:argument-list-wrapping" />
+        <error line="191" column="142" source="standard:argument-list-wrapping" />
+        <error line="191" column="143" source="standard:argument-list-wrapping" />
+        <error line="192" column="1" source="standard:max-line-length" />
+        <error line="192" column="20" source="standard:argument-list-wrapping" />
+        <error line="192" column="53" source="standard:argument-list-wrapping" />
+        <error line="192" column="75" source="standard:argument-list-wrapping" />
+        <error line="192" column="136" source="standard:argument-list-wrapping" />
+        <error line="192" column="137" source="standard:argument-list-wrapping" />
+        <error line="192" column="138" source="standard:argument-list-wrapping" />
+        <error line="201" column="1" source="standard:max-line-length" />
+        <error line="201" column="20" source="standard:argument-list-wrapping" />
+        <error line="201" column="53" source="standard:argument-list-wrapping" />
+        <error line="201" column="75" source="standard:argument-list-wrapping" />
+        <error line="201" column="133" source="standard:argument-list-wrapping" />
+        <error line="201" column="134" source="standard:argument-list-wrapping" />
+        <error line="201" column="135" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksInterceptorTest.kt">
+        <error line="80" column="1" source="standard:max-line-length" />
+        <error line="80" column="58" source="standard:argument-list-wrapping" />
+        <error line="80" column="77" source="standard:argument-list-wrapping" />
+        <error line="80" column="96" source="standard:argument-list-wrapping" />
+        <error line="80" column="102" source="standard:argument-list-wrapping" />
+        <error line="80" column="108" source="standard:argument-list-wrapping" />
+        <error line="80" column="115" source="standard:argument-list-wrapping" />
+        <error line="80" column="122" source="standard:argument-list-wrapping" />
+        <error line="80" column="129" source="standard:argument-list-wrapping" />
+        <error line="80" column="134" source="standard:argument-list-wrapping" />
+        <error line="86" column="1" source="standard:max-line-length" />
+        <error line="86" column="58" source="standard:argument-list-wrapping" />
+        <error line="86" column="77" source="standard:argument-list-wrapping" />
+        <error line="86" column="96" source="standard:argument-list-wrapping" />
+        <error line="86" column="102" source="standard:argument-list-wrapping" />
+        <error line="86" column="109" source="standard:argument-list-wrapping" />
+        <error line="86" column="116" source="standard:argument-list-wrapping" />
+        <error line="86" column="122" source="standard:argument-list-wrapping" />
+        <error line="86" column="129" source="standard:argument-list-wrapping" />
+        <error line="86" column="134" source="standard:argument-list-wrapping" />
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="92" column="58" source="standard:argument-list-wrapping" />
+        <error line="92" column="77" source="standard:argument-list-wrapping" />
+        <error line="92" column="85" source="standard:argument-list-wrapping" />
+        <error line="92" column="91" source="standard:argument-list-wrapping" />
+        <error line="92" column="98" source="standard:argument-list-wrapping" />
+        <error line="92" column="105" source="standard:argument-list-wrapping" />
+        <error line="92" column="111" source="standard:argument-list-wrapping" />
+        <error line="92" column="118" source="standard:argument-list-wrapping" />
+        <error line="92" column="122" source="standard:argument-list-wrapping" />
+        <error line="98" column="1" source="standard:max-line-length" />
+        <error line="98" column="58" source="standard:argument-list-wrapping" />
+        <error line="98" column="77" source="standard:argument-list-wrapping" />
+        <error line="98" column="96" source="standard:argument-list-wrapping" />
+        <error line="98" column="102" source="standard:argument-list-wrapping" />
+        <error line="98" column="109" source="standard:argument-list-wrapping" />
+        <error line="98" column="116" source="standard:argument-list-wrapping" />
+        <error line="98" column="123" source="standard:argument-list-wrapping" />
+        <error line="98" column="129" source="standard:argument-list-wrapping" />
+        <error line="98" column="134" source="standard:argument-list-wrapping" />
+        <error line="111" column="1" source="standard:max-line-length" />
+        <error line="111" column="58" source="standard:argument-list-wrapping" />
+        <error line="111" column="77" source="standard:argument-list-wrapping" />
+        <error line="111" column="96" source="standard:argument-list-wrapping" />
+        <error line="111" column="102" source="standard:argument-list-wrapping" />
+        <error line="111" column="108" source="standard:argument-list-wrapping" />
+        <error line="111" column="115" source="standard:argument-list-wrapping" />
+        <error line="111" column="122" source="standard:argument-list-wrapping" />
+        <error line="111" column="129" source="standard:argument-list-wrapping" />
+        <error line="111" column="134" source="standard:argument-list-wrapping" />
+        <error line="124" column="1" source="standard:max-line-length" />
+        <error line="124" column="58" source="standard:argument-list-wrapping" />
+        <error line="124" column="77" source="standard:argument-list-wrapping" />
+        <error line="124" column="96" source="standard:argument-list-wrapping" />
+        <error line="124" column="102" source="standard:argument-list-wrapping" />
+        <error line="124" column="108" source="standard:argument-list-wrapping" />
+        <error line="124" column="115" source="standard:argument-list-wrapping" />
+        <error line="124" column="122" source="standard:argument-list-wrapping" />
+        <error line="124" column="129" source="standard:argument-list-wrapping" />
+        <error line="124" column="134" source="standard:argument-list-wrapping" />
+        <error line="137" column="1" source="standard:max-line-length" />
+        <error line="137" column="58" source="standard:argument-list-wrapping" />
+        <error line="137" column="77" source="standard:argument-list-wrapping" />
+        <error line="137" column="96" source="standard:argument-list-wrapping" />
+        <error line="137" column="102" source="standard:argument-list-wrapping" />
+        <error line="137" column="108" source="standard:argument-list-wrapping" />
+        <error line="137" column="115" source="standard:argument-list-wrapping" />
+        <error line="137" column="122" source="standard:argument-list-wrapping" />
+        <error line="137" column="129" source="standard:argument-list-wrapping" />
+        <error line="137" column="134" source="standard:argument-list-wrapping" />
+        <error line="142" column="1" source="standard:max-line-length" />
+        <error line="142" column="59" source="standard:argument-list-wrapping" />
+        <error line="142" column="78" source="standard:argument-list-wrapping" />
+        <error line="142" column="97" source="standard:argument-list-wrapping" />
+        <error line="142" column="103" source="standard:argument-list-wrapping" />
+        <error line="142" column="109" source="standard:argument-list-wrapping" />
+        <error line="142" column="116" source="standard:argument-list-wrapping" />
+        <error line="142" column="123" source="standard:argument-list-wrapping" />
+        <error line="142" column="130" source="standard:argument-list-wrapping" />
+        <error line="142" column="135" source="standard:argument-list-wrapping" />
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="148" column="58" source="standard:argument-list-wrapping" />
+        <error line="148" column="77" source="standard:argument-list-wrapping" />
+        <error line="148" column="96" source="standard:argument-list-wrapping" />
+        <error line="148" column="102" source="standard:argument-list-wrapping" />
+        <error line="148" column="109" source="standard:argument-list-wrapping" />
+        <error line="148" column="116" source="standard:argument-list-wrapping" />
+        <error line="148" column="123" source="standard:argument-list-wrapping" />
+        <error line="148" column="130" source="standard:argument-list-wrapping" />
+        <error line="148" column="135" source="standard:argument-list-wrapping" />
+        <error line="154" column="1" source="standard:max-line-length" />
+        <error line="154" column="58" source="standard:argument-list-wrapping" />
+        <error line="154" column="77" source="standard:argument-list-wrapping" />
+        <error line="154" column="96" source="standard:argument-list-wrapping" />
+        <error line="154" column="115" source="standard:argument-list-wrapping" />
+        <error line="154" column="121" source="standard:argument-list-wrapping" />
+        <error line="154" column="127" source="standard:argument-list-wrapping" />
+        <error line="154" column="134" source="standard:argument-list-wrapping" />
+        <error line="154" column="141" source="standard:argument-list-wrapping" />
+        <error line="154" column="146" source="standard:argument-list-wrapping" />
+        <error line="160" column="1" source="standard:max-line-length" />
+        <error line="160" column="58" source="standard:argument-list-wrapping" />
+        <error line="160" column="77" source="standard:argument-list-wrapping" />
+        <error line="160" column="96" source="standard:argument-list-wrapping" />
+        <error line="160" column="115" source="standard:argument-list-wrapping" />
+        <error line="160" column="121" source="standard:argument-list-wrapping" />
+        <error line="160" column="127" source="standard:argument-list-wrapping" />
+        <error line="160" column="133" source="standard:argument-list-wrapping" />
+        <error line="160" column="140" source="standard:argument-list-wrapping" />
+        <error line="160" column="145" source="standard:argument-list-wrapping" />
+        <error line="166" column="1" source="standard:max-line-length" />
+        <error line="166" column="58" source="standard:argument-list-wrapping" />
+        <error line="166" column="77" source="standard:argument-list-wrapping" />
+        <error line="166" column="99" source="standard:argument-list-wrapping" />
+        <error line="166" column="114" source="standard:argument-list-wrapping" />
+        <error line="166" column="120" source="standard:argument-list-wrapping" />
+        <error line="166" column="126" source="standard:argument-list-wrapping" />
+        <error line="166" column="132" source="standard:argument-list-wrapping" />
+        <error line="166" column="139" source="standard:argument-list-wrapping" />
+        <error line="166" column="144" source="standard:argument-list-wrapping" />
+        <error line="169" column="1" source="standard:max-line-length" />
+        <error line="169" column="54" source="standard:argument-list-wrapping" />
+        <error line="169" column="73" source="standard:argument-list-wrapping" />
+        <error line="169" column="96" source="standard:argument-list-wrapping" />
+        <error line="169" column="118" source="standard:argument-list-wrapping" />
+        <error line="169" column="124" source="standard:argument-list-wrapping" />
+        <error line="169" column="130" source="standard:argument-list-wrapping" />
+        <error line="169" column="136" source="standard:argument-list-wrapping" />
+        <error line="169" column="143" source="standard:argument-list-wrapping" />
+        <error line="169" column="148" source="standard:argument-list-wrapping" />
+        <error line="172" column="1" source="standard:max-line-length" />
+        <error line="172" column="54" source="standard:argument-list-wrapping" />
+        <error line="172" column="73" source="standard:argument-list-wrapping" />
+        <error line="172" column="100" source="standard:argument-list-wrapping" />
+        <error line="172" column="122" source="standard:argument-list-wrapping" />
+        <error line="172" column="128" source="standard:argument-list-wrapping" />
+        <error line="172" column="134" source="standard:argument-list-wrapping" />
+        <error line="172" column="140" source="standard:argument-list-wrapping" />
+        <error line="172" column="147" source="standard:argument-list-wrapping" />
+        <error line="172" column="152" source="standard:argument-list-wrapping" />
+        <error line="175" column="1" source="standard:max-line-length" />
+        <error line="175" column="54" source="standard:argument-list-wrapping" />
+        <error line="175" column="73" source="standard:argument-list-wrapping" />
+        <error line="175" column="99" source="standard:argument-list-wrapping" />
+        <error line="175" column="126" source="standard:argument-list-wrapping" />
+        <error line="175" column="132" source="standard:argument-list-wrapping" />
+        <error line="175" column="138" source="standard:argument-list-wrapping" />
+        <error line="175" column="144" source="standard:argument-list-wrapping" />
+        <error line="175" column="151" source="standard:argument-list-wrapping" />
+        <error line="175" column="156" source="standard:argument-list-wrapping" />
+        <error line="178" column="1" source="standard:max-line-length" />
+        <error line="178" column="54" source="standard:argument-list-wrapping" />
+        <error line="178" column="73" source="standard:argument-list-wrapping" />
+        <error line="178" column="97" source="standard:argument-list-wrapping" />
+        <error line="178" column="124" source="standard:argument-list-wrapping" />
+        <error line="178" column="130" source="standard:argument-list-wrapping" />
+        <error line="178" column="136" source="standard:argument-list-wrapping" />
+        <error line="178" column="142" source="standard:argument-list-wrapping" />
+        <error line="178" column="149" source="standard:argument-list-wrapping" />
+        <error line="178" column="154" source="standard:argument-list-wrapping" />
+        <error line="181" column="1" source="standard:max-line-length" />
+        <error line="181" column="54" source="standard:argument-list-wrapping" />
+        <error line="181" column="73" source="standard:argument-list-wrapping" />
+        <error line="181" column="102" source="standard:argument-list-wrapping" />
+        <error line="181" column="126" source="standard:argument-list-wrapping" />
+        <error line="181" column="132" source="standard:argument-list-wrapping" />
+        <error line="181" column="138" source="standard:argument-list-wrapping" />
+        <error line="181" column="144" source="standard:argument-list-wrapping" />
+        <error line="181" column="151" source="standard:argument-list-wrapping" />
+        <error line="181" column="156" source="standard:argument-list-wrapping" />
+        <error line="187" column="1" source="standard:max-line-length" />
+        <error line="187" column="58" source="standard:argument-list-wrapping" />
+        <error line="187" column="77" source="standard:argument-list-wrapping" />
+        <error line="187" column="96" source="standard:argument-list-wrapping" />
+        <error line="187" column="102" source="standard:argument-list-wrapping" />
+        <error line="187" column="109" source="standard:argument-list-wrapping" />
+        <error line="187" column="116" source="standard:argument-list-wrapping" />
+        <error line="187" column="123" source="standard:argument-list-wrapping" />
+        <error line="187" column="129" source="standard:argument-list-wrapping" />
+        <error line="187" column="133" source="standard:argument-list-wrapping" />
+        <error line="193" column="1" source="standard:max-line-length" />
+        <error line="193" column="58" source="standard:argument-list-wrapping" />
+        <error line="193" column="77" source="standard:argument-list-wrapping" />
+        <error line="193" column="96" source="standard:argument-list-wrapping" />
+        <error line="193" column="102" source="standard:argument-list-wrapping" />
+        <error line="193" column="109" source="standard:argument-list-wrapping" />
+        <error line="193" column="116" source="standard:argument-list-wrapping" />
+        <error line="193" column="123" source="standard:argument-list-wrapping" />
+        <error line="193" column="130" source="standard:argument-list-wrapping" />
+        <error line="193" column="135" source="standard:argument-list-wrapping" />
+        <error line="274" column="1" source="standard:max-line-length" />
+        <error line="426" column="1" source="standard:max-line-length" />
+        <error line="426" column="58" source="standard:argument-list-wrapping" />
+        <error line="426" column="77" source="standard:argument-list-wrapping" />
+        <error line="426" column="92" source="standard:argument-list-wrapping" />
+        <error line="426" column="98" source="standard:argument-list-wrapping" />
+        <error line="426" column="104" source="standard:argument-list-wrapping" />
+        <error line="426" column="110" source="standard:argument-list-wrapping" />
+        <error line="426" column="117" source="standard:argument-list-wrapping" />
+        <error line="426" column="124" source="standard:argument-list-wrapping" />
+        <error line="426" column="129" source="standard:argument-list-wrapping" />
+        <error line="432" column="1" source="standard:max-line-length" />
+        <error line="432" column="58" source="standard:argument-list-wrapping" />
+        <error line="432" column="77" source="standard:argument-list-wrapping" />
+        <error line="432" column="90" source="standard:argument-list-wrapping" />
+        <error line="432" column="96" source="standard:argument-list-wrapping" />
+        <error line="432" column="102" source="standard:argument-list-wrapping" />
+        <error line="432" column="109" source="standard:argument-list-wrapping" />
+        <error line="432" column="116" source="standard:argument-list-wrapping" />
+        <error line="432" column="123" source="standard:argument-list-wrapping" />
+        <error line="432" column="128" source="standard:argument-list-wrapping" />
+        <error line="438" column="1" source="standard:max-line-length" />
+        <error line="438" column="58" source="standard:argument-list-wrapping" />
+        <error line="438" column="77" source="standard:argument-list-wrapping" />
+        <error line="438" column="93" source="standard:argument-list-wrapping" />
+        <error line="438" column="99" source="standard:argument-list-wrapping" />
+        <error line="438" column="105" source="standard:argument-list-wrapping" />
+        <error line="438" column="112" source="standard:argument-list-wrapping" />
+        <error line="438" column="119" source="standard:argument-list-wrapping" />
+        <error line="438" column="126" source="standard:argument-list-wrapping" />
+        <error line="438" column="131" source="standard:argument-list-wrapping" />
+        <error line="452" column="1" source="standard:max-line-length" />
+        <error line="452" column="58" source="standard:argument-list-wrapping" />
+        <error line="452" column="77" source="standard:argument-list-wrapping" />
+        <error line="452" column="96" source="standard:argument-list-wrapping" />
+        <error line="452" column="102" source="standard:argument-list-wrapping" />
+        <error line="452" column="108" source="standard:argument-list-wrapping" />
+        <error line="452" column="115" source="standard:argument-list-wrapping" />
+        <error line="452" column="122" source="standard:argument-list-wrapping" />
+        <error line="452" column="129" source="standard:argument-list-wrapping" />
+        <error line="452" column="134" source="standard:argument-list-wrapping" />
+        <error line="482" column="1" source="standard:max-line-length" />
+        <error line="482" column="58" source="standard:argument-list-wrapping" />
+        <error line="482" column="77" source="standard:argument-list-wrapping" />
+        <error line="482" column="88" source="standard:argument-list-wrapping" />
+        <error line="482" column="94" source="standard:argument-list-wrapping" />
+        <error line="482" column="101" source="standard:argument-list-wrapping" />
+        <error line="482" column="107" source="standard:argument-list-wrapping" />
+        <error line="482" column="114" source="standard:argument-list-wrapping" />
+        <error line="482" column="121" source="standard:argument-list-wrapping" />
+        <error line="482" column="126" source="standard:argument-list-wrapping" />
+        <error line="560" column="1" source="standard:max-line-length" />
+        <error line="560" column="58" source="standard:argument-list-wrapping" />
+        <error line="560" column="77" source="standard:argument-list-wrapping" />
+        <error line="560" column="96" source="standard:argument-list-wrapping" />
+        <error line="560" column="102" source="standard:argument-list-wrapping" />
+        <error line="560" column="108" source="standard:argument-list-wrapping" />
+        <error line="560" column="115" source="standard:argument-list-wrapping" />
+        <error line="560" column="122" source="standard:argument-list-wrapping" />
+        <error line="560" column="129" source="standard:argument-list-wrapping" />
+        <error line="560" column="134" source="standard:argument-list-wrapping" />
+        <error line="565" column="1" source="standard:max-line-length" />
+        <error line="565" column="54" source="standard:argument-list-wrapping" />
+        <error line="565" column="73" source="standard:argument-list-wrapping" />
+        <error line="565" column="92" source="standard:argument-list-wrapping" />
+        <error line="565" column="98" source="standard:argument-list-wrapping" />
+        <error line="565" column="104" source="standard:argument-list-wrapping" />
+        <error line="565" column="111" source="standard:argument-list-wrapping" />
+        <error line="565" column="118" source="standard:argument-list-wrapping" />
+        <error line="565" column="125" source="standard:argument-list-wrapping" />
+        <error line="565" column="130" source="standard:argument-list-wrapping" />
+        <error line="586" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/app-links/src/test/java/mozilla/components/feature/app/links/AppLinksUseCasesTest.kt">
+        <error line="83" column="1" source="standard:max-line-length" />
+        <error line="328" column="1" source="standard:max-line-length" />
+        <error line="602" column="1" source="standard:max-line-length" />
+        <error line="602" column="22" source="standard:property-wrapping" />
+        <error line="602" column="37" source="standard:argument-list-wrapping" />
+        <error line="602" column="99" source="standard:argument-list-wrapping" />
+        <error line="602" column="115" source="standard:argument-list-wrapping" />
+        <error line="602" column="138" source="standard:argument-list-wrapping" />
+        <error line="602" column="148" source="standard:argument-list-wrapping" />
+        <error line="602" column="149" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/BookmarksStorageSuggestionProviderTest.kt">
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="149" column="23" source="standard:property-wrapping" />
+        <error line="149" column="59" source="standard:argument-list-wrapping" />
+        <error line="149" column="70" source="standard:argument-list-wrapping" />
+        <error line="149" column="78" source="standard:argument-list-wrapping" />
+        <error line="149" column="95" source="standard:argument-list-wrapping" />
+        <error line="149" column="121" source="standard:argument-list-wrapping" />
+        <error line="178" column="1" source="standard:max-line-length" />
+        <error line="197" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/CombinedHistorySuggestionProviderTest.kt">
+        <error line="47" column="1" source="standard:max-line-length" />
+        <error line="51" column="1" source="standard:max-line-length" />
+        <error line="51" column="107" source="standard:argument-list-wrapping" />
+        <error line="51" column="118" source="standard:argument-list-wrapping" />
+        <error line="51" column="126" source="standard:argument-list-wrapping" />
+        <error line="73" column="1" source="standard:max-line-length" />
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="77" column="116" source="standard:argument-list-wrapping" />
+        <error line="77" column="119" source="standard:argument-list-wrapping" />
+        <error line="77" column="124" source="standard:argument-list-wrapping" />
+        <error line="77" column="127" source="standard:argument-list-wrapping" />
+        <error line="77" column="135" source="standard:argument-list-wrapping" />
+        <error line="107" column="1" source="standard:max-line-length" />
+        <error line="111" column="1" source="standard:max-line-length" />
+        <error line="111" column="116" source="standard:argument-list-wrapping" />
+        <error line="111" column="119" source="standard:argument-list-wrapping" />
+        <error line="111" column="124" source="standard:argument-list-wrapping" />
+        <error line="111" column="127" source="standard:argument-list-wrapping" />
+        <error line="111" column="135" source="standard:argument-list-wrapping" />
+        <error line="121" column="1" source="standard:max-line-length" />
+        <error line="125" column="1" source="standard:max-line-length" />
+        <error line="125" column="116" source="standard:argument-list-wrapping" />
+        <error line="125" column="119" source="standard:argument-list-wrapping" />
+        <error line="125" column="124" source="standard:argument-list-wrapping" />
+        <error line="125" column="127" source="standard:argument-list-wrapping" />
+        <error line="125" column="135" source="standard:argument-list-wrapping" />
+        <error line="135" column="1" source="standard:max-line-length" />
+        <error line="139" column="1" source="standard:max-line-length" />
+        <error line="139" column="107" source="standard:argument-list-wrapping" />
+        <error line="139" column="118" source="standard:argument-list-wrapping" />
+        <error line="139" column="126" source="standard:argument-list-wrapping" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="186" column="1" source="standard:max-line-length" />
+        <error line="186" column="103" source="standard:argument-list-wrapping" />
+        <error line="186" column="114" source="standard:argument-list-wrapping" />
+        <error line="186" column="122" source="standard:argument-list-wrapping" />
+        <error line="209" column="1" source="standard:max-line-length" />
+        <error line="209" column="116" source="standard:argument-list-wrapping" />
+        <error line="209" column="119" source="standard:argument-list-wrapping" />
+        <error line="209" column="124" source="standard:argument-list-wrapping" />
+        <error line="209" column="127" source="standard:argument-list-wrapping" />
+        <error line="209" column="135" source="standard:argument-list-wrapping" />
+        <error line="210" column="1" source="standard:max-line-length" />
+        <error line="210" column="23" source="standard:property-wrapping" />
+        <error line="210" column="58" source="standard:argument-list-wrapping" />
+        <error line="210" column="67" source="standard:argument-list-wrapping" />
+        <error line="210" column="77" source="standard:argument-list-wrapping" />
+        <error line="210" column="85" source="standard:argument-list-wrapping" />
+        <error line="210" column="113" source="standard:argument-list-wrapping" />
+        <error line="210" column="139" source="standard:argument-list-wrapping" />
+        <error line="220" column="1" source="standard:max-line-length" />
+        <error line="250" column="1" source="standard:max-line-length" />
+        <error line="290" column="1" source="standard:max-line-length" />
+        <error line="314" column="1" source="standard:max-line-length" />
+        <error line="347" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryMetadataSuggestionProviderTest.kt">
+        <error line="93" column="1" source="standard:max-line-length" />
+        <error line="93" column="101" source="standard:argument-list-wrapping" />
+        <error line="93" column="121" source="standard:argument-list-wrapping" />
+        <error line="170" column="1" source="standard:max-line-length" />
+        <error line="170" column="101" source="standard:argument-list-wrapping" />
+        <error line="170" column="121" source="standard:argument-list-wrapping" />
+        <error line="187" column="1" source="standard:max-line-length" />
+        <error line="187" column="101" source="standard:argument-list-wrapping" />
+        <error line="187" column="121" source="standard:argument-list-wrapping" />
+        <error line="217" column="1" source="standard:max-line-length" />
+        <error line="217" column="101" source="standard:argument-list-wrapping" />
+        <error line="217" column="121" source="standard:argument-list-wrapping" />
+        <error line="239" column="1" source="standard:max-line-length" />
+        <error line="257" column="1" source="standard:max-line-length" />
+        <error line="285" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/HistoryStorageSuggestionProviderTest.kt">
+        <error line="84" column="1" source="standard:max-line-length" />
+        <error line="84" column="116" source="standard:argument-list-wrapping" />
+        <error line="84" column="119" source="standard:argument-list-wrapping" />
+        <error line="84" column="124" source="standard:argument-list-wrapping" />
+        <error line="84" column="127" source="standard:argument-list-wrapping" />
+        <error line="84" column="143" source="standard:argument-list-wrapping" />
+        <error line="95" column="1" source="standard:max-line-length" />
+        <error line="95" column="116" source="standard:argument-list-wrapping" />
+        <error line="95" column="119" source="standard:argument-list-wrapping" />
+        <error line="95" column="124" source="standard:argument-list-wrapping" />
+        <error line="95" column="127" source="standard:argument-list-wrapping" />
+        <error line="95" column="143" source="standard:argument-list-wrapping" />
+        <error line="157" column="1" source="standard:max-line-length" />
+        <error line="191" column="1" source="standard:max-line-length" />
+        <error line="238" column="1" source="standard:max-line-length" />
+        <error line="238" column="100" source="standard:argument-list-wrapping" />
+        <error line="238" column="155" source="standard:argument-list-wrapping" />
+        <error line="265" column="1" source="standard:max-line-length" />
+        <error line="265" column="116" source="standard:argument-list-wrapping" />
+        <error line="265" column="119" source="standard:argument-list-wrapping" />
+        <error line="265" column="124" source="standard:argument-list-wrapping" />
+        <error line="265" column="127" source="standard:argument-list-wrapping" />
+        <error line="265" column="143" source="standard:argument-list-wrapping" />
+        <error line="283" column="1" source="standard:max-line-length" />
+        <error line="283" column="116" source="standard:argument-list-wrapping" />
+        <error line="283" column="119" source="standard:argument-list-wrapping" />
+        <error line="283" column="124" source="standard:argument-list-wrapping" />
+        <error line="283" column="127" source="standard:argument-list-wrapping" />
+        <error line="283" column="143" source="standard:argument-list-wrapping" />
+        <error line="324" column="1" source="standard:max-line-length" />
+        <error line="342" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchSuggestionProviderTest.kt">
+        <error line="41" column="1" source="standard:max-line-length" />
+        <error line="42" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SearchTermSuggestionsProviderTest.kt">
+        <error line="81" column="1" source="standard:max-line-length" />
+        <error line="91" column="1" source="standard:max-line-length" />
+        <error line="103" column="1" source="standard:max-line-length" />
+        <error line="130" column="1" source="standard:max-line-length" />
+        <error line="157" column="1" source="standard:max-line-length" />
+        <error line="180" column="1" source="standard:max-line-length" />
+        <error line="197" column="1" source="standard:max-line-length" />
+        <error line="249" column="1" source="standard:max-line-length" />
+        <error line="292" column="1" source="standard:max-line-length" />
+        <error line="310" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionAutocompleteProviderTest.kt">
+        <error line="55" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt">
+        <error line="142" column="1" source="standard:max-line-length" />
+        <error line="352" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/containers/src/test/java/mozilla/components/feature/containers/ContainerMiddlewareTest.kt">
+        <error line="65" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/contextmenu/src/test/java/mozilla/components/feature/contextmenu/ContextMenuCandidateTest.kt">
+        <error line="1608" column="1" source="standard:max-line-length" />
+        <error line="1608" column="49" source="standard:argument-list-wrapping" />
+        <error line="1608" column="52" source="standard:argument-list-wrapping" />
+        <error line="1608" column="126" source="standard:argument-list-wrapping" />
+        <error line="1608" column="127" source="standard:argument-list-wrapping" />
+        <error line="1706" column="1" source="standard:max-line-length" />
+        <error line="1706" column="49" source="standard:argument-list-wrapping" />
+        <error line="1706" column="52" source="standard:argument-list-wrapping" />
+        <error line="1706" column="126" source="standard:argument-list-wrapping" />
+        <error line="1706" column="127" source="standard:argument-list-wrapping" />
+        <error line="2024" column="1" source="standard:max-line-length" />
+        <error line="2043" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabConfigHelperTest.kt">
+        <error line="245" column="1" source="standard:max-line-length" />
+        <error line="245" column="42" source="standard:argument-list-wrapping" />
+        <error line="245" column="89" source="standard:argument-list-wrapping" />
+        <error line="245" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt">
+        <error line="146" column="1" source="standard:max-line-length" />
+        <error line="146" column="22" source="standard:property-wrapping" />
+        <error line="146" column="48" source="standard:argument-list-wrapping" />
+        <error line="146" column="55" source="standard:argument-list-wrapping" />
+        <error line="146" column="64" source="standard:argument-list-wrapping" />
+        <error line="146" column="87" source="standard:argument-list-wrapping" />
+        <error line="146" column="108" source="standard:argument-list-wrapping" />
+        <error line="146" column="123" source="standard:argument-list-wrapping" />
+        <error line="418" column="1" source="standard:max-line-length" />
+        <error line="418" column="48" source="standard:argument-list-wrapping" />
+        <error line="418" column="90" source="standard:argument-list-wrapping" />
+        <error line="418" column="105" source="standard:argument-list-wrapping" />
+        <error line="418" column="121" source="standard:argument-list-wrapping" />
+        <error line="418" column="144" source="standard:argument-list-wrapping" />
+        <error line="1073" column="1" source="standard:max-line-length" />
+        <error line="1103" column="1" source="standard:max-line-length" />
+        <error line="1103" column="45" source="standard:argument-list-wrapping" />
+        <error line="1103" column="56" source="standard:argument-list-wrapping" />
+        <error line="1103" column="139" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/downloads/src/androidTest/java/mozilla/components/feature/downloads/OnDeviceDownloadStorageTest.kt">
+        <error line="91" column="1" source="standard:max-line-length" />
+        <error line="100" column="1" source="standard:max-line-length" />
+        <error line="127" column="1" source="standard:max-line-length" />
+        <error line="277" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/downloads/src/androidTest/java/mozilla/components/feature/downloads/db/DownloadDaoTest.kt">
+        <error line="109" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/downloads/src/main/java/mozilla/components/feature/downloads/db/DownloadsDatabase.kt">
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="60" column="30" source="standard:argument-list-wrapping" />
+        <error line="60" column="282" source="standard:argument-list-wrapping" />
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="62" column="30" source="standard:argument-list-wrapping" />
+        <error line="62" column="273" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/AbstractFetchDownloadServiceTest.kt">
+        <error line="200" column="1" source="standard:max-line-length" />
+        <error line="200" column="106" source="standard:argument-list-wrapping" />
+        <error line="200" column="121" source="standard:argument-list-wrapping" />
+        <error line="238" column="1" source="standard:max-line-length" />
+        <error line="238" column="112" source="standard:argument-list-wrapping" />
+        <error line="238" column="127" source="standard:argument-list-wrapping" />
+        <error line="256" column="1" source="standard:max-line-length" />
+        <error line="280" column="1" source="standard:max-line-length" />
+        <error line="457" column="1" source="standard:max-line-length" />
+        <error line="457" column="22" source="standard:argument-list-wrapping" />
+        <error line="457" column="60" source="standard:argument-list-wrapping" />
+        <error line="457" column="129" source="standard:argument-list-wrapping" />
+        <error line="895" column="1" source="standard:max-line-length" />
+        <error line="895" column="114" source="standard:argument-list-wrapping" />
+        <error line="895" column="129" source="standard:argument-list-wrapping" />
+        <error line="1326" column="1" source="standard:max-line-length" />
+        <error line="1326" column="23" source="standard:property-wrapping" />
+        <error line="1326" column="28" source="standard:argument-list-wrapping" />
+        <error line="1326" column="42" source="standard:argument-list-wrapping" />
+        <error line="1326" column="74" source="standard:argument-list-wrapping" />
+        <error line="1326" column="86" source="standard:argument-list-wrapping" />
+        <error line="1326" column="122" source="standard:argument-list-wrapping" />
+        <error line="1326" column="123" source="standard:argument-list-wrapping" />
+        <error line="1453" column="1" source="standard:max-line-length" />
+        <error line="1453" column="115" source="standard:argument-list-wrapping" />
+        <error line="1453" column="130" source="standard:argument-list-wrapping" />
+        <error line="1495" column="1" source="standard:max-line-length" />
+        <error line="1495" column="130" source="standard:argument-list-wrapping" />
+        <error line="1495" column="145" source="standard:argument-list-wrapping" />
+        <error line="1536" column="1" source="standard:max-line-length" />
+        <error line="1536" column="145" source="standard:argument-list-wrapping" />
+        <error line="1536" column="160" source="standard:argument-list-wrapping" />
+        <error line="1569" column="1" source="standard:max-line-length" />
+        <error line="1569" column="136" source="standard:argument-list-wrapping" />
+        <error line="1569" column="151" source="standard:argument-list-wrapping" />
+        <error line="1679" column="1" source="standard:max-line-length" />
+        <error line="1743" column="1" source="standard:max-line-length" />
+        <error line="1942" column="1" source="standard:max-line-length" />
+        <error line="1942" column="118" source="standard:argument-list-wrapping" />
+        <error line="1942" column="133" source="standard:argument-list-wrapping" />
+        <error line="2012" column="1" source="standard:max-line-length" />
+        <error line="2060" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadDialogFragmentTest.kt">
+        <error line="34" column="1" source="standard:max-line-length" />
+        <error line="53" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadMiddlewareTest.kt">
+        <error line="301" column="1" source="standard:max-line-length" />
+        <error line="329" column="1" source="standard:max-line-length" />
+        <error line="358" column="1" source="standard:max-line-length" />
+        <error line="389" column="1" source="standard:max-line-length" />
+        <error line="420" column="1" source="standard:max-line-length" />
+        <error line="450" column="1" source="standard:max-line-length" />
+        <error line="480" column="1" source="standard:max-line-length" />
+        <error line="500" column="1" source="standard:max-line-length" />
+        <error line="525" column="1" source="standard:max-line-length" />
+        <error line="536" column="1" source="standard:max-line-length" />
+        <error line="536" column="30" source="standard:property-wrapping" />
+        <error line="536" column="45" source="standard:argument-list-wrapping" />
+        <error line="536" column="77" source="standard:argument-list-wrapping" />
+        <error line="536" column="99" source="standard:argument-list-wrapping" />
+        <error line="536" column="115" source="standard:argument-list-wrapping" />
+        <error line="536" column="133" source="standard:argument-list-wrapping" />
+        <error line="537" column="1" source="standard:max-line-length" />
+        <error line="537" column="37" source="standard:property-wrapping" />
+        <error line="537" column="52" source="standard:argument-list-wrapping" />
+        <error line="537" column="84" source="standard:argument-list-wrapping" />
+        <error line="537" column="106" source="standard:argument-list-wrapping" />
+        <error line="537" column="122" source="standard:argument-list-wrapping" />
+        <error line="537" column="140" source="standard:argument-list-wrapping" />
+        <error line="540" column="1" source="standard:max-line-length" />
+        <error line="540" column="35" source="standard:argument-list-wrapping" />
+        <error line="540" column="60" source="standard:argument-list-wrapping" />
+        <error line="540" column="99" source="standard:argument-list-wrapping" />
+        <error line="540" column="150" source="standard:argument-list-wrapping" />
+        <error line="551" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadStorageTest.kt">
+        <error line="34" column="1" source="standard:max-line-length" />
+        <error line="34" column="21" source="standard:argument-list-wrapping" />
+        <error line="34" column="52" source="standard:argument-list-wrapping" />
+        <error line="34" column="62" source="standard:argument-list-wrapping" />
+        <error line="34" column="76" source="standard:argument-list-wrapping" />
+        <error line="34" column="130" source="standard:argument-list-wrapping" />
+        <error line="34" column="131" source="standard:argument-list-wrapping" />
+        <error line="34" column="132" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/DownloadsFeatureTest.kt">
+        <error line="302" column="1" source="standard:max-line-length" />
+        <error line="338" column="1" source="standard:max-line-length" />
+        <error line="593" column="1" source="standard:max-line-length" />
+        <error line="622" column="1" source="standard:max-line-length" />
+        <error line="653" column="1" source="standard:max-line-length" />
+        <error line="675" column="1" source="standard:max-line-length" />
+        <error line="697" column="1" source="standard:max-line-length" />
+        <error line="886" column="1" source="standard:max-line-length" />
+        <error line="886" column="21" source="standard:property-wrapping" />
+        <error line="886" column="36" source="standard:argument-list-wrapping" />
+        <error line="886" column="50" source="standard:argument-list-wrapping" />
+        <error line="886" column="89" source="standard:argument-list-wrapping" />
+        <error line="886" column="108" source="standard:argument-list-wrapping" />
+        <error line="886" column="127" source="standard:argument-list-wrapping" />
+        <error line="886" column="137" source="standard:argument-list-wrapping" />
+        <error line="886" column="155" source="standard:argument-list-wrapping" />
+        <error line="926" column="1" source="standard:max-line-length" />
+        <error line="926" column="21" source="standard:property-wrapping" />
+        <error line="926" column="36" source="standard:argument-list-wrapping" />
+        <error line="926" column="50" source="standard:argument-list-wrapping" />
+        <error line="926" column="89" source="standard:argument-list-wrapping" />
+        <error line="926" column="108" source="standard:argument-list-wrapping" />
+        <error line="926" column="127" source="standard:argument-list-wrapping" />
+        <error line="926" column="137" source="standard:argument-list-wrapping" />
+        <error line="926" column="155" source="standard:argument-list-wrapping" />
+        <error line="948" column="1" source="standard:max-line-length" />
+        <error line="955" column="1" source="standard:max-line-length" />
+        <error line="955" column="21" source="standard:property-wrapping" />
+        <error line="955" column="36" source="standard:argument-list-wrapping" />
+        <error line="955" column="50" source="standard:argument-list-wrapping" />
+        <error line="955" column="89" source="standard:argument-list-wrapping" />
+        <error line="955" column="108" source="standard:argument-list-wrapping" />
+        <error line="955" column="127" source="standard:argument-list-wrapping" />
+        <error line="955" column="137" source="standard:argument-list-wrapping" />
+        <error line="955" column="155" source="standard:argument-list-wrapping" />
+        <error line="1010" column="1" source="standard:max-line-length" />
+        <error line="1056" column="1" source="standard:max-line-length" />
+        <error line="1056" column="21" source="standard:property-wrapping" />
+        <error line="1056" column="36" source="standard:argument-list-wrapping" />
+        <error line="1056" column="50" source="standard:argument-list-wrapping" />
+        <error line="1056" column="82" source="standard:argument-list-wrapping" />
+        <error line="1056" column="101" source="standard:argument-list-wrapping" />
+        <error line="1056" column="120" source="standard:argument-list-wrapping" />
+        <error line="1056" column="130" source="standard:argument-list-wrapping" />
+        <error line="1056" column="148" source="standard:argument-list-wrapping" />
+        <error line="1091" column="1" source="standard:max-line-length" />
+        <error line="1091" column="21" source="standard:property-wrapping" />
+        <error line="1091" column="36" source="standard:argument-list-wrapping" />
+        <error line="1091" column="50" source="standard:argument-list-wrapping" />
+        <error line="1091" column="82" source="standard:argument-list-wrapping" />
+        <error line="1091" column="101" source="standard:argument-list-wrapping" />
+        <error line="1091" column="120" source="standard:argument-list-wrapping" />
+        <error line="1091" column="130" source="standard:argument-list-wrapping" />
+        <error line="1091" column="148" source="standard:argument-list-wrapping" />
+        <error line="1168" column="1" source="standard:max-line-length" />
+        <error line="1168" column="26" source="standard:property-wrapping" />
+        <error line="1168" column="41" source="standard:argument-list-wrapping" />
+        <error line="1168" column="55" source="standard:argument-list-wrapping" />
+        <error line="1168" column="87" source="standard:argument-list-wrapping" />
+        <error line="1168" column="111" source="standard:argument-list-wrapping" />
+        <error line="1168" column="142" source="standard:argument-list-wrapping" />
+        <error line="1168" column="162" source="standard:argument-list-wrapping" />
+        <error line="1168" column="196" source="standard:argument-list-wrapping" />
+        <error line="1252" column="1" source="standard:max-line-length" />
+        <error line="1252" column="21" source="standard:property-wrapping" />
+        <error line="1252" column="36" source="standard:argument-list-wrapping" />
+        <error line="1252" column="50" source="standard:argument-list-wrapping" />
+        <error line="1252" column="89" source="standard:argument-list-wrapping" />
+        <error line="1252" column="108" source="standard:argument-list-wrapping" />
+        <error line="1252" column="127" source="standard:argument-list-wrapping" />
+        <error line="1252" column="137" source="standard:argument-list-wrapping" />
+        <error line="1252" column="155" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/SimpleDownloadDialogFragmentTest.kt">
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="130" column="1" source="standard:max-line-length" />
+        <error line="130" column="22" source="standard:argument-list-wrapping" />
+        <error line="130" column="107" source="standard:argument-list-wrapping" />
+        <error line="130" column="174" source="standard:argument-list-wrapping" />
+        <error line="131" column="1" source="standard:max-line-length" />
+        <error line="131" column="22" source="standard:argument-list-wrapping" />
+        <error line="131" column="61" source="standard:argument-list-wrapping" />
+        <error line="131" column="121" source="standard:argument-list-wrapping" />
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="132" column="22" source="standard:argument-list-wrapping" />
+        <error line="132" column="101" source="standard:argument-list-wrapping" />
+        <error line="132" column="139" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/db/DownloadEntityTest.kt">
+        <error line="83" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/ext/DownloadStateKtTest.kt">
+        <error line="18" column="1" source="standard:max-line-length" />
+        <error line="33" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/AndroidDownloadManagerTest.kt">
+        <error line="49" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/manager/FetchDownloadManagerTest.kt">
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="187" column="1" source="standard:max-line-length" />
+        <error line="187" column="27" source="standard:argument-list-wrapping" />
+        <error line="187" column="138" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/ui/DownloadAppChooserDialogTest.kt">
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="54" column="1" source="standard:max-line-length" />
+        <error line="54" column="21" source="standard:property-wrapping" />
+        <error line="54" column="36" source="standard:argument-list-wrapping" />
+        <error line="54" column="50" source="standard:argument-list-wrapping" />
+        <error line="54" column="89" source="standard:argument-list-wrapping" />
+        <error line="54" column="108" source="standard:argument-list-wrapping" />
+        <error line="54" column="127" source="standard:argument-list-wrapping" />
+        <error line="54" column="137" source="standard:argument-list-wrapping" />
+        <error line="54" column="155" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/downloads/src/test/java/mozilla/components/feature/downloads/ui/DownloaderAppAdapterTest.kt">
+        <error line="30" column="1" source="standard:max-line-length" />
+        <error line="30" column="21" source="standard:property-wrapping" />
+        <error line="30" column="36" source="standard:argument-list-wrapping" />
+        <error line="30" column="50" source="standard:argument-list-wrapping" />
+        <error line="30" column="82" source="standard:argument-list-wrapping" />
+        <error line="30" column="101" source="standard:argument-list-wrapping" />
+        <error line="30" column="120" source="standard:argument-list-wrapping" />
+        <error line="30" column="130" source="standard:argument-list-wrapping" />
+        <error line="30" column="148" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsMiddlewareTest.kt">
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="132" column="33" source="standard:property-wrapping" />
+        <error line="132" column="49" source="standard:argument-list-wrapping" />
+        <error line="132" column="141" source="standard:argument-list-wrapping" />
+        <error line="145" column="1" source="standard:max-line-length" />
+        <error line="145" column="38" source="standard:property-wrapping" />
+        <error line="145" column="54" source="standard:argument-list-wrapping" />
+        <error line="145" column="129" source="standard:argument-list-wrapping" />
+        <error line="205" column="1" source="standard:max-line-length" />
+        <error line="205" column="33" source="standard:property-wrapping" />
+        <error line="205" column="49" source="standard:argument-list-wrapping" />
+        <error line="205" column="141" source="standard:argument-list-wrapping" />
+        <error line="218" column="1" source="standard:max-line-length" />
+        <error line="218" column="38" source="standard:property-wrapping" />
+        <error line="218" column="54" source="standard:argument-list-wrapping" />
+        <error line="218" column="129" source="standard:argument-list-wrapping" />
+        <error line="224" column="1" source="standard:max-line-length" />
+        <error line="279" column="1" source="standard:max-line-length" />
+        <error line="279" column="33" source="standard:property-wrapping" />
+        <error line="279" column="49" source="standard:argument-list-wrapping" />
+        <error line="279" column="141" source="standard:argument-list-wrapping" />
+        <error line="292" column="1" source="standard:max-line-length" />
+        <error line="292" column="38" source="standard:property-wrapping" />
+        <error line="292" column="54" source="standard:argument-list-wrapping" />
+        <error line="292" column="129" source="standard:argument-list-wrapping" />
+        <error line="298" column="1" source="standard:max-line-length" />
+        <error line="353" column="1" source="standard:max-line-length" />
+        <error line="353" column="33" source="standard:property-wrapping" />
+        <error line="353" column="49" source="standard:argument-list-wrapping" />
+        <error line="353" column="141" source="standard:argument-list-wrapping" />
+        <error line="366" column="1" source="standard:max-line-length" />
+        <error line="366" column="38" source="standard:property-wrapping" />
+        <error line="366" column="54" source="standard:argument-list-wrapping" />
+        <error line="366" column="129" source="standard:argument-list-wrapping" />
+        <error line="374" column="1" source="standard:max-line-length" />
+        <error line="374" column="26" source="standard:argument-list-wrapping" />
+        <error line="374" column="117" source="standard:argument-list-wrapping" />
+        <error line="374" column="131" source="standard:argument-list-wrapping" />
+        <error line="376" column="1" source="standard:max-line-length" />
+        <error line="376" column="28" source="standard:property-wrapping" />
+        <error line="376" column="44" source="standard:argument-list-wrapping" />
+        <error line="376" column="136" source="standard:argument-list-wrapping" />
+        <error line="463" column="1" source="standard:max-line-length" />
+        <error line="463" column="33" source="standard:property-wrapping" />
+        <error line="463" column="49" source="standard:argument-list-wrapping" />
+        <error line="463" column="141" source="standard:argument-list-wrapping" />
+        <error line="476" column="1" source="standard:max-line-length" />
+        <error line="476" column="38" source="standard:property-wrapping" />
+        <error line="476" column="54" source="standard:argument-list-wrapping" />
+        <error line="476" column="129" source="standard:argument-list-wrapping" />
+        <error line="494" column="1" source="standard:max-line-length" />
+        <error line="494" column="33" source="standard:property-wrapping" />
+        <error line="494" column="49" source="standard:argument-list-wrapping" />
+        <error line="494" column="141" source="standard:argument-list-wrapping" />
+        <error line="507" column="1" source="standard:max-line-length" />
+        <error line="507" column="38" source="standard:property-wrapping" />
+        <error line="507" column="54" source="standard:argument-list-wrapping" />
+        <error line="507" column="129" source="standard:argument-list-wrapping" />
+        <error line="513" column="1" source="standard:max-line-length" />
+        <error line="588" column="1" source="standard:max-line-length" />
+        <error line="588" column="33" source="standard:property-wrapping" />
+        <error line="588" column="49" source="standard:argument-list-wrapping" />
+        <error line="588" column="141" source="standard:argument-list-wrapping" />
+        <error line="601" column="1" source="standard:max-line-length" />
+        <error line="601" column="38" source="standard:property-wrapping" />
+        <error line="601" column="54" source="standard:argument-list-wrapping" />
+        <error line="601" column="129" source="standard:argument-list-wrapping" />
+        <error line="619" column="1" source="standard:max-line-length" />
+        <error line="619" column="33" source="standard:property-wrapping" />
+        <error line="619" column="49" source="standard:argument-list-wrapping" />
+        <error line="619" column="141" source="standard:argument-list-wrapping" />
+        <error line="632" column="1" source="standard:max-line-length" />
+        <error line="632" column="38" source="standard:property-wrapping" />
+        <error line="632" column="54" source="standard:argument-list-wrapping" />
+        <error line="632" column="129" source="standard:argument-list-wrapping" />
+        <error line="638" column="1" source="standard:max-line-length" />
+        <error line="713" column="1" source="standard:max-line-length" />
+        <error line="713" column="33" source="standard:property-wrapping" />
+        <error line="713" column="49" source="standard:argument-list-wrapping" />
+        <error line="713" column="141" source="standard:argument-list-wrapping" />
+        <error line="726" column="1" source="standard:max-line-length" />
+        <error line="726" column="38" source="standard:property-wrapping" />
+        <error line="726" column="54" source="standard:argument-list-wrapping" />
+        <error line="726" column="129" source="standard:argument-list-wrapping" />
+        <error line="744" column="1" source="standard:max-line-length" />
+        <error line="744" column="33" source="standard:property-wrapping" />
+        <error line="744" column="49" source="standard:argument-list-wrapping" />
+        <error line="744" column="141" source="standard:argument-list-wrapping" />
+        <error line="757" column="1" source="standard:max-line-length" />
+        <error line="757" column="38" source="standard:property-wrapping" />
+        <error line="757" column="54" source="standard:argument-list-wrapping" />
+        <error line="757" column="129" source="standard:argument-list-wrapping" />
+        <error line="765" column="1" source="standard:max-line-length" />
+        <error line="765" column="26" source="standard:argument-list-wrapping" />
+        <error line="765" column="117" source="standard:argument-list-wrapping" />
+        <error line="765" column="131" source="standard:argument-list-wrapping" />
+        <error line="767" column="1" source="standard:max-line-length" />
+        <error line="767" column="28" source="standard:property-wrapping" />
+        <error line="767" column="44" source="standard:argument-list-wrapping" />
+        <error line="767" column="136" source="standard:argument-list-wrapping" />
+        <error line="780" column="1" source="standard:max-line-length" />
+        <error line="826" column="1" source="standard:max-line-length" />
+        <error line="826" column="33" source="standard:property-wrapping" />
+        <error line="826" column="49" source="standard:argument-list-wrapping" />
+        <error line="826" column="147" source="standard:argument-list-wrapping" />
+        <error line="835" column="1" source="standard:max-line-length" />
+        <error line="835" column="38" source="standard:property-wrapping" />
+        <error line="835" column="54" source="standard:argument-list-wrapping" />
+        <error line="835" column="129" source="standard:argument-list-wrapping" />
+        <error line="841" column="1" source="standard:max-line-length" />
+        <error line="888" column="1" source="standard:max-line-length" />
+        <error line="888" column="33" source="standard:property-wrapping" />
+        <error line="888" column="49" source="standard:argument-list-wrapping" />
+        <error line="888" column="147" source="standard:argument-list-wrapping" />
+        <error line="897" column="1" source="standard:max-line-length" />
+        <error line="897" column="38" source="standard:property-wrapping" />
+        <error line="897" column="54" source="standard:argument-list-wrapping" />
+        <error line="897" column="129" source="standard:argument-list-wrapping" />
+        <error line="905" column="1" source="standard:max-line-length" />
+        <error line="905" column="26" source="standard:argument-list-wrapping" />
+        <error line="905" column="117" source="standard:argument-list-wrapping" />
+        <error line="905" column="131" source="standard:argument-list-wrapping" />
+        <error line="907" column="1" source="standard:max-line-length" />
+        <error line="907" column="28" source="standard:property-wrapping" />
+        <error line="907" column="44" source="standard:argument-list-wrapping" />
+        <error line="907" column="142" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestFactsTest.kt">
+        <error line="21" column="1" source="standard:max-line-length" />
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="49" column="32" source="standard:property-wrapping" />
+        <error line="49" column="48" source="standard:argument-list-wrapping" />
+        <error line="49" column="140" source="standard:argument-list-wrapping" />
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="95" column="1" source="standard:max-line-length" />
+        <error line="95" column="37" source="standard:property-wrapping" />
+        <error line="95" column="53" source="standard:argument-list-wrapping" />
+        <error line="95" column="145" source="standard:argument-list-wrapping" />
+        <error line="108" column="1" source="standard:max-line-length" />
+        <error line="108" column="42" source="standard:property-wrapping" />
+        <error line="108" column="58" source="standard:argument-list-wrapping" />
+        <error line="108" column="133" source="standard:argument-list-wrapping" />
+        <error line="115" column="1" source="standard:max-line-length" />
+        <error line="139" column="1" source="standard:max-line-length" />
+        <error line="139" column="32" source="standard:property-wrapping" />
+        <error line="139" column="48" source="standard:argument-list-wrapping" />
+        <error line="139" column="146" source="standard:argument-list-wrapping" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="177" column="1" source="standard:max-line-length" />
+        <error line="177" column="37" source="standard:property-wrapping" />
+        <error line="177" column="53" source="standard:argument-list-wrapping" />
+        <error line="177" column="151" source="standard:argument-list-wrapping" />
+        <error line="186" column="1" source="standard:max-line-length" />
+        <error line="186" column="42" source="standard:property-wrapping" />
+        <error line="186" column="58" source="standard:argument-list-wrapping" />
+        <error line="186" column="133" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProviderTest.kt">
+        <error line="131" column="1" source="standard:max-line-length" />
+        <error line="131" column="22" source="standard:argument-list-wrapping" />
+        <error line="131" column="98" source="standard:argument-list-wrapping" />
+        <error line="131" column="124" source="standard:argument-list-wrapping" />
+        <error line="195" column="1" source="standard:max-line-length" />
+        <error line="195" column="26" source="standard:argument-list-wrapping" />
+        <error line="195" column="32" source="standard:argument-list-wrapping" />
+        <error line="195" column="85" source="standard:argument-list-wrapping" />
+        <error line="195" column="141" source="standard:argument-list-wrapping" />
+        <error line="195" column="144" source="standard:argument-list-wrapping" />
+        <error line="195" column="151" source="standard:argument-list-wrapping" />
+        <error line="197" column="1" source="standard:max-line-length" />
+        <error line="197" column="28" source="standard:property-wrapping" />
+        <error line="197" column="44" source="standard:argument-list-wrapping" />
+        <error line="197" column="138" source="standard:argument-list-wrapping" />
+        <error line="200" column="1" source="standard:max-line-length" />
+        <error line="200" column="33" source="standard:property-wrapping" />
+        <error line="200" column="49" source="standard:argument-list-wrapping" />
+        <error line="200" column="148" source="standard:argument-list-wrapping" />
+        <error line="246" column="1" source="standard:max-line-length" />
+        <error line="246" column="22" source="standard:argument-list-wrapping" />
+        <error line="246" column="98" source="standard:argument-list-wrapping" />
+        <error line="246" column="129" source="standard:argument-list-wrapping" />
+        <error line="249" column="1" source="standard:max-line-length" />
+        <error line="249" column="26" source="standard:argument-list-wrapping" />
+        <error line="249" column="32" source="standard:argument-list-wrapping" />
+        <error line="249" column="85" source="standard:argument-list-wrapping" />
+        <error line="249" column="141" source="standard:argument-list-wrapping" />
+        <error line="249" column="144" source="standard:argument-list-wrapping" />
+        <error line="249" column="151" source="standard:argument-list-wrapping" />
+        <error line="251" column="1" source="standard:max-line-length" />
+        <error line="251" column="28" source="standard:property-wrapping" />
+        <error line="251" column="44" source="standard:argument-list-wrapping" />
+        <error line="251" column="132" source="standard:argument-list-wrapping" />
+        <error line="258" column="1" source="standard:max-line-length" />
+        <error line="258" column="33" source="standard:property-wrapping" />
+        <error line="258" column="49" source="standard:argument-list-wrapping" />
+        <error line="258" column="142" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/intent/src/test/java/mozilla/components/feature/intent/ext/IntentExtensionsTest.kt">
+        <error line="69" column="1" source="standard:max-line-length" />
+        <error line="69" column="76" source="standard:argument-list-wrapping" />
+        <error line="69" column="93" source="standard:argument-list-wrapping" />
+        <error line="69" column="101" source="standard:argument-list-wrapping" />
+        <error line="69" column="124" source="standard:argument-list-wrapping" />
+        <error line="69" column="130" source="standard:argument-list-wrapping" />
+        <error line="69" column="131" source="standard:argument-list-wrapping" />
+        <error line="69" column="132" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/media/src/test/java/mozilla/components/feature/media/MediaSessionFeatureTest.kt">
+        <error line="106" column="1" source="standard:max-line-length" />
+        <error line="135" column="1" source="standard:max-line-length" />
+        <error line="154" column="1" source="standard:max-line-length" />
+        <error line="173" column="1" source="standard:max-line-length" />
+        <error line="192" column="1" source="standard:max-line-length" />
+        <error line="211" column="1" source="standard:max-line-length" />
+        <error line="230" column="1" source="standard:max-line-length" />
+        <error line="249" column="1" source="standard:max-line-length" />
+        <error line="272" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/media/src/test/java/mozilla/components/feature/media/fullscreen/MediaSessionFullscreenFeatureTest.kt">
+        <error line="48" column="1" source="standard:max-line-length" />
+        <error line="79" column="1" source="standard:max-line-length" />
+        <error line="113" column="1" source="standard:max-line-length" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="188" column="1" source="standard:max-line-length" />
+        <error line="290" column="1" source="standard:max-line-length" />
+        <error line="344" column="1" source="standard:max-line-length" />
+        <error line="392" column="1" source="standard:max-line-length" />
+        <error line="436" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/media/src/test/java/mozilla/components/feature/media/middleware/LastMediaAccessMiddlewareTest.kt">
+        <error line="235" column="1" source="standard:max-line-length" />
+        <error line="262" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/media/src/test/java/mozilla/components/feature/media/middleware/RecordingDevicesMiddlewareTest.kt">
+        <error line="99" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/media/src/test/java/mozilla/components/feature/media/notification/MediaNotificationTest.kt">
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="57" column="103" source="standard:argument-list-wrapping" />
+        <error line="57" column="118" source="standard:argument-list-wrapping" />
+        <error line="57" column="124" source="standard:argument-list-wrapping" />
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="77" column="103" source="standard:argument-list-wrapping" />
+        <error line="77" column="118" source="standard:argument-list-wrapping" />
+        <error line="77" column="124" source="standard:argument-list-wrapping" />
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="97" column="103" source="standard:argument-list-wrapping" />
+        <error line="97" column="118" source="standard:argument-list-wrapping" />
+        <error line="97" column="124" source="standard:argument-list-wrapping" />
+        <error line="117" column="1" source="standard:max-line-length" />
+        <error line="117" column="103" source="standard:argument-list-wrapping" />
+        <error line="117" column="118" source="standard:argument-list-wrapping" />
+        <error line="117" column="124" source="standard:argument-list-wrapping" />
+        <error line="138" column="1" source="standard:max-line-length" />
+        <error line="138" column="103" source="standard:argument-list-wrapping" />
+        <error line="138" column="118" source="standard:argument-list-wrapping" />
+        <error line="138" column="124" source="standard:argument-list-wrapping" />
+        <error line="165" column="1" source="standard:max-line-length" />
+        <error line="165" column="103" source="standard:argument-list-wrapping" />
+        <error line="165" column="118" source="standard:argument-list-wrapping" />
+        <error line="165" column="124" source="standard:argument-list-wrapping" />
+        <error line="192" column="1" source="standard:max-line-length" />
+        <error line="192" column="103" source="standard:argument-list-wrapping" />
+        <error line="192" column="118" source="standard:argument-list-wrapping" />
+        <error line="192" column="124" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/media/src/test/java/mozilla/components/feature/media/service/AbstractMediaSessionServiceTest.kt">
+        <error line="51" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaServiceBinderTest.kt">
+        <error line="22" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/media/src/test/java/mozilla/components/feature/media/service/MediaSessionServiceDelegateTest.kt">
+        <error line="189" column="1" source="standard:max-line-length" />
+        <error line="203" column="1" source="standard:max-line-length" />
+        <error line="229" column="1" source="standard:max-line-length" />
+        <error line="229" column="46" source="standard:argument-list-wrapping" />
+        <error line="229" column="53" source="standard:argument-list-wrapping" />
+        <error line="229" column="82" source="standard:argument-list-wrapping" />
+        <error line="229" column="100" source="standard:argument-list-wrapping" />
+        <error line="229" column="107" source="standard:argument-list-wrapping" />
+        <error line="229" column="114" source="standard:argument-list-wrapping" />
+        <error line="229" column="117" source="standard:argument-list-wrapping" />
+        <error line="229" column="122" source="standard:argument-list-wrapping" />
+        <error line="229" column="123" source="standard:argument-list-wrapping" />
+        <error line="233" column="1" source="standard:max-line-length" />
+        <error line="288" column="1" source="standard:max-line-length" />
+        <error line="335" column="1" source="standard:max-line-length" />
+        <error line="521" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/SelectAccountDialog.kt">
+        <error line="168" column="1" source="standard:max-line-length" />
+        <error line="172" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/main/java/mozilla/components/feature/prompts/identitycredential/SelectProviderDialog.kt">
+        <error line="144" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/PromptFeatureTest.kt">
+        <error line="318" column="1" source="standard:max-line-length" />
+        <error line="485" column="1" source="standard:max-line-length" />
+        <error line="577" column="1" source="standard:max-line-length" />
+        <error line="607" column="1" source="standard:max-line-length" />
+        <error line="636" column="1" source="standard:max-line-length" />
+        <error line="735" column="1" source="standard:max-line-length" />
+        <error line="1087" column="1" source="standard:max-line-length" />
+        <error line="1207" column="1" source="standard:max-line-length" />
+        <error line="1231" column="1" source="standard:max-line-length" />
+        <error line="1924" column="1" source="standard:max-line-length" />
+        <error line="1948" column="1" source="standard:max-line-length" />
+        <error line="1972" column="1" source="standard:max-line-length" />
+        <error line="2064" column="1" source="standard:max-line-length" />
+        <error line="2101" column="1" source="standard:max-line-length" />
+        <error line="2138" column="1" source="standard:max-line-length" />
+        <error line="2646" column="1" source="standard:max-line-length" />
+        <error line="2766" column="1" source="standard:max-line-length" />
+        <error line="2839" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/address/AddressPickerTest.kt">
+        <error line="87" column="1" source="standard:max-line-length" />
+        <error line="112" column="1" source="standard:max-line-length" />
+        <error line="114" column="1" source="standard:max-line-length" />
+        <error line="114" column="24" source="standard:property-wrapping" />
+        <error line="114" column="47" source="standard:argument-list-wrapping" />
+        <error line="114" column="66" source="standard:argument-list-wrapping" />
+        <error line="114" column="94" source="standard:argument-list-wrapping" />
+        <error line="114" column="123" source="standard:argument-list-wrapping" />
+        <error line="114" column="138" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardItemViewHolderTest.kt">
+        <error line="60" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardPickerTest.kt">
+        <error line="70" column="1" source="standard:max-line-length" />
+        <error line="96" column="1" source="standard:max-line-length" />
+        <error line="103" column="1" source="standard:max-line-length" />
+        <error line="105" column="1" source="standard:max-line-length" />
+        <error line="105" column="24" source="standard:property-wrapping" />
+        <error line="105" column="47" source="standard:argument-list-wrapping" />
+        <error line="105" column="66" source="standard:argument-list-wrapping" />
+        <error line="105" column="94" source="standard:argument-list-wrapping" />
+        <error line="105" column="123" source="standard:argument-list-wrapping" />
+        <error line="105" column="138" source="standard:argument-list-wrapping" />
+        <error line="142" column="1" source="standard:max-line-length" />
+        <error line="160" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardSaveDialogFragmentTest.kt">
+        <error line="96" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/creditcard/CreditCardSelectBarTest.kt">
+        <error line="99" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/dialog/TimePickerDialogFragmentTest.kt">
+        <error line="258" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ext/EditTextTest.kt">
+        <error line="34" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/ext/PromptRequestTest.kt">
+        <error line="20" column="1" source="standard:max-line-length" />
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="47" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/file/FilePickerTest.kt">
+        <error line="86" column="1" source="standard:max-line-length" />
+        <error line="86" column="24" source="standard:property-wrapping" />
+        <error line="86" column="47" source="standard:argument-list-wrapping" />
+        <error line="86" column="66" source="standard:argument-list-wrapping" />
+        <error line="86" column="94" source="standard:argument-list-wrapping" />
+        <error line="86" column="123" source="standard:argument-list-wrapping" />
+        <error line="86" column="138" source="standard:argument-list-wrapping" />
+        <error line="185" column="1" source="standard:max-line-length" />
+        <error line="208" column="1" source="standard:max-line-length" />
+        <error line="334" column="1" source="standard:max-line-length" />
+        <error line="368" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/file/FileUploadsDirCleanerTest.kt">
+        <error line="49" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/login/LoginPickerTest.kt">
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="60" column="24" source="standard:property-wrapping" />
+        <error line="60" column="47" source="standard:argument-list-wrapping" />
+        <error line="60" column="66" source="standard:argument-list-wrapping" />
+        <error line="60" column="94" source="standard:argument-list-wrapping" />
+        <error line="60" column="123" source="standard:argument-list-wrapping" />
+        <error line="60" column="138" source="standard:argument-list-wrapping" />
+        <error line="120" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/login/StrongPasswordPromptViewListenerTest.kt">
+        <error line="82" column="1" source="standard:max-line-length" />
+        <error line="82" column="84" source="standard:argument-list-wrapping" />
+        <error line="82" column="93" source="standard:argument-list-wrapping" />
+        <error line="82" column="98" source="standard:argument-list-wrapping" />
+        <error line="82" column="126" source="standard:argument-list-wrapping" />
+        <error line="90" column="1" source="standard:max-line-length" />
+        <error line="90" column="84" source="standard:argument-list-wrapping" />
+        <error line="90" column="93" source="standard:argument-list-wrapping" />
+        <error line="90" column="98" source="standard:argument-list-wrapping" />
+        <error line="90" column="126" source="standard:argument-list-wrapping" />
+        <error line="104" column="1" source="standard:max-line-length" />
+        <error line="119" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/widget/MonthAndYearPickerTest.kt">
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="150" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/prompts/src/test/java/mozilla/components/feature/prompts/widget/TimePrecisionPickerTest.kt">
+        <error line="55" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/push/src/test/java/mozilla/components/feature/push/AutoPushFeatureTest.kt">
+        <error line="194" column="1" source="standard:max-line-length" />
+        <error line="194" column="119" source="standard:argument-list-wrapping" />
+        <error line="194" column="121" source="standard:argument-list-wrapping" />
+        <error line="343" column="1" source="standard:max-line-length" />
+        <error line="343" column="60" source="standard:argument-list-wrapping" />
+        <error line="343" column="67" source="standard:argument-list-wrapping" />
+        <error line="343" column="91" source="standard:argument-list-wrapping" />
+        <error line="343" column="108" source="standard:argument-list-wrapping" />
+        <error line="343" column="126" source="standard:argument-list-wrapping" />
+        <error line="343" column="127" source="standard:argument-list-wrapping" />
+        <error line="343" column="128" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/pwa/src/androidTest/java/mozilla/components/feature/pwa/db/ManifestDatabaseMigrationTest.kt">
+        <error line="36" column="1" source="standard:max-line-length" />
+        <error line="36" column="21" source="standard:argument-list-wrapping" />
+        <error line="36" column="175" source="standard:argument-list-wrapping" />
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="65" column="21" source="standard:argument-list-wrapping" />
+        <error line="65" column="175" source="standard:argument-list-wrapping" />
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="94" column="21" source="standard:argument-list-wrapping" />
+        <error line="94" column="133" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ManifestStorageTest.kt">
+        <error line="120" column="1" source="standard:max-line-length" />
+        <error line="120" column="24" source="standard:property-wrapping" />
+        <error line="120" column="40" source="standard:argument-list-wrapping" />
+        <error line="120" column="59" source="standard:argument-list-wrapping" />
+        <error line="120" column="93" source="standard:argument-list-wrapping" />
+        <error line="120" column="129" source="standard:argument-list-wrapping" />
+        <error line="121" column="1" source="standard:max-line-length" />
+        <error line="121" column="24" source="standard:property-wrapping" />
+        <error line="121" column="40" source="standard:argument-list-wrapping" />
+        <error line="121" column="59" source="standard:argument-list-wrapping" />
+        <error line="121" column="93" source="standard:argument-list-wrapping" />
+        <error line="121" column="129" source="standard:argument-list-wrapping" />
+        <error line="122" column="1" source="standard:max-line-length" />
+        <error line="122" column="24" source="standard:property-wrapping" />
+        <error line="122" column="40" source="standard:argument-list-wrapping" />
+        <error line="122" column="59" source="standard:argument-list-wrapping" />
+        <error line="122" column="93" source="standard:argument-list-wrapping" />
+        <error line="122" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppInterceptorTest.kt">
+        <error line="47" column="1" source="standard:max-line-length" />
+        <error line="47" column="56" source="standard:argument-list-wrapping" />
+        <error line="47" column="75" source="standard:argument-list-wrapping" />
+        <error line="47" column="93" source="standard:argument-list-wrapping" />
+        <error line="47" column="99" source="standard:argument-list-wrapping" />
+        <error line="47" column="105" source="standard:argument-list-wrapping" />
+        <error line="47" column="112" source="standard:argument-list-wrapping" />
+        <error line="47" column="119" source="standard:argument-list-wrapping" />
+        <error line="47" column="126" source="standard:argument-list-wrapping" />
+        <error line="47" column="131" source="standard:argument-list-wrapping" />
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="57" column="56" source="standard:argument-list-wrapping" />
+        <error line="57" column="75" source="standard:argument-list-wrapping" />
+        <error line="57" column="93" source="standard:argument-list-wrapping" />
+        <error line="57" column="99" source="standard:argument-list-wrapping" />
+        <error line="57" column="105" source="standard:argument-list-wrapping" />
+        <error line="57" column="112" source="standard:argument-list-wrapping" />
+        <error line="57" column="119" source="standard:argument-list-wrapping" />
+        <error line="57" column="126" source="standard:argument-list-wrapping" />
+        <error line="57" column="131" source="standard:argument-list-wrapping" />
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="67" column="56" source="standard:argument-list-wrapping" />
+        <error line="67" column="75" source="standard:argument-list-wrapping" />
+        <error line="67" column="83" source="standard:argument-list-wrapping" />
+        <error line="67" column="89" source="standard:argument-list-wrapping" />
+        <error line="67" column="95" source="standard:argument-list-wrapping" />
+        <error line="67" column="102" source="standard:argument-list-wrapping" />
+        <error line="67" column="109" source="standard:argument-list-wrapping" />
+        <error line="67" column="116" source="standard:argument-list-wrapping" />
+        <error line="67" column="121" source="standard:argument-list-wrapping" />
+        <error line="83" column="1" source="standard:max-line-length" />
+        <error line="83" column="56" source="standard:argument-list-wrapping" />
+        <error line="83" column="75" source="standard:argument-list-wrapping" />
+        <error line="83" column="93" source="standard:argument-list-wrapping" />
+        <error line="83" column="99" source="standard:argument-list-wrapping" />
+        <error line="83" column="105" source="standard:argument-list-wrapping" />
+        <error line="83" column="112" source="standard:argument-list-wrapping" />
+        <error line="83" column="119" source="standard:argument-list-wrapping" />
+        <error line="83" column="126" source="standard:argument-list-wrapping" />
+        <error line="83" column="131" source="standard:argument-list-wrapping" />
+        <error line="98" column="1" source="standard:max-line-length" />
+        <error line="98" column="56" source="standard:argument-list-wrapping" />
+        <error line="98" column="75" source="standard:argument-list-wrapping" />
+        <error line="98" column="93" source="standard:argument-list-wrapping" />
+        <error line="98" column="99" source="standard:argument-list-wrapping" />
+        <error line="98" column="105" source="standard:argument-list-wrapping" />
+        <error line="98" column="112" source="standard:argument-list-wrapping" />
+        <error line="98" column="119" source="standard:argument-list-wrapping" />
+        <error line="98" column="126" source="standard:argument-list-wrapping" />
+        <error line="98" column="131" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/pwa/src/test/java/mozilla/components/feature/pwa/WebAppUseCasesTest.kt">
+        <error line="128" column="1" source="standard:max-line-length" />
+        <error line="128" column="22" source="standard:argument-list-wrapping" />
+        <error line="128" column="74" source="standard:argument-list-wrapping" />
+        <error line="128" column="89" source="standard:argument-list-wrapping" />
+        <error line="128" column="102" source="standard:argument-list-wrapping" />
+        <error line="128" column="109" source="standard:argument-list-wrapping" />
+        <error line="128" column="124" source="standard:argument-list-wrapping" />
+        <error line="128" column="142" source="standard:argument-list-wrapping" />
+        <error line="128" column="153" source="standard:argument-list-wrapping" />
+        <error line="128" column="154" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/ActivityKtTest.kt">
+        <error line="80" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/pwa/src/test/java/mozilla/components/feature/pwa/ext/UriKtTest.kt">
+        <error line="48" column="1" source="standard:max-line-length" />
+        <error line="50" column="1" source="standard:max-line-length" />
+        <error line="50" column="20" source="standard:argument-list-wrapping" />
+        <error line="50" column="90" source="standard:argument-list-wrapping" />
+        <error line="50" column="124" source="standard:argument-list-wrapping" />
+        <error line="50" column="125" source="standard:argument-list-wrapping" />
+        <error line="51" column="1" source="standard:max-line-length" />
+        <error line="51" column="21" source="standard:argument-list-wrapping" />
+        <error line="51" column="89" source="standard:argument-list-wrapping" />
+        <error line="51" column="122" source="standard:argument-list-wrapping" />
+        <error line="51" column="123" source="standard:argument-list-wrapping" />
+        <error line="52" column="1" source="standard:max-line-length" />
+        <error line="52" column="21" source="standard:argument-list-wrapping" />
+        <error line="52" column="91" source="standard:argument-list-wrapping" />
+        <error line="52" column="125" source="standard:argument-list-wrapping" />
+        <error line="52" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/pwa/src/test/java/mozilla/components/feature/pwa/intent/TrustedWebActivityIntentProcessorTest.kt">
+        <error line="31" column="1" source="standard:max-line-length" />
+        <error line="31" column="9" source="standard:argument-list-wrapping" />
+        <error line="31" column="134" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/qr/src/test/java/mozilla/components/feature/qr/QrFragmentTest.kt">
+        <error line="359" column="1" source="standard:max-line-length" />
+        <error line="359" column="67" source="standard:argument-list-wrapping" />
+        <error line="359" column="89" source="standard:argument-list-wrapping" />
+        <error line="359" column="122" source="standard:argument-list-wrapping" />
+        <error line="359" column="123" source="standard:argument-list-wrapping" />
+        <error line="652" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/readerview/src/test/java/mozilla/components/feature/readerview/ReaderViewFeatureTest.kt">
+        <error line="226" column="1" source="standard:max-line-length" />
+        <error line="226" column="32" source="standard:property-wrapping" />
+        <error line="226" column="37" source="standard:argument-list-wrapping" />
+        <error line="226" column="55" source="standard:argument-list-wrapping" />
+        <error line="226" column="68" source="standard:argument-list-wrapping" />
+        <error line="226" column="76" source="standard:argument-list-wrapping" />
+        <error line="226" column="83" source="standard:argument-list-wrapping" />
+        <error line="226" column="91" source="standard:argument-list-wrapping" />
+        <error line="226" column="92" source="standard:wrapping" />
+        <error line="226" column="108" source="standard:argument-list-wrapping" />
+        <error line="226" column="132" source="standard:argument-list-wrapping" />
+        <error line="226" column="133" source="standard:argument-list-wrapping" />
+        <error line="282" column="1" source="standard:max-line-length" />
+        <error line="282" column="32" source="standard:property-wrapping" />
+        <error line="282" column="51" source="standard:argument-list-wrapping" />
+        <error line="282" column="64" source="standard:argument-list-wrapping" />
+        <error line="282" column="72" source="standard:argument-list-wrapping" />
+        <error line="282" column="79" source="standard:argument-list-wrapping" />
+        <error line="282" column="87" source="standard:argument-list-wrapping" />
+        <error line="282" column="88" source="standard:wrapping" />
+        <error line="282" column="129" source="standard:argument-list-wrapping" />
+        <error line="285" column="1" source="standard:max-line-length" />
+        <error line="285" column="32" source="standard:argument-list-wrapping" />
+        <error line="285" column="59" source="standard:argument-list-wrapping" />
+        <error line="285" column="67" source="standard:argument-list-wrapping" />
+        <error line="285" column="199" source="standard:argument-list-wrapping" />
+        <error line="285" column="200" source="standard:argument-list-wrapping" />
+        <error line="573" column="1" source="standard:max-line-length" />
+        <error line="573" column="22" source="standard:argument-list-wrapping" />
+        <error line="573" column="67" source="standard:argument-list-wrapping" />
+        <error line="573" column="125" source="standard:argument-list-wrapping" />
     </file>
     <file name="components/feature/readerview/src/test/java/mozilla/ext/context.kt">
         <error line="1" column="1" source="standard:filename" />
     </file>
+    <file name="components/feature/recentlyclosed/src/test/java/mozilla/components/feature/recentlyclosed/RecentlyClosedMiddlewareTest.kt">
+        <error line="180" column="1" source="standard:max-line-length" />
+        <error line="215" column="1" source="standard:max-line-length" />
+        <error line="308" column="1" source="standard:max-line-length" />
+    </file>
     <file name="components/feature/search/src/test/java/mozilla/components/feature/search/BrowserStoreSeachAdapterTest.kt">
         <error line="1" column="1" source="standard:filename" />
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="32" column="29" source="standard:argument-list-wrapping" />
+        <error line="32" column="45" source="standard:argument-list-wrapping" />
+        <error line="32" column="65" source="standard:argument-list-wrapping" />
+        <error line="32" column="94" source="standard:argument-list-wrapping" />
+        <error line="32" column="141" source="standard:argument-list-wrapping" />
+        <error line="32" column="142" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/SearchUseCasesTest.kt">
+        <error line="173" column="1" source="standard:max-line-length" />
+        <error line="236" column="1" source="standard:max-line-length" />
+        <error line="522" column="1" source="standard:max-line-length" />
+        <error line="538" column="1" source="standard:max-line-length" />
+        <error line="554" column="1" source="standard:max-line-length" />
+        <error line="567" column="1" source="standard:max-line-length" />
+        <error line="567" column="20" source="standard:property-wrapping" />
+        <error line="567" column="34" source="standard:argument-list-wrapping" />
+        <error line="567" column="50" source="standard:argument-list-wrapping" />
+        <error line="567" column="93" source="standard:argument-list-wrapping" />
+        <error line="567" column="134" source="standard:argument-list-wrapping" />
+        <error line="567" column="135" source="standard:argument-list-wrapping" />
+        <error line="595" column="1" source="standard:max-line-length" />
+        <error line="595" column="20" source="standard:property-wrapping" />
+        <error line="595" column="34" source="standard:argument-list-wrapping" />
+        <error line="595" column="50" source="standard:argument-list-wrapping" />
+        <error line="595" column="84" source="standard:argument-list-wrapping" />
+        <error line="595" column="125" source="standard:argument-list-wrapping" />
+        <error line="595" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/ext/SearchEngineKtTest.kt">
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="97" column="43" source="standard:argument-list-wrapping" />
+        <error line="97" column="53" source="standard:argument-list-wrapping" />
+        <error line="97" column="138" source="standard:argument-list-wrapping" />
+        <error line="97" column="139" source="standard:argument-list-wrapping" />
+        <error line="134" column="1" source="standard:max-line-length" />
+        <error line="134" column="42" source="standard:argument-list-wrapping" />
+        <error line="134" column="280" source="standard:argument-list-wrapping" />
+        <error line="142" column="1" source="standard:max-line-length" />
+        <error line="142" column="42" source="standard:argument-list-wrapping" />
+        <error line="142" column="121" source="standard:argument-list-wrapping" />
+        <error line="146" column="1" source="standard:max-line-length" />
+        <error line="146" column="42" source="standard:argument-list-wrapping" />
+        <error line="146" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/middleware/SearchMiddlewareTest.kt">
+        <error line="1139" column="1" source="standard:max-line-length" />
+        <error line="1139" column="27" source="standard:argument-list-wrapping" />
+        <error line="1139" column="122" source="standard:argument-list-wrapping" />
+        <error line="1140" column="1" source="standard:max-line-length" />
+        <error line="1140" column="27" source="standard:argument-list-wrapping" />
+        <error line="1140" column="121" source="standard:argument-list-wrapping" />
+        <error line="1164" column="1" source="standard:max-line-length" />
+        <error line="1164" column="27" source="standard:argument-list-wrapping" />
+        <error line="1164" column="121" source="standard:argument-list-wrapping" />
+        <error line="1193" column="1" source="standard:max-line-length" />
+        <error line="1193" column="27" source="standard:argument-list-wrapping" />
+        <error line="1193" column="121" source="standard:argument-list-wrapping" />
+        <error line="1220" column="1" source="standard:max-line-length" />
+        <error line="1220" column="27" source="standard:argument-list-wrapping" />
+        <error line="1220" column="122" source="standard:argument-list-wrapping" />
+        <error line="1221" column="1" source="standard:max-line-length" />
+        <error line="1221" column="27" source="standard:argument-list-wrapping" />
+        <error line="1221" column="121" source="standard:argument-list-wrapping" />
+        <error line="1251" column="1" source="standard:max-line-length" />
+        <error line="1251" column="27" source="standard:argument-list-wrapping" />
+        <error line="1251" column="122" source="standard:argument-list-wrapping" />
+        <error line="1252" column="1" source="standard:max-line-length" />
+        <error line="1252" column="27" source="standard:argument-list-wrapping" />
+        <error line="1252" column="121" source="standard:argument-list-wrapping" />
+        <error line="1342" column="1" source="standard:max-line-length" />
+        <error line="1400" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/region/RegionMiddlewareTest.kt">
+        <error line="126" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/storage/SearchEngineReaderTest.kt">
+        <error line="56" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/suggestions/ParserTest.kt">
+        <error line="17" column="1" source="standard:max-line-length" />
+        <error line="20" column="1" source="standard:max-line-length" />
+        <error line="20" column="30" source="standard:property-wrapping" />
+        <error line="26" column="1" source="standard:max-line-length" />
+        <error line="29" column="1" source="standard:max-line-length" />
+        <error line="29" column="30" source="standard:property-wrapping" />
+        <error line="44" column="1" source="standard:max-line-length" />
+        <error line="47" column="1" source="standard:max-line-length" />
+        <error line="47" column="30" source="standard:property-wrapping" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="56" column="1" source="standard:max-line-length" />
+        <error line="56" column="30" source="standard:property-wrapping" />
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="65" column="30" source="standard:property-wrapping" />
+        <error line="71" column="1" source="standard:max-line-length" />
+        <error line="74" column="1" source="standard:max-line-length" />
+        <error line="74" column="30" source="standard:property-wrapping" />
+        <error line="80" column="1" source="standard:max-line-length" />
+        <error line="83" column="1" source="standard:max-line-length" />
+        <error line="83" column="30" source="standard:property-wrapping" />
+        <error line="89" column="1" source="standard:max-line-length" />
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="92" column="30" source="standard:property-wrapping" />
+        <error line="98" column="1" source="standard:max-line-length" />
+        <error line="101" column="1" source="standard:max-line-length" />
+        <error line="101" column="30" source="standard:property-wrapping" />
+        <error line="101" column="38" source="standard:argument-list-wrapping" />
+        <error line="101" column="49" source="standard:argument-list-wrapping" />
+        <error line="101" column="60" source="standard:argument-list-wrapping" />
+        <error line="101" column="103" source="standard:argument-list-wrapping" />
+        <error line="101" column="140" source="standard:argument-list-wrapping" />
+        <error line="101" column="154" source="standard:argument-list-wrapping" />
+        <error line="107" column="1" source="standard:max-line-length" />
+        <error line="110" column="1" source="standard:max-line-length" />
+        <error line="110" column="30" source="standard:property-wrapping" />
+        <error line="110" column="38" source="standard:argument-list-wrapping" />
+        <error line="110" column="62" source="standard:argument-list-wrapping" />
+        <error line="110" column="80" source="standard:argument-list-wrapping" />
+        <error line="110" column="91" source="standard:argument-list-wrapping" />
+        <error line="110" column="110" source="standard:argument-list-wrapping" />
+        <error line="110" column="125" source="standard:argument-list-wrapping" />
+        <error line="116" column="1" source="standard:max-line-length" />
+        <error line="119" column="1" source="standard:max-line-length" />
+        <error line="119" column="30" source="standard:property-wrapping" />
+        <error line="125" column="1" source="standard:max-line-length" />
+        <error line="128" column="1" source="standard:max-line-length" />
+        <error line="128" column="30" source="standard:property-wrapping" />
+        <error line="143" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/suggestions/SearchSuggestionClientTest.kt">
+        <error line="23" column="1" source="standard:max-line-length" />
+        <error line="23" column="62" source="standard:wrapping" />
+        <error line="24" column="1" source="standard:max-line-length" />
+        <error line="24" column="61" source="standard:wrapping" />
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="38" column="30" source="standard:property-wrapping" />
+        <error line="54" column="1" source="standard:max-line-length" />
+        <error line="54" column="30" source="standard:property-wrapping" />
+        <error line="54" column="38" source="standard:argument-list-wrapping" />
+        <error line="54" column="62" source="standard:argument-list-wrapping" />
+        <error line="54" column="80" source="standard:argument-list-wrapping" />
+        <error line="54" column="91" source="standard:argument-list-wrapping" />
+        <error line="54" column="110" source="standard:argument-list-wrapping" />
+        <error line="54" column="125" source="standard:argument-list-wrapping" />
+        <error line="104" column="1" source="standard:max-line-length" />
+        <error line="104" column="30" source="standard:property-wrapping" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/telemetry/SerpTelemetryRepositoryTest.kt">
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/telemetry/ads/AdsTelemetryTest.kt">
+        <error line="158" column="1" source="standard:max-line-length" />
+        <error line="183" column="1" source="standard:max-line-length" />
+        <error line="214" column="1" source="standard:max-line-length" />
+        <error line="240" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/search/src/test/java/mozilla/components/feature/search/telemetry/incontent/InContentTelemetryTest.kt">
+        <error line="151" column="1" source="standard:max-line-length" />
+        <error line="173" column="1" source="standard:max-line-length" />
+        <error line="195" column="1" source="standard:max-line-length" />
+        <error line="217" column="1" source="standard:max-line-length" />
+        <error line="239" column="1" source="standard:max-line-length" />
+        <error line="261" column="1" source="standard:max-line-length" />
+        <error line="283" column="1" source="standard:max-line-length" />
+        <error line="305" column="1" source="standard:max-line-length" />
+        <error line="327" column="1" source="standard:max-line-length" />
+        <error line="349" column="1" source="standard:max-line-length" />
+        <error line="371" column="1" source="standard:max-line-length" />
+        <error line="393" column="1" source="standard:max-line-length" />
+        <error line="415" column="1" source="standard:max-line-length" />
+        <error line="437" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/serviceworker/src/test/java/mozilla/components/feature/serviceworker/ServiceWorkerSupportTest.kt">
+        <error line="27" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/session/src/test/java/mozilla/components/feature/session/HistoryDelegateTest.kt">
+        <error line="128" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/session/src/test/java/mozilla/components/feature/session/TrackingProtectionUseCasesTest.kt">
+        <error line="160" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/session/src/test/java/mozilla/components/feature/session/behavior/EngineViewBrowserToolbarBehaviorTest.kt">
+        <error line="100" column="1" source="standard:max-line-length" />
+        <error line="116" column="1" source="standard:max-line-length" />
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="164" column="1" source="standard:max-line-length" />
+        <error line="180" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/sitepermissions/src/androidTest/java/mozilla/components/feature/sitepermissions/db/OnDeviceSitePermissionsStorageTest.kt">
+        <error line="79" column="1" source="standard:max-line-length" />
+        <error line="147" column="1" source="standard:max-line-length" />
+        <error line="169" column="1" source="standard:max-line-length" />
+        <error line="192" column="1" source="standard:max-line-length" />
+        <error line="216" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFactsTest.kt">
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="99" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/sitepermissions/src/test/java/mozilla/components/feature/sitepermissions/SitePermissionsFeatureTest.kt">
+        <error line="125" column="1" source="standard:max-line-length" />
+        <error line="125" column="25" source="standard:argument-list-wrapping" />
+        <error line="125" column="38" source="standard:argument-list-wrapping" />
+        <error line="125" column="66" source="standard:argument-list-wrapping" />
+        <error line="125" column="94" source="standard:argument-list-wrapping" />
+        <error line="125" column="124" source="standard:argument-list-wrapping" />
+        <error line="125" column="125" source="standard:argument-list-wrapping" />
+        <error line="125" column="126" source="standard:argument-list-wrapping" />
+        <error line="176" column="1" source="standard:max-line-length" />
+        <error line="188" column="1" source="standard:max-line-length" />
+        <error line="200" column="1" source="standard:max-line-length" />
+        <error line="212" column="1" source="standard:max-line-length" />
+        <error line="224" column="1" source="standard:max-line-length" />
+        <error line="238" column="1" source="standard:max-line-length" />
+        <error line="287" column="1" source="standard:max-line-length" />
+        <error line="348" column="1" source="standard:max-line-length" />
+        <error line="429" column="1" source="standard:max-line-length" />
+        <error line="459" column="1" source="standard:max-line-length" />
+        <error line="494" column="1" source="standard:max-line-length" />
+        <error line="519" column="1" source="standard:max-line-length" />
+        <error line="534" column="1" source="standard:max-line-length" />
+        <error line="586" column="1" source="standard:max-line-length" />
+        <error line="604" column="1" source="standard:max-line-length" />
+        <error line="622" column="1" source="standard:max-line-length" />
+        <error line="649" column="1" source="standard:max-line-length" />
+        <error line="677" column="1" source="standard:max-line-length" />
+        <error line="705" column="1" source="standard:max-line-length" />
+        <error line="750" column="1" source="standard:max-line-length" />
+        <error line="768" column="1" source="standard:max-line-length" />
+        <error line="785" column="1" source="standard:max-line-length" />
+        <error line="802" column="1" source="standard:max-line-length" />
+        <error line="871" column="1" source="standard:max-line-length" />
+        <error line="894" column="1" source="standard:max-line-length" />
+        <error line="917" column="1" source="standard:max-line-length" />
+        <error line="940" column="1" source="standard:max-line-length" />
+        <error line="959" column="1" source="standard:max-line-length" />
+        <error line="978" column="1" source="standard:max-line-length" />
+        <error line="1000" column="1" source="standard:max-line-length" />
+        <error line="1024" column="1" source="standard:max-line-length" />
+        <error line="1044" column="1" source="standard:max-line-length" />
+        <error line="1065" column="1" source="standard:max-line-length" />
+        <error line="1088" column="1" source="standard:max-line-length" />
+        <error line="1137" column="1" source="standard:max-line-length" />
+        <error line="1377" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsAutocompleteProviderKtTest.kt">
+        <error line="28" column="1" source="standard:max-line-length" />
+        <error line="55" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/SyncedTabsStorageSuggestionProviderTest.kt">
+        <error line="64" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/ext/SyncedTabsStorageKtTest.kt">
+        <error line="34" column="1" source="standard:max-line-length" />
+        <error line="52" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt">
+        <error line="84" column="1" source="standard:max-line-length" />
+        <error line="84" column="21" source="standard:argument-list-wrapping" />
+        <error line="84" column="110" source="standard:argument-list-wrapping" />
+        <error line="84" column="122" source="standard:argument-list-wrapping" />
+        <error line="84" column="137" source="standard:argument-list-wrapping" />
+        <error line="85" column="1" source="standard:max-line-length" />
+        <error line="85" column="21" source="standard:argument-list-wrapping" />
+        <error line="85" column="106" source="standard:argument-list-wrapping" />
+        <error line="85" column="118" source="standard:argument-list-wrapping" />
+        <error line="85" column="133" source="standard:argument-list-wrapping" />
+        <error line="110" column="1" source="standard:max-line-length" />
+        <error line="110" column="21" source="standard:argument-list-wrapping" />
+        <error line="110" column="110" source="standard:argument-list-wrapping" />
+        <error line="110" column="122" source="standard:argument-list-wrapping" />
+        <error line="110" column="137" source="standard:argument-list-wrapping" />
+        <error line="111" column="1" source="standard:max-line-length" />
+        <error line="111" column="21" source="standard:argument-list-wrapping" />
+        <error line="111" column="106" source="standard:argument-list-wrapping" />
+        <error line="111" column="118" source="standard:argument-list-wrapping" />
+        <error line="111" column="133" source="standard:argument-list-wrapping" />
+        <error line="267" column="1" source="standard:max-line-length" />
+        <error line="267" column="21" source="standard:argument-list-wrapping" />
+        <error line="267" column="110" source="standard:argument-list-wrapping" />
+        <error line="267" column="122" source="standard:argument-list-wrapping" />
+        <error line="267" column="137" source="standard:argument-list-wrapping" />
+        <error line="268" column="1" source="standard:max-line-length" />
+        <error line="268" column="21" source="standard:argument-list-wrapping" />
+        <error line="268" column="106" source="standard:argument-list-wrapping" />
+        <error line="268" column="118" source="standard:argument-list-wrapping" />
+        <error line="268" column="133" source="standard:argument-list-wrapping" />
+        <error line="305" column="1" source="standard:max-line-length" />
+        <error line="305" column="21" source="standard:argument-list-wrapping" />
+        <error line="305" column="110" source="standard:argument-list-wrapping" />
+        <error line="305" column="122" source="standard:argument-list-wrapping" />
+        <error line="305" column="137" source="standard:argument-list-wrapping" />
+        <error line="335" column="1" source="standard:max-line-length" />
+        <error line="335" column="21" source="standard:argument-list-wrapping" />
+        <error line="335" column="110" source="standard:argument-list-wrapping" />
+        <error line="335" column="122" source="standard:argument-list-wrapping" />
+        <error line="335" column="137" source="standard:argument-list-wrapping" />
+        <error line="336" column="1" source="standard:max-line-length" />
+        <error line="336" column="21" source="standard:argument-list-wrapping" />
+        <error line="336" column="106" source="standard:argument-list-wrapping" />
+        <error line="336" column="118" source="standard:argument-list-wrapping" />
+        <error line="336" column="133" source="standard:argument-list-wrapping" />
+        <error line="366" column="1" source="standard:max-line-length" />
+        <error line="366" column="21" source="standard:argument-list-wrapping" />
+        <error line="366" column="110" source="standard:argument-list-wrapping" />
+        <error line="366" column="122" source="standard:argument-list-wrapping" />
+        <error line="366" column="137" source="standard:argument-list-wrapping" />
+        <error line="367" column="1" source="standard:max-line-length" />
+        <error line="367" column="21" source="standard:argument-list-wrapping" />
+        <error line="367" column="106" source="standard:argument-list-wrapping" />
+        <error line="367" column="118" source="standard:argument-list-wrapping" />
+        <error line="367" column="133" source="standard:argument-list-wrapping" />
+        <error line="372" column="1" source="standard:max-line-length" />
+        <error line="372" column="21" source="standard:argument-list-wrapping" />
+        <error line="372" column="110" source="standard:argument-list-wrapping" />
+        <error line="372" column="122" source="standard:argument-list-wrapping" />
+        <error line="372" column="137" source="standard:argument-list-wrapping" />
+        <error line="373" column="1" source="standard:max-line-length" />
+        <error line="373" column="21" source="standard:argument-list-wrapping" />
+        <error line="373" column="106" source="standard:argument-list-wrapping" />
+        <error line="373" column="118" source="standard:argument-list-wrapping" />
+        <error line="373" column="133" source="standard:argument-list-wrapping" />
+        <error line="378" column="1" source="standard:max-line-length" />
+        <error line="378" column="90" source="standard:argument-list-wrapping" />
+        <error line="378" column="99" source="standard:argument-list-wrapping" />
+        <error line="378" column="110" source="standard:argument-list-wrapping" />
+        <error line="378" column="133" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/tabs/src/test/java/mozilla/components/feature/tabs/TabsUseCasesTest.kt">
+        <error line="255" column="1" source="standard:max-line-length" />
+        <error line="269" column="1" source="standard:max-line-length" />
+        <error line="314" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/tabs/src/test/java/mozilla/components/feature/tabs/ext/TabSessionStateTest.kt">
+        <error line="17" column="1" source="standard:max-line-length" />
+        <error line="20" column="1" source="standard:max-line-length" />
+        <error line="27" column="1" source="standard:max-line-length" />
+        <error line="30" column="1" source="standard:max-line-length" />
+        <error line="30" column="57" source="standard:argument-list-wrapping" />
+        <error line="30" column="95" source="standard:argument-list-wrapping" />
+        <error line="30" column="121" source="standard:argument-list-wrapping" />
+        <error line="37" column="1" source="standard:max-line-length" />
+        <error line="40" column="1" source="standard:max-line-length" />
+        <error line="40" column="57" source="standard:argument-list-wrapping" />
+        <error line="40" column="95" source="standard:argument-list-wrapping" />
+        <error line="40" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt">
+        <error line="349" column="1" source="standard:max-line-length" />
+        <error line="378" column="1" source="standard:max-line-length" />
+        <error line="487" column="1" source="standard:max-line-length" />
+        <error line="548" column="1" source="standard:max-line-length" />
+        <error line="548" column="44" source="standard:parameter-list-wrapping" />
+        <error line="548" column="66" source="standard:parameter-list-wrapping" />
+        <error line="548" column="110" source="standard:parameter-list-wrapping" />
+        <error line="548" column="123" source="standard:parameter-list-wrapping" />
+        <error line="556" column="1" source="standard:max-line-length" />
+        <error line="556" column="42" source="standard:parameter-list-wrapping" />
+        <error line="556" column="64" source="standard:parameter-list-wrapping" />
+        <error line="556" column="108" source="standard:parameter-list-wrapping" />
+        <error line="556" column="123" source="standard:parameter-list-wrapping" />
+        <error line="556" column="149" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarBehaviorControllerTest.kt">
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="168" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarPresenterTest.kt">
+        <error line="508" column="1" source="standard:max-line-length" />
+        <error line="529" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/WebExtensionToolbarFeatureTest.kt">
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="58" column="39" source="standard:argument-list-wrapping" />
+        <error line="58" column="45" source="standard:argument-list-wrapping" />
+        <error line="58" column="52" source="standard:argument-list-wrapping" />
+        <error line="58" column="60" source="standard:argument-list-wrapping" />
+        <error line="58" column="66" source="standard:argument-list-wrapping" />
+        <error line="58" column="104" source="standard:argument-list-wrapping" />
+        <error line="58" column="134" source="standard:argument-list-wrapping" />
+        <error line="61" column="1" source="standard:max-line-length" />
+        <error line="61" column="39" source="standard:argument-list-wrapping" />
+        <error line="61" column="45" source="standard:argument-list-wrapping" />
+        <error line="61" column="52" source="standard:argument-list-wrapping" />
+        <error line="61" column="60" source="standard:argument-list-wrapping" />
+        <error line="61" column="66" source="standard:argument-list-wrapping" />
+        <error line="61" column="107" source="standard:argument-list-wrapping" />
+        <error line="61" column="140" source="standard:argument-list-wrapping" />
+        <error line="213" column="1" source="standard:max-line-length" />
+        <error line="213" column="48" source="standard:argument-list-wrapping" />
+        <error line="213" column="58" source="standard:argument-list-wrapping" />
+        <error line="213" column="97" source="standard:argument-list-wrapping" />
+        <error line="213" column="128" source="standard:argument-list-wrapping" />
+        <error line="368" column="1" source="standard:max-line-length" />
+        <error line="368" column="31" source="standard:argument-list-wrapping" />
+        <error line="368" column="41" source="standard:argument-list-wrapping" />
+        <error line="368" column="74" source="standard:argument-list-wrapping" />
+        <error line="368" column="95" source="standard:argument-list-wrapping" />
+        <error line="368" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/DefaultTopSitesStorageTest.kt">
+        <error line="164" column="1" source="standard:max-line-length" />
+        <error line="220" column="1" source="standard:max-line-length" />
+        <error line="341" column="1" source="standard:max-line-length" />
+        <error line="483" column="1" source="standard:max-line-length" />
+        <error line="800" column="1" source="standard:max-line-length" />
+        <error line="888" column="1" source="standard:max-line-length" />
+        <error line="975" column="1" source="standard:max-line-length" />
+        <error line="1074" column="1" source="standard:max-line-length" />
+        <error line="1129" column="1" source="standard:max-line-length" />
+        <error line="1129" column="27" source="standard:property-wrapping" />
+        <error line="1129" column="47" source="standard:argument-list-wrapping" />
+        <error line="1129" column="277" source="standard:argument-list-wrapping" />
+        <error line="1129" column="285" source="standard:argument-list-wrapping" />
+        <error line="1131" column="1" source="standard:max-line-length" />
+        <error line="1131" column="27" source="standard:property-wrapping" />
+        <error line="1131" column="47" source="standard:argument-list-wrapping" />
+        <error line="1131" column="167" source="standard:argument-list-wrapping" />
+        <error line="1131" column="180" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/top-sites/src/test/java/mozilla/components/feature/top/sites/PinnedSitesStorageTest.kt">
+        <error line="43" column="1" source="standard:max-line-length" />
+        <error line="43" column="34" source="standard:argument-list-wrapping" />
+        <error line="43" column="55" source="standard:argument-list-wrapping" />
+        <error line="43" column="90" source="standard:argument-list-wrapping" />
+        <error line="43" column="108" source="standard:argument-list-wrapping" />
+        <error line="43" column="122" source="standard:argument-list-wrapping" />
+        <error line="64" column="1" source="standard:max-line-length" />
+        <error line="64" column="38" source="standard:argument-list-wrapping" />
+        <error line="64" column="55" source="standard:argument-list-wrapping" />
+        <error line="64" column="63" source="standard:argument-list-wrapping" />
+        <error line="64" column="82" source="standard:argument-list-wrapping" />
+        <error line="64" column="115" source="standard:argument-list-wrapping" />
+        <error line="64" column="134" source="standard:argument-list-wrapping" />
+        <error line="64" column="147" source="standard:argument-list-wrapping" />
+        <error line="64" column="148" source="standard:argument-list-wrapping" />
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="65" column="38" source="standard:argument-list-wrapping" />
+        <error line="65" column="55" source="standard:argument-list-wrapping" />
+        <error line="65" column="63" source="standard:argument-list-wrapping" />
+        <error line="65" column="82" source="standard:argument-list-wrapping" />
+        <error line="65" column="115" source="standard:argument-list-wrapping" />
+        <error line="65" column="133" source="standard:argument-list-wrapping" />
+        <error line="65" column="146" source="standard:argument-list-wrapping" />
+        <error line="65" column="147" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/feature/webnotifications/src/test/java/mozilla/components/feature/webnotifications/WebNotificationIntentProcessorTest.kt">
+        <error line="34" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/lib/crash-sentry/src/test/java/mozilla/components/lib/crash/sentry/SentryServiceTest.kt">
+        <error line="157" column="1" source="standard:max-line-length" />
+        <error line="205" column="1" source="standard:max-line-length" />
+        <error line="231" column="1" source="standard:max-line-length" />
+        <error line="259" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/lib/crash-sentry/src/test/java/mozilla/components/lib/crash/sentry/eventprocessors/RustCrashEventProcessorTest.kt">
+        <error line="24" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashReporterTest.kt">
+        <error line="712" column="1" source="standard:max-line-length" />
+        <error line="745" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/lib/crash/src/test/java/mozilla/components/lib/crash/CrashTest.kt">
+        <error line="23" column="1" source="standard:max-line-length" />
+        <error line="25" column="1" source="standard:max-line-length" />
+        <error line="42" column="1" source="standard:max-line-length" />
+        <error line="46" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/lib/crash/src/test/java/mozilla/components/lib/crash/NativeCodeCrashTest.kt">
+        <error line="27" column="1" source="standard:max-line-length" />
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="47" column="1" source="standard:max-line-length" />
+        <error line="51" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/lib/crash/src/test/java/mozilla/components/lib/crash/handler/CrashHandlerServiceTest.kt">
+        <error line="64" column="1" source="standard:max-line-length" />
+        <error line="68" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/lib/crash/src/test/java/mozilla/components/lib/crash/service/GleanCrashReporterServiceTest.kt">
+        <error line="151" column="1" source="standard:max-line-length" />
+        <error line="157" column="1" source="standard:max-line-length" />
+        <error line="289" column="1" source="standard:max-line-length" />
+        <error line="294" column="1" source="standard:max-line-length" />
+        <error line="299" column="1" source="standard:max-line-length" />
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="374" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/lib/crash/src/test/java/mozilla/components/lib/crash/service/MozillaSocorroServiceTest.kt">
+        <error line="448" column="1" source="standard:max-line-length" />
+        <error line="448" column="20" source="standard:argument-list-wrapping" />
+        <error line="448" column="37" source="standard:argument-list-wrapping" />
+        <error line="448" column="293" source="standard:argument-list-wrapping" />
+        <error line="448" column="294" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashReportServiceTest.kt">
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="54" column="1" source="standard:max-line-length" />
+        <error line="105" column="1" source="standard:max-line-length" />
+        <error line="107" column="1" source="standard:max-line-length" />
+        <error line="120" column="1" source="standard:max-line-length" />
+        <error line="125" column="1" source="standard:max-line-length" />
+        <error line="143" column="1" source="standard:max-line-length" />
+        <error line="147" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/lib/crash/src/test/java/mozilla/components/lib/crash/service/SendCrashTelemetryServiceTest.kt">
+        <error line="48" column="1" source="standard:max-line-length" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="95" column="1" source="standard:max-line-length" />
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="110" column="1" source="standard:max-line-length" />
+        <error line="115" column="1" source="standard:max-line-length" />
+        <error line="134" column="1" source="standard:max-line-length" />
+        <error line="138" column="1" source="standard:max-line-length" />
     </file>
     <file name="components/lib/jexl/src/main/java/mozilla/components/lib/jexl/ast/nodes.kt">
         <error line="1" column="1" source="standard:filename" />
     </file>
+    <file name="components/lib/state/src/test/java/mozilla/components/lib/state/ext/StoreExtensionsKtTest.kt">
+        <error line="523" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesProviderTest.kt">
+        <error line="70" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="115" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/contile/src/test/java/mozilla/components/service/contile/ContileTopSitesUseCasesTest.kt">
+        <error line="21" column="1" source="standard:max-line-length" />
+        <error line="36" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/digitalassetlinks/src/test/java/mozilla/components/service/digitalassetlinks/local/StatementApiTest.kt">
+        <error line="217" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaAccountManagerTest.kt">
+        <error line="71" column="1" source="standard:max-line-length" />
+        <error line="71" column="24" source="standard:argument-list-wrapping" />
+        <error line="71" column="45" source="standard:argument-list-wrapping" />
+        <error line="71" column="132" source="standard:argument-list-wrapping" />
+        <error line="104" column="1" source="standard:max-line-length" />
+        <error line="104" column="23" source="standard:argument-list-wrapping" />
+        <error line="104" column="32" source="standard:argument-list-wrapping" />
+        <error line="104" column="40" source="standard:argument-list-wrapping" />
+        <error line="104" column="96" source="standard:argument-list-wrapping" />
+        <error line="104" column="108" source="standard:argument-list-wrapping" />
+        <error line="104" column="120" source="standard:argument-list-wrapping" />
+        <error line="104" column="135" source="standard:argument-list-wrapping" />
+        <error line="104" column="151" source="standard:argument-list-wrapping" />
+        <error line="137" column="1" source="standard:max-line-length" />
+        <error line="383" column="1" source="standard:max-line-length" />
+        <error line="383" column="22" source="standard:argument-list-wrapping" />
+        <error line="383" column="69" source="standard:argument-list-wrapping" />
+        <error line="383" column="121" source="standard:argument-list-wrapping" />
+        <error line="428" column="1" source="standard:max-line-length" />
+        <error line="428" column="22" source="standard:argument-list-wrapping" />
+        <error line="428" column="69" source="standard:argument-list-wrapping" />
+        <error line="428" column="121" source="standard:argument-list-wrapping" />
+        <error line="455" column="1" source="standard:max-line-length" />
+        <error line="677" column="1" source="standard:max-line-length" />
+        <error line="677" column="22" source="standard:property-wrapping" />
+        <error line="677" column="54" source="standard:argument-list-wrapping" />
+        <error line="677" column="67" source="standard:argument-list-wrapping" />
+        <error line="677" column="76" source="standard:argument-list-wrapping" />
+        <error line="677" column="92" source="standard:argument-list-wrapping" />
+        <error line="677" column="109" source="standard:argument-list-wrapping" />
+        <error line="677" column="130" source="standard:argument-list-wrapping" />
+        <error line="722" column="1" source="standard:max-line-length" />
+        <error line="722" column="22" source="standard:property-wrapping" />
+        <error line="722" column="54" source="standard:argument-list-wrapping" />
+        <error line="722" column="67" source="standard:argument-list-wrapping" />
+        <error line="722" column="76" source="standard:argument-list-wrapping" />
+        <error line="722" column="92" source="standard:argument-list-wrapping" />
+        <error line="722" column="109" source="standard:argument-list-wrapping" />
+        <error line="722" column="130" source="standard:argument-list-wrapping" />
+        <error line="779" column="1" source="standard:max-line-length" />
+        <error line="779" column="22" source="standard:property-wrapping" />
+        <error line="779" column="54" source="standard:argument-list-wrapping" />
+        <error line="779" column="67" source="standard:argument-list-wrapping" />
+        <error line="779" column="76" source="standard:argument-list-wrapping" />
+        <error line="779" column="92" source="standard:argument-list-wrapping" />
+        <error line="779" column="109" source="standard:argument-list-wrapping" />
+        <error line="779" column="130" source="standard:argument-list-wrapping" />
+        <error line="786" column="1" source="standard:max-line-length" />
+        <error line="786" column="22" source="standard:argument-list-wrapping" />
+        <error line="786" column="69" source="standard:argument-list-wrapping" />
+        <error line="786" column="97" source="standard:argument-list-wrapping" />
+        <error line="786" column="128" source="standard:argument-list-wrapping" />
+        <error line="786" column="134" source="standard:argument-list-wrapping" />
+        <error line="786" column="135" source="standard:argument-list-wrapping" />
+        <error line="816" column="1" source="standard:max-line-length" />
+        <error line="816" column="22" source="standard:property-wrapping" />
+        <error line="816" column="54" source="standard:argument-list-wrapping" />
+        <error line="816" column="67" source="standard:argument-list-wrapping" />
+        <error line="816" column="76" source="standard:argument-list-wrapping" />
+        <error line="816" column="92" source="standard:argument-list-wrapping" />
+        <error line="816" column="109" source="standard:argument-list-wrapping" />
+        <error line="816" column="130" source="standard:argument-list-wrapping" />
+        <error line="871" column="1" source="standard:max-line-length" />
+        <error line="871" column="22" source="standard:property-wrapping" />
+        <error line="871" column="56" source="standard:argument-list-wrapping" />
+        <error line="871" column="69" source="standard:argument-list-wrapping" />
+        <error line="871" column="78" source="standard:argument-list-wrapping" />
+        <error line="871" column="94" source="standard:argument-list-wrapping" />
+        <error line="871" column="111" source="standard:argument-list-wrapping" />
+        <error line="871" column="132" source="standard:argument-list-wrapping" />
+        <error line="919" column="1" source="standard:max-line-length" />
+        <error line="919" column="22" source="standard:property-wrapping" />
+        <error line="919" column="56" source="standard:argument-list-wrapping" />
+        <error line="919" column="69" source="standard:argument-list-wrapping" />
+        <error line="919" column="78" source="standard:argument-list-wrapping" />
+        <error line="919" column="94" source="standard:argument-list-wrapping" />
+        <error line="919" column="111" source="standard:argument-list-wrapping" />
+        <error line="919" column="132" source="standard:argument-list-wrapping" />
+        <error line="980" column="1" source="standard:max-line-length" />
+        <error line="980" column="22" source="standard:property-wrapping" />
+        <error line="980" column="54" source="standard:argument-list-wrapping" />
+        <error line="980" column="67" source="standard:argument-list-wrapping" />
+        <error line="980" column="76" source="standard:argument-list-wrapping" />
+        <error line="980" column="92" source="standard:argument-list-wrapping" />
+        <error line="980" column="109" source="standard:argument-list-wrapping" />
+        <error line="980" column="130" source="standard:argument-list-wrapping" />
+        <error line="1294" column="1" source="standard:max-line-length" />
+        <error line="1585" column="1" source="standard:max-line-length" />
+        <error line="1585" column="84" source="standard:argument-list-wrapping" />
+        <error line="1585" column="100" source="standard:argument-list-wrapping" />
+        <error line="1585" column="124" source="standard:argument-list-wrapping" />
+        <error line="1585" column="125" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/FxaDeviceConstellationTest.kt">
+        <error line="104" column="1" source="standard:max-line-length" />
+        <error line="104" column="54" source="standard:argument-list-wrapping" />
+        <error line="104" column="67" source="standard:argument-list-wrapping" />
+        <error line="104" column="90" source="standard:argument-list-wrapping" />
+        <error line="104" column="96" source="standard:argument-list-wrapping" />
+        <error line="104" column="151" source="standard:argument-list-wrapping" />
+        <error line="104" column="152" source="standard:argument-list-wrapping" />
+        <error line="171" column="1" source="standard:max-line-length" />
+        <error line="171" column="76" source="standard:argument-list-wrapping" />
+        <error line="171" column="126" source="standard:argument-list-wrapping" />
+        <error line="193" column="1" source="standard:max-line-length" />
+        <error line="193" column="61" source="standard:argument-list-wrapping" />
+        <error line="193" column="74" source="standard:argument-list-wrapping" />
+        <error line="193" column="89" source="standard:argument-list-wrapping" />
+        <error line="193" column="107" source="standard:argument-list-wrapping" />
+        <error line="193" column="117" source="standard:argument-list-wrapping" />
+        <error line="193" column="127" source="standard:argument-list-wrapping" />
+        <error line="193" column="128" source="standard:argument-list-wrapping" />
+        <error line="303" column="1" source="standard:max-line-length" />
+        <error line="303" column="22" source="standard:argument-list-wrapping" />
+        <error line="303" column="112" source="standard:argument-list-wrapping" />
+        <error line="303" column="126" source="standard:argument-list-wrapping" />
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="304" column="22" source="standard:argument-list-wrapping" />
+        <error line="304" column="112" source="standard:argument-list-wrapping" />
+        <error line="304" column="133" source="standard:argument-list-wrapping" />
+        <error line="478" column="1" source="standard:max-line-length" />
+        <error line="487" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/UtilsKtTest.kt">
+        <error line="380" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/manager/StateKtTest.kt">
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="58" column="91" source="standard:argument-list-wrapping" />
+        <error line="58" column="125" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/service/firefox-accounts/src/test/java/mozilla/components/service/fxa/store/SyncStoreSupportTest.kt">
+        <error line="118" column="1" source="standard:max-line-length" />
+        <error line="144" column="1" source="standard:max-line-length" />
+        <error line="159" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/location/src/test/java/mozilla/components/service/location/MozillaLocationServiceTest.kt">
+        <error line="236" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/nimbus/src/main/java/mozilla/components/service/nimbus/messaging/OnDiskMessageMetadataStorage.kt">
+        <error line="84" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingControllerTest.kt">
+        <error line="55" column="1" source="standard:max-line-length" />
+        <error line="76" column="1" source="standard:max-line-length" />
+        <error line="98" column="1" source="standard:max-line-length" />
+        <error line="120" column="1" source="standard:max-line-length" />
+        <error line="162" column="1" source="standard:max-line-length" />
+        <error line="187" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorageTest.kt">
+        <error line="265" column="1" source="standard:max-line-length" />
+        <error line="292" column="1" source="standard:max-line-length" />
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="356" column="1" source="standard:max-line-length" />
+        <error line="368" column="1" source="standard:max-line-length" />
+        <error line="619" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/OnDiskMessageMetadataStorageTest.kt">
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="105" column="1" source="standard:max-line-length" />
+        <error line="124" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/androidTest/java/mozilla/components/service/pocket/stories/db/PocketRecommendationsDatabaseTest.kt">
+        <error line="707" column="1" source="standard:max-line-length" />
+        <error line="716" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesConfigTest.kt">
+        <error line="39" column="1" source="standard:max-line-length" />
+        <error line="39" column="22" source="standard:argument-list-wrapping" />
+        <error line="39" column="63" source="standard:argument-list-wrapping" />
+        <error line="39" column="125" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoriesServiceTest.kt">
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="68" column="1" source="standard:max-line-length" />
+        <error line="76" column="1" source="standard:max-line-length" />
+        <error line="101" column="1" source="standard:max-line-length" />
+        <error line="177" column="1" source="standard:max-line-length" />
+        <error line="202" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/PocketStoryTest.kt">
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="66" column="1" source="standard:max-line-length" />
+        <error line="84" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/ext/MappersKtTest.kt">
+        <error line="17" column="1" source="standard:max-line-length" />
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="77" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/ext/PocketStoryKtTest.kt">
+        <error line="30" column="1" source="standard:max-line-length" />
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="110" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResources.kt">
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="33" column="1" source="standard:max-line-length" />
+        <error line="41" column="1" source="standard:max-line-length" />
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="56" column="1" source="standard:max-line-length" />
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="76" column="1" source="standard:max-line-length" />
+        <error line="93" column="1" source="standard:max-line-length" />
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="110" column="1" source="standard:max-line-length" />
+        <error line="111" column="1" source="standard:max-line-length" />
+        <error line="129" column="1" source="standard:max-line-length" />
+        <error line="138" column="1" source="standard:max-line-length" />
+        <error line="139" column="1" source="standard:max-line-length" />
+        <error line="148" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/SpocsUseCasesTest.kt">
+        <error line="88" column="1" source="standard:max-line-length" />
+        <error line="99" column="1" source="standard:max-line-length" />
+        <error line="106" column="1" source="standard:max-line-length" />
+        <error line="106" column="63" source="standard:argument-list-wrapping" />
+        <error line="106" column="73" source="standard:argument-list-wrapping" />
+        <error line="106" column="87" source="standard:argument-list-wrapping" />
+        <error line="106" column="99" source="standard:argument-list-wrapping" />
+        <error line="106" column="107" source="standard:argument-list-wrapping" />
+        <error line="106" column="130" source="standard:argument-list-wrapping" />
+        <error line="116" column="1" source="standard:max-line-length" />
+        <error line="129" column="1" source="standard:max-line-length" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="156" column="1" source="standard:max-line-length" />
+        <error line="177" column="1" source="standard:max-line-length" />
+        <error line="195" column="1" source="standard:max-line-length" />
+        <error line="202" column="1" source="standard:max-line-length" />
+        <error line="237" column="1" source="standard:max-line-length" />
+        <error line="248" column="1" source="standard:max-line-length" />
+        <error line="255" column="1" source="standard:max-line-length" />
+        <error line="255" column="59" source="standard:argument-list-wrapping" />
+        <error line="255" column="69" source="standard:argument-list-wrapping" />
+        <error line="255" column="83" source="standard:argument-list-wrapping" />
+        <error line="255" column="95" source="standard:argument-list-wrapping" />
+        <error line="255" column="103" source="standard:argument-list-wrapping" />
+        <error line="255" column="126" source="standard:argument-list-wrapping" />
+        <error line="265" column="1" source="standard:max-line-length" />
+        <error line="277" column="1" source="standard:max-line-length" />
+        <error line="300" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/api/SpocsEndpointRawTest.kt">
+        <error line="103" column="1" source="standard:max-line-length" />
+        <error line="166" column="1" source="standard:max-line-length" />
+        <error line="288" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/api/SpocsEndpointTest.kt">
+        <error line="70" column="1" source="standard:max-line-length" />
+        <error line="137" column="1" source="standard:max-line-length" />
+        <error line="149" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/spocs/db/SpocsDaoTest.kt">
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="76" column="1" source="standard:max-line-length" />
+        <error line="90" column="1" source="standard:max-line-length" />
+        <error line="104" column="1" source="standard:max-line-length" />
+        <error line="118" column="1" source="standard:max-line-length" />
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="146" column="1" source="standard:max-line-length" />
+        <error line="160" column="1" source="standard:max-line-length" />
+        <error line="174" column="1" source="standard:max-line-length" />
+        <error line="188" column="1" source="standard:max-line-length" />
+        <error line="202" column="1" source="standard:max-line-length" />
+        <error line="243" column="1" source="standard:max-line-length" />
+        <error line="258" column="1" source="standard:max-line-length" />
+        <error line="273" column="1" source="standard:max-line-length" />
+        <error line="290" column="1" source="standard:max-line-length" />
+        <error line="306" column="1" source="standard:max-line-length" />
+        <error line="322" column="1" source="standard:max-line-length" />
+        <error line="338" column="1" source="standard:max-line-length" />
+        <error line="354" column="1" source="standard:max-line-length" />
+        <error line="370" column="1" source="standard:max-line-length" />
+        <error line="386" column="1" source="standard:max-line-length" />
+        <error line="402" column="1" source="standard:max-line-length" />
+        <error line="418" column="1" source="standard:max-line-length" />
+        <error line="434" column="1" source="standard:max-line-length" />
+        <error line="450" column="1" source="standard:max-line-length" />
+        <error line="459" column="1" source="standard:max-line-length" />
+        <error line="481" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/PocketRecommendationsRepositoryTest.kt">
+        <error line="39" column="1" source="standard:max-line-length" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="65" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/PocketStoriesUseCasesTest.kt">
+        <error line="75" column="1" source="standard:max-line-length" />
+        <error line="83" column="1" source="standard:max-line-length" />
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="107" column="1" source="standard:max-line-length" />
+        <error line="127" column="1" source="standard:max-line-length" />
+        <error line="134" column="1" source="standard:max-line-length" />
+        <error line="143" column="1" source="standard:max-line-length" />
+        <error line="168" column="1" source="standard:max-line-length" />
+        <error line="175" column="1" source="standard:max-line-length" />
+        <error line="184" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/api/PocketEndpointTest.kt">
+        <error line="92" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/api/PocketJSONParserTest.kt">
+        <error line="86" column="1" source="standard:max-line-length" />
+        <error line="105" column="1" source="standard:max-line-length" />
+        <error line="124" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/api/PocketResponseTest.kt">
+        <error line="23" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/db/PocketRecommendationsDaoTest.kt">
+        <error line="64" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="93" column="1" source="standard:max-line-length" />
+        <error line="107" column="1" source="standard:max-line-length" />
+        <error line="121" column="1" source="standard:max-line-length" />
+        <error line="135" column="1" source="standard:max-line-length" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="177" column="1" source="standard:max-line-length" />
+        <error line="191" column="1" source="standard:max-line-length" />
+        <error line="224" column="1" source="standard:max-line-length" />
+        <error line="248" column="1" source="standard:max-line-length" />
+        <error line="263" column="1" source="standard:max-line-length" />
+        <error line="280" column="1" source="standard:max-line-length" />
+        <error line="296" column="1" source="standard:max-line-length" />
+        <error line="312" column="1" source="standard:max-line-length" />
+        <error line="328" column="1" source="standard:max-line-length" />
+        <error line="344" column="1" source="standard:max-line-length" />
+        <error line="360" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/update/PocketStoriesRefreshSchedulerTest.kt">
+        <error line="39" column="1" source="standard:max-line-length" />
+        <error line="72" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/update/RefreshPocketWorkerTest.kt">
+        <error line="53" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/update/RefreshSpocsWorkerTest.kt">
+        <error line="53" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/pocket/src/test/java/mozilla/components/service/pocket/update/SpocsRefreshSchedulerTest.kt">
+        <error line="45" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="111" column="1" source="standard:max-line-length" />
+        <error line="130" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCreditCardsAddressesStorageTest.kt">
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="63" column="22" source="standard:argument-list-wrapping" />
+        <error line="63" column="39" source="standard:argument-list-wrapping" />
+        <error line="63" column="62" source="standard:argument-list-wrapping" />
+        <error line="63" column="97" source="standard:argument-list-wrapping" />
+        <error line="63" column="127" source="standard:argument-list-wrapping" />
+        <error line="63" column="128" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/AutofillCryptoTest.kt">
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="94" column="31" source="standard:argument-list-wrapping" />
+        <error line="94" column="60" source="standard:argument-list-wrapping" />
+        <error line="94" column="133" source="standard:argument-list-wrapping" />
+        <error line="129" column="1" source="standard:max-line-length" />
+        <error line="129" column="25" source="standard:property-wrapping" />
+        <error line="129" column="37" source="standard:argument-list-wrapping" />
+        <error line="129" column="106" source="standard:argument-list-wrapping" />
+        <error line="129" column="125" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/service/sync-autofill/src/test/java/mozilla/components/service/sync/autofill/GeckoCreditCardsAddressesStorageDelegateTest.kt">
+        <error line="87" column="1" source="standard:max-line-length" />
+        <error line="87" column="65" source="standard:argument-list-wrapping" />
+        <error line="87" column="83" source="standard:argument-list-wrapping" />
+        <error line="87" column="90" source="standard:argument-list-wrapping" />
+        <error line="87" column="128" source="standard:argument-list-wrapping" />
+        <error line="101" column="1" source="standard:max-line-length" />
+        <error line="101" column="65" source="standard:argument-list-wrapping" />
+        <error line="101" column="83" source="standard:argument-list-wrapping" />
+        <error line="101" column="90" source="standard:argument-list-wrapping" />
+        <error line="101" column="129" source="standard:argument-list-wrapping" />
+        <error line="126" column="1" source="standard:max-line-length" />
+        <error line="126" column="120" source="standard:argument-list-wrapping" />
+        <error line="126" column="135" source="standard:argument-list-wrapping" />
+        <error line="144" column="1" source="standard:max-line-length" />
+        <error line="170" column="1" source="standard:max-line-length" />
+        <error line="170" column="132" source="standard:argument-list-wrapping" />
+        <error line="170" column="147" source="standard:argument-list-wrapping" />
+        <error line="222" column="1" source="standard:max-line-length" />
+        <error line="222" column="65" source="standard:argument-list-wrapping" />
+        <error line="222" column="83" source="standard:argument-list-wrapping" />
+        <error line="222" column="90" source="standard:argument-list-wrapping" />
+        <error line="222" column="125" source="standard:argument-list-wrapping" />
+        <error line="231" column="1" source="standard:max-line-length" />
+        <error line="236" column="1" source="standard:max-line-length" />
+        <error line="236" column="65" source="standard:argument-list-wrapping" />
+        <error line="236" column="83" source="standard:argument-list-wrapping" />
+        <error line="236" column="90" source="standard:argument-list-wrapping" />
+        <error line="236" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/support/base/src/test/java/mozilla/components/support/base/ext/NotificationManagerCompatTest.kt">
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="104" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/base/src/test/java/mozilla/components/support/base/ext/ThrowableTest.kt">
+        <error line="28" column="1" source="standard:max-line-length" />
+        <error line="28" column="16" source="standard:argument-list-wrapping" />
+        <error line="28" column="59" source="standard:argument-list-wrapping" />
+        <error line="28" column="176" source="standard:argument-list-wrapping" />
+        <error line="28" column="177" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/support/base/src/test/java/mozilla/components/support/base/utils/NamedThreadFactoryTest.kt">
+        <error line="24" column="1" source="standard:max-line-length" />
+    </file>
     <file name="components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/SharedPreferences.kt">
         <error line="1" column="1" source="standard:filename" />
     </file>
+    <file name="components/support/ktx/src/test/java/mozilla/components/support/ktx/android/content/SharedPreferencesStringTest.kt">
+        <error line="36" column="1" source="standard:max-line-length" />
+        <error line="48" column="1" source="standard:max-line-length" />
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="72" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/ktx/src/test/java/mozilla/components/support/ktx/android/graphics/BitmapKtTest.kt">
+        <error line="31" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/ktx/src/test/java/mozilla/components/support/ktx/android/org/json/JSONObjectTest.kt">
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="38" column="22" source="standard:argument-list-wrapping" />
+        <error line="38" column="155" source="standard:argument-list-wrapping" />
+        <error line="38" column="187" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/support/ktx/src/test/java/mozilla/components/support/ktx/android/view/ActivityTest.kt">
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="69" column="1" source="standard:max-line-length" />
+        <error line="69" column="33" source="standard:argument-list-wrapping" />
+        <error line="69" column="83" source="standard:argument-list-wrapping" />
+        <error line="69" column="131" source="standard:argument-list-wrapping" />
+        <error line="70" column="1" source="standard:max-line-length" />
+        <error line="70" column="22" source="standard:argument-list-wrapping" />
+        <error line="70" column="92" source="standard:argument-list-wrapping" />
+        <error line="70" column="130" source="standard:argument-list-wrapping" />
+        <error line="75" column="1" source="standard:max-line-length" />
+        <error line="82" column="1" source="standard:max-line-length" />
+        <error line="82" column="42" source="standard:argument-list-wrapping" />
+        <error line="82" column="92" source="standard:argument-list-wrapping" />
+        <error line="82" column="140" source="standard:argument-list-wrapping" />
+        <error line="86" column="1" source="standard:max-line-length" />
+        <error line="93" column="1" source="standard:max-line-length" />
+        <error line="99" column="1" source="standard:max-line-length" />
+        <error line="110" column="1" source="standard:max-line-length" />
+        <error line="116" column="1" source="standard:max-line-length" />
+        <error line="120" column="1" source="standard:max-line-length" />
+        <error line="133" column="1" source="standard:max-line-length" />
+        <error line="133" column="22" source="standard:argument-list-wrapping" />
+        <error line="133" column="88" source="standard:argument-list-wrapping" />
+        <error line="133" column="126" source="standard:argument-list-wrapping" />
+        <error line="141" column="1" source="standard:max-line-length" />
+        <error line="141" column="42" source="standard:argument-list-wrapping" />
+        <error line="141" column="92" source="standard:argument-list-wrapping" />
+        <error line="141" column="140" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/support/ktx/src/test/java/mozilla/components/support/ktx/kotlin/StringTest.kt">
+        <error line="532" column="1" source="standard:max-line-length" />
+        <error line="538" column="1" source="standard:max-line-length" />
+        <error line="558" column="1" source="standard:max-line-length" />
+        <error line="572" column="1" source="standard:max-line-length" />
+        <error line="581" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/locale/src/test/java/mozilla/components/support/locale/LocaleManagerTest.kt">
+        <error line="108" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/locale/src/test/java/mozilla/components/support/locale/LocaleMiddlewareTest.kt">
+        <error line="44" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/remotesettings/src/test/java/mozilla/components/support/remotesettings/RemoteSettingsClientTest.kt">
+        <error line="111" column="1" source="standard:max-line-length" />
+        <error line="111" column="26" source="standard:argument-list-wrapping" />
+        <error line="111" column="55" source="standard:argument-list-wrapping" />
+        <error line="111" column="123" source="standard:argument-list-wrapping" />
+        <error line="113" column="1" source="standard:max-line-length" />
+        <error line="113" column="26" source="standard:argument-list-wrapping" />
+        <error line="113" column="94" source="standard:argument-list-wrapping" />
+        <error line="113" column="146" source="standard:argument-list-wrapping" />
+        <error line="113" column="166" source="standard:argument-list-wrapping" />
+        <error line="113" column="167" source="standard:argument-list-wrapping" />
+        <error line="118" column="1" source="standard:max-line-length" />
+        <error line="161" column="1" source="standard:max-line-length" />
+        <error line="161" column="26" source="standard:argument-list-wrapping" />
+        <error line="161" column="41" source="standard:argument-list-wrapping" />
+        <error line="161" column="140" source="standard:argument-list-wrapping" />
+        <error line="161" column="146" source="standard:argument-list-wrapping" />
+        <error line="161" column="147" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/support/test/src/main/java/mozilla/components/support/test/Mock.kt">
+        <error line="28" column="1" source="standard:max-line-length" />
+        <error line="28" column="111" source="standard:argument-list-wrapping" />
+        <error line="28" column="124" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/support/test/src/main/java/mozilla/components/support/test/rule/Helpers.kt">
+        <error line="47" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/test/src/main/java/mozilla/components/support/test/rule/MainCoroutineRule.kt">
+        <error line="25" column="1" source="standard:max-line-length" />
+        <error line="25" column="13" source="standard:argument-list-wrapping" />
+        <error line="25" column="80" source="standard:argument-list-wrapping" />
+        <error line="25" column="121" source="standard:argument-list-wrapping" />
+    </file>
     <file name="components/support/utils/src/main/java/mozilla/components/support/utils/intents.kt">
         <error line="1" column="1" source="standard:filename" />
+    </file>
+    <file name="components/support/utils/src/test/java/mozilla/components/support/utils/BootUtilsTest.kt">
+        <error line="35" column="1" source="standard:max-line-length" />
+        <error line="43" column="1" source="standard:max-line-length" />
+        <error line="62" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/utils/src/test/java/mozilla/components/support/utils/BrowsersTest.kt">
+        <error line="24" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/utils/src/test/java/mozilla/components/support/utils/CreditCardUtilsTest.kt">
+        <error line="14" column="1" source="standard:max-line-length" />
+        <error line="91" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/utils/src/test/java/mozilla/components/support/utils/DownloadUtilsTest.kt">
+        <error line="137" column="1" source="standard:max-line-length" />
+        <error line="137" column="41" source="standard:argument-list-wrapping" />
+        <error line="137" column="47" source="standard:argument-list-wrapping" />
+        <error line="137" column="53" source="standard:argument-list-wrapping" />
+        <error line="137" column="146" source="standard:argument-list-wrapping" />
+        <error line="137" column="163" source="standard:argument-list-wrapping" />
+        <error line="145" column="1" source="standard:max-line-length" />
+        <error line="145" column="22" source="standard:argument-list-wrapping" />
+        <error line="145" column="35" source="standard:argument-list-wrapping" />
+        <error line="145" column="63" source="standard:argument-list-wrapping" />
+        <error line="145" column="69" source="standard:argument-list-wrapping" />
+        <error line="145" column="75" source="standard:argument-list-wrapping" />
+        <error line="145" column="102" source="standard:argument-list-wrapping" />
+        <error line="145" column="128" source="standard:argument-list-wrapping" />
+        <error line="145" column="129" source="standard:argument-list-wrapping" />
+        <error line="147" column="1" source="standard:max-line-length" />
+        <error line="147" column="22" source="standard:argument-list-wrapping" />
+        <error line="147" column="35" source="standard:argument-list-wrapping" />
+        <error line="147" column="63" source="standard:argument-list-wrapping" />
+        <error line="147" column="69" source="standard:argument-list-wrapping" />
+        <error line="147" column="75" source="standard:argument-list-wrapping" />
+        <error line="147" column="107" source="standard:argument-list-wrapping" />
+        <error line="147" column="133" source="standard:argument-list-wrapping" />
+        <error line="147" column="134" source="standard:argument-list-wrapping" />
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="148" column="22" source="standard:argument-list-wrapping" />
+        <error line="148" column="35" source="standard:argument-list-wrapping" />
+        <error line="148" column="63" source="standard:argument-list-wrapping" />
+        <error line="148" column="69" source="standard:argument-list-wrapping" />
+        <error line="148" column="75" source="standard:argument-list-wrapping" />
+        <error line="148" column="107" source="standard:argument-list-wrapping" />
+        <error line="148" column="128" source="standard:argument-list-wrapping" />
+        <error line="148" column="129" source="standard:argument-list-wrapping" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="149" column="22" source="standard:argument-list-wrapping" />
+        <error line="149" column="35" source="standard:argument-list-wrapping" />
+        <error line="149" column="63" source="standard:argument-list-wrapping" />
+        <error line="149" column="69" source="standard:argument-list-wrapping" />
+        <error line="149" column="75" source="standard:argument-list-wrapping" />
+        <error line="149" column="107" source="standard:argument-list-wrapping" />
+        <error line="149" column="128" source="standard:argument-list-wrapping" />
+        <error line="149" column="129" source="standard:argument-list-wrapping" />
+        <error line="154" column="1" source="standard:max-line-length" />
+        <error line="154" column="22" source="standard:argument-list-wrapping" />
+        <error line="154" column="34" source="standard:argument-list-wrapping" />
+        <error line="154" column="62" source="standard:argument-list-wrapping" />
+        <error line="154" column="68" source="standard:argument-list-wrapping" />
+        <error line="154" column="74" source="standard:argument-list-wrapping" />
+        <error line="154" column="105" source="standard:argument-list-wrapping" />
+        <error line="154" column="146" source="standard:argument-list-wrapping" />
+        <error line="154" column="147" source="standard:argument-list-wrapping" />
+        <error line="157" column="1" source="standard:max-line-length" />
+        <error line="157" column="22" source="standard:argument-list-wrapping" />
+        <error line="157" column="34" source="standard:argument-list-wrapping" />
+        <error line="157" column="62" source="standard:argument-list-wrapping" />
+        <error line="157" column="68" source="standard:argument-list-wrapping" />
+        <error line="157" column="74" source="standard:argument-list-wrapping" />
+        <error line="157" column="105" source="standard:argument-list-wrapping" />
+        <error line="157" column="134" source="standard:argument-list-wrapping" />
+        <error line="157" column="135" source="standard:argument-list-wrapping" />
+        <error line="158" column="1" source="standard:max-line-length" />
+        <error line="158" column="22" source="standard:argument-list-wrapping" />
+        <error line="158" column="34" source="standard:argument-list-wrapping" />
+        <error line="158" column="62" source="standard:argument-list-wrapping" />
+        <error line="158" column="68" source="standard:argument-list-wrapping" />
+        <error line="158" column="74" source="standard:argument-list-wrapping" />
+        <error line="158" column="105" source="standard:argument-list-wrapping" />
+        <error line="158" column="152" source="standard:argument-list-wrapping" />
+        <error line="158" column="153" source="standard:argument-list-wrapping" />
+        <error line="163" column="1" source="standard:max-line-length" />
+        <error line="163" column="22" source="standard:argument-list-wrapping" />
+        <error line="163" column="34" source="standard:argument-list-wrapping" />
+        <error line="163" column="62" source="standard:argument-list-wrapping" />
+        <error line="163" column="68" source="standard:argument-list-wrapping" />
+        <error line="163" column="74" source="standard:argument-list-wrapping" />
+        <error line="163" column="105" source="standard:argument-list-wrapping" />
+        <error line="163" column="134" source="standard:argument-list-wrapping" />
+        <error line="163" column="135" source="standard:argument-list-wrapping" />
+        <error line="178" column="1" source="standard:max-line-length" />
+        <error line="178" column="22" source="standard:argument-list-wrapping" />
+        <error line="178" column="70" source="standard:argument-list-wrapping" />
+        <error line="178" column="110" source="standard:argument-list-wrapping" />
+        <error line="178" column="121" source="standard:argument-list-wrapping" />
+        <error line="178" column="124" source="standard:argument-list-wrapping" />
+        <error line="178" column="125" source="standard:argument-list-wrapping" />
+        <error line="178" column="126" source="standard:argument-list-wrapping" />
+        <error line="179" column="1" source="standard:max-line-length" />
+        <error line="179" column="22" source="standard:argument-list-wrapping" />
+        <error line="179" column="70" source="standard:argument-list-wrapping" />
+        <error line="179" column="110" source="standard:argument-list-wrapping" />
+        <error line="179" column="121" source="standard:argument-list-wrapping" />
+        <error line="179" column="124" source="standard:argument-list-wrapping" />
+        <error line="179" column="134" source="standard:argument-list-wrapping" />
+        <error line="179" column="135" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/support/utils/src/test/java/mozilla/components/support/utils/SafeUrlTest.kt">
+        <error line="44" column="1" source="standard:max-line-length" />
+        <error line="56" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/utils/src/test/java/mozilla/components/support/utils/ext/StringTest.kt">
+        <error line="13" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/webextensions/src/main/java/mozilla/components/support/webextensions/WebExtensionSupport.kt">
+        <error line="192" column="1" source="standard:max-line-length" />
+        <error line="192" column="39" source="standard:parameter-list-wrapping" />
+        <error line="192" column="64" source="standard:parameter-list-wrapping" />
+        <error line="192" column="94" source="standard:parameter-list-wrapping" />
+        <error line="192" column="111" source="standard:parameter-list-wrapping" />
+        <error line="192" column="122" source="standard:parameter-list-wrapping" />
+        <error line="223" column="1" source="standard:max-line-length" />
+        <error line="223" column="44" source="standard:property-wrapping" />
+        <error line="223" column="53" source="standard:argument-list-wrapping" />
+        <error line="223" column="60" source="standard:argument-list-wrapping" />
+        <error line="223" column="78" source="standard:argument-list-wrapping" />
+        <error line="223" column="99" source="standard:argument-list-wrapping" />
+        <error line="223" column="110" source="standard:argument-list-wrapping" />
+        <error line="223" column="123" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionPopupObserverTest.kt">
+        <error line="44" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/support/webextensions/src/test/java/mozilla/components/support/webextensions/WebExtensionSupportTest.kt">
+        <error line="222" column="1" source="standard:max-line-length" />
+        <error line="222" column="41" source="standard:argument-list-wrapping" />
+        <error line="222" column="53" source="standard:argument-list-wrapping" />
+        <error line="222" column="86" source="standard:argument-list-wrapping" />
+        <error line="222" column="117" source="standard:argument-list-wrapping" />
+        <error line="222" column="164" source="standard:argument-list-wrapping" />
+        <error line="336" column="1" source="standard:max-line-length" />
+        <error line="336" column="37" source="standard:argument-list-wrapping" />
+        <error line="336" column="49" source="standard:argument-list-wrapping" />
+        <error line="336" column="82" source="standard:argument-list-wrapping" />
+        <error line="336" column="113" source="standard:argument-list-wrapping" />
+        <error line="336" column="160" source="standard:argument-list-wrapping" />
+        <error line="373" column="1" source="standard:max-line-length" />
+        <error line="373" column="29" source="standard:argument-list-wrapping" />
+        <error line="373" column="39" source="standard:argument-list-wrapping" />
+        <error line="373" column="72" source="standard:argument-list-wrapping" />
+        <error line="373" column="112" source="standard:argument-list-wrapping" />
+        <error line="373" column="159" source="standard:argument-list-wrapping" />
+        <error line="425" column="1" source="standard:max-line-length" />
+        <error line="425" column="22" source="standard:argument-list-wrapping" />
+        <error line="425" column="30" source="standard:argument-list-wrapping" />
+        <error line="425" column="130" source="standard:argument-list-wrapping" />
+        <error line="602" column="1" source="standard:max-line-length" />
+        <error line="602" column="24" source="standard:property-wrapping" />
+        <error line="602" column="41" source="standard:argument-list-wrapping" />
+        <error line="602" column="51" source="standard:argument-list-wrapping" />
+        <error line="602" column="84" source="standard:argument-list-wrapping" />
+        <error line="602" column="131" source="standard:argument-list-wrapping" />
+        <error line="894" column="1" source="standard:max-line-length" />
+        <error line="894" column="22" source="standard:argument-list-wrapping" />
+        <error line="894" column="49" source="standard:argument-list-wrapping" />
+        <error line="894" column="134" source="standard:argument-list-wrapping" />
+        <error line="901" column="1" source="standard:max-line-length" />
+        <error line="901" column="22" source="standard:argument-list-wrapping" />
+        <error line="901" column="49" source="standard:argument-list-wrapping" />
+        <error line="901" column="134" source="standard:argument-list-wrapping" />
+        <error line="912" column="1" source="standard:max-line-length" />
+        <error line="1028" column="1" source="standard:max-line-length" />
+        <error line="1028" column="29" source="standard:argument-list-wrapping" />
+        <error line="1028" column="39" source="standard:argument-list-wrapping" />
+        <error line="1028" column="72" source="standard:argument-list-wrapping" />
+        <error line="1028" column="112" source="standard:argument-list-wrapping" />
+        <error line="1028" column="159" source="standard:argument-list-wrapping" />
+        <error line="1071" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="components/tooling/fetch-tests/src/main/java/mozilla/components/tooling/fetch/tests/FetchTestCases.kt">
+        <error line="89" column="1" source="standard:max-line-length" />
+        <error line="89" column="30" source="standard:argument-list-wrapping" />
+        <error line="89" column="44" source="standard:argument-list-wrapping" />
+        <error line="89" column="128" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="components/ui/autocomplete/src/test/java/mozilla/components/ui/autocomplete/InlineAutocompleteEditTextTest.kt">
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="373" column="1" source="standard:max-line-length" />
+        <error line="481" column="1" source="standard:max-line-length" />
+        <error line="515" column="1" source="standard:max-line-length" />
+        <error line="525" column="1" source="standard:max-line-length" />
     </file>
 </baseline>

--- a/fenix/.editorconfig
+++ b/fenix/.editorconfig
@@ -1,7 +1,9 @@
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma_on_call_site=true
 ij_kotlin_allow_trailing_comma=true
-max_line_length = 120 # Matches maxLineLength in detekt.yml
+
+# Matches maxLineLength in detekt.yml
+max_line_length = 120
 
 [*]
 insert_final_newline = true

--- a/fenix/ktlint-baseline.xml
+++ b/fenix/ktlint-baseline.xml
@@ -2,9 +2,2626 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-
 <baseline version="1.0">
-    <file name="app/src/test/java/org/mozilla/fenix/home/recentvisits/view/RecentBookmarksViewHolderTest.kt">
-        <error line="36" column="6" source="standard:block-comment-initial-star-alignment" />
+    <file name="app/src/androidTest/java/org/mozilla/fenix/helpers/AppAndSystemHelper.kt">
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="84" column="1" source="standard:max-line-length" />
+        <error line="190" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/helpers/DataGenerationHelper.kt">
+        <error line="61" column="1" source="standard:max-line-length" />
+        <error line="61" column="119" source="standard:argument-list-wrapping" />
+        <error line="61" column="123" source="standard:argument-list-wrapping" />
+        <error line="61" column="131" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/helpers/RecyclerViewIdlingResource.kt">
+        <error line="10" column="1" source="standard:max-line-length" />
+        <error line="10" column="46" source="standard:parameter-list-wrapping" />
+        <error line="10" column="111" source="standard:parameter-list-wrapping" />
+        <error line="10" column="136" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/onboarding/view/OnboardingMapperTest.kt">
+        <error line="47" column="1" source="standard:max-line-length" />
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="126" column="1" source="standard:max-line-length" />
+        <error line="142" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt">
+        <error line="118" column="1" source="standard:max-line-length" />
+        <error line="118" column="20" source="standard:argument-list-wrapping" />
+        <error line="118" column="74" source="standard:argument-list-wrapping" />
+        <error line="118" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt">
+        <error line="686" column="1" source="standard:max-line-length" />
+        <error line="686" column="49" source="standard:argument-list-wrapping" />
+        <error line="686" column="67" source="standard:argument-list-wrapping" />
+        <error line="686" column="96" source="standard:argument-list-wrapping" />
+        <error line="686" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/ComposeBookmarksTest.kt">
+        <error line="669" column="1" source="standard:max-line-length" />
+        <error line="669" column="49" source="standard:argument-list-wrapping" />
+        <error line="669" column="67" source="standard:argument-list-wrapping" />
+        <error line="669" column="96" source="standard:argument-list-wrapping" />
+        <error line="669" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/ComposeHistoryTest.kt">
+        <error line="381" column="1" source="standard:max-line-length" />
+        <error line="381" column="49" source="standard:argument-list-wrapping" />
+        <error line="381" column="67" source="standard:argument-list-wrapping" />
+        <error line="381" column="96" source="standard:argument-list-wrapping" />
+        <error line="381" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/ComposeSearchTest.kt">
+        <error line="396" column="1" source="standard:max-line-length" />
+        <error line="396" column="55" source="standard:argument-list-wrapping" />
+        <error line="396" column="82" source="standard:argument-list-wrapping" />
+        <error line="396" column="108" source="standard:argument-list-wrapping" />
+        <error line="396" column="121" source="standard:argument-list-wrapping" />
+        <error line="442" column="1" source="standard:max-line-length" />
+        <error line="442" column="55" source="standard:argument-list-wrapping" />
+        <error line="442" column="82" source="standard:argument-list-wrapping" />
+        <error line="442" column="108" source="standard:argument-list-wrapping" />
+        <error line="442" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/FirefoxSuggestTest.kt">
+        <error line="44" column="1" source="standard:max-line-length" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="61" column="1" source="standard:max-line-length" />
+        <error line="65" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt">
+        <error line="411" column="1" source="standard:max-line-length" />
+        <error line="411" column="55" source="standard:argument-list-wrapping" />
+        <error line="411" column="82" source="standard:argument-list-wrapping" />
+        <error line="411" column="108" source="standard:argument-list-wrapping" />
+        <error line="411" column="121" source="standard:argument-list-wrapping" />
+        <error line="457" column="1" source="standard:max-line-length" />
+        <error line="457" column="55" source="standard:argument-list-wrapping" />
+        <error line="457" column="82" source="standard:argument-list-wrapping" />
+        <error line="457" column="108" source="standard:argument-list-wrapping" />
+        <error line="457" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHTTPSOnlyModeTest.kt">
+        <error line="26" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt">
+        <error line="281" column="1" source="standard:max-line-length" />
+        <error line="290" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/AccountSettingsRobot.kt">
+        <error line="66" column="1" source="standard:max-line-length" />
+        <error line="66" column="59" source="standard:argument-list-wrapping" />
+        <error line="66" column="82" source="standard:argument-list-wrapping" />
+        <error line="66" column="119" source="standard:argument-list-wrapping" />
+        <error line="66" column="150" source="standard:argument-list-wrapping" />
+        <error line="66" column="151" source="standard:argument-list-wrapping" />
+        <error line="66" column="152" source="standard:argument-list-wrapping" />
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="67" column="53" source="standard:argument-list-wrapping" />
+        <error line="67" column="76" source="standard:argument-list-wrapping" />
+        <error line="67" column="113" source="standard:argument-list-wrapping" />
+        <error line="67" column="144" source="standard:argument-list-wrapping" />
+        <error line="67" column="145" source="standard:argument-list-wrapping" />
+        <error line="67" column="146" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/AddToHomeScreenRobot.kt">
+        <error line="34" column="1" source="standard:max-line-length" />
+        <error line="34" column="15" source="standard:argument-list-wrapping" />
+        <error line="34" column="20" source="standard:argument-list-wrapping" />
+        <error line="34" column="146" source="standard:argument-list-wrapping" />
+        <error line="39" column="1" source="standard:max-line-length" />
+        <error line="39" column="15" source="standard:argument-list-wrapping" />
+        <error line="39" column="20" source="standard:argument-list-wrapping" />
+        <error line="39" column="142" source="standard:argument-list-wrapping" />
+        <error line="44" column="1" source="standard:max-line-length" />
+        <error line="44" column="15" source="standard:argument-list-wrapping" />
+        <error line="44" column="20" source="standard:argument-list-wrapping" />
+        <error line="44" column="131" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt">
+        <error line="213" column="1" source="standard:max-line-length" />
+        <error line="213" column="15" source="standard:argument-list-wrapping" />
+        <error line="213" column="20" source="standard:argument-list-wrapping" />
+        <error line="213" column="147" source="standard:argument-list-wrapping" />
+        <error line="266" column="1" source="standard:max-line-length" />
+        <error line="266" column="15" source="standard:argument-list-wrapping" />
+        <error line="266" column="20" source="standard:argument-list-wrapping" />
+        <error line="266" column="129" source="standard:argument-list-wrapping" />
+        <error line="309" column="1" source="standard:max-line-length" />
+        <error line="309" column="111" source="standard:argument-list-wrapping" />
+        <error line="309" column="122" source="standard:argument-list-wrapping" />
+        <error line="357" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt">
+        <error line="481" column="1" source="standard:max-line-length" />
+        <error line="481" column="38" source="standard:argument-list-wrapping" />
+        <error line="481" column="65" source="standard:argument-list-wrapping" />
+        <error line="481" column="90" source="standard:argument-list-wrapping" />
+        <error line="481" column="123" source="standard:argument-list-wrapping" />
+        <error line="483" column="1" source="standard:max-line-length" />
+        <error line="483" column="38" source="standard:argument-list-wrapping" />
+        <error line="483" column="65" source="standard:argument-list-wrapping" />
+        <error line="483" column="90" source="standard:argument-list-wrapping" />
+        <error line="483" column="123" source="standard:argument-list-wrapping" />
+        <error line="559" column="1" source="standard:max-line-length" />
+        <error line="559" column="19" source="standard:argument-list-wrapping" />
+        <error line="559" column="24" source="standard:argument-list-wrapping" />
+        <error line="559" column="127" source="standard:argument-list-wrapping" />
+        <error line="561" column="1" source="standard:max-line-length" />
+        <error line="561" column="19" source="standard:argument-list-wrapping" />
+        <error line="561" column="24" source="standard:argument-list-wrapping" />
+        <error line="561" column="126" source="standard:argument-list-wrapping" />
+        <error line="564" column="1" source="standard:max-line-length" />
+        <error line="564" column="19" source="standard:argument-list-wrapping" />
+        <error line="564" column="24" source="standard:argument-list-wrapping" />
+        <error line="564" column="121" source="standard:argument-list-wrapping" />
+        <error line="566" column="1" source="standard:max-line-length" />
+        <error line="566" column="19" source="standard:argument-list-wrapping" />
+        <error line="566" column="24" source="standard:argument-list-wrapping" />
+        <error line="566" column="129" source="standard:argument-list-wrapping" />
+        <error line="568" column="1" source="standard:max-line-length" />
+        <error line="568" column="19" source="standard:argument-list-wrapping" />
+        <error line="568" column="24" source="standard:argument-list-wrapping" />
+        <error line="568" column="128" source="standard:argument-list-wrapping" />
+        <error line="760" column="1" source="standard:max-line-length" />
+        <error line="760" column="23" source="standard:argument-list-wrapping" />
+        <error line="760" column="28" source="standard:argument-list-wrapping" />
+        <error line="760" column="128" source="standard:argument-list-wrapping" />
+        <error line="834" column="1" source="standard:max-line-length" />
+        <error line="834" column="53" source="standard:argument-list-wrapping" />
+        <error line="834" column="72" source="standard:argument-list-wrapping" />
+        <error line="834" column="90" source="standard:argument-list-wrapping" />
+        <error line="834" column="122" source="standard:argument-list-wrapping" />
+        <error line="834" column="123" source="standard:argument-list-wrapping" />
+        <error line="834" column="124" source="standard:argument-list-wrapping" />
+        <error line="897" column="1" source="standard:max-line-length" />
+        <error line="1002" column="1" source="standard:max-line-length" />
+        <error line="1002" column="34" source="standard:parameter-list-wrapping" />
+        <error line="1002" column="80" source="standard:parameter-list-wrapping" />
+        <error line="1002" column="122" source="standard:parameter-list-wrapping" />
+        <error line="1063" column="1" source="standard:max-line-length" />
+        <error line="1063" column="47" source="standard:parameter-list-wrapping" />
+        <error line="1063" column="93" source="standard:parameter-list-wrapping" />
+        <error line="1063" column="134" source="standard:parameter-list-wrapping" />
+        <error line="1066" column="1" source="standard:max-line-length" />
+        <error line="1066" column="19" source="standard:argument-list-wrapping" />
+        <error line="1066" column="24" source="standard:argument-list-wrapping" />
+        <error line="1066" column="123" source="standard:argument-list-wrapping" />
+        <error line="1150" column="1" source="standard:max-line-length" />
+        <error line="1158" column="1" source="standard:max-line-length" />
+        <error line="1166" column="1" source="standard:max-line-length" />
+        <error line="1184" column="1" source="standard:max-line-length" />
+        <error line="1193" column="1" source="standard:max-line-length" />
+        <error line="1207" column="1" source="standard:max-line-length" />
+        <error line="1207" column="19" source="standard:argument-list-wrapping" />
+        <error line="1207" column="24" source="standard:argument-list-wrapping" />
+        <error line="1207" column="125" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt">
+        <error line="168" column="1" source="standard:max-line-length" />
+        <error line="168" column="34" source="standard:argument-list-wrapping" />
+        <error line="168" column="111" source="standard:argument-list-wrapping" />
+        <error line="168" column="125" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt">
+        <error line="462" column="1" source="standard:max-line-length" />
+        <error line="470" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt">
+        <error line="233" column="1" source="standard:max-line-length" />
+        <error line="233" column="19" source="standard:argument-list-wrapping" />
+        <error line="233" column="24" source="standard:argument-list-wrapping" />
+        <error line="233" column="134" source="standard:argument-list-wrapping" />
+        <error line="241" column="1" source="standard:max-line-length" />
+        <error line="241" column="19" source="standard:argument-list-wrapping" />
+        <error line="241" column="24" source="standard:argument-list-wrapping" />
+        <error line="241" column="138" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/EnhancedTrackingProtectionRobot.kt">
+        <error line="181" column="1" source="standard:max-line-length" />
+        <error line="188" column="1" source="standard:max-line-length" />
+        <error line="207" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/FindInPageRobot.kt">
+        <error line="47" column="1" source="standard:max-line-length" />
+        <error line="47" column="29" source="standard:argument-list-wrapping" />
+        <error line="47" column="110" source="standard:argument-list-wrapping" />
+        <error line="47" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt">
+        <error line="305" column="1" source="standard:max-line-length" />
+        <error line="305" column="34" source="standard:argument-list-wrapping" />
+        <error line="305" column="107" source="standard:argument-list-wrapping" />
+        <error line="305" column="121" source="standard:argument-list-wrapping" />
+        <error line="350" column="1" source="standard:max-line-length" />
+        <error line="350" column="34" source="standard:argument-list-wrapping" />
+        <error line="350" column="116" source="standard:argument-list-wrapping" />
+        <error line="350" column="130" source="standard:argument-list-wrapping" />
+        <error line="453" column="1" source="standard:max-line-length" />
+        <error line="453" column="34" source="standard:parameter-list-wrapping" />
+        <error line="453" column="80" source="standard:parameter-list-wrapping" />
+        <error line="453" column="122" source="standard:parameter-list-wrapping" />
+        <error line="518" column="1" source="standard:max-line-length" />
+        <error line="561" column="1" source="standard:max-line-length" />
+        <error line="563" column="1" source="standard:max-line-length" />
+        <error line="563" column="19" source="standard:argument-list-wrapping" />
+        <error line="563" column="24" source="standard:argument-list-wrapping" />
+        <error line="563" column="142" source="standard:argument-list-wrapping" />
+        <error line="581" column="1" source="standard:max-line-length" />
+        <error line="636" column="1" source="standard:max-line-length" />
+        <error line="637" column="1" source="standard:max-line-length" />
+        <error line="637" column="19" source="standard:argument-list-wrapping" />
+        <error line="637" column="24" source="standard:argument-list-wrapping" />
+        <error line="637" column="122" source="standard:argument-list-wrapping" />
+        <error line="640" column="1" source="standard:max-line-length" />
+        <error line="640" column="19" source="standard:argument-list-wrapping" />
+        <error line="640" column="24" source="standard:argument-list-wrapping" />
+        <error line="640" column="163" source="standard:argument-list-wrapping" />
+        <error line="666" column="1" source="standard:max-line-length" />
+        <error line="666" column="45" source="standard:parameter-list-wrapping" />
+        <error line="666" column="91" source="standard:parameter-list-wrapping" />
+        <error line="666" column="133" source="standard:parameter-list-wrapping" />
+        <error line="683" column="1" source="standard:max-line-length" />
+        <error line="693" column="1" source="standard:max-line-length" />
+        <error line="717" column="1" source="standard:max-line-length" />
+        <error line="717" column="42" source="standard:parameter-list-wrapping" />
+        <error line="717" column="88" source="standard:parameter-list-wrapping" />
+        <error line="717" column="130" source="standard:parameter-list-wrapping" />
+        <error line="728" column="1" source="standard:max-line-length" />
+        <error line="740" column="1" source="standard:max-line-length" />
+        <error line="769" column="1" source="standard:max-line-length" />
+        <error line="807" column="1" source="standard:max-line-length" />
+        <error line="807" column="35" source="standard:parameter-list-wrapping" />
+        <error line="807" column="81" source="standard:parameter-list-wrapping" />
+        <error line="807" column="122" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/LibrarySubMenusMultipleSelectionToolbarRobot.kt">
+        <error line="116" column="1" source="standard:max-line-length" />
+        <error line="135" column="1" source="standard:max-line-length" />
+        <error line="135" column="33" source="standard:parameter-list-wrapping" />
+        <error line="135" column="79" source="standard:parameter-list-wrapping" />
+        <error line="135" column="121" source="standard:parameter-list-wrapping" />
+        <error line="144" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt">
+        <error line="211" column="1" source="standard:max-line-length" />
+        <error line="211" column="34" source="standard:parameter-list-wrapping" />
+        <error line="211" column="80" source="standard:parameter-list-wrapping" />
+        <error line="211" column="122" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt">
+        <error line="69" column="1" source="standard:max-line-length" />
+        <error line="69" column="15" source="standard:argument-list-wrapping" />
+        <error line="69" column="20" source="standard:argument-list-wrapping" />
+        <error line="69" column="122" source="standard:argument-list-wrapping" />
+        <error line="88" column="1" source="standard:max-line-length" />
+        <error line="88" column="23" source="standard:argument-list-wrapping" />
+        <error line="88" column="28" source="standard:argument-list-wrapping" />
+        <error line="88" column="161" source="standard:argument-list-wrapping" />
+        <error line="200" column="1" source="standard:max-line-length" />
+        <error line="200" column="15" source="standard:argument-list-wrapping" />
+        <error line="200" column="20" source="standard:argument-list-wrapping" />
+        <error line="200" column="136" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/RecentlyClosedTabsRobot.kt">
+        <error line="89" column="1" source="standard:max-line-length" />
+        <error line="96" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt">
+        <error line="348" column="1" source="standard:max-line-length" />
+        <error line="355" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt">
+        <error line="247" column="1" source="standard:max-line-length" />
+        <error line="264" column="1" source="standard:max-line-length" />
+        <error line="283" column="1" source="standard:max-line-length" />
+        <error line="291" column="1" source="standard:max-line-length" />
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="334" column="1" source="standard:max-line-length" />
+        <error line="343" column="1" source="standard:max-line-length" />
+        <error line="353" column="1" source="standard:max-line-length" />
+        <error line="370" column="1" source="standard:max-line-length" />
+        <error line="379" column="1" source="standard:max-line-length" />
+        <error line="388" column="1" source="standard:max-line-length" />
+        <error line="397" column="1" source="standard:max-line-length" />
+        <error line="397" column="57" source="standard:parameter-list-wrapping" />
+        <error line="397" column="122" source="standard:parameter-list-wrapping" />
+        <error line="415" column="1" source="standard:max-line-length" />
+        <error line="424" column="1" source="standard:max-line-length" />
+        <error line="431" column="1" source="standard:max-line-length" />
+        <error line="438" column="1" source="standard:max-line-length" />
+        <error line="450" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt">
+        <error line="215" column="1" source="standard:max-line-length" />
+        <error line="215" column="50" source="standard:argument-list-wrapping" />
+        <error line="215" column="58" source="standard:argument-list-wrapping" />
+        <error line="215" column="72" source="standard:argument-list-wrapping" />
+        <error line="215" column="81" source="standard:argument-list-wrapping" />
+        <error line="215" column="96" source="standard:argument-list-wrapping" />
+        <error line="215" column="122" source="standard:argument-list-wrapping" />
+        <error line="215" column="123" source="standard:argument-list-wrapping" />
+        <error line="215" column="124" source="standard:argument-list-wrapping" />
+        <error line="215" column="125" source="standard:argument-list-wrapping" />
+        <error line="215" column="126" source="standard:argument-list-wrapping" />
+        <error line="261" column="1" source="standard:max-line-length" />
+        <error line="261" column="42" source="standard:argument-list-wrapping" />
+        <error line="261" column="189" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAccessibilityRobot.kt">
+        <error line="108" column="1" source="standard:max-line-length" />
+        <error line="108" column="16" source="standard:argument-list-wrapping" />
+        <error line="108" column="24" source="standard:argument-list-wrapping" />
+        <error line="108" column="33" source="standard:argument-list-wrapping" />
+        <error line="108" column="153" source="standard:argument-list-wrapping" />
+        <error line="108" column="154" source="standard:argument-list-wrapping" />
+        <error line="108" column="155" source="standard:argument-list-wrapping" />
+        <error line="179" column="1" source="standard:max-line-length" />
+        <error line="179" column="83" source="standard:argument-list-wrapping" />
+        <error line="179" column="194" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.kt">
+        <error line="30" column="1" source="standard:max-line-length" />
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="38" column="25" source="standard:parameter-list-wrapping" />
+        <error line="38" column="75" source="standard:parameter-list-wrapping" />
+        <error line="38" column="129" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt">
+        <error line="261" column="1" source="standard:max-line-length" />
+        <error line="261" column="39" source="standard:argument-list-wrapping" />
+        <error line="261" column="48" source="standard:argument-list-wrapping" />
+        <error line="261" column="126" source="standard:argument-list-wrapping" />
+        <error line="261" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt">
+        <error line="444" column="1" source="standard:max-line-length" />
+        <error line="444" column="30" source="standard:argument-list-wrapping" />
+        <error line="444" column="49" source="standard:argument-list-wrapping" />
+        <error line="444" column="121" source="standard:argument-list-wrapping" />
+        <error line="444" column="122" source="standard:argument-list-wrapping" />
+        <error line="447" column="1" source="standard:max-line-length" />
+        <error line="447" column="30" source="standard:argument-list-wrapping" />
+        <error line="447" column="49" source="standard:argument-list-wrapping" />
+        <error line="447" column="67" source="standard:argument-list-wrapping" />
+        <error line="447" column="126" source="standard:argument-list-wrapping" />
+        <error line="447" column="127" source="standard:argument-list-wrapping" />
+        <error line="447" column="128" source="standard:argument-list-wrapping" />
+        <error line="457" column="1" source="standard:max-line-length" />
+        <error line="465" column="1" source="standard:max-line-length" />
+        <error line="496" column="1" source="standard:max-line-length" />
+        <error line="496" column="45" source="standard:property-wrapping" />
+        <error line="496" column="65" source="standard:argument-list-wrapping" />
+        <error line="496" column="83" source="standard:argument-list-wrapping" />
+        <error line="496" column="141" source="standard:argument-list-wrapping" />
+        <error line="496" column="142" source="standard:argument-list-wrapping" />
+        <error line="497" column="1" source="standard:max-line-length" />
+        <error line="497" column="46" source="standard:property-wrapping" />
+        <error line="497" column="66" source="standard:argument-list-wrapping" />
+        <error line="497" column="84" source="standard:argument-list-wrapping" />
+        <error line="497" column="150" source="standard:argument-list-wrapping" />
+        <error line="497" column="151" source="standard:argument-list-wrapping" />
+        <error line="527" column="1" source="standard:max-line-length" />
+        <error line="527" column="47" source="standard:property-wrapping" />
+        <error line="527" column="67" source="standard:argument-list-wrapping" />
+        <error line="527" column="85" source="standard:argument-list-wrapping" />
+        <error line="527" column="142" source="standard:argument-list-wrapping" />
+        <error line="527" column="143" source="standard:argument-list-wrapping" />
+        <error line="528" column="1" source="standard:max-line-length" />
+        <error line="528" column="48" source="standard:property-wrapping" />
+        <error line="528" column="68" source="standard:argument-list-wrapping" />
+        <error line="528" column="86" source="standard:argument-list-wrapping" />
+        <error line="528" column="151" source="standard:argument-list-wrapping" />
+        <error line="528" column="152" source="standard:argument-list-wrapping" />
+        <error line="529" column="1" source="standard:max-line-length" />
+        <error line="529" column="49" source="standard:property-wrapping" />
+        <error line="529" column="69" source="standard:argument-list-wrapping" />
+        <error line="529" column="87" source="standard:argument-list-wrapping" />
+        <error line="529" column="146" source="standard:argument-list-wrapping" />
+        <error line="529" column="147" source="standard:argument-list-wrapping" />
+        <error line="530" column="1" source="standard:max-line-length" />
+        <error line="530" column="54" source="standard:argument-list-wrapping" />
+        <error line="530" column="80" source="standard:argument-list-wrapping" />
+        <error line="530" column="98" source="standard:argument-list-wrapping" />
+        <error line="530" column="147" source="standard:argument-list-wrapping" />
+        <error line="530" column="148" source="standard:argument-list-wrapping" />
+        <error line="530" column="149" source="standard:argument-list-wrapping" />
+        <error line="533" column="1" source="standard:max-line-length" />
+        <error line="533" column="63" source="standard:argument-list-wrapping" />
+        <error line="533" column="89" source="standard:argument-list-wrapping" />
+        <error line="533" column="107" source="standard:argument-list-wrapping" />
+        <error line="533" column="159" source="standard:argument-list-wrapping" />
+        <error line="533" column="160" source="standard:argument-list-wrapping" />
+        <error line="533" column="161" source="standard:argument-list-wrapping" />
+        <error line="535" column="1" source="standard:max-line-length" />
+        <error line="535" column="60" source="standard:argument-list-wrapping" />
+        <error line="535" column="121" source="standard:argument-list-wrapping" />
+        <error line="539" column="1" source="standard:max-line-length" />
+        <error line="539" column="64" source="standard:argument-list-wrapping" />
+        <error line="539" column="88" source="standard:argument-list-wrapping" />
+        <error line="539" column="131" source="standard:argument-list-wrapping" />
+        <error line="539" column="132" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataOnQuitRobot.kt">
+        <error line="113" column="1" source="standard:max-line-length" />
+        <error line="113" column="41" source="standard:property-wrapping" />
+        <error line="113" column="49" source="standard:argument-list-wrapping" />
+        <error line="113" column="58" source="standard:argument-list-wrapping" />
+        <error line="113" column="121" source="standard:argument-list-wrapping" />
+        <error line="113" column="122" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt">
+        <error line="161" column="1" source="standard:max-line-length" />
+        <error line="161" column="80" source="standard:argument-list-wrapping" />
+        <error line="161" column="106" source="standard:argument-list-wrapping" />
+        <error line="161" column="128" source="standard:argument-list-wrapping" />
+        <error line="161" column="129" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuEnhancedTrackingProtectionExceptionsRobot.kt">
+        <error line="55" column="1" source="standard:max-line-length" />
+        <error line="62" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuEnhancedTrackingProtectionRobot.kt">
+        <error line="138" column="1" source="standard:max-line-length" />
+        <error line="138" column="16" source="standard:argument-list-wrapping" />
+        <error line="138" column="25" source="standard:argument-list-wrapping" />
+        <error line="138" column="152" source="standard:argument-list-wrapping" />
+        <error line="138" column="153" source="standard:argument-list-wrapping" />
+        <error line="138" column="161" source="standard:argument-list-wrapping" />
+        <error line="138" column="169" source="standard:argument-list-wrapping" />
+        <error line="138" column="182" source="standard:argument-list-wrapping" />
+        <error line="138" column="183" source="standard:argument-list-wrapping" />
+        <error line="146" column="1" source="standard:max-line-length" />
+        <error line="146" column="16" source="standard:argument-list-wrapping" />
+        <error line="146" column="25" source="standard:argument-list-wrapping" />
+        <error line="146" column="152" source="standard:argument-list-wrapping" />
+        <error line="146" column="153" source="standard:argument-list-wrapping" />
+        <error line="146" column="161" source="standard:argument-list-wrapping" />
+        <error line="146" column="169" source="standard:argument-list-wrapping" />
+        <error line="146" column="182" source="standard:argument-list-wrapping" />
+        <error line="146" column="183" source="standard:argument-list-wrapping" />
+        <error line="244" column="1" source="standard:max-line-length" />
+        <error line="271" column="1" source="standard:max-line-length" />
+        <error line="271" column="117" source="standard:argument-list-wrapping" />
+        <error line="271" column="125" source="standard:argument-list-wrapping" />
+        <error line="271" column="138" source="standard:argument-list-wrapping" />
+        <error line="271" column="139" source="standard:argument-list-wrapping" />
+        <error line="273" column="1" source="standard:max-line-length" />
+        <error line="273" column="12" source="standard:argument-list-wrapping" />
+        <error line="273" column="21" source="standard:argument-list-wrapping" />
+        <error line="273" column="157" source="standard:argument-list-wrapping" />
+        <error line="273" column="158" source="standard:argument-list-wrapping" />
+        <error line="273" column="166" source="standard:argument-list-wrapping" />
+        <error line="273" column="174" source="standard:argument-list-wrapping" />
+        <error line="273" column="187" source="standard:argument-list-wrapping" />
+        <error line="273" column="188" source="standard:argument-list-wrapping" />
+        <error line="275" column="1" source="standard:max-line-length" />
+        <error line="275" column="114" source="standard:argument-list-wrapping" />
+        <error line="275" column="122" source="standard:argument-list-wrapping" />
+        <error line="275" column="135" source="standard:argument-list-wrapping" />
+        <error line="275" column="136" source="standard:argument-list-wrapping" />
+        <error line="277" column="1" source="standard:max-line-length" />
+        <error line="277" column="12" source="standard:argument-list-wrapping" />
+        <error line="277" column="21" source="standard:argument-list-wrapping" />
+        <error line="277" column="134" source="standard:argument-list-wrapping" />
+        <error line="277" column="135" source="standard:argument-list-wrapping" />
+        <error line="277" column="143" source="standard:argument-list-wrapping" />
+        <error line="277" column="151" source="standard:argument-list-wrapping" />
+        <error line="277" column="164" source="standard:argument-list-wrapping" />
+        <error line="277" column="165" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHttpsOnlyModeRobot.kt">
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="38" column="20" source="standard:argument-list-wrapping" />
+        <error line="38" column="28" source="standard:argument-list-wrapping" />
+        <error line="38" column="37" source="standard:argument-list-wrapping" />
+        <error line="38" column="148" source="standard:argument-list-wrapping" />
+        <error line="38" column="149" source="standard:argument-list-wrapping" />
+        <error line="38" column="150" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordOptionsToSaveRobot.kt">
+        <error line="76" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt">
+        <error line="104" column="1" source="standard:max-line-length" />
+        <error line="111" column="1" source="standard:max-line-length" />
+        <error line="125" column="1" source="standard:max-line-length" />
+        <error line="134" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.kt">
+        <error line="194" column="1" source="standard:max-line-length" />
+        <error line="201" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsCommonRobot.kt">
+        <error line="37" column="1" source="standard:max-line-length" />
+        <error line="184" column="1" source="standard:max-line-length" />
+        <error line="241" column="1" source="standard:max-line-length" />
+        <error line="241" column="26" source="standard:argument-list-wrapping" />
+        <error line="241" column="108" source="standard:argument-list-wrapping" />
+        <error line="241" column="122" source="standard:argument-list-wrapping" />
+        <error line="244" column="1" source="standard:max-line-length" />
+        <error line="244" column="62" source="standard:argument-list-wrapping" />
+        <error line="244" column="86" source="standard:argument-list-wrapping" />
+        <error line="244" column="133" source="standard:argument-list-wrapping" />
+        <error line="244" column="134" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsExceptionsRobot.kt">
+        <error line="111" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SitePermissionsRobot.kt">
+        <error line="140" column="1" source="standard:max-line-length" />
+        <error line="140" column="102" source="standard:argument-list-wrapping" />
+        <error line="140" column="110" source="standard:argument-list-wrapping" />
+        <error line="140" column="123" source="standard:argument-list-wrapping" />
+        <error line="140" column="124" source="standard:argument-list-wrapping" />
+        <error line="141" column="1" source="standard:max-line-length" />
+        <error line="141" column="128" source="standard:argument-list-wrapping" />
+        <error line="141" column="136" source="standard:argument-list-wrapping" />
+        <error line="141" column="149" source="standard:argument-list-wrapping" />
+        <error line="141" column="150" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/SiteSecurityRobot.kt">
+        <error line="29" column="1" source="standard:max-line-length" />
+        <error line="29" column="104" source="standard:argument-list-wrapping" />
+        <error line="29" column="109" source="standard:argument-list-wrapping" />
+        <error line="29" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuBookmarksRobot.kt">
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="63" column="35" source="standard:parameter-list-wrapping" />
+        <error line="63" column="81" source="standard:parameter-list-wrapping" />
+        <error line="63" column="123" source="standard:parameter-list-wrapping" />
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="91" column="1" source="standard:max-line-length" />
+        <error line="91" column="39" source="standard:parameter-list-wrapping" />
+        <error line="91" column="85" source="standard:parameter-list-wrapping" />
+        <error line="91" column="127" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt">
+        <error line="273" column="1" source="standard:max-line-length" />
+        <error line="446" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt">
+        <error line="112" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/main/java/org/mozilla/fenix/debugsettings/store/DebugDrawerStore.kt">
+        <error line="26" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt">
+        <error line="771" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt">
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="76" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/ServiceWorkerSupportTest.kt">
+        <error line="41" column="1" source="standard:max-line-length" />
+        <error line="48" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/addons/ExtensionsProcessDisabledBackgroundControllerTest.kt">
+        <error line="26" column="1" source="standard:max-line-length" />
+        <error line="49" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/addons/ExtensionsProcessDisabledForegroundControllerTest.kt">
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="79" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragmentTest.kt">
+        <error line="56" column="1" source="standard:max-line-length" />
+        <error line="191" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/browser/BaseBrowserFragmentTest.kt">
+        <error line="111" column="1" source="standard:max-line-length" />
+        <error line="121" column="1" source="standard:max-line-length" />
+        <error line="131" column="1" source="standard:max-line-length" />
+        <error line="141" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/browser/BrowserFragmentTest.kt">
+        <error line="220" column="1" source="standard:max-line-length" />
+        <error line="232" column="1" source="standard:max-line-length" />
+        <error line="256" column="1" source="standard:max-line-length" />
+        <error line="352" column="1" source="standard:max-line-length" />
+        <error line="401" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/browser/StandardSnackbarErrorBindingTest.kt">
+        <error line="112" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/browser/infobanner/DynamicInfoBannerTest.kt">
+        <error line="36" column="1" source="standard:max-line-length" />
+        <error line="36" column="20" source="standard:argument-list-wrapping" />
+        <error line="36" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/collections/DefaultCollectionCreationControllerTest.kt">
+        <error line="221" column="1" source="standard:max-line-length" />
+        <error line="227" column="1" source="standard:max-line-length" />
+        <error line="234" column="1" source="standard:max-line-length" />
+        <error line="243" column="1" source="standard:max-line-length" />
+        <error line="250" column="1" source="standard:max-line-length" />
+        <error line="259" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt">
+        <error line="258" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/FenixSnackbarBehaviorTest.kt">
+        <error line="52" column="1" source="standard:max-line-length" />
+        <error line="72" column="1" source="standard:max-line-length" />
+        <error line="84" column="1" source="standard:max-line-length" />
+        <error line="96" column="1" source="standard:max-line-length" />
+        <error line="122" column="1" source="standard:max-line-length" />
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="174" column="1" source="standard:max-line-length" />
+        <error line="197" column="1" source="standard:max-line-length" />
+        <error line="223" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/FindInPageIntegrationTest.kt">
+        <error line="26" column="1" source="standard:max-line-length" />
+        <error line="52" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="104" column="1" source="standard:max-line-length" />
+        <error line="130" column="1" source="standard:max-line-length" />
+        <error line="156" column="1" source="standard:max-line-length" />
+        <error line="182" column="1" source="standard:max-line-length" />
+        <error line="208" column="1" source="standard:max-line-length" />
+        <error line="245" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/PrivateShortcutCreateManagerTest.kt">
+        <error line="45" column="1" source="standard:max-line-length" />
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="63" column="17" source="standard:wrapping" />
+        <error line="63" column="44" source="standard:argument-list-wrapping" />
+        <error line="63" column="57" source="standard:argument-list-wrapping" />
+        <error line="63" column="60" source="standard:argument-list-wrapping" />
+        <error line="63" column="77" source="standard:argument-list-wrapping" />
+        <error line="63" column="151" source="standard:argument-list-wrapping" />
+        <error line="70" column="1" source="standard:max-line-length" />
+        <error line="70" column="22" source="standard:argument-list-wrapping" />
+        <error line="70" column="116" source="standard:argument-list-wrapping" />
+        <error line="70" column="145" source="standard:argument-list-wrapping" />
+        <error line="71" column="1" source="standard:max-line-length" />
+        <error line="71" column="22" source="standard:argument-list-wrapping" />
+        <error line="71" column="116" source="standard:argument-list-wrapping" />
+        <error line="71" column="144" source="standard:argument-list-wrapping" />
+        <error line="81" column="1" source="standard:max-line-length" />
+        <error line="81" column="22" source="standard:argument-list-wrapping" />
+        <error line="81" column="83" source="standard:argument-list-wrapping" />
+        <error line="81" column="108" source="standard:argument-list-wrapping" />
+        <error line="81" column="135" source="standard:argument-list-wrapping" />
+        <error line="81" column="136" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt">
+        <error line="183" column="1" source="standard:max-line-length" />
+        <error line="210" column="1" source="standard:max-line-length" />
+        <error line="237" column="1" source="standard:max-line-length" />
+        <error line="253" column="1" source="standard:max-line-length" />
+        <error line="269" column="1" source="standard:max-line-length" />
+        <error line="296" column="1" source="standard:max-line-length" />
+        <error line="323" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/UrlRequestInterceptorTest.kt">
+        <error line="33" column="1" source="standard:max-line-length" />
+        <error line="46" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/accounts/FenixAccountManagerTest.kt">
+        <error line="48" column="1" source="standard:max-line-length" />
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="106" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/appstate/AppStoreReducerTest.kt">
+        <error line="19" column="1" source="standard:max-line-length" />
+        <error line="63" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/history/PagedHistoryProviderTest.kt">
+        <error line="342" column="1" source="standard:max-line-length" />
+        <error line="342" column="34" source="standard:property-wrapping" />
+        <error line="342" column="54" source="standard:argument-list-wrapping" />
+        <error line="342" column="111" source="standard:argument-list-wrapping" />
+        <error line="342" column="122" source="standard:argument-list-wrapping" />
+        <error line="342" column="126" source="standard:argument-list-wrapping" />
+        <error line="393" column="1" source="standard:max-line-length" />
+        <error line="393" column="18" source="standard:wrapping" />
+        <error line="393" column="75" source="standard:argument-list-wrapping" />
+        <error line="393" column="90" source="standard:argument-list-wrapping" />
+        <error line="393" column="105" source="standard:argument-list-wrapping" />
+        <error line="393" column="120" source="standard:argument-list-wrapping" />
+        <error line="393" column="133" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/metrics/DefaultMetricsStorageTest.kt">
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="57" column="41" source="standard:argument-list-wrapping" />
+        <error line="57" column="50" source="standard:argument-list-wrapping" />
+        <error line="57" column="60" source="standard:argument-list-wrapping" />
+        <error line="57" column="83" source="standard:argument-list-wrapping" />
+        <error line="57" column="106" source="standard:argument-list-wrapping" />
+        <error line="57" column="124" source="standard:argument-list-wrapping" />
+        <error line="57" column="134" source="standard:argument-list-wrapping" />
+        <error line="61" column="1" source="standard:max-line-length" />
+        <error line="61" column="113" source="standard:argument-list-wrapping" />
+        <error line="61" column="123" source="standard:argument-list-wrapping" />
+        <error line="72" column="1" source="standard:max-line-length" />
+        <error line="72" column="132" source="standard:argument-list-wrapping" />
+        <error line="72" column="142" source="standard:argument-list-wrapping" />
+        <error line="82" column="1" source="standard:max-line-length" />
+        <error line="82" column="124" source="standard:argument-list-wrapping" />
+        <error line="82" column="134" source="standard:argument-list-wrapping" />
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="92" column="124" source="standard:argument-list-wrapping" />
+        <error line="92" column="134" source="standard:argument-list-wrapping" />
+        <error line="112" column="1" source="standard:max-line-length" />
+        <error line="112" column="147" source="standard:argument-list-wrapping" />
+        <error line="112" column="157" source="standard:argument-list-wrapping" />
+        <error line="124" column="1" source="standard:max-line-length" />
+        <error line="124" column="138" source="standard:argument-list-wrapping" />
+        <error line="124" column="148" source="standard:argument-list-wrapping" />
+        <error line="136" column="1" source="standard:max-line-length" />
+        <error line="136" column="150" source="standard:argument-list-wrapping" />
+        <error line="136" column="160" source="standard:argument-list-wrapping" />
+        <error line="140" column="1" source="standard:max-line-length" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="149" column="168" source="standard:argument-list-wrapping" />
+        <error line="149" column="178" source="standard:argument-list-wrapping" />
+        <error line="163" column="1" source="standard:max-line-length" />
+        <error line="163" column="141" source="standard:argument-list-wrapping" />
+        <error line="163" column="151" source="standard:argument-list-wrapping" />
+        <error line="175" column="1" source="standard:max-line-length" />
+        <error line="175" column="129" source="standard:argument-list-wrapping" />
+        <error line="175" column="139" source="standard:argument-list-wrapping" />
+        <error line="199" column="1" source="standard:max-line-length" />
+        <error line="199" column="111" source="standard:argument-list-wrapping" />
+        <error line="199" column="121" source="standard:argument-list-wrapping" />
+        <error line="211" column="1" source="standard:max-line-length" />
+        <error line="211" column="117" source="standard:argument-list-wrapping" />
+        <error line="211" column="127" source="standard:argument-list-wrapping" />
+        <error line="223" column="1" source="standard:max-line-length" />
+        <error line="223" column="131" source="standard:argument-list-wrapping" />
+        <error line="223" column="141" source="standard:argument-list-wrapping" />
+        <error line="232" column="1" source="standard:max-line-length" />
+        <error line="232" column="123" source="standard:argument-list-wrapping" />
+        <error line="232" column="133" source="standard:argument-list-wrapping" />
+        <error line="241" column="1" source="standard:max-line-length" />
+        <error line="241" column="138" source="standard:argument-list-wrapping" />
+        <error line="241" column="148" source="standard:argument-list-wrapping" />
+        <error line="251" column="1" source="standard:max-line-length" />
+        <error line="251" column="130" source="standard:argument-list-wrapping" />
+        <error line="251" column="140" source="standard:argument-list-wrapping" />
+        <error line="261" column="1" source="standard:max-line-length" />
+        <error line="272" column="1" source="standard:max-line-length" />
+        <error line="324" column="1" source="standard:max-line-length" />
+        <error line="324" column="136" source="standard:argument-list-wrapping" />
+        <error line="324" column="146" source="standard:argument-list-wrapping" />
+        <error line="334" column="1" source="standard:max-line-length" />
+        <error line="334" column="132" source="standard:argument-list-wrapping" />
+        <error line="334" column="142" source="standard:argument-list-wrapping" />
+        <error line="356" column="1" source="standard:max-line-length" />
+        <error line="356" column="132" source="standard:argument-list-wrapping" />
+        <error line="356" column="142" source="standard:argument-list-wrapping" />
+        <error line="366" column="1" source="standard:max-line-length" />
+        <error line="366" column="128" source="standard:argument-list-wrapping" />
+        <error line="366" column="138" source="standard:argument-list-wrapping" />
+        <error line="388" column="1" source="standard:max-line-length" />
+        <error line="388" column="114" source="standard:argument-list-wrapping" />
+        <error line="388" column="124" source="standard:argument-list-wrapping" />
+        <error line="427" column="1" source="standard:max-line-length" />
+        <error line="427" column="137" source="standard:argument-list-wrapping" />
+        <error line="427" column="147" source="standard:argument-list-wrapping" />
+        <error line="440" column="1" source="standard:max-line-length" />
+        <error line="440" column="129" source="standard:argument-list-wrapping" />
+        <error line="440" column="139" source="standard:argument-list-wrapping" />
+        <error line="455" column="1" source="standard:max-line-length" />
+        <error line="455" column="131" source="standard:argument-list-wrapping" />
+        <error line="455" column="141" source="standard:argument-list-wrapping" />
+        <error line="470" column="1" source="standard:max-line-length" />
+        <error line="470" column="122" source="standard:argument-list-wrapping" />
+        <error line="470" column="132" source="standard:argument-list-wrapping" />
+        <error line="483" column="1" source="standard:max-line-length" />
+        <error line="483" column="125" source="standard:argument-list-wrapping" />
+        <error line="483" column="135" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/metrics/InstallReferrerMetricsServiceTest.kt">
+        <error line="42" column="1" source="standard:max-line-length" />
+        <error line="42" column="23" source="standard:property-wrapping" />
+        <error line="42" column="34" source="standard:argument-list-wrapping" />
+        <error line="42" column="53" source="standard:argument-list-wrapping" />
+        <error line="42" column="72" source="standard:argument-list-wrapping" />
+        <error line="42" column="95" source="standard:argument-list-wrapping" />
+        <error line="42" column="116" source="standard:argument-list-wrapping" />
+        <error line="42" column="129" source="standard:argument-list-wrapping" />
+        <error line="54" column="1" source="standard:max-line-length" />
+        <error line="73" column="1" source="standard:max-line-length" />
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="94" column="51" source="standard:argument-list-wrapping" />
+        <error line="94" column="144" source="standard:argument-list-wrapping" />
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="97" column="23" source="standard:property-wrapping" />
+        <error line="97" column="34" source="standard:argument-list-wrapping" />
+        <error line="97" column="53" source="standard:argument-list-wrapping" />
+        <error line="97" column="72" source="standard:argument-list-wrapping" />
+        <error line="97" column="95" source="standard:argument-list-wrapping" />
+        <error line="97" column="116" source="standard:argument-list-wrapping" />
+        <error line="97" column="129" source="standard:argument-list-wrapping" />
+        <error line="124" column="1" source="standard:max-line-length" />
+        <error line="124" column="60" source="standard:argument-list-wrapping" />
+        <error line="124" column="136" source="standard:argument-list-wrapping" />
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="132" column="60" source="standard:argument-list-wrapping" />
+        <error line="132" column="183" source="standard:argument-list-wrapping" />
+        <error line="140" column="1" source="standard:max-line-length" />
+        <error line="140" column="60" source="standard:argument-list-wrapping" />
+        <error line="140" column="183" source="standard:argument-list-wrapping" />
+        <error line="147" column="1" source="standard:max-line-length" />
+        <error line="147" column="54" source="standard:argument-list-wrapping" />
+        <error line="147" column="142" source="standard:argument-list-wrapping" />
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="148" column="32" source="standard:property-wrapping" />
+        <error line="148" column="43" source="standard:argument-list-wrapping" />
+        <error line="148" column="56" source="standard:argument-list-wrapping" />
+        <error line="148" column="69" source="standard:argument-list-wrapping" />
+        <error line="148" column="84" source="standard:argument-list-wrapping" />
+        <error line="148" column="172" source="standard:argument-list-wrapping" />
+        <error line="148" column="181" source="standard:argument-list-wrapping" />
+        <error line="164" column="1" source="standard:max-line-length" />
+        <error line="176" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt">
+        <error line="590" column="1" source="standard:max-line-length" />
+        <error line="591" column="1" source="standard:max-line-length" />
+        <error line="648" column="1" source="standard:max-line-length" />
+        <error line="648" column="19" source="standard:property-wrapping" />
+        <error line="648" column="25" source="standard:argument-list-wrapping" />
+        <error line="648" column="55" source="standard:argument-list-wrapping" />
+        <error line="648" column="70" source="standard:argument-list-wrapping" />
+        <error line="648" column="122" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTest.kt">
+        <error line="96" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTestRobolectric.kt">
+        <error line="214" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarCFRPresenterTest.kt">
+        <error line="52" column="1" source="standard:max-line-length" />
+        <error line="75" column="1" source="standard:max-line-length" />
+        <error line="175" column="1" source="standard:max-line-length" />
+        <error line="231" column="1" source="standard:max-line-length" />
+        <error line="294" column="1" source="standard:max-line-length" />
+        <error line="325" column="1" source="standard:max-line-length" />
+        <error line="338" column="1" source="standard:max-line-length" />
+        <error line="362" column="1" source="standard:max-line-length" />
+        <error line="378" column="1" source="standard:max-line-length" />
+        <error line="397" column="1" source="standard:max-line-length" />
+        <error line="412" column="1" source="standard:max-line-length" />
+        <error line="424" column="1" source="standard:max-line-length" />
+        <error line="440" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarViewTest.kt">
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="84" column="1" source="standard:max-line-length" />
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="110" column="1" source="standard:max-line-length" />
+        <error line="138" column="1" source="standard:max-line-length" />
+        <error line="151" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt">
+        <error line="151" column="1" source="standard:max-line-length" />
+        <error line="151" column="16" source="standard:wrapping" />
+        <error line="151" column="107" source="standard:wrapping" />
+        <error line="151" column="135" source="standard:argument-list-wrapping" />
+        <error line="151" column="139" source="standard:argument-list-wrapping" />
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="339" column="1" source="standard:max-line-length" />
+        <error line="687" column="1" source="standard:max-line-length" />
+        <error line="722" column="1" source="standard:max-line-length" />
+        <error line="790" column="1" source="standard:max-line-length" />
+        <error line="801" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/compose/LinkTextTest.kt">
+        <error line="60" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/crashes/CrashContentViewTest.kt">
+        <error line="92" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/crashes/CrashReporterControllerTest.kt">
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="69" column="1" source="standard:max-line-length" />
+        <error line="80" column="1" source="standard:max-line-length" />
+        <error line="85" column="1" source="standard:max-line-length" />
+        <error line="85" column="46" source="standard:argument-list-wrapping" />
+        <error line="85" column="57" source="standard:argument-list-wrapping" />
+        <error line="85" column="60" source="standard:argument-list-wrapping" />
+        <error line="85" column="72" source="standard:argument-list-wrapping" />
+        <error line="85" column="102" source="standard:argument-list-wrapping" />
+        <error line="85" column="117" source="standard:argument-list-wrapping" />
+        <error line="85" column="125" source="standard:argument-list-wrapping" />
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="99" column="1" source="standard:max-line-length" />
+        <error line="99" column="46" source="standard:argument-list-wrapping" />
+        <error line="99" column="57" source="standard:argument-list-wrapping" />
+        <error line="99" column="60" source="standard:argument-list-wrapping" />
+        <error line="99" column="72" source="standard:argument-list-wrapping" />
+        <error line="99" column="103" source="standard:argument-list-wrapping" />
+        <error line="99" column="118" source="standard:argument-list-wrapping" />
+        <error line="99" column="126" source="standard:argument-list-wrapping" />
+        <error line="108" column="1" source="standard:max-line-length" />
+        <error line="113" column="1" source="standard:max-line-length" />
+        <error line="113" column="46" source="standard:argument-list-wrapping" />
+        <error line="113" column="57" source="standard:argument-list-wrapping" />
+        <error line="113" column="60" source="standard:argument-list-wrapping" />
+        <error line="113" column="72" source="standard:argument-list-wrapping" />
+        <error line="113" column="103" source="standard:argument-list-wrapping" />
+        <error line="113" column="118" source="standard:argument-list-wrapping" />
+        <error line="113" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivityTest.kt">
+        <error line="117" column="1" source="standard:max-line-length" />
+        <error line="145" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/customtabs/FennecWebAppIntentProcessorTest.kt">
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="32" column="19" source="standard:property-wrapping" />
+        <error line="32" column="25" source="standard:argument-list-wrapping" />
+        <error line="32" column="140" source="standard:argument-list-wrapping" />
+        <error line="40" column="1" source="standard:max-line-length" />
+        <error line="40" column="19" source="standard:property-wrapping" />
+        <error line="40" column="25" source="standard:argument-list-wrapping" />
+        <error line="40" column="134" source="standard:argument-list-wrapping" />
+        <error line="56" column="1" source="standard:max-line-length" />
+        <error line="56" column="19" source="standard:property-wrapping" />
+        <error line="56" column="25" source="standard:argument-list-wrapping" />
+        <error line="56" column="125" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/debugsettings/DefaultDebugSettingsRepositoryTest.kt">
+        <error line="18" column="1" source="standard:max-line-length" />
+        <error line="18" column="83" source="standard:argument-list-wrapping" />
+        <error line="18" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/downloads/DynamicDownloadDialogBehaviorTest.kt">
+        <error line="232" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/downloads/FirstPartyDownloadDialogTest.kt">
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="79" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/downloads/StartDownloadDialogTest.kt">
+        <error line="84" column="1" source="standard:max-line-length" />
+        <error line="176" column="1" source="standard:max-line-length" />
+        <error line="176" column="26" source="standard:argument-list-wrapping" />
+        <error line="176" column="51" source="standard:argument-list-wrapping" />
+        <error line="176" column="123" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt">
+        <error line="29" column="1" source="standard:max-line-length" />
+        <error line="29" column="105" source="standard:argument-list-wrapping" />
+        <error line="29" column="151" source="standard:argument-list-wrapping" />
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="32" column="20" source="standard:property-wrapping" />
+        <error line="32" column="29" source="standard:argument-list-wrapping" />
+        <error line="32" column="73" source="standard:argument-list-wrapping" />
+        <error line="32" column="112" source="standard:argument-list-wrapping" />
+        <error line="32" column="149" source="standard:argument-list-wrapping" />
+        <error line="32" column="181" source="standard:argument-list-wrapping" />
+        <error line="32" column="217" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/ext/AppStateTest.kt">
+        <error line="39" column="1" source="standard:max-line-length" />
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="105" column="1" source="standard:max-line-length" />
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="170" column="1" source="standard:max-line-length" />
+        <error line="222" column="1" source="standard:max-line-length" />
+        <error line="226" column="1" source="standard:max-line-length" />
+        <error line="226" column="56" source="standard:argument-list-wrapping" />
+        <error line="226" column="97" source="standard:argument-list-wrapping" />
+        <error line="226" column="122" source="standard:argument-list-wrapping" />
+        <error line="226" column="123" source="standard:argument-list-wrapping" />
+        <error line="244" column="1" source="standard:max-line-length" />
+        <error line="278" column="1" source="standard:max-line-length" />
+        <error line="314" column="1" source="standard:max-line-length" />
+        <error line="333" column="1" source="standard:max-line-length" />
+        <error line="361" column="1" source="standard:max-line-length" />
+        <error line="374" column="1" source="standard:max-line-length" />
+        <error line="382" column="1" source="standard:max-line-length" />
+        <error line="411" column="1" source="standard:max-line-length" />
+        <error line="427" column="1" source="standard:max-line-length" />
+        <error line="443" column="1" source="standard:max-line-length" />
+        <error line="497" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/ext/BrowserStateTest.kt">
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="79" column="1" source="standard:max-line-length" />
+        <error line="98" column="1" source="standard:max-line-length" />
+        <error line="124" column="1" source="standard:max-line-length" />
+        <error line="167" column="1" source="standard:max-line-length" />
+        <error line="211" column="1" source="standard:max-line-length" />
+        <error line="253" column="1" source="standard:max-line-length" />
+        <error line="263" column="1" source="standard:max-line-length" />
+        <error line="275" column="1" source="standard:max-line-length" />
+        <error line="347" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/ext/ContextTest.kt">
+        <error line="95" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/ext/DownloadItemKtTest.kt">
+        <error line="31" column="1" source="standard:max-line-length" />
+        <error line="31" column="22" source="standard:argument-list-wrapping" />
+        <error line="31" column="51" source="standard:argument-list-wrapping" />
+        <error line="31" column="122" source="standard:argument-list-wrapping" />
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="32" column="22" source="standard:argument-list-wrapping" />
+        <error line="32" column="51" source="standard:argument-list-wrapping" />
+        <error line="32" column="122" source="standard:argument-list-wrapping" />
+        <error line="33" column="1" source="standard:max-line-length" />
+        <error line="33" column="22" source="standard:argument-list-wrapping" />
+        <error line="33" column="56" source="standard:argument-list-wrapping" />
+        <error line="33" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/ext/TopSiteTest.kt">
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="72" column="1" source="standard:max-line-length" />
+        <error line="94" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/ext/UriTest.kt">
+        <error line="18" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/extension/WebExtensionPromptFeatureTest.kt">
+        <error line="91" column="1" source="standard:max-line-length" />
+        <error line="146" column="1" source="standard:max-line-length" />
+        <error line="163" column="1" source="standard:max-line-length" />
+        <error line="197" column="1" source="standard:max-line-length" />
+        <error line="242" column="1" source="standard:max-line-length" />
+        <error line="273" column="1" source="standard:max-line-length" />
+        <error line="312" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt">
+        <error line="1064" column="1" source="standard:max-line-length" />
+        <error line="1075" column="1" source="standard:max-line-length" />
+        <error line="1086" column="1" source="standard:max-line-length" />
+        <error line="1097" column="1" source="standard:max-line-length" />
+        <error line="1108" column="1" source="standard:max-line-length" />
+        <error line="1168" column="1" source="standard:max-line-length" />
+        <error line="1178" column="1" source="standard:max-line-length" />
+        <error line="1190" column="1" source="standard:max-line-length" />
+        <error line="1202" column="1" source="standard:max-line-length" />
+        <error line="1215" column="1" source="standard:max-line-length" />
+        <error line="1267" column="1" source="standard:max-line-length" />
+        <error line="1285" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/HomeFragmentTest.kt">
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="87" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/HomeMenuViewTest.kt">
+        <error line="115" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/PocketUpdatesMiddlewareTest.kt">
+        <error line="88" column="1" source="standard:max-line-length" />
+        <error line="188" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/RecentTabsListFeatureTest.kt">
+        <error line="59" column="1" source="standard:max-line-length" />
+        <error line="75" column="1" source="standard:max-line-length" />
+        <error line="123" column="1" source="standard:max-line-length" />
+        <error line="153" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/blocklist/BlocklistHandlerTest.kt">
+        <error line="159" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/blocklist/BlocklistMiddlewareTest.kt">
+        <error line="88" column="1" source="standard:max-line-length" />
+        <error line="91" column="1" source="standard:max-line-length" />
+        <error line="91" column="66" source="standard:argument-list-wrapping" />
+        <error line="91" column="122" source="standard:argument-list-wrapping" />
+        <error line="142" column="1" source="standard:max-line-length" />
+        <error line="361" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/intent/HomeDeepLinkIntentProcessorTest.kt">
+        <error line="239" column="1" source="standard:max-line-length" />
+        <error line="239" column="20" source="standard:argument-list-wrapping" />
+        <error line="239" column="45" source="standard:argument-list-wrapping" />
+        <error line="239" column="111" source="standard:argument-list-wrapping" />
+        <error line="239" column="126" source="standard:argument-list-wrapping" />
+        <error line="239" column="129" source="standard:argument-list-wrapping" />
+        <error line="239" column="130" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/intent/OpenSpecificTabIntentProcessorTest.kt">
+        <error line="72" column="1" source="standard:max-line-length" />
+        <error line="72" column="20" source="standard:property-wrapping" />
+        <error line="72" column="34" source="standard:argument-list-wrapping" />
+        <error line="72" column="121" source="standard:argument-list-wrapping" />
+        <error line="85" column="1" source="standard:max-line-length" />
+        <error line="90" column="1" source="standard:max-line-length" />
+        <error line="90" column="20" source="standard:property-wrapping" />
+        <error line="90" column="34" source="standard:argument-list-wrapping" />
+        <error line="90" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt">
+        <error line="73" column="1" source="standard:max-line-length" />
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="77" column="37" source="standard:property-wrapping" />
+        <error line="77" column="79" source="standard:argument-list-wrapping" />
+        <error line="77" column="112" source="standard:argument-list-wrapping" />
+        <error line="77" column="134" source="standard:argument-list-wrapping" />
+        <error line="82" column="1" source="standard:max-line-length" />
+        <error line="82" column="34" source="standard:property-wrapping" />
+        <error line="82" column="76" source="standard:argument-list-wrapping" />
+        <error line="82" column="106" source="standard:argument-list-wrapping" />
+        <error line="82" column="133" source="standard:argument-list-wrapping" />
+        <error line="119" column="1" source="standard:max-line-length" />
+        <error line="123" column="1" source="standard:max-line-length" />
+        <error line="123" column="37" source="standard:property-wrapping" />
+        <error line="123" column="79" source="standard:argument-list-wrapping" />
+        <error line="123" column="112" source="standard:argument-list-wrapping" />
+        <error line="123" column="134" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/privatebrowsing/DefaultPrivateBrowsingControllerTest.kt">
+        <error line="62" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/recentbookmarks/DefaultRecentBookmarksControllerTest.kt">
+        <error line="89" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeatureTest.kt">
+        <error line="131" column="1" source="standard:max-line-length" />
+        <error line="144" column="1" source="standard:max-line-length" />
+        <error line="144" column="19" source="standard:wrapping" />
+        <error line="144" column="43" source="standard:argument-list-wrapping" />
+        <error line="144" column="69" source="standard:argument-list-wrapping" />
+        <error line="144" column="86" source="standard:argument-list-wrapping" />
+        <error line="144" column="114" source="standard:argument-list-wrapping" />
+        <error line="144" column="129" source="standard:argument-list-wrapping" />
+        <error line="144" column="130" source="standard:argument-list-wrapping" />
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="187" column="1" source="standard:max-line-length" />
+        <error line="221" column="1" source="standard:max-line-length" />
+        <error line="249" column="1" source="standard:max-line-length" />
+        <error line="276" column="1" source="standard:max-line-length" />
+        <error line="412" column="1" source="standard:max-line-length" />
+        <error line="462" column="1" source="standard:max-line-length" />
+        <error line="487" column="1" source="standard:max-line-length" />
+        <error line="515" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/recentvisits/HistoryMetadataMiddlewareTest.kt">
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="105" column="1" source="standard:max-line-length" />
+        <error line="120" column="1" source="standard:max-line-length" />
+        <error line="135" column="1" source="standard:max-line-length" />
+        <error line="135" column="24" source="standard:argument-list-wrapping" />
+        <error line="135" column="63" source="standard:argument-list-wrapping" />
+        <error line="135" column="71" source="standard:argument-list-wrapping" />
+        <error line="135" column="118" source="standard:argument-list-wrapping" />
+        <error line="135" column="134" source="standard:argument-list-wrapping" />
+        <error line="135" column="135" source="standard:argument-list-wrapping" />
+        <error line="145" column="1" source="standard:max-line-length" />
+        <error line="159" column="1" source="standard:max-line-length" />
+        <error line="159" column="24" source="standard:argument-list-wrapping" />
+        <error line="159" column="63" source="standard:argument-list-wrapping" />
+        <error line="159" column="71" source="standard:argument-list-wrapping" />
+        <error line="159" column="78" source="standard:argument-list-wrapping" />
+        <error line="159" column="90" source="standard:argument-list-wrapping" />
+        <error line="159" column="107" source="standard:argument-list-wrapping" />
+        <error line="159" column="127" source="standard:argument-list-wrapping" />
+        <error line="159" column="130" source="standard:argument-list-wrapping" />
+        <error line="159" column="142" source="standard:argument-list-wrapping" />
+        <error line="159" column="159" source="standard:argument-list-wrapping" />
+        <error line="159" column="166" source="standard:argument-list-wrapping" />
+        <error line="159" column="167" source="standard:argument-list-wrapping" />
+        <error line="159" column="170" source="standard:argument-list-wrapping" />
+        <error line="159" column="186" source="standard:argument-list-wrapping" />
+        <error line="159" column="187" source="standard:argument-list-wrapping" />
+        <error line="169" column="1" source="standard:max-line-length" />
+        <error line="195" column="1" source="standard:max-line-length" />
+        <error line="195" column="24" source="standard:argument-list-wrapping" />
+        <error line="195" column="63" source="standard:argument-list-wrapping" />
+        <error line="195" column="77" source="standard:argument-list-wrapping" />
+        <error line="195" column="84" source="standard:argument-list-wrapping" />
+        <error line="195" column="96" source="standard:argument-list-wrapping" />
+        <error line="195" column="124" source="standard:argument-list-wrapping" />
+        <error line="195" column="162" source="standard:argument-list-wrapping" />
+        <error line="195" column="163" source="standard:argument-list-wrapping" />
+        <error line="195" column="166" source="standard:argument-list-wrapping" />
+        <error line="195" column="167" source="standard:argument-list-wrapping" />
+        <error line="195" column="168" source="standard:argument-list-wrapping" />
+        <error line="196" column="1" source="standard:max-line-length" />
+        <error line="196" column="24" source="standard:argument-list-wrapping" />
+        <error line="196" column="63" source="standard:argument-list-wrapping" />
+        <error line="196" column="71" source="standard:argument-list-wrapping" />
+        <error line="196" column="78" source="standard:argument-list-wrapping" />
+        <error line="196" column="90" source="standard:argument-list-wrapping" />
+        <error line="196" column="94" source="standard:argument-list-wrapping" />
+        <error line="196" column="134" source="standard:argument-list-wrapping" />
+        <error line="196" column="135" source="standard:argument-list-wrapping" />
+        <error line="196" column="138" source="standard:argument-list-wrapping" />
+        <error line="196" column="154" source="standard:argument-list-wrapping" />
+        <error line="196" column="155" source="standard:argument-list-wrapping" />
+        <error line="204" column="1" source="standard:max-line-length" />
+        <error line="204" column="24" source="standard:argument-list-wrapping" />
+        <error line="204" column="63" source="standard:argument-list-wrapping" />
+        <error line="204" column="77" source="standard:argument-list-wrapping" />
+        <error line="204" column="84" source="standard:argument-list-wrapping" />
+        <error line="204" column="96" source="standard:argument-list-wrapping" />
+        <error line="204" column="124" source="standard:argument-list-wrapping" />
+        <error line="204" column="162" source="standard:argument-list-wrapping" />
+        <error line="204" column="165" source="standard:argument-list-wrapping" />
+        <error line="204" column="177" source="standard:argument-list-wrapping" />
+        <error line="204" column="188" source="standard:argument-list-wrapping" />
+        <error line="204" column="209" source="standard:argument-list-wrapping" />
+        <error line="204" column="210" source="standard:argument-list-wrapping" />
+        <error line="204" column="213" source="standard:argument-list-wrapping" />
+        <error line="204" column="214" source="standard:argument-list-wrapping" />
+        <error line="204" column="215" source="standard:argument-list-wrapping" />
+        <error line="214" column="1" source="standard:max-line-length" />
+        <error line="214" column="24" source="standard:argument-list-wrapping" />
+        <error line="214" column="63" source="standard:argument-list-wrapping" />
+        <error line="214" column="71" source="standard:argument-list-wrapping" />
+        <error line="214" column="78" source="standard:argument-list-wrapping" />
+        <error line="214" column="90" source="standard:argument-list-wrapping" />
+        <error line="214" column="101" source="standard:argument-list-wrapping" />
+        <error line="214" column="122" source="standard:argument-list-wrapping" />
+        <error line="214" column="123" source="standard:argument-list-wrapping" />
+        <error line="214" column="126" source="standard:argument-list-wrapping" />
+        <error line="214" column="142" source="standard:argument-list-wrapping" />
+        <error line="214" column="143" source="standard:argument-list-wrapping" />
+        <error line="226" column="1" source="standard:max-line-length" />
+        <error line="226" column="24" source="standard:argument-list-wrapping" />
+        <error line="226" column="63" source="standard:argument-list-wrapping" />
+        <error line="226" column="71" source="standard:argument-list-wrapping" />
+        <error line="226" column="78" source="standard:argument-list-wrapping" />
+        <error line="226" column="90" source="standard:argument-list-wrapping" />
+        <error line="226" column="101" source="standard:argument-list-wrapping" />
+        <error line="226" column="122" source="standard:argument-list-wrapping" />
+        <error line="226" column="125" source="standard:argument-list-wrapping" />
+        <error line="226" column="137" source="standard:argument-list-wrapping" />
+        <error line="226" column="158" source="standard:argument-list-wrapping" />
+        <error line="226" column="189" source="standard:argument-list-wrapping" />
+        <error line="226" column="190" source="standard:argument-list-wrapping" />
+        <error line="226" column="193" source="standard:argument-list-wrapping" />
+        <error line="226" column="209" source="standard:argument-list-wrapping" />
+        <error line="226" column="210" source="standard:argument-list-wrapping" />
+        <error line="239" column="1" source="standard:max-line-length" />
+        <error line="265" column="1" source="standard:max-line-length" />
+        <error line="265" column="24" source="standard:argument-list-wrapping" />
+        <error line="265" column="63" source="standard:argument-list-wrapping" />
+        <error line="265" column="77" source="standard:argument-list-wrapping" />
+        <error line="265" column="84" source="standard:argument-list-wrapping" />
+        <error line="265" column="96" source="standard:argument-list-wrapping" />
+        <error line="265" column="124" source="standard:argument-list-wrapping" />
+        <error line="265" column="162" source="standard:argument-list-wrapping" />
+        <error line="265" column="163" source="standard:argument-list-wrapping" />
+        <error line="265" column="166" source="standard:argument-list-wrapping" />
+        <error line="265" column="167" source="standard:argument-list-wrapping" />
+        <error line="265" column="168" source="standard:argument-list-wrapping" />
+        <error line="271" column="1" source="standard:max-line-length" />
+        <error line="271" column="24" source="standard:argument-list-wrapping" />
+        <error line="271" column="74" source="standard:argument-list-wrapping" />
+        <error line="271" column="82" source="standard:argument-list-wrapping" />
+        <error line="271" column="101" source="standard:argument-list-wrapping" />
+        <error line="271" column="147" source="standard:argument-list-wrapping" />
+        <error line="271" column="153" source="standard:argument-list-wrapping" />
+        <error line="271" column="157" source="standard:argument-list-wrapping" />
+        <error line="271" column="158" source="standard:argument-list-wrapping" />
+        <error line="271" column="159" source="standard:argument-list-wrapping" />
+        <error line="277" column="1" source="standard:max-line-length" />
+        <error line="277" column="24" source="standard:argument-list-wrapping" />
+        <error line="277" column="63" source="standard:argument-list-wrapping" />
+        <error line="277" column="71" source="standard:argument-list-wrapping" />
+        <error line="277" column="78" source="standard:argument-list-wrapping" />
+        <error line="277" column="90" source="standard:argument-list-wrapping" />
+        <error line="277" column="94" source="standard:argument-list-wrapping" />
+        <error line="277" column="138" source="standard:argument-list-wrapping" />
+        <error line="277" column="139" source="standard:argument-list-wrapping" />
+        <error line="277" column="142" source="standard:argument-list-wrapping" />
+        <error line="277" column="158" source="standard:argument-list-wrapping" />
+        <error line="277" column="159" source="standard:argument-list-wrapping" />
+        <error line="279" column="1" source="standard:max-line-length" />
+        <error line="279" column="24" source="standard:argument-list-wrapping" />
+        <error line="279" column="63" source="standard:argument-list-wrapping" />
+        <error line="279" column="71" source="standard:argument-list-wrapping" />
+        <error line="279" column="78" source="standard:argument-list-wrapping" />
+        <error line="279" column="90" source="standard:argument-list-wrapping" />
+        <error line="279" column="101" source="standard:argument-list-wrapping" />
+        <error line="279" column="122" source="standard:argument-list-wrapping" />
+        <error line="279" column="123" source="standard:argument-list-wrapping" />
+        <error line="279" column="126" source="standard:argument-list-wrapping" />
+        <error line="279" column="142" source="standard:argument-list-wrapping" />
+        <error line="279" column="143" source="standard:argument-list-wrapping" />
+        <error line="280" column="1" source="standard:max-line-length" />
+        <error line="280" column="24" source="standard:argument-list-wrapping" />
+        <error line="280" column="63" source="standard:argument-list-wrapping" />
+        <error line="280" column="77" source="standard:argument-list-wrapping" />
+        <error line="280" column="84" source="standard:argument-list-wrapping" />
+        <error line="280" column="96" source="standard:argument-list-wrapping" />
+        <error line="280" column="124" source="standard:argument-list-wrapping" />
+        <error line="280" column="162" source="standard:argument-list-wrapping" />
+        <error line="280" column="165" source="standard:argument-list-wrapping" />
+        <error line="280" column="177" source="standard:argument-list-wrapping" />
+        <error line="280" column="188" source="standard:argument-list-wrapping" />
+        <error line="280" column="209" source="standard:argument-list-wrapping" />
+        <error line="280" column="210" source="standard:argument-list-wrapping" />
+        <error line="280" column="213" source="standard:argument-list-wrapping" />
+        <error line="280" column="214" source="standard:argument-list-wrapping" />
+        <error line="280" column="215" source="standard:argument-list-wrapping" />
+        <error line="327" column="1" source="standard:max-line-length" />
+        <error line="327" column="24" source="standard:argument-list-wrapping" />
+        <error line="327" column="63" source="standard:argument-list-wrapping" />
+        <error line="327" column="77" source="standard:argument-list-wrapping" />
+        <error line="327" column="84" source="standard:argument-list-wrapping" />
+        <error line="327" column="96" source="standard:argument-list-wrapping" />
+        <error line="327" column="124" source="standard:argument-list-wrapping" />
+        <error line="327" column="162" source="standard:argument-list-wrapping" />
+        <error line="327" column="163" source="standard:argument-list-wrapping" />
+        <error line="327" column="166" source="standard:argument-list-wrapping" />
+        <error line="327" column="167" source="standard:argument-list-wrapping" />
+        <error line="327" column="168" source="standard:argument-list-wrapping" />
+        <error line="328" column="1" source="standard:max-line-length" />
+        <error line="328" column="24" source="standard:argument-list-wrapping" />
+        <error line="328" column="63" source="standard:argument-list-wrapping" />
+        <error line="328" column="71" source="standard:argument-list-wrapping" />
+        <error line="328" column="78" source="standard:argument-list-wrapping" />
+        <error line="328" column="90" source="standard:argument-list-wrapping" />
+        <error line="328" column="94" source="standard:argument-list-wrapping" />
+        <error line="328" column="134" source="standard:argument-list-wrapping" />
+        <error line="328" column="135" source="standard:argument-list-wrapping" />
+        <error line="328" column="138" source="standard:argument-list-wrapping" />
+        <error line="328" column="154" source="standard:argument-list-wrapping" />
+        <error line="328" column="155" source="standard:argument-list-wrapping" />
+        <error line="336" column="1" source="standard:max-line-length" />
+        <error line="336" column="24" source="standard:argument-list-wrapping" />
+        <error line="336" column="63" source="standard:argument-list-wrapping" />
+        <error line="336" column="71" source="standard:argument-list-wrapping" />
+        <error line="336" column="78" source="standard:argument-list-wrapping" />
+        <error line="336" column="90" source="standard:argument-list-wrapping" />
+        <error line="336" column="94" source="standard:argument-list-wrapping" />
+        <error line="336" column="134" source="standard:argument-list-wrapping" />
+        <error line="336" column="137" source="standard:argument-list-wrapping" />
+        <error line="336" column="149" source="standard:argument-list-wrapping" />
+        <error line="336" column="160" source="standard:argument-list-wrapping" />
+        <error line="336" column="181" source="standard:argument-list-wrapping" />
+        <error line="336" column="182" source="standard:argument-list-wrapping" />
+        <error line="336" column="185" source="standard:argument-list-wrapping" />
+        <error line="336" column="186" source="standard:argument-list-wrapping" />
+        <error line="336" column="187" source="standard:argument-list-wrapping" />
+        <error line="348" column="1" source="standard:max-line-length" />
+        <error line="348" column="24" source="standard:argument-list-wrapping" />
+        <error line="348" column="63" source="standard:argument-list-wrapping" />
+        <error line="348" column="77" source="standard:argument-list-wrapping" />
+        <error line="348" column="84" source="standard:argument-list-wrapping" />
+        <error line="348" column="96" source="standard:argument-list-wrapping" />
+        <error line="348" column="124" source="standard:argument-list-wrapping" />
+        <error line="348" column="162" source="standard:argument-list-wrapping" />
+        <error line="348" column="165" source="standard:argument-list-wrapping" />
+        <error line="348" column="177" source="standard:argument-list-wrapping" />
+        <error line="348" column="188" source="standard:argument-list-wrapping" />
+        <error line="348" column="209" source="standard:argument-list-wrapping" />
+        <error line="348" column="210" source="standard:argument-list-wrapping" />
+        <error line="348" column="213" source="standard:argument-list-wrapping" />
+        <error line="348" column="214" source="standard:argument-list-wrapping" />
+        <error line="348" column="215" source="standard:argument-list-wrapping" />
+        <error line="358" column="1" source="standard:max-line-length" />
+        <error line="384" column="1" source="standard:max-line-length" />
+        <error line="384" column="24" source="standard:argument-list-wrapping" />
+        <error line="384" column="63" source="standard:argument-list-wrapping" />
+        <error line="384" column="77" source="standard:argument-list-wrapping" />
+        <error line="384" column="84" source="standard:argument-list-wrapping" />
+        <error line="384" column="96" source="standard:argument-list-wrapping" />
+        <error line="384" column="124" source="standard:argument-list-wrapping" />
+        <error line="384" column="162" source="standard:argument-list-wrapping" />
+        <error line="384" column="163" source="standard:argument-list-wrapping" />
+        <error line="384" column="166" source="standard:argument-list-wrapping" />
+        <error line="384" column="167" source="standard:argument-list-wrapping" />
+        <error line="384" column="168" source="standard:argument-list-wrapping" />
+        <error line="385" column="1" source="standard:max-line-length" />
+        <error line="385" column="24" source="standard:argument-list-wrapping" />
+        <error line="385" column="63" source="standard:argument-list-wrapping" />
+        <error line="385" column="71" source="standard:argument-list-wrapping" />
+        <error line="385" column="78" source="standard:argument-list-wrapping" />
+        <error line="385" column="90" source="standard:argument-list-wrapping" />
+        <error line="385" column="94" source="standard:argument-list-wrapping" />
+        <error line="385" column="134" source="standard:argument-list-wrapping" />
+        <error line="385" column="135" source="standard:argument-list-wrapping" />
+        <error line="385" column="138" source="standard:argument-list-wrapping" />
+        <error line="385" column="154" source="standard:argument-list-wrapping" />
+        <error line="385" column="155" source="standard:argument-list-wrapping" />
+        <error line="393" column="1" source="standard:max-line-length" />
+        <error line="393" column="24" source="standard:argument-list-wrapping" />
+        <error line="393" column="63" source="standard:argument-list-wrapping" />
+        <error line="393" column="71" source="standard:argument-list-wrapping" />
+        <error line="393" column="78" source="standard:argument-list-wrapping" />
+        <error line="393" column="90" source="standard:argument-list-wrapping" />
+        <error line="393" column="94" source="standard:argument-list-wrapping" />
+        <error line="393" column="134" source="standard:argument-list-wrapping" />
+        <error line="393" column="137" source="standard:argument-list-wrapping" />
+        <error line="393" column="149" source="standard:argument-list-wrapping" />
+        <error line="393" column="160" source="standard:argument-list-wrapping" />
+        <error line="393" column="181" source="standard:argument-list-wrapping" />
+        <error line="393" column="182" source="standard:argument-list-wrapping" />
+        <error line="393" column="185" source="standard:argument-list-wrapping" />
+        <error line="393" column="186" source="standard:argument-list-wrapping" />
+        <error line="393" column="187" source="standard:argument-list-wrapping" />
+        <error line="405" column="1" source="standard:max-line-length" />
+        <error line="405" column="24" source="standard:argument-list-wrapping" />
+        <error line="405" column="63" source="standard:argument-list-wrapping" />
+        <error line="405" column="77" source="standard:argument-list-wrapping" />
+        <error line="405" column="84" source="standard:argument-list-wrapping" />
+        <error line="405" column="96" source="standard:argument-list-wrapping" />
+        <error line="405" column="124" source="standard:argument-list-wrapping" />
+        <error line="405" column="162" source="standard:argument-list-wrapping" />
+        <error line="405" column="165" source="standard:argument-list-wrapping" />
+        <error line="405" column="177" source="standard:argument-list-wrapping" />
+        <error line="405" column="188" source="standard:argument-list-wrapping" />
+        <error line="405" column="209" source="standard:argument-list-wrapping" />
+        <error line="405" column="210" source="standard:argument-list-wrapping" />
+        <error line="405" column="213" source="standard:argument-list-wrapping" />
+        <error line="405" column="214" source="standard:argument-list-wrapping" />
+        <error line="405" column="215" source="standard:argument-list-wrapping" />
+        <error line="429" column="1" source="standard:max-line-length" />
+        <error line="446" column="1" source="standard:max-line-length" />
+        <error line="597" column="1" source="standard:max-line-length" />
+        <error line="616" column="1" source="standard:max-line-length" />
+        <error line="632" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/recentvisits/HistoryMetadataServiceTest.kt">
+        <error line="41" column="1" source="standard:max-line-length" />
+        <error line="47" column="1" source="standard:max-line-length" />
+        <error line="47" column="26" source="standard:property-wrapping" />
+        <error line="47" column="46" source="standard:argument-list-wrapping" />
+        <error line="47" column="69" source="standard:argument-list-wrapping" />
+        <error line="47" column="91" source="standard:argument-list-wrapping" />
+        <error line="47" column="123" source="standard:argument-list-wrapping" />
+        <error line="48" column="1" source="standard:max-line-length" />
+        <error line="48" column="86" source="standard:argument-list-wrapping" />
+        <error line="48" column="121" source="standard:argument-list-wrapping" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="64" column="1" source="standard:max-line-length" />
+        <error line="71" column="1" source="standard:max-line-length" />
+        <error line="71" column="86" source="standard:argument-list-wrapping" />
+        <error line="71" column="121" source="standard:argument-list-wrapping" />
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="107" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/recentvisits/RecentVisitsFeatureTest.kt">
+        <error line="118" column="1" source="standard:max-line-length" />
+        <error line="178" column="1" source="standard:max-line-length" />
+        <error line="237" column="1" source="standard:max-line-length" />
+        <error line="296" column="1" source="standard:max-line-length" />
+        <error line="317" column="1" source="standard:max-line-length" />
+        <error line="337" column="1" source="standard:max-line-length" />
+        <error line="349" column="1" source="standard:max-line-length" />
+        <error line="362" column="1" source="standard:max-line-length" />
+        <error line="409" column="1" source="standard:max-line-length" />
+        <error line="433" column="1" source="standard:max-line-length" />
+        <error line="452" column="1" source="standard:max-line-length" />
+        <error line="468" column="1" source="standard:max-line-length" />
+        <error line="484" column="1" source="standard:max-line-length" />
+        <error line="501" column="1" source="standard:max-line-length" />
+        <error line="522" column="1" source="standard:max-line-length" />
+        <error line="544" column="1" source="standard:max-line-length" />
+        <error line="554" column="1" source="standard:max-line-length" />
+        <error line="567" column="1" source="standard:max-line-length" />
+        <error line="586" column="1" source="standard:max-line-length" />
+        <error line="633" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapterTest.kt">
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlViewTest.kt">
+        <error line="223" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolderTest.kt">
+        <error line="114" column="1" source="standard:max-line-length" />
+        <error line="141" column="1" source="standard:max-line-length" />
+        <error line="141" column="112" source="standard:argument-list-wrapping" />
+        <error line="141" column="121" source="standard:argument-list-wrapping" />
+        <error line="141" column="129" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/home/topsites/TopSitesPagerAdapterTest.kt">
+        <error line="67" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt">
+        <error line="420" column="1" source="standard:max-line-length" />
+        <error line="529" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/library/bookmarks/DesktopFoldersTest.kt">
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="49" column="22" source="standard:argument-list-wrapping" />
+        <error line="49" column="73" source="standard:argument-list-wrapping" />
+        <error line="49" column="91" source="standard:argument-list-wrapping" />
+        <error line="49" column="100" source="standard:argument-list-wrapping" />
+        <error line="49" column="118" source="standard:argument-list-wrapping" />
+        <error line="49" column="124" source="standard:argument-list-wrapping" />
+        <error line="49" column="125" source="standard:argument-list-wrapping" />
+        <error line="49" column="126" source="standard:argument-list-wrapping" />
+        <error line="50" column="1" source="standard:max-line-length" />
+        <error line="50" column="22" source="standard:argument-list-wrapping" />
+        <error line="50" column="73" source="standard:argument-list-wrapping" />
+        <error line="50" column="91" source="standard:argument-list-wrapping" />
+        <error line="50" column="100" source="standard:argument-list-wrapping" />
+        <error line="50" column="118" source="standard:argument-list-wrapping" />
+        <error line="50" column="126" source="standard:argument-list-wrapping" />
+        <error line="50" column="127" source="standard:argument-list-wrapping" />
+        <error line="50" column="128" source="standard:argument-list-wrapping" />
+        <error line="51" column="1" source="standard:max-line-length" />
+        <error line="51" column="22" source="standard:argument-list-wrapping" />
+        <error line="51" column="86" source="standard:argument-list-wrapping" />
+        <error line="51" column="104" source="standard:argument-list-wrapping" />
+        <error line="51" column="113" source="standard:argument-list-wrapping" />
+        <error line="51" column="131" source="standard:argument-list-wrapping" />
+        <error line="51" column="137" source="standard:argument-list-wrapping" />
+        <error line="51" column="138" source="standard:argument-list-wrapping" />
+        <error line="51" column="139" source="standard:argument-list-wrapping" />
+        <error line="52" column="1" source="standard:max-line-length" />
+        <error line="52" column="22" source="standard:argument-list-wrapping" />
+        <error line="52" column="89" source="standard:argument-list-wrapping" />
+        <error line="52" column="107" source="standard:argument-list-wrapping" />
+        <error line="52" column="116" source="standard:argument-list-wrapping" />
+        <error line="52" column="134" source="standard:argument-list-wrapping" />
+        <error line="52" column="143" source="standard:argument-list-wrapping" />
+        <error line="52" column="144" source="standard:argument-list-wrapping" />
+        <error line="52" column="145" source="standard:argument-list-wrapping" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="53" column="22" source="standard:argument-list-wrapping" />
+        <error line="53" column="89" source="standard:argument-list-wrapping" />
+        <error line="53" column="107" source="standard:argument-list-wrapping" />
+        <error line="53" column="116" source="standard:argument-list-wrapping" />
+        <error line="53" column="134" source="standard:argument-list-wrapping" />
+        <error line="53" column="143" source="standard:argument-list-wrapping" />
+        <error line="53" column="144" source="standard:argument-list-wrapping" />
+        <error line="53" column="145" source="standard:argument-list-wrapping" />
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="58" column="22" source="standard:argument-list-wrapping" />
+        <error line="58" column="86" source="standard:argument-list-wrapping" />
+        <error line="58" column="104" source="standard:argument-list-wrapping" />
+        <error line="58" column="113" source="standard:argument-list-wrapping" />
+        <error line="58" column="131" source="standard:argument-list-wrapping" />
+        <error line="58" column="137" source="standard:argument-list-wrapping" />
+        <error line="58" column="140" source="standard:argument-list-wrapping" />
+        <error line="58" column="145" source="standard:argument-list-wrapping" />
+        <error line="58" column="146" source="standard:argument-list-wrapping" />
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="60" column="22" source="standard:argument-list-wrapping" />
+        <error line="60" column="86" source="standard:argument-list-wrapping" />
+        <error line="60" column="104" source="standard:argument-list-wrapping" />
+        <error line="60" column="113" source="standard:argument-list-wrapping" />
+        <error line="60" column="131" source="standard:argument-list-wrapping" />
+        <error line="60" column="137" source="standard:argument-list-wrapping" />
+        <error line="60" column="140" source="standard:argument-list-wrapping" />
+        <error line="60" column="145" source="standard:argument-list-wrapping" />
+        <error line="60" column="146" source="standard:argument-list-wrapping" />
+        <error line="61" column="1" source="standard:max-line-length" />
+        <error line="61" column="22" source="standard:argument-list-wrapping" />
+        <error line="61" column="89" source="standard:argument-list-wrapping" />
+        <error line="61" column="107" source="standard:argument-list-wrapping" />
+        <error line="61" column="116" source="standard:argument-list-wrapping" />
+        <error line="61" column="134" source="standard:argument-list-wrapping" />
+        <error line="61" column="143" source="standard:argument-list-wrapping" />
+        <error line="61" column="146" source="standard:argument-list-wrapping" />
+        <error line="61" column="151" source="standard:argument-list-wrapping" />
+        <error line="61" column="152" source="standard:argument-list-wrapping" />
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="62" column="22" source="standard:argument-list-wrapping" />
+        <error line="62" column="89" source="standard:argument-list-wrapping" />
+        <error line="62" column="107" source="standard:argument-list-wrapping" />
+        <error line="62" column="116" source="standard:argument-list-wrapping" />
+        <error line="62" column="134" source="standard:argument-list-wrapping" />
+        <error line="62" column="143" source="standard:argument-list-wrapping" />
+        <error line="62" column="146" source="standard:argument-list-wrapping" />
+        <error line="62" column="151" source="standard:argument-list-wrapping" />
+        <error line="62" column="152" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/library/bookmarks/UtilsKtTest.kt">
+        <error line="96" column="1" source="standard:max-line-length" />
+        <error line="96" column="25" source="standard:parameter-list-wrapping" />
+        <error line="96" column="39" source="standard:parameter-list-wrapping" />
+        <error line="96" column="60" source="standard:parameter-list-wrapping" />
+        <error line="96" column="91" source="standard:parameter-list-wrapping" />
+        <error line="96" column="122" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/library/history/HistoryFragmentStoreTest.kt">
+        <error line="16" column="1" source="standard:max-line-length" />
+        <error line="16" column="47" source="standard:argument-list-wrapping" />
+        <error line="16" column="50" source="standard:argument-list-wrapping" />
+        <error line="16" column="59" source="standard:argument-list-wrapping" />
+        <error line="16" column="66" source="standard:argument-list-wrapping" />
+        <error line="16" column="78" source="standard:argument-list-wrapping" />
+        <error line="16" column="121" source="standard:argument-list-wrapping" />
+        <error line="16" column="122" source="standard:argument-list-wrapping" />
+        <error line="16" column="123" source="standard:argument-list-wrapping" />
+        <error line="17" column="1" source="standard:max-line-length" />
+        <error line="17" column="50" source="standard:argument-list-wrapping" />
+        <error line="17" column="53" source="standard:argument-list-wrapping" />
+        <error line="17" column="62" source="standard:argument-list-wrapping" />
+        <error line="17" column="69" source="standard:argument-list-wrapping" />
+        <error line="17" column="81" source="standard:argument-list-wrapping" />
+        <error line="17" column="124" source="standard:argument-list-wrapping" />
+        <error line="17" column="125" source="standard:argument-list-wrapping" />
+        <error line="17" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/library/history/state/HistoryNavigationMiddlewareTest.kt">
+        <error line="189" column="1" source="standard:max-line-length" />
+        <error line="189" column="44" source="standard:argument-list-wrapping" />
+        <error line="189" column="66" source="standard:argument-list-wrapping" />
+        <error line="189" column="117" source="standard:argument-list-wrapping" />
+        <error line="189" column="121" source="standard:argument-list-wrapping" />
+        <error line="189" column="122" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/library/history/state/HistoryStorageMiddlewareTest.kt">
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="85" column="1" source="standard:max-line-length" />
+        <error line="142" column="1" source="standard:max-line-length" />
+        <error line="172" column="1" source="standard:max-line-length" />
+        <error line="201" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/library/history/state/HistorySyncMiddlewareTest.kt">
+        <error line="29" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/library/historymetadata/view/HistoryMetadataGroupItemViewHolderTest.kt">
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="53" column="92" source="standard:argument-list-wrapping" />
+        <error line="53" column="98" source="standard:argument-list-wrapping" />
+        <error line="53" column="123" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/messaging/state/MessagingMiddlewareTest.kt">
+        <error line="262" column="1" source="standard:max-line-length" />
+        <error line="293" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/messaging/state/MessagingReducerTest.kt">
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="49" column="31" source="standard:parameter-list-wrapping" />
+        <error line="49" column="43" source="standard:parameter-list-wrapping" />
+        <error line="49" column="72" source="standard:parameter-list-wrapping" />
+        <error line="49" column="132" source="standard:parameter-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/nimbus/NimbusBranchesStoreTest.kt">
+        <error line="28" column="1" source="standard:max-line-length" />
+        <error line="43" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/nimbus/NimbusSystemTest.kt">
+        <error line="84" column="1" source="standard:max-line-length" />
+        <error line="95" column="1" source="standard:max-line-length" />
+        <error line="105" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/onboarding/view/OnboardingMapperTest.kt">
+        <error line="14" column="1" source="standard:max-line-length" />
+        <error line="82" column="1" source="standard:max-line-length" />
+        <error line="116" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/perf/ProfilerMarkerFactProcessorTest.kt">
+        <error line="40" column="1" source="standard:max-line-length" />
+        <error line="50" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/perf/StartupPathProviderTest.kt">
+        <error line="56" column="1" source="standard:max-line-length" />
+        <error line="61" column="1" source="standard:max-line-length" />
+        <error line="101" column="1" source="standard:max-line-length" />
+        <error line="120" column="1" source="standard:max-line-length" />
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="142" column="1" source="standard:max-line-length" />
+        <error line="152" column="1" source="standard:max-line-length" />
+        <error line="162" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/perf/StartupStateProviderTest.kt">
+        <error line="110" column="1" source="standard:max-line-length" />
+        <error line="126" column="1" source="standard:max-line-length" />
+        <error line="144" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/perf/StartupTypeTelemetryTest.kt">
+        <error line="73" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/perf/StrictModeManagerTest.kt">
+        <error line="74" column="1" source="standard:max-line-length" />
+        <error line="113" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/perf/ThreadPenaltyDeathWithIgnoresListenerTest.kt">
+        <error line="83" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt">
+        <error line="448" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/search/SearchDialogFragmentTest.kt">
+        <error line="59" column="1" source="standard:max-line-length" />
+        <error line="71" column="1" source="standard:max-line-length" />
+        <error line="85" column="1" source="standard:max-line-length" />
+        <error line="98" column="1" source="standard:max-line-length" />
+        <error line="123" column="1" source="standard:max-line-length" />
+        <error line="149" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt">
+        <error line="232" column="1" source="standard:max-line-length" />
+        <error line="262" column="1" source="standard:max-line-length" />
+        <error line="281" column="1" source="standard:max-line-length" />
+        <error line="300" column="1" source="standard:max-line-length" />
+        <error line="319" column="1" source="standard:max-line-length" />
+        <error line="340" column="1" source="standard:max-line-length" />
+        <error line="364" column="1" source="standard:max-line-length" />
+        <error line="388" column="1" source="standard:max-line-length" />
+        <error line="412" column="1" source="standard:max-line-length" />
+        <error line="436" column="1" source="standard:max-line-length" />
+        <error line="457" column="1" source="standard:max-line-length" />
+        <error line="478" column="1" source="standard:max-line-length" />
+        <error line="499" column="1" source="standard:max-line-length" />
+        <error line="520" column="1" source="standard:max-line-length" />
+        <error line="541" column="1" source="standard:max-line-length" />
+        <error line="563" column="1" source="standard:max-line-length" />
+        <error line="579" column="1" source="standard:max-line-length" />
+        <error line="595" column="1" source="standard:max-line-length" />
+        <error line="611" column="1" source="standard:max-line-length" />
+        <error line="654" column="1" source="standard:max-line-length" />
+        <error line="694" column="1" source="standard:max-line-length" />
+        <error line="766" column="1" source="standard:max-line-length" />
+        <error line="808" column="1" source="standard:max-line-length" />
+        <error line="847" column="1" source="standard:max-line-length" />
+        <error line="897" column="1" source="standard:max-line-length" />
+        <error line="1182" column="1" source="standard:max-line-length" />
+        <error line="1219" column="1" source="standard:max-line-length" />
+        <error line="1234" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/search/awesomebar/AwesomeBarViewTest.kt">
+        <error line="90" column="1" source="standard:max-line-length" />
+        <error line="111" column="1" source="standard:max-line-length" />
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="153" column="1" source="standard:max-line-length" />
+        <error line="174" column="1" source="standard:max-line-length" />
+        <error line="195" column="1" source="standard:max-line-length" />
+        <error line="216" column="1" source="standard:max-line-length" />
+        <error line="237" column="1" source="standard:max-line-length" />
+        <error line="257" column="1" source="standard:max-line-length" />
+        <error line="282" column="1" source="standard:max-line-length" />
+        <error line="310" column="1" source="standard:max-line-length" />
+        <error line="326" column="1" source="standard:max-line-length" />
+        <error line="326" column="59" source="standard:wrapping" />
+        <error line="330" column="1" source="standard:max-line-length" />
+        <error line="330" column="52" source="standard:wrapping" />
+        <error line="336" column="1" source="standard:max-line-length" />
+        <error line="352" column="1" source="standard:max-line-length" />
+        <error line="352" column="58" source="standard:wrapping" />
+        <error line="356" column="1" source="standard:max-line-length" />
+        <error line="356" column="52" source="standard:wrapping" />
+        <error line="362" column="1" source="standard:max-line-length" />
+        <error line="394" column="1" source="standard:max-line-length" />
+        <error line="426" column="1" source="standard:max-line-length" />
+        <error line="446" column="1" source="standard:max-line-length" />
+        <error line="446" column="59" source="standard:wrapping" />
+        <error line="450" column="1" source="standard:max-line-length" />
+        <error line="450" column="52" source="standard:wrapping" />
+        <error line="456" column="1" source="standard:max-line-length" />
+        <error line="476" column="1" source="standard:max-line-length" />
+        <error line="476" column="58" source="standard:wrapping" />
+        <error line="480" column="1" source="standard:max-line-length" />
+        <error line="480" column="52" source="standard:wrapping" />
+        <error line="486" column="1" source="standard:max-line-length" />
+        <error line="507" column="1" source="standard:max-line-length" />
+        <error line="507" column="59" source="standard:wrapping" />
+        <error line="516" column="1" source="standard:max-line-length" />
+        <error line="537" column="1" source="standard:max-line-length" />
+        <error line="537" column="58" source="standard:wrapping" />
+        <error line="546" column="1" source="standard:max-line-length" />
+        <error line="574" column="1" source="standard:max-line-length" />
+        <error line="602" column="1" source="standard:max-line-length" />
+        <error line="626" column="1" source="standard:max-line-length" />
+        <error line="626" column="52" source="standard:wrapping" />
+        <error line="632" column="1" source="standard:max-line-length" />
+        <error line="656" column="1" source="standard:max-line-length" />
+        <error line="656" column="52" source="standard:wrapping" />
+        <error line="662" column="1" source="standard:max-line-length" />
+        <error line="687" column="1" source="standard:max-line-length" />
+        <error line="712" column="1" source="standard:max-line-length" />
+        <error line="727" column="1" source="standard:max-line-length" />
+        <error line="742" column="1" source="standard:max-line-length" />
+        <error line="768" column="1" source="standard:max-line-length" />
+        <error line="791" column="1" source="standard:max-line-length" />
+        <error line="814" column="1" source="standard:max-line-length" />
+        <error line="836" column="1" source="standard:max-line-length" />
+        <error line="850" column="1" source="standard:max-line-length" />
+        <error line="873" column="1" source="standard:max-line-length" />
+        <error line="896" column="1" source="standard:max-line-length" />
+        <error line="919" column="1" source="standard:max-line-length" />
+        <error line="942" column="1" source="standard:max-line-length" />
+        <error line="965" column="1" source="standard:max-line-length" />
+        <error line="987" column="1" source="standard:max-line-length" />
+        <error line="1000" column="1" source="standard:max-line-length" />
+        <error line="1016" column="1" source="standard:max-line-length" />
+        <error line="1020" column="1" source="standard:max-line-length" />
+        <error line="1026" column="1" source="standard:max-line-length" />
+        <error line="1038" column="1" source="standard:max-line-length" />
+        <error line="1054" column="1" source="standard:max-line-length" />
+        <error line="1058" column="1" source="standard:max-line-length" />
+        <error line="1064" column="1" source="standard:max-line-length" />
+        <error line="1076" column="1" source="standard:max-line-length" />
+        <error line="1106" column="1" source="standard:max-line-length" />
+        <error line="1127" column="1" source="standard:max-line-length" />
+        <error line="1148" column="1" source="standard:max-line-length" />
+        <error line="1169" column="1" source="standard:max-line-length" />
+        <error line="1190" column="1" source="standard:max-line-length" />
+        <error line="1209" column="1" source="standard:max-line-length" />
+        <error line="1248" column="1" source="standard:max-line-length" />
+        <error line="1268" column="1" source="standard:max-line-length" />
+        <error line="1291" column="1" source="standard:max-line-length" />
+        <error line="1312" column="1" source="standard:max-line-length" />
+        <error line="1324" column="1" source="standard:max-line-length" />
+        <error line="1336" column="1" source="standard:max-line-length" />
+        <error line="1350" column="1" source="standard:max-line-length" />
+        <error line="1364" column="1" source="standard:max-line-length" />
+        <error line="1386" column="1" source="standard:max-line-length" />
+        <error line="1410" column="1" source="standard:max-line-length" />
+        <error line="1432" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarActionTest.kt">
+        <error line="165" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt">
+        <error line="160" column="1" source="standard:max-line-length" />
+        <error line="237" column="1" source="standard:max-line-length" />
+        <error line="237" column="88" source="standard:argument-list-wrapping" />
+        <error line="237" column="123" source="standard:argument-list-wrapping" />
+        <error line="259" column="1" source="standard:max-line-length" />
+        <error line="259" column="94" source="standard:argument-list-wrapping" />
+        <error line="259" column="126" source="standard:argument-list-wrapping" />
+        <error line="303" column="1" source="standard:max-line-length" />
+        <error line="303" column="88" source="standard:argument-list-wrapping" />
+        <error line="303" column="123" source="standard:argument-list-wrapping" />
+        <error line="347" column="1" source="standard:max-line-length" />
+        <error line="347" column="87" source="standard:argument-list-wrapping" />
+        <error line="347" column="122" source="standard:argument-list-wrapping" />
+        <error line="428" column="1" source="standard:max-line-length" />
+        <error line="437" column="1" source="standard:max-line-length" />
+        <error line="446" column="1" source="standard:max-line-length" />
+        <error line="458" column="1" source="standard:max-line-length" />
+        <error line="470" column="1" source="standard:max-line-length" />
+        <error line="501" column="1" source="standard:max-line-length" />
+        <error line="532" column="1" source="standard:max-line-length" />
+        <error line="594" column="1" source="standard:max-line-length" />
+        <error line="625" column="1" source="standard:max-line-length" />
+        <error line="655" column="1" source="standard:max-line-length" />
+        <error line="684" column="1" source="standard:max-line-length" />
+        <error line="711" column="1" source="standard:max-line-length" />
+        <error line="738" column="1" source="standard:max-line-length" />
+        <error line="760" column="1" source="standard:max-line-length" />
+        <error line="782" column="1" source="standard:max-line-length" />
+        <error line="816" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/session/PrivateNotificationServiceTest.kt">
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="58" column="52" source="standard:argument-list-wrapping" />
+        <error line="58" column="87" source="standard:argument-list-wrapping" />
+        <error line="58" column="124" source="standard:argument-list-wrapping" />
+        <error line="73" column="1" source="standard:max-line-length" />
+        <error line="73" column="52" source="standard:argument-list-wrapping" />
+        <error line="73" column="87" source="standard:argument-list-wrapping" />
+        <error line="73" column="124" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/CustomEtpCookiesOptionsDropDownListPreferenceTest.kt">
+        <error line="24" column="1" source="standard:max-line-length" />
+        <error line="44" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/DropDownListPreferenceTest.kt">
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="41" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/HomeSettingsFragmentTest.kt">
+        <error line="74" column="1" source="standard:max-line-length" />
+        <error line="85" column="1" source="standard:max-line-length" />
+        <error line="96" column="1" source="standard:max-line-length" />
+        <error line="105" column="1" source="standard:max-line-length" />
+        <error line="114" column="1" source="standard:max-line-length" />
+        <error line="125" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/PhoneFeatureTest.kt">
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="78" column="22" source="standard:argument-list-wrapping" />
+        <error line="78" column="77" source="standard:argument-list-wrapping" />
+        <error line="78" column="124" source="standard:argument-list-wrapping" />
+        <error line="79" column="1" source="standard:max-line-length" />
+        <error line="79" column="22" source="standard:argument-list-wrapping" />
+        <error line="79" column="79" source="standard:argument-list-wrapping" />
+        <error line="79" column="128" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/PreferenceBackedRadioButtonTest.kt">
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="95" column="1" source="standard:max-line-length" />
+        <error line="118" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt">
+        <error line="246" column="1" source="standard:max-line-length" />
+        <error line="263" column="1" source="standard:max-line-length" />
+        <error line="279" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/SupportUtilsTest.kt">
+        <error line="22" column="1" source="standard:max-line-length" />
+        <error line="22" column="45" source="standard:argument-list-wrapping" />
+        <error line="22" column="65" source="standard:argument-list-wrapping" />
+        <error line="22" column="112" source="standard:argument-list-wrapping" />
+        <error line="22" column="119" source="standard:argument-list-wrapping" />
+        <error line="22" column="125" source="standard:argument-list-wrapping" />
+        <error line="22" column="129" source="standard:argument-list-wrapping" />
+        <error line="22" column="130" source="standard:argument-list-wrapping" />
+        <error line="26" column="1" source="standard:max-line-length" />
+        <error line="26" column="45" source="standard:argument-list-wrapping" />
+        <error line="26" column="65" source="standard:argument-list-wrapping" />
+        <error line="26" column="109" source="standard:argument-list-wrapping" />
+        <error line="26" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt">
+        <error line="78" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/address/AddressEditorViewTest.kt">
+        <error line="124" column="1" source="standard:max-line-length" />
+        <error line="162" column="1" source="standard:max-line-length" />
+        <error line="178" column="1" source="standard:max-line-length" />
+        <error line="192" column="1" source="standard:max-line-length" />
+        <error line="206" column="1" source="standard:max-line-length" />
+        <error line="230" column="1" source="standard:max-line-length" />
+        <error line="258" column="1" source="standard:max-line-length" />
+        <error line="269" column="1" source="standard:max-line-length" />
+        <error line="269" column="22" source="standard:argument-list-wrapping" />
+        <error line="269" column="77" source="standard:argument-list-wrapping" />
+        <error line="269" column="124" source="standard:argument-list-wrapping" />
+        <error line="273" column="1" source="standard:max-line-length" />
+        <error line="286" column="1" source="standard:max-line-length" />
+        <error line="295" column="1" source="standard:max-line-length" />
+        <error line="295" column="22" source="standard:argument-list-wrapping" />
+        <error line="295" column="77" source="standard:argument-list-wrapping" />
+        <error line="295" column="124" source="standard:argument-list-wrapping" />
+        <error line="308" column="1" source="standard:max-line-length" />
+        <error line="308" column="22" source="standard:argument-list-wrapping" />
+        <error line="308" column="77" source="standard:argument-list-wrapping" />
+        <error line="308" column="124" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/address/controller/DefaultAddressEditorControllerTest.kt">
+        <error line="54" column="1" source="standard:max-line-length" />
+        <error line="79" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleViewHoldersTest.kt">
+        <error line="74" column="1" source="standard:max-line-length" />
+        <error line="84" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/autofill/AutofillFragmentStoreTest.kt">
+        <error line="40" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/autofill/AutofillSettingFragmentTest.kt">
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="85" column="1" source="standard:max-line-length" />
+        <error line="113" column="1" source="standard:max-line-length" />
+        <error line="144" column="1" source="standard:max-line-length" />
+        <error line="173" column="1" source="standard:max-line-length" />
+        <error line="187" column="1" source="standard:max-line-length" />
+        <error line="215" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt">
+        <error line="106" column="1" source="standard:max-line-length" />
+        <error line="214" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt">
+        <error line="34" column="1" source="standard:max-line-length" />
+        <error line="44" column="1" source="standard:max-line-length" />
+        <error line="54" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt">
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="62" column="20" source="standard:wrapping" />
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="68" column="1" source="standard:max-line-length" />
+        <error line="102" column="1" source="standard:max-line-length" />
+        <error line="102" column="86" source="standard:argument-list-wrapping" />
+        <error line="102" column="129" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt">
+        <error line="149" column="1" source="standard:max-line-length" />
+        <error line="359" column="1" source="standard:max-line-length" />
+        <error line="385" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt">
+        <error line="309" column="1" source="standard:max-line-length" />
+        <error line="309" column="26" source="standard:argument-list-wrapping" />
+        <error line="309" column="47" source="standard:argument-list-wrapping" />
+        <error line="309" column="125" source="standard:argument-list-wrapping" />
+        <error line="311" column="1" source="standard:max-line-length" />
+        <error line="311" column="26" source="standard:argument-list-wrapping" />
+        <error line="311" column="51" source="standard:argument-list-wrapping" />
+        <error line="311" column="126" source="standard:argument-list-wrapping" />
+        <error line="312" column="1" source="standard:max-line-length" />
+        <error line="312" column="26" source="standard:argument-list-wrapping" />
+        <error line="312" column="48" source="standard:argument-list-wrapping" />
+        <error line="312" column="123" source="standard:argument-list-wrapping" />
+        <error line="313" column="1" source="standard:max-line-length" />
+        <error line="313" column="26" source="standard:argument-list-wrapping" />
+        <error line="313" column="57" source="standard:argument-list-wrapping" />
+        <error line="313" column="102" source="standard:argument-list-wrapping" />
+        <error line="313" column="121" source="standard:argument-list-wrapping" />
+        <error line="313" column="141" source="standard:argument-list-wrapping" />
+        <error line="316" column="1" source="standard:max-line-length" />
+        <error line="316" column="26" source="standard:argument-list-wrapping" />
+        <error line="316" column="51" source="standard:argument-list-wrapping" />
+        <error line="316" column="133" source="standard:argument-list-wrapping" />
+        <error line="319" column="1" source="standard:max-line-length" />
+        <error line="319" column="26" source="standard:argument-list-wrapping" />
+        <error line="319" column="51" source="standard:argument-list-wrapping" />
+        <error line="319" column="127" source="standard:argument-list-wrapping" />
+        <error line="320" column="1" source="standard:max-line-length" />
+        <error line="320" column="26" source="standard:argument-list-wrapping" />
+        <error line="320" column="58" source="standard:argument-list-wrapping" />
+        <error line="320" column="103" source="standard:argument-list-wrapping" />
+        <error line="320" column="126" source="standard:argument-list-wrapping" />
+        <error line="320" column="137" source="standard:argument-list-wrapping" />
+        <error line="322" column="1" source="standard:max-line-length" />
+        <error line="322" column="26" source="standard:argument-list-wrapping" />
+        <error line="322" column="51" source="standard:argument-list-wrapping" />
+        <error line="322" column="130" source="standard:argument-list-wrapping" />
+        <error line="323" column="1" source="standard:max-line-length" />
+        <error line="323" column="26" source="standard:argument-list-wrapping" />
+        <error line="323" column="57" source="standard:argument-list-wrapping" />
+        <error line="323" column="102" source="standard:argument-list-wrapping" />
+        <error line="323" column="125" source="standard:argument-list-wrapping" />
+        <error line="323" column="145" source="standard:argument-list-wrapping" />
+        <error line="326" column="1" source="standard:max-line-length" />
+        <error line="326" column="26" source="standard:argument-list-wrapping" />
+        <error line="326" column="53" source="standard:argument-list-wrapping" />
+        <error line="326" column="98" source="standard:argument-list-wrapping" />
+        <error line="326" column="123" source="standard:argument-list-wrapping" />
+        <error line="326" column="137" source="standard:argument-list-wrapping" />
+        <error line="327" column="1" source="standard:max-line-length" />
+        <error line="327" column="26" source="standard:argument-list-wrapping" />
+        <error line="327" column="53" source="standard:argument-list-wrapping" />
+        <error line="327" column="98" source="standard:argument-list-wrapping" />
+        <error line="327" column="123" source="standard:argument-list-wrapping" />
+        <error line="327" column="131" source="standard:argument-list-wrapping" />
+        <error line="328" column="1" source="standard:max-line-length" />
+        <error line="328" column="26" source="standard:argument-list-wrapping" />
+        <error line="328" column="51" source="standard:argument-list-wrapping" />
+        <error line="328" column="96" source="standard:argument-list-wrapping" />
+        <error line="328" column="121" source="standard:argument-list-wrapping" />
+        <error line="328" column="132" source="standard:argument-list-wrapping" />
+        <error line="329" column="1" source="standard:max-line-length" />
+        <error line="329" column="26" source="standard:argument-list-wrapping" />
+        <error line="329" column="48" source="standard:argument-list-wrapping" />
+        <error line="329" column="129" source="standard:argument-list-wrapping" />
+        <error line="330" column="1" source="standard:max-line-length" />
+        <error line="330" column="26" source="standard:argument-list-wrapping" />
+        <error line="330" column="57" source="standard:argument-list-wrapping" />
+        <error line="330" column="102" source="standard:argument-list-wrapping" />
+        <error line="330" column="127" source="standard:argument-list-wrapping" />
+        <error line="330" column="147" source="standard:argument-list-wrapping" />
+        <error line="333" column="1" source="standard:max-line-length" />
+        <error line="333" column="26" source="standard:argument-list-wrapping" />
+        <error line="333" column="49" source="standard:argument-list-wrapping" />
+        <error line="333" column="129" source="standard:argument-list-wrapping" />
+        <error line="334" column="1" source="standard:max-line-length" />
+        <error line="334" column="26" source="standard:argument-list-wrapping" />
+        <error line="334" column="49" source="standard:argument-list-wrapping" />
+        <error line="334" column="123" source="standard:argument-list-wrapping" />
+        <error line="335" column="1" source="standard:max-line-length" />
+        <error line="335" column="26" source="standard:argument-list-wrapping" />
+        <error line="335" column="51" source="standard:argument-list-wrapping" />
+        <error line="335" column="128" source="standard:argument-list-wrapping" />
+        <error line="336" column="1" source="standard:max-line-length" />
+        <error line="336" column="26" source="standard:argument-list-wrapping" />
+        <error line="336" column="48" source="standard:argument-list-wrapping" />
+        <error line="336" column="125" source="standard:argument-list-wrapping" />
+        <error line="337" column="1" source="standard:max-line-length" />
+        <error line="337" column="26" source="standard:argument-list-wrapping" />
+        <error line="337" column="57" source="standard:argument-list-wrapping" />
+        <error line="337" column="102" source="standard:argument-list-wrapping" />
+        <error line="337" column="123" source="standard:argument-list-wrapping" />
+        <error line="337" column="143" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/quicksettings/ext/PhoneFeatureExtKtTest.kt">
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="65" column="21" source="standard:argument-list-wrapping" />
+        <error line="65" column="57" source="standard:argument-list-wrapping" />
+        <error line="65" column="90" source="standard:argument-list-wrapping" />
+        <error line="65" column="115" source="standard:argument-list-wrapping" />
+        <error line="65" column="122" source="standard:argument-list-wrapping" />
+        <error line="65" column="123" source="standard:argument-list-wrapping" />
+        <error line="66" column="1" source="standard:max-line-length" />
+        <error line="66" column="21" source="standard:argument-list-wrapping" />
+        <error line="66" column="121" source="standard:argument-list-wrapping" />
+        <error line="70" column="1" source="standard:max-line-length" />
+        <error line="70" column="21" source="standard:argument-list-wrapping" />
+        <error line="70" column="57" source="standard:argument-list-wrapping" />
+        <error line="70" column="89" source="standard:argument-list-wrapping" />
+        <error line="70" column="114" source="standard:argument-list-wrapping" />
+        <error line="70" column="121" source="standard:argument-list-wrapping" />
+        <error line="70" column="122" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerHandlingDetailsViewTest.kt">
+        <error line="90" column="1" source="standard:max-line-length" />
+        <error line="108" column="1" source="standard:max-line-length" />
+        <error line="125" column="1" source="standard:max-line-length" />
+        <error line="159" column="1" source="standard:max-line-length" />
+        <error line="172" column="1" source="standard:max-line-length" />
+        <error line="186" column="1" source="standard:max-line-length" />
+        <error line="201" column="1" source="standard:max-line-length" />
+        <error line="208" column="1" source="standard:max-line-length" />
+        <error line="215" column="1" source="standard:max-line-length" />
+        <error line="235" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/DefaultCookieBannerDetailsControllerTest.kt">
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="176" column="1" source="standard:max-line-length" />
+        <error line="224" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/search/SearchEngineFragmentTest.kt">
+        <error line="33" column="1" source="standard:max-line-length" />
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="57" column="59" source="standard:argument-list-wrapping" />
+        <error line="57" column="81" source="standard:argument-list-wrapping" />
+        <error line="57" column="122" source="standard:argument-list-wrapping" />
+        <error line="57" column="123" source="standard:argument-list-wrapping" />
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="62" column="59" source="standard:argument-list-wrapping" />
+        <error line="62" column="81" source="standard:argument-list-wrapping" />
+        <error line="62" column="123" source="standard:argument-list-wrapping" />
+        <error line="62" column="124" source="standard:argument-list-wrapping" />
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="67" column="61" source="standard:argument-list-wrapping" />
+        <error line="67" column="83" source="standard:argument-list-wrapping" />
+        <error line="67" column="135" source="standard:argument-list-wrapping" />
+        <error line="67" column="136" source="standard:argument-list-wrapping" />
+        <error line="72" column="1" source="standard:max-line-length" />
+        <error line="72" column="59" source="standard:argument-list-wrapping" />
+        <error line="72" column="81" source="standard:argument-list-wrapping" />
+        <error line="72" column="122" source="standard:argument-list-wrapping" />
+        <error line="72" column="123" source="standard:argument-list-wrapping" />
+        <error line="87" column="1" source="standard:max-line-length" />
+        <error line="87" column="59" source="standard:argument-list-wrapping" />
+        <error line="87" column="81" source="standard:argument-list-wrapping" />
+        <error line="87" column="125" source="standard:argument-list-wrapping" />
+        <error line="87" column="126" source="standard:argument-list-wrapping" />
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="92" column="59" source="standard:argument-list-wrapping" />
+        <error line="92" column="81" source="standard:argument-list-wrapping" />
+        <error line="92" column="125" source="standard:argument-list-wrapping" />
+        <error line="92" column="126" source="standard:argument-list-wrapping" />
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="97" column="59" source="standard:argument-list-wrapping" />
+        <error line="97" column="81" source="standard:argument-list-wrapping" />
+        <error line="97" column="128" source="standard:argument-list-wrapping" />
+        <error line="97" column="129" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/search/SearchStringValidatorTest.kt">
+        <error line="37" column="1" source="standard:max-line-length" />
+        <error line="37" column="64" source="standard:argument-list-wrapping" />
+        <error line="37" column="72" source="standard:argument-list-wrapping" />
+        <error line="37" column="121" source="standard:argument-list-wrapping" />
+        <error line="63" column="1" source="standard:max-line-length" />
+        <error line="63" column="64" source="standard:argument-list-wrapping" />
+        <error line="63" column="72" source="standard:argument-list-wrapping" />
+        <error line="63" column="121" source="standard:argument-list-wrapping" />
+        <error line="72" column="1" source="standard:max-line-length" />
+        <error line="72" column="64" source="standard:argument-list-wrapping" />
+        <error line="72" column="72" source="standard:argument-list-wrapping" />
+        <error line="72" column="121" source="standard:argument-list-wrapping" />
+        <error line="86" column="1" source="standard:max-line-length" />
+        <error line="86" column="64" source="standard:argument-list-wrapping" />
+        <error line="86" column="72" source="standard:argument-list-wrapping" />
+        <error line="86" column="121" source="standard:argument-list-wrapping" />
+        <error line="100" column="1" source="standard:max-line-length" />
+        <error line="100" column="64" source="standard:argument-list-wrapping" />
+        <error line="100" column="72" source="standard:argument-list-wrapping" />
+        <error line="100" column="121" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragmentTest.kt">
+        <error line="134" column="1" source="standard:max-line-length" />
+        <error line="150" column="1" source="standard:max-line-length" />
+        <error line="166" column="1" source="standard:max-line-length" />
+        <error line="187" column="1" source="standard:max-line-length" />
+        <error line="208" column="1" source="standard:max-line-length" />
+        <error line="224" column="1" source="standard:max-line-length" />
+        <error line="240" column="1" source="standard:max-line-length" />
+        <error line="261" column="1" source="standard:max-line-length" />
+        <error line="282" column="1" source="standard:max-line-length" />
+        <error line="298" column="1" source="standard:max-line-length" />
+        <error line="314" column="1" source="standard:max-line-length" />
+        <error line="335" column="1" source="standard:max-line-length" />
+        <error line="356" column="1" source="standard:max-line-length" />
+        <error line="384" column="1" source="standard:max-line-length" />
+        <error line="412" column="1" source="standard:max-line-length" />
+        <error line="440" column="1" source="standard:max-line-length" />
+        <error line="468" column="1" source="standard:max-line-length" />
+        <error line="496" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsWifiIntegrationTest.kt">
+        <error line="47" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="107" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/settings/wallpaper/ExtensionsTest.kt">
+        <error line="16" column="1" source="standard:max-line-length" />
+        <error line="19" column="1" source="standard:max-line-length" />
+        <error line="19" column="46" source="standard:wrapping" />
+        <error line="19" column="83" source="standard:argument-list-wrapping" />
+        <error line="19" column="116" source="standard:argument-list-wrapping" />
+        <error line="19" column="139" source="standard:argument-list-wrapping" />
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="41" column="1" source="standard:max-line-length" />
+        <error line="41" column="56" source="standard:wrapping" />
+        <error line="41" column="93" source="standard:argument-list-wrapping" />
+        <error line="41" column="126" source="standard:argument-list-wrapping" />
+        <error line="41" column="149" source="standard:argument-list-wrapping" />
+        <error line="49" column="1" source="standard:max-line-length" />
+        <error line="59" column="1" source="standard:max-line-length" />
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="79" column="1" source="standard:max-line-length" />
+        <error line="79" column="46" source="standard:wrapping" />
+        <error line="79" column="83" source="standard:argument-list-wrapping" />
+        <error line="79" column="116" source="standard:argument-list-wrapping" />
+        <error line="79" column="139" source="standard:argument-list-wrapping" />
+        <error line="91" column="1" source="standard:max-line-length" />
+        <error line="93" column="1" source="standard:max-line-length" />
+        <error line="93" column="33" source="standard:property-wrapping" />
+        <error line="93" column="70" source="standard:argument-list-wrapping" />
+        <error line="93" column="103" source="standard:argument-list-wrapping" />
+        <error line="93" column="127" source="standard:argument-list-wrapping" />
+        <error line="95" column="1" source="standard:max-line-length" />
+        <error line="95" column="33" source="standard:property-wrapping" />
+        <error line="95" column="70" source="standard:argument-list-wrapping" />
+        <error line="95" column="103" source="standard:argument-list-wrapping" />
+        <error line="95" column="127" source="standard:argument-list-wrapping" />
+        <error line="97" column="1" source="standard:max-line-length" />
+        <error line="97" column="34" source="standard:property-wrapping" />
+        <error line="97" column="71" source="standard:argument-list-wrapping" />
+        <error line="97" column="104" source="standard:argument-list-wrapping" />
+        <error line="97" column="128" source="standard:argument-list-wrapping" />
+        <error line="99" column="1" source="standard:max-line-length" />
+        <error line="99" column="33" source="standard:property-wrapping" />
+        <error line="99" column="70" source="standard:argument-list-wrapping" />
+        <error line="99" column="103" source="standard:argument-list-wrapping" />
+        <error line="99" column="127" source="standard:argument-list-wrapping" />
+        <error line="101" column="1" source="standard:max-line-length" />
+        <error line="101" column="34" source="standard:property-wrapping" />
+        <error line="101" column="71" source="standard:argument-list-wrapping" />
+        <error line="101" column="104" source="standard:argument-list-wrapping" />
+        <error line="101" column="128" source="standard:argument-list-wrapping" />
+        <error line="115" column="1" source="standard:max-line-length" />
+        <error line="117" column="1" source="standard:max-line-length" />
+        <error line="117" column="33" source="standard:property-wrapping" />
+        <error line="117" column="70" source="standard:argument-list-wrapping" />
+        <error line="117" column="102" source="standard:argument-list-wrapping" />
+        <error line="117" column="125" source="standard:argument-list-wrapping" />
+        <error line="140" column="1" source="standard:max-line-length" />
+        <error line="151" column="1" source="standard:max-line-length" />
+        <error line="153" column="1" source="standard:max-line-length" />
+        <error line="153" column="46" source="standard:wrapping" />
+        <error line="153" column="83" source="standard:argument-list-wrapping" />
+        <error line="153" column="116" source="standard:argument-list-wrapping" />
+        <error line="153" column="139" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/share/SaveToPDFMiddlewareTest.kt">
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="104" column="1" source="standard:max-line-length" />
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="256" column="1" source="standard:max-line-length" />
+        <error line="277" column="1" source="standard:max-line-length" />
+        <error line="322" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/shopping/ReviewQualityCheckFeatureTest.kt">
+        <error line="242" column="1" source="standard:max-line-length" />
+        <error line="299" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/shopping/middleware/DefaultReviewQualityCheckServiceTest.kt">
+        <error line="41" column="1" source="standard:max-line-length" />
+        <error line="128" column="1" source="standard:max-line-length" />
+        <error line="159" column="1" source="standard:max-line-length" />
+        <error line="188" column="1" source="standard:max-line-length" />
+        <error line="245" column="1" source="standard:max-line-length" />
+        <error line="281" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/shopping/middleware/ProductAnalysisMapperTest.kt">
+        <error line="56" column="1" source="standard:max-line-length" />
+        <error line="174" column="1" source="standard:max-line-length" />
+        <error line="339" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/shopping/middleware/ReviewQualityCheckTelemetryMiddlewareTest.kt">
+        <error line="92" column="1" source="standard:max-line-length" />
+        <error line="100" column="1" source="standard:max-line-length" />
+        <error line="116" column="1" source="standard:max-line-length" />
+        <error line="132" column="1" source="standard:max-line-length" />
+        <error line="150" column="1" source="standard:max-line-length" />
+        <error line="236" column="1" source="standard:max-line-length" />
+        <error line="244" column="1" source="standard:max-line-length" />
+        <error line="252" column="1" source="standard:max-line-length" />
+        <error line="278" column="1" source="standard:max-line-length" />
+        <error line="303" column="1" source="standard:max-line-length" />
+        <error line="327" column="1" source="standard:max-line-length" />
+        <error line="358" column="1" source="standard:max-line-length" />
+        <error line="397" column="1" source="standard:max-line-length" />
+        <error line="459" column="1" source="standard:max-line-length" />
+        <error line="480" column="1" source="standard:max-line-length" />
+        <error line="501" column="1" source="standard:max-line-length" />
+        <error line="501" column="85" source="standard:parameter-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStateTest.kt">
+        <error line="19" column="1" source="standard:max-line-length" />
+        <error line="89" column="1" source="standard:max-line-length" />
+        <error line="122" column="1" source="standard:max-line-length" />
+        <error line="159" column="1" source="standard:max-line-length" />
+        <error line="172" column="1" source="standard:max-line-length" />
+        <error line="188" column="1" source="standard:max-line-length" />
+        <error line="205" column="1" source="standard:max-line-length" />
+        <error line="236" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/shopping/store/ReviewQualityCheckStoreTest.kt">
+        <error line="55" column="1" source="standard:max-line-length" />
+        <error line="136" column="1" source="standard:max-line-length" />
+        <error line="164" column="1" source="standard:max-line-length" />
+        <error line="189" column="1" source="standard:max-line-length" />
+        <error line="224" column="1" source="standard:max-line-length" />
+        <error line="267" column="1" source="standard:max-line-length" />
+        <error line="310" column="1" source="standard:max-line-length" />
+        <error line="353" column="1" source="standard:max-line-length" />
+        <error line="555" column="1" source="standard:max-line-length" />
+        <error line="592" column="1" source="standard:max-line-length" />
+        <error line="636" column="1" source="standard:max-line-length" />
+        <error line="664" column="1" source="standard:max-line-length" />
+        <error line="690" column="1" source="standard:max-line-length" />
+        <error line="823" column="1" source="standard:max-line-length" />
+        <error line="863" column="1" source="standard:max-line-length" />
+        <error line="936" column="1" source="standard:max-line-length" />
+        <error line="1126" column="1" source="standard:max-line-length" />
+        <error line="1293" column="1" source="standard:max-line-length" />
+        <error line="1338" column="1" source="standard:max-line-length" />
+        <error line="1381" column="1" source="standard:max-line-length" />
+        <error line="1416" column="1" source="standard:max-line-length" />
+        <error line="1457" column="1" source="standard:max-line-length" />
+        <error line="1498" column="1" source="standard:max-line-length" />
+        <error line="1541" column="1" source="standard:max-line-length" />
+        <error line="1574" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/sync/ext/SyncedDeviceTabsTest.kt">
+        <error line="95" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt">
+        <error line="196" column="1" source="standard:max-line-length" />
+        <error line="223" column="1" source="standard:max-line-length" />
+        <error line="257" column="1" source="standard:max-line-length" />
+        <error line="271" column="1" source="standard:max-line-length" />
+        <error line="278" column="1" source="standard:max-line-length" />
+        <error line="300" column="1" source="standard:max-line-length" />
+        <error line="315" column="1" source="standard:max-line-length" />
+        <error line="328" column="1" source="standard:max-line-length" />
+        <error line="340" column="1" source="standard:max-line-length" />
+        <error line="367" column="1" source="standard:max-line-length" />
+        <error line="393" column="1" source="standard:max-line-length" />
+        <error line="422" column="1" source="standard:max-line-length" />
+        <error line="451" column="1" source="standard:max-line-length" />
+        <error line="472" column="1" source="standard:max-line-length" />
+        <error line="493" column="1" source="standard:max-line-length" />
+        <error line="510" column="1" source="standard:max-line-length" />
+        <error line="526" column="1" source="standard:max-line-length" />
+        <error line="572" column="1" source="standard:max-line-length" />
+        <error line="598" column="1" source="standard:max-line-length" />
+        <error line="626" column="1" source="standard:max-line-length" />
+        <error line="657" column="1" source="standard:max-line-length" />
+        <error line="688" column="1" source="standard:max-line-length" />
+        <error line="711" column="1" source="standard:max-line-length" />
+        <error line="739" column="1" source="standard:max-line-length" />
+        <error line="777" column="1" source="standard:max-line-length" />
+        <error line="789" column="1" source="standard:max-line-length" />
+        <error line="848" column="1" source="standard:max-line-length" />
+        <error line="904" column="1" source="standard:max-line-length" />
+        <error line="930" column="1" source="standard:max-line-length" />
+        <error line="974" column="1" source="standard:max-line-length" />
+        <error line="975" column="1" source="standard:max-line-length" />
+        <error line="975" column="25" source="standard:property-wrapping" />
+        <error line="975" column="42" source="standard:argument-list-wrapping" />
+        <error line="975" column="113" source="standard:argument-list-wrapping" />
+        <error line="975" column="130" source="standard:argument-list-wrapping" />
+        <error line="976" column="1" source="standard:max-line-length" />
+        <error line="976" column="25" source="standard:property-wrapping" />
+        <error line="976" column="42" source="standard:argument-list-wrapping" />
+        <error line="976" column="111" source="standard:argument-list-wrapping" />
+        <error line="976" column="128" source="standard:argument-list-wrapping" />
+        <error line="1005" column="1" source="standard:max-line-length" />
+        <error line="1066" column="1" source="standard:max-line-length" />
+        <error line="1084" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayInteractorTest.kt">
+        <error line="144" column="1" source="standard:max-line-length" />
+        <error line="151" column="1" source="standard:max-line-length" />
+        <error line="158" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt">
+        <error line="126" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/tabstray/SecureTabsTrayBindingTest.kt">
+        <error line="68" column="1" source="standard:max-line-length" />
+        <error line="87" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/tabstray/TabSheetBehaviorManagerTest.kt">
+        <error line="71" column="1" source="standard:max-line-length" />
+        <error line="134" column="1" source="standard:max-line-length" />
+        <error line="160" column="1" source="standard:max-line-length" />
+        <error line="192" column="1" source="standard:max-line-length" />
+        <error line="225" column="1" source="standard:max-line-length" />
+        <error line="256" column="1" source="standard:max-line-length" />
+        <error line="280" column="1" source="standard:max-line-length" />
+        <error line="312" column="1" source="standard:max-line-length" />
+        <error line="342" column="1" source="standard:max-line-length" />
+        <error line="372" column="1" source="standard:max-line-length" />
+        <error line="385" column="1" source="standard:max-line-length" />
+        <error line="428" column="1" source="standard:max-line-length" />
+        <error line="443" column="1" source="standard:max-line-length" />
+        <error line="458" column="1" source="standard:max-line-length" />
+        <error line="473" column="1" source="standard:max-line-length" />
+        <error line="488" column="1" source="standard:max-line-length" />
+        <error line="503" column="1" source="standard:max-line-length" />
+        <error line="518" column="1" source="standard:max-line-length" />
+        <error line="533" column="1" source="standard:max-line-length" />
+        <error line="548" column="1" source="standard:max-line-length" />
+        <error line="563" column="1" source="standard:max-line-length" />
+        <error line="579" column="1" source="standard:max-line-length" />
+        <error line="595" column="1" source="standard:max-line-length" />
+        <error line="611" column="1" source="standard:max-line-length" />
+        <error line="627" column="1" source="standard:max-line-length" />
+        <error line="643" column="1" source="standard:max-line-length" />
+        <error line="659" column="1" source="standard:max-line-length" />
+        <error line="678" column="1" source="standard:max-line-length" />
+        <error line="746" column="1" source="standard:max-line-length" />
+        <error line="771" column="1" source="standard:max-line-length" />
+        <error line="796" column="1" source="standard:max-line-length" />
+        <error line="821" column="1" source="standard:max-line-length" />
+        <error line="847" column="1" source="standard:max-line-length" />
+        <error line="873" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt">
+        <error line="93" column="1" source="standard:max-line-length" />
+        <error line="126" column="1" source="standard:max-line-length" />
+        <error line="158" column="1" source="standard:max-line-length" />
+        <error line="191" column="1" source="standard:max-line-length" />
+        <error line="291" column="1" source="standard:max-line-length" />
+        <error line="306" column="1" source="standard:max-line-length" />
+        <error line="317" column="1" source="standard:max-line-length" />
+        <error line="339" column="1" source="standard:max-line-length" />
+        <error line="350" column="1" source="standard:max-line-length" />
+        <error line="351" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayStateTest.kt">
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="83" column="1" source="standard:max-line-length" />
+        <error line="99" column="1" source="standard:max-line-length" />
+        <error line="128" column="1" source="standard:max-line-length" />
+        <error line="145" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolderTest.kt">
+        <error line="89" column="1" source="standard:max-line-length" />
+        <error line="126" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabsViewErrorTypeTest.kt">
+        <error line="23" column="1" source="standard:max-line-length" />
+        <error line="26" column="1" source="standard:max-line-length" />
+        <error line="26" column="117" source="standard:argument-list-wrapping" />
+        <error line="26" column="126" source="standard:argument-list-wrapping" />
+        <error line="26" column="139" source="standard:argument-list-wrapping" />
+        <error line="27" column="1" source="standard:max-line-length" />
+        <error line="27" column="107" source="standard:argument-list-wrapping" />
+        <error line="27" column="116" source="standard:argument-list-wrapping" />
+        <error line="27" column="129" source="standard:argument-list-wrapping" />
+        <error line="28" column="1" source="standard:max-line-length" />
+        <error line="28" column="115" source="standard:argument-list-wrapping" />
+        <error line="28" column="124" source="standard:argument-list-wrapping" />
+        <error line="28" column="137" source="standard:argument-list-wrapping" />
+        <error line="32" column="1" source="standard:max-line-length" />
+        <error line="32" column="22" source="standard:argument-list-wrapping" />
+        <error line="32" column="90" source="standard:argument-list-wrapping" />
+        <error line="32" column="126" source="standard:argument-list-wrapping" />
+        <error line="38" column="1" source="standard:max-line-length" />
+        <error line="38" column="22" source="standard:argument-list-wrapping" />
+        <error line="38" column="82" source="standard:argument-list-wrapping" />
+        <error line="38" column="122" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/telemetry/TelemetryMiddlewareTest.kt">
+        <error line="103" column="1" source="standard:max-line-length" />
+        <error line="137" column="1" source="standard:max-line-length" />
+        <error line="148" column="1" source="standard:max-line-length" />
+        <error line="372" column="1" source="standard:max-line-length" />
+        <error line="372" column="36" source="standard:argument-list-wrapping" />
+        <error line="372" column="42" source="standard:argument-list-wrapping" />
+        <error line="372" column="51" source="standard:argument-list-wrapping" />
+        <error line="372" column="82" source="standard:argument-list-wrapping" />
+        <error line="372" column="108" source="standard:argument-list-wrapping" />
+        <error line="372" column="126" source="standard:argument-list-wrapping" />
+        <error line="372" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragmentTest.kt">
+        <error line="25" column="1" source="standard:max-line-length" />
+        <error line="43" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/translations/preferences/downloadlanguages/DownloadLanguagesFeatureTest.kt">
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="90" column="1" source="standard:max-line-length" />
+        <error line="103" column="1" source="standard:max-line-length" />
+        <error line="116" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/utils/ClipboardHandlerTest.kt">
+        <error line="84" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt">
+        <error line="720" column="1" source="standard:max-line-length" />
+        <error line="738" column="1" source="standard:max-line-length" />
+        <error line="754" column="1" source="standard:max-line-length" />
+        <error line="773" column="1" source="standard:max-line-length" />
+        <error line="801" column="1" source="standard:max-line-length" />
+        <error line="809" column="1" source="standard:max-line-length" />
+        <error line="814" column="1" source="standard:max-line-length" />
+        <error line="822" column="1" source="standard:max-line-length" />
+        <error line="867" column="1" source="standard:max-line-length" />
+        <error line="906" column="1" source="standard:max-line-length" />
+        <error line="956" column="1" source="standard:max-line-length" />
+        <error line="971" column="1" source="standard:max-line-length" />
+        <error line="986" column="1" source="standard:max-line-length" />
+        <error line="1000" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/wallpapers/LegacyWallpaperMigrationTest.kt">
+        <error line="65" column="1" source="standard:max-line-length" />
+        <error line="85" column="1" source="standard:max-line-length" />
+        <error line="138" column="1" source="standard:max-line-length" />
+        <error line="159" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperDownloaderTest.kt">
+        <error line="59" column="1" source="standard:max-line-length" />
+        <error line="79" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperTest.kt">
+        <error line="20" column="1" source="standard:max-line-length" />
+        <error line="27" column="1" source="standard:max-line-length" />
+        <error line="34" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/wallpapers/WallpapersUseCasesTest.kt">
+        <error line="129" column="1" source="standard:max-line-length" />
+        <error line="159" column="1" source="standard:max-line-length" />
+        <error line="189" column="1" source="standard:max-line-length" />
+        <error line="215" column="1" source="standard:max-line-length" />
+        <error line="220" column="1" source="standard:max-line-length" />
+        <error line="245" column="1" source="standard:max-line-length" />
+        <error line="270" column="1" source="standard:max-line-length" />
+        <error line="301" column="1" source="standard:max-line-length" />
+        <error line="328" column="1" source="standard:max-line-length" />
+        <error line="352" column="1" source="standard:max-line-length" />
+        <error line="382" column="1" source="standard:max-line-length" />
+        <error line="404" column="1" source="standard:max-line-length" />
+        <error line="421" column="1" source="standard:max-line-length" />
+        <error line="421" column="17" source="standard:wrapping" />
+        <error line="421" column="40" source="standard:argument-list-wrapping" />
+        <error line="421" column="95" source="standard:argument-list-wrapping" />
+        <error line="421" column="114" source="standard:argument-list-wrapping" />
+        <error line="421" column="150" source="standard:argument-list-wrapping" />
+        <error line="421" column="151" source="standard:argument-list-wrapping" />
+        <error line="422" column="1" source="standard:max-line-length" />
+        <error line="422" column="17" source="standard:wrapping" />
+        <error line="422" column="40" source="standard:argument-list-wrapping" />
+        <error line="422" column="95" source="standard:argument-list-wrapping" />
+        <error line="422" column="114" source="standard:argument-list-wrapping" />
+        <error line="422" column="149" source="standard:argument-list-wrapping" />
+        <error line="422" column="150" source="standard:argument-list-wrapping" />
+        <error line="428" column="1" source="standard:max-line-length" />
+        <error line="445" column="1" source="standard:max-line-length" />
+        <error line="445" column="17" source="standard:wrapping" />
+        <error line="445" column="40" source="standard:argument-list-wrapping" />
+        <error line="445" column="95" source="standard:argument-list-wrapping" />
+        <error line="445" column="114" source="standard:argument-list-wrapping" />
+        <error line="445" column="150" source="standard:argument-list-wrapping" />
+        <error line="445" column="151" source="standard:argument-list-wrapping" />
+        <error line="446" column="1" source="standard:max-line-length" />
+        <error line="446" column="17" source="standard:wrapping" />
+        <error line="446" column="40" source="standard:argument-list-wrapping" />
+        <error line="446" column="95" source="standard:argument-list-wrapping" />
+        <error line="446" column="114" source="standard:argument-list-wrapping" />
+        <error line="446" column="144" source="standard:argument-list-wrapping" />
+        <error line="446" column="145" source="standard:argument-list-wrapping" />
+        <error line="451" column="1" source="standard:max-line-length" />
+        <error line="475" column="1" source="standard:max-line-length" />
+        <error line="499" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/widget/SearchWidgetProviderTest.kt">
+        <error line="145" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/fenix/wifi/WifiConnectionMonitorTest.kt">
+        <error line="176" column="1" source="standard:max-line-length" />
     </file>
 </baseline>

--- a/focus-android/.editorconfig
+++ b/focus-android/.editorconfig
@@ -1,6 +1,8 @@
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma_on_call_site=true
 ij_kotlin_allow_trailing_comma=true
-max_line_length = 120 # Matches maxLineLength in detekt.yml
+
+# Matches maxLineLength in detekt.yml
+max_line_length = 120
 
 ktlint_standard_filename = disabled

--- a/focus-android/build.gradle
+++ b/focus-android/build.gradle
@@ -140,7 +140,7 @@ tasks.register('ktlint', JavaExec) {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
     mainClass.set("com.pinterest.ktlint.Main")
-    args "app/**/*.kt", "!**/build/**/*.kt", "buildSrc/**/*.kt"
+    args "app/**/*.kt", "!**/build/**/*.kt", "buildSrc/**/*.kt", "--baseline=ktlint-baseline.xml"
 }
 
 
@@ -148,7 +148,7 @@ tasks.register('ktlintFormat', JavaExec) {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
     mainClass.set("com.pinterest.ktlint.Main")
-    args "-F", "app/**/*.kt", "!**/build/**/*.kt", "buildSrc/**/*.kt"
+    args "-F", "app/**/*.kt", "!**/build/**/*.kt", "buildSrc/**/*.kt", "--baseline=ktlint-baseline.xml"
     jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }
 

--- a/focus-android/ktlint-baseline.xml
+++ b/focus-android/ktlint-baseline.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<baseline version="1.0">
+    <file name="app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt">
+        <error line="247" column="1" source="standard:max-line-length" />
+        <error line="247" column="114" source="standard:argument-list-wrapping" />
+        <error line="247" column="138" source="standard:argument-list-wrapping" />
+        <error line="247" column="142" source="standard:argument-list-wrapping" />
+        <error line="526" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt">
+        <error line="165" column="1" source="standard:max-line-length" />
+        <error line="165" column="52" source="standard:argument-list-wrapping" />
+        <error line="165" column="76" source="standard:argument-list-wrapping" />
+        <error line="165" column="126" source="standard:argument-list-wrapping" />
+        <error line="165" column="127" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/focus/activity/robots/SettingsPrivacyMenuRobot.kt">
+        <error line="262" column="1" source="standard:max-line-length" />
+        <error line="722" column="1" source="standard:max-line-length" />
+        <error line="722" column="27" source="standard:argument-list-wrapping" />
+        <error line="722" column="45" source="standard:argument-list-wrapping" />
+        <error line="722" column="128" source="standard:argument-list-wrapping" />
+        <error line="722" column="129" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/androidTest/java/org/mozilla/focus/screenshots/HomeScreenScreenshots.kt">
+        <error line="118" column="1" source="standard:max-line-length" />
+        <error line="118" column="39" source="standard:argument-list-wrapping" />
+        <error line="118" column="63" source="standard:argument-list-wrapping" />
+        <error line="118" column="129" source="standard:argument-list-wrapping" />
+        <error line="118" column="130" source="standard:argument-list-wrapping" />
+        <error line="121" column="1" source="standard:max-line-length" />
+        <error line="121" column="39" source="standard:argument-list-wrapping" />
+        <error line="121" column="121" source="standard:argument-list-wrapping" />
+        <error line="123" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/biometrics/BiometricAuthenticationFragmentTest.kt">
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="65" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/browser/integration/BrowserToolbarIntegrationTest.kt">
+        <error line="174" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/cfr/CfrMiddlewareTest.kt">
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="74" column="1" source="standard:max-line-length" />
+        <error line="95" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/ext/BrowserToolbarTest.kt">
+        <error line="46" column="1" source="standard:max-line-length" />
+        <error line="46" column="20" source="standard:argument-list-wrapping" />
+        <error line="46" column="126" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/ext/StringTest.kt">
+        <error line="43" column="1" source="standard:max-line-length" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="58" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/ext/UriTest.kt">
+        <error line="22" column="1" source="standard:max-line-length" />
+        <error line="22" column="29" source="standard:argument-list-wrapping" />
+        <error line="22" column="42" source="standard:argument-list-wrapping" />
+        <error line="22" column="128" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/menu/BrowserMenuControllerTest.kt">
+        <error line="121" column="1" source="standard:max-line-length" />
+        <error line="129" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/onboarding/OnboardingStorageTest.kt">
+        <error line="31" column="1" source="standard:max-line-length" />
+        <error line="42" column="1" source="standard:max-line-length" />
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="61" column="1" source="standard:max-line-length" />
+        <error line="67" column="1" source="standard:max-line-length" />
+        <error line="67" column="22" source="standard:argument-list-wrapping" />
+        <error line="67" column="93" source="standard:argument-list-wrapping" />
+        <error line="67" column="115" source="standard:argument-list-wrapping" />
+        <error line="67" column="137" source="standard:argument-list-wrapping" />
+        <error line="67" column="170" source="standard:argument-list-wrapping" />
+        <error line="67" column="173" source="standard:argument-list-wrapping" />
+        <error line="67" column="175" source="standard:argument-list-wrapping" />
+        <error line="67" column="176" source="standard:argument-list-wrapping" />
+        <error line="71" column="1" source="standard:max-line-length" />
+        <error line="77" column="1" source="standard:max-line-length" />
+        <error line="77" column="22" source="standard:argument-list-wrapping" />
+        <error line="77" column="94" source="standard:argument-list-wrapping" />
+        <error line="77" column="116" source="standard:argument-list-wrapping" />
+        <error line="77" column="138" source="standard:argument-list-wrapping" />
+        <error line="77" column="171" source="standard:argument-list-wrapping" />
+        <error line="77" column="174" source="standard:argument-list-wrapping" />
+        <error line="77" column="176" source="standard:argument-list-wrapping" />
+        <error line="77" column="177" source="standard:argument-list-wrapping" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/searchwidget/ExternalIntentNavigationTest.kt">
+        <error line="51" column="1" source="standard:max-line-length" />
+        <error line="62" column="1" source="standard:max-line-length" />
+        <error line="76" column="1" source="standard:max-line-length" />
+        <error line="89" column="1" source="standard:max-line-length" />
+        <error line="114" column="1" source="standard:max-line-length" />
+        <error line="126" column="1" source="standard:max-line-length" />
+        <error line="140" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/searchwidget/SearchWidgetProviderTest.kt">
+        <error line="30" column="1" source="standard:max-line-length" />
+        <error line="37" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/sitepermissions/SitePermissionOptionsStorageTest.kt">
+        <error line="30" column="1" source="standard:max-line-length" />
+        <error line="40" column="1" source="standard:max-line-length" />
+        <error line="50" column="1" source="standard:max-line-length" />
+        <error line="60" column="1" source="standard:max-line-length" />
+        <error line="70" column="1" source="standard:max-line-length" />
+        <error line="78" column="1" source="standard:max-line-length" />
+        <error line="86" column="1" source="standard:max-line-length" />
+        <error line="94" column="1" source="standard:max-line-length" />
+        <error line="102" column="1" source="standard:max-line-length" />
+        <error line="110" column="1" source="standard:max-line-length" />
+        <error line="118" column="1" source="standard:max-line-length" />
+        <error line="126" column="1" source="standard:max-line-length" />
+        <error line="134" column="1" source="standard:max-line-length" />
+        <error line="142" column="1" source="standard:max-line-length" />
+        <error line="150" column="1" source="standard:max-line-length" />
+        <error line="158" column="1" source="standard:max-line-length" />
+        <error line="166" column="1" source="standard:max-line-length" />
+        <error line="174" column="1" source="standard:max-line-length" />
+        <error line="182" column="1" source="standard:max-line-length" />
+        <error line="190" column="1" source="standard:max-line-length" />
+        <error line="198" column="1" source="standard:max-line-length" />
+        <error line="206" column="1" source="standard:max-line-length" />
+        <error line="214" column="1" source="standard:max-line-length" />
+        <error line="225" column="1" source="standard:max-line-length" />
+        <error line="236" column="1" source="standard:max-line-length" />
+        <error line="247" column="1" source="standard:max-line-length" />
+        <error line="258" column="1" source="standard:max-line-length" />
+        <error line="269" column="1" source="standard:max-line-length" />
+        <error line="280" column="1" source="standard:max-line-length" />
+        <error line="288" column="1" source="standard:max-line-length" />
+        <error line="296" column="1" source="standard:max-line-length" />
+        <error line="304" column="1" source="standard:max-line-length" />
+        <error line="312" column="1" source="standard:max-line-length" />
+        <error line="320" column="1" source="standard:max-line-length" />
+        <error line="328" column="1" source="standard:max-line-length" />
+        <error line="336" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/sitepermissions/SitePermissionOptionsStoreTest.kt">
+        <error line="34" column="1" source="standard:max-line-length" />
+        <error line="34" column="134" source="standard:argument-list-wrapping" />
+        <error line="34" column="155" source="standard:argument-list-wrapping" />
+        <error line="43" column="1" source="standard:max-line-length" />
+        <error line="54" column="1" source="standard:max-line-length" />
+        <error line="57" column="1" source="standard:max-line-length" />
+        <error line="57" column="68" source="standard:argument-list-wrapping" />
+        <error line="57" column="100" source="standard:argument-list-wrapping" />
+        <error line="57" column="121" source="standard:argument-list-wrapping" />
+        <error line="62" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/sitepermissions/SitePermissionsFragmentTest.kt">
+        <error line="48" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/telemetry/StartupPathProviderTest.kt">
+        <error line="53" column="1" source="standard:max-line-length" />
+        <error line="58" column="1" source="standard:max-line-length" />
+        <error line="102" column="1" source="standard:max-line-length" />
+        <error line="122" column="1" source="standard:max-line-length" />
+        <error line="136" column="1" source="standard:max-line-length" />
+        <error line="147" column="1" source="standard:max-line-length" />
+        <error line="158" column="1" source="standard:max-line-length" />
+        <error line="170" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/telemetry/StartupStateProviderTest.kt">
+        <error line="108" column="1" source="standard:max-line-length" />
+        <error line="124" column="1" source="standard:max-line-length" />
+        <error line="142" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/telemetry/StartupTypeTelemetryTest.kt">
+        <error line="75" column="1" source="standard:max-line-length" />
+    </file>
+    <file name="app/src/test/java/org/mozilla/focus/utils/IntentUtilsTest.kt">
+        <error line="13" column="1" source="standard:max-line-length" />
+        <error line="18" column="1" source="standard:max-line-length" />
+    </file>
+</baseline>


### PR DESCRIPTION
Updated ktlint-baseline with the current warnings suppressed until we can find a good time to run `ktlintFormat` globally on the entire project.

Filed BZ-1876836 as a follow-up to remove the baseline file in the future.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1876419