### PR TITLE
Bug 1876419 - Fix ktlint errors in ToolbarAutocompleteFeatureTest

### DIFF
--- a/android-components/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
+++ b/android-components/components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarAutocompleteFeatureTest.kt
@@ -545,7 +545,11 @@ class ToolbarAutocompleteFeatureTest {
     }
 
     @Suppress("SameParameterValue")
-    private fun verifyNoAutocompleteResult(toolbar: TestToolbar, autocompleteDelegate: AutocompleteDelegate, query: String) = runTest {
+    private fun verifyNoAutocompleteResult(
+        toolbar: TestToolbar,
+        autocompleteDelegate: AutocompleteDelegate,
+        query: String,
+    ) = runTest {
         toolbar.autocompleteFilter!!(query, autocompleteDelegate)
 
         verify(autocompleteDelegate, never()).applyAutocompleteResult(any(), any())
@@ -553,7 +557,12 @@ class ToolbarAutocompleteFeatureTest {
         reset(autocompleteDelegate)
     }
 
-    private fun verifyAutocompleteResult(toolbar: TestToolbar, autocompleteDelegate: AutocompleteDelegate, query: String, result: AutocompleteResult) = runTest {
+    private fun verifyAutocompleteResult(
+        toolbar: TestToolbar,
+        autocompleteDelegate: AutocompleteDelegate,
+        query: String,
+        result: AutocompleteResult,
+    ) = runTest {
         toolbar.autocompleteFilter!!.invoke(query, autocompleteDelegate)
 
         verify(autocompleteDelegate, times(1)).applyAutocompleteResult(eq(result), any())

--- a/android-components/ktlint-baseline.xml
+++ b/android-components/ktlint-baseline.xml
@@ -3731,17 +3731,6 @@
         <error line="349" column="1" source="standard:max-line-length" />
         <error line="378" column="1" source="standard:max-line-length" />
         <error line="487" column="1" source="standard:max-line-length" />
-        <error line="548" column="1" source="standard:max-line-length" />
-        <error line="548" column="44" source="standard:parameter-list-wrapping" />
-        <error line="548" column="66" source="standard:parameter-list-wrapping" />
-        <error line="548" column="110" source="standard:parameter-list-wrapping" />
-        <error line="548" column="123" source="standard:parameter-list-wrapping" />
-        <error line="556" column="1" source="standard:max-line-length" />
-        <error line="556" column="42" source="standard:parameter-list-wrapping" />
-        <error line="556" column="64" source="standard:parameter-list-wrapping" />
-        <error line="556" column="108" source="standard:parameter-list-wrapping" />
-        <error line="556" column="123" source="standard:parameter-list-wrapping" />
-        <error line="556" column="149" source="standard:parameter-list-wrapping" />
     </file>
     <file name="components/feature/toolbar/src/test/java/mozilla/components/feature/toolbar/ToolbarBehaviorControllerTest.kt">
         <error line="148" column="1" source="standard:max-line-length" />


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1876419