### PR TITLE
Revert "Bug 1875923 - Update max_line_length in editorconfig to match detekt"

### DIFF
--- a/android-components/.editorconfig
+++ b/android-components/.editorconfig
@@ -9,7 +9,6 @@ root = True
 [*.kt]
 indent_size = 4
 indent_style = space
-max_line_length = 120 # Matches maxLineLength in detekt.yml
 
 ij_kotlin_allow_trailing_comma_on_call_site=true
 ij_kotlin_allow_trailing_comma=true

--- a/fenix/.editorconfig
+++ b/fenix/.editorconfig
@@ -1,7 +1,6 @@
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma_on_call_site=true
 ij_kotlin_allow_trailing_comma=true
-max_line_length = 120 # Matches maxLineLength in detekt.yml
 
 [*]
 insert_final_newline = true

--- a/focus-android/.editorconfig
+++ b/focus-android/.editorconfig
@@ -1,6 +1,5 @@
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma_on_call_site=true
 ij_kotlin_allow_trailing_comma=true
-max_line_length = 120 # Matches maxLineLength in detekt.yml
 
 ktlint_standard_filename = disabled


### PR DESCRIPTION
Reverts mozilla-mobile/firefox-android#5250
https://bugzilla.mozilla.org/show_bug.cgi?id=1875923
https://bugzilla.mozilla.org/show_bug.cgi?id=1875923