### PR TITLE
Bug 1844252 - Fix verifyVideoPlaybackSystemNotificationTest UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ComposeTabDrawerRobot.kt
@@ -235,7 +235,10 @@ class ComposeTabDrawerRobot(private val composeTestRule: HomeActivityComposeTest
     /**
      * Closes a tab when there is only one tab open.
      */
+    @OptIn(ExperimentalTestApi::class)
     fun closeTab() {
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag(TabsTrayTestTag.tabItemClose))
+        composeTestRule.closeTabButton().assertExists()
         composeTestRule.closeTabButton().performClick()
         Log.i(TAG, "closeTab: Clicked close tab button")
     }


### PR DESCRIPTION
Summary:

- The problem seem to be happening when trying to click the close button of the open tab (`closeTab`)
- To overcome this problem before performing the click, I've added a wait for the button to exist and an assertion
- To be 100% sure that it works properly, I've removed the RetryRule and the UI test successfully passed 200x on Firebase ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1844252