### PR TITLE
Bug 1813875 - Prevent the inherited theming implementation being applied to Custom Tabs views

### DIFF
--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/manifest/WebAppManifestParser.kt
@@ -207,7 +207,7 @@ private fun parseFingerprints(app: JSONObject): List<WebAppManifest.ExternalAppl
 
 @Suppress("MagicNumber")
 private fun serializeColor(color: Int?): String? = color?.let {
-    String.format("#%06X", 0xFFFFFF and color)
+    String.format("#%06X", 0xFFFFFF and it)
 }
 
 private fun serializeRelatedApplications(

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -233,8 +233,10 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
 
         // There is disk read violations on some devices such as samsung and pixel for android 9/10
         components.strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
-            // Theme setup should always be called before super.onCreate
-            setupThemeAndBrowsingMode(getModeFromIntentOrLastKnown(intent))
+            // Browsing mode & theme setup should always be called before super.onCreate.
+            setupBrowsingMode(getModeFromIntentOrLastKnown(intent))
+            setupTheme()
+
             super.onCreate(savedInstanceState)
         }
 
@@ -870,12 +872,18 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         return false
     }
 
-    private fun setupThemeAndBrowsingMode(mode: BrowsingMode) {
+    private fun setupBrowsingMode(mode: BrowsingMode) {
         settings().lastKnownMode = mode
         browsingModeManager = createBrowsingModeManager(mode)
+    }
+
+    private fun setupTheme() {
         themeManager = createThemeManager()
-        themeManager.setActivityTheme(this)
-        themeManager.applyStatusBarTheme(this)
+        // ExternalAppBrowserActivity handles it's own theming as it can be customized.
+        if (this !is ExternalAppBrowserActivity) {
+            themeManager.setActivityTheme(this)
+            themeManager.applyStatusBarTheme(this)
+        }
     }
 
     // Stop active media when activity is destroyed.

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -13,7 +13,6 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -138,6 +137,7 @@ import org.mozilla.fenix.components.toolbar.ToolbarIntegration
 import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.components.toolbar.interactor.DefaultBrowserToolbarInteractor
 import org.mozilla.fenix.crashes.CrashContentIntegration
+import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
 import org.mozilla.fenix.databinding.FragmentBrowserBinding
 import org.mozilla.fenix.downloads.DynamicDownloadDialog
 import org.mozilla.fenix.downloads.FirstPartyDownloadDialog
@@ -266,7 +266,11 @@ abstract class BaseBrowserFragment :
         _binding = FragmentBrowserBinding.inflate(inflater, container, false)
 
         val activity = activity as HomeActivity
-        activity.themeManager.applyStatusBarTheme(activity)
+        // ExternalAppBrowserActivity handles it's own theming as it can be customized.
+        if (activity !is ExternalAppBrowserActivity) {
+            activity.themeManager.applyStatusBarTheme(activity)
+        }
+
         val originalContext = ActivityContextWrapper.getOriginalContext(activity)
         binding.engineView.setActivityContext(originalContext)
 
@@ -1567,7 +1571,10 @@ abstract class BaseBrowserFragment :
             activity?.exitImmersiveMode()
             (view as? SwipeGestureLayout)?.isSwipeEnabled = true
             (activity as? HomeActivity)?.let { activity ->
-                activity.themeManager.applyStatusBarTheme(activity)
+                // ExternalAppBrowserActivity handles it's own theming as it can be customized.
+                if (activity !is ExternalAppBrowserActivity) {
+                    activity.themeManager.applyStatusBarTheme(activity)
+                }
             }
             if (webAppToolbarShouldBeVisible) {
                 browserToolbarView.view.isVisible = true


### PR DESCRIPTION
Based on my understanding that `ExternalAppBrowserActivity` should handle its own theming via the web manifest, I _think_ the issue that we are seeing (with the multiple bugs related to the status bar icons not being visible) is due to additional theming provided by the `HomeActivity` parent class (potentially another symptom of the coupled nature between Home and External App Browser). 

For now, I have gated these checks to make it explicit this is not required in External App browser usage. Ongoing refactoring of the `HomeActivity` will remove these, along with the other `ExternalAppBrowserActivity` gates.

I think there is a **separate issue** being [reported](https://bugzilla.mozilla.org/show_bug.cgi?id=1814646) in that Custom Tabs do not sync with the browser theme (light/dark) (see the Twitter app in the demo) - however, this may be by design - more investigation needed.

@MatthewTighe I believe this will have some crossover with https://bugzilla.mozilla.org/show_bug.cgi?id=1861459 - hopefully it should even be beneficial in the refactoring.

Original (Waffle & Twitter status icons not visible):

https://github.com/mozilla-mobile/firefox-android/assets/1833156/76faff1f-1ed7-43cc-90f3-65572f021419

Bug fix:

https://github.com/mozilla-mobile/firefox-android/assets/1833156/37779813-75e8-4121-8244-30a7749b355f



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





















### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1813875