### PR TITLE
Bug 1876596 - Add probe for debug drawer secret setting

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -11353,3 +11353,19 @@ fx_suggest:
     expires: never
     send_in_pings:
       - fx-suggest
+debug_drawer:
+  debug_drawer_enabled:
+    type: boolean
+    description: |
+      Whether or not the user has enabled the Debug Drawer feature.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1876596
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/5356
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: never

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
+import org.mozilla.fenix.GleanMetrics.DebugDrawer as DebugDrawerMetrics
 
 class SecretSettingsFragment : PreferenceFragmentCompat() {
 
@@ -114,6 +115,7 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
                 onPreferenceChangeListener =
                     Preference.OnPreferenceChangeListener { _, newValue ->
                         debugSettingsRepository.setDebugDrawerEnabled(enabled = newValue as Boolean)
+                        DebugDrawerMetrics.debugDrawerEnabled.set(newValue)
                         true
                     }
             }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1876596