### PR TITLE
Bug 1868469 - Update the url immediately for existing engineSession

### DIFF
--- a/android-components/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
+++ b/android-components/components/feature/session/src/main/java/mozilla/components/feature/session/SessionUseCases.kt
@@ -4,6 +4,7 @@
 
 package mozilla.components.feature.session
 
+import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.CrashAction
 import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.LastAccessAction
@@ -98,6 +99,13 @@ class SessionUseCases(
                     parent = parentEngineSession,
                     flags = flags,
                     additionalHeaders = additionalHeaders,
+                )
+                // Update the url in content immediately until the engine updates with any new changes to the state.
+                store.dispatch(
+                    ContentAction.UpdateUrlAction(
+                        loadSessionId,
+                        url,
+                    ),
                 )
                 store.dispatch(
                     EngineAction.OptimizedLoadUrlTriggeredAction(

--- a/android-components/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
+++ b/android-components/components/feature/session/src/test/java/mozilla/components/feature/session/SessionUseCasesTest.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.state.action.EngineAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.engine.EngineMiddleware
 import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createCustomTab
@@ -80,6 +81,7 @@ class SessionUseCasesTest {
             assertEquals("mozilla", action.tabId)
             assertEquals("https://getpocket.com", action.url)
         }
+        assertEquals("https://getpocket.com", store.state.selectedTab?.content?.url)
 
         useCases.loadUrl("https://www.mozilla.org", LoadUrlFlags.select(LoadUrlFlags.EXTERNAL))
         store.waitUntilIdle()
@@ -93,6 +95,7 @@ class SessionUseCasesTest {
             assertEquals("https://www.mozilla.org", action.url)
             assertEquals(LoadUrlFlags.select(LoadUrlFlags.EXTERNAL), action.flags)
         }
+        assertEquals("https://www.mozilla.org", store.state.selectedTab?.content?.url)
 
         useCases.loadUrl("https://firefox.com", store.state.selectedTabId)
         store.waitUntilIdle()
@@ -102,6 +105,7 @@ class SessionUseCasesTest {
             assertEquals("mozilla", action.tabId)
             assertEquals("https://firefox.com", action.url)
         }
+        assertEquals("https://firefox.com", store.state.selectedTab?.content?.url)
 
         useCases.loadUrl.invoke(
             "https://developer.mozilla.org",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,13 +19,16 @@ permalink: /changelog/
 
 * **all components**
   * All new usages of the `concept-fetch` component to make fetch requests now have conservative-mode off by default. Current features will continue to use conservative mode until individually updated.
-  
+
 * **browser-toolbar**
   * Add `showMenuButton` and `hideMenuButton` API to `BrowserToolbar` and `DisplayToolbar` to allow hiding and showing of the menu button in
   the `BrowserToolbar` [Bug 1864760](https://bugzilla.mozilla.org/show_bug.cgi?id=1864760)
 
 * **feature-customtabs**
   * Fallback behaviour when failing to open a new window in custom tab will now be loading the URL directly in the same custom tab. [Bug 1832357](https://bugzilla.mozilla.org/show_bug.cgi?id=1832357)
+
+* **feature-session**
+  * Update URL in the store immediately when using the optimized load URL code path.
 
 # 123.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v122..releases_v123)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
@@ -85,7 +85,7 @@ class CrashReportingTest : TestSetup() {
             verifyPageContent(tabCrashMessage)
         }.openTabDrawer {
             verifyExistingOpenTabs(firstWebPage.title)
-            verifyExistingOpenTabs(secondWebPage.title)
+            verifyExistingOpenTabs("about:crashcontent")
         }.closeTabDrawer {
         }.goToHomescreen {
             verifyExistingTopSitesList()


### PR DESCRIPTION
When we have an existing `engineSession` we use an optimized route to load the url without needing to dispatch the load action. This is still a valid performance improvement to make page loads faster.

However, in this code path we do not end up update the url in the state until we get back a response from the Engine. This gives a perceived performance loss of slow browsing. Updating the url gives UI components an immediate update which reflects a change that would have been entered by the user.

It was considered if we should do this in a middleware, but since this is an optimized route, we should not wait for the middleware to process the action before we perform the state update.

#### Before
[Screen_recording_20240131_171947.webm](https://github.com/mozilla-mobile/firefox-android/assets/1370580/63b16639-1200-4705-b286-b5e9e3c6b5f3)

#### After
[Screen_recording_20240131_172149.webm](https://github.com/mozilla-mobile/firefox-android/assets/1370580/91ecfda6-0b7a-4a45-bfb3-ede05911a470)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1868469