### PR TITLE
Bug 1874522 - Repalce coil-kt with AndroidSVG

### DIFF
--- a/android-components/components/browser/icons/build.gradle
+++ b/android-components/components/browser/icons/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
     implementation ComponentsDependencies.thirdparty_disklrucache
 
-    implementation ComponentsDependencies.thirdparty_coil_svg
+    implementation ComponentsDependencies.thirdparty_androidsvg
 
     testImplementation project(':support-test')
     testImplementation project(':lib-fetch-httpurlconnection')

--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -26,7 +26,7 @@ object Versions {
     const val jacoco = "0.8.11"
     const val okhttp = "4.12.0"
     const val okio = "3.8.0"
-    const val coil = "2.4.0"
+    const val androidsvg = "1.4"
 
     const val android_gradle_plugin = "8.2.2"
 
@@ -211,14 +211,7 @@ object ComponentsDependencies {
     const val thirdparty_sentry = "io.sentry:sentry-android:${Versions.sentry}"
     const val thirdparty_zxing = "com.google.zxing:core:${Versions.zxing}"
     const val thirdparty_disklrucache = "com.jakewharton:disklrucache:${Versions.disklrucache}"
-    /**
-     *  ⚠️️ DO NOT use any NETWORK based operations provided by the Coil library.
-     *  ⚠️️ The Coil library should be used for DECODING data only.
-     *
-     *  Fenix is using SvgDecoder.kt for SVG decoding. However this dependency will also expose other
-     *  API features that Fenix should not use.
-     */
-    const val thirdparty_coil_svg = "io.coil-kt:coil-svg:${Versions.coil}"
+    const val thirdparty_androidsvg = "com.caverock:androidsvg-aar:${Versions.androidsvg}"
 
     const val firebase_messaging = "com.google.firebase:firebase-messaging:${Versions.Firebase.messaging}"
 }


### PR DESCRIPTION
1. Use AndriodSVG directly
    It is safe to use AndroidSVG , because it is the dependency of coil-svg

    Since android-components has its own cache mechanism , using coil-kt is just bloating.

2. Catch OOM error just like https://github.com/mozilla-mobile/firefox-android/blob/76213dc84f49a0400e009ea06e3d09fd3ad68ded/android-components/components/support/images/src/main/java/mozilla/components/support/images/decoder/AndroidImageDecoder.kt#L36
3. Set target bitmap size according to desiredSize to avoid svg too large which could also cause OOM

The code is **largely borrowed** from  https://github.com/coil-kt/coil/blob/2.4.0/coil-svg/src/main/java/coil/decode/SvgDecoder.kt with some fixed options.

( **However  I'm not sure if this patch will really fix the bug. and also i'm not sure if the bug was caused by using coil-svg**)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
5. Click on `View task in Taskcluster` in the new `DETAILS` section.
6. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1879116