### PR TITLE
Bug 1877938 - Remove redundant assertion functions from BookmarksRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -138,7 +138,7 @@ class BookmarksTest {
             clickAddFolderButton()
             addNewFolderName(bookmarksFolderName)
             navigateUp()
-            verifyKeyboardHidden()
+            verifyKeyboardHidden(isExpectedToBeVisible = false)
             verifyBookmarkFolderIsNotCreated(bookmarksFolderName)
         }
     }
@@ -210,7 +210,7 @@ class BookmarksTest {
             ) {}
         }.openThreeDotMenu(defaultWebPage.title) {
         }.clickCopy {
-            verifyCopySnackBarText()
+            verifySnackBarText(expectedText = "URL copied")
             navigateUp()
         }
 
@@ -497,7 +497,7 @@ class BookmarksTest {
         }
 
         bookmarksMenu {
-            verifyDeleteMultipleBookmarksSnackBar()
+            verifySnackBarText(expectedText = "Bookmarks deleted")
             clickUndoDeleteButton()
             verifyBookmarkedURL(firstWebPage.url.toString())
             verifyBookmarkedURL(secondWebPage.url.toString())
@@ -515,7 +515,7 @@ class BookmarksTest {
         }
 
         bookmarksMenu {
-            verifyDeleteMultipleBookmarksSnackBar()
+            verifySnackBarText(expectedText = "Bookmarks deleted")
         }
     }
 
@@ -603,7 +603,7 @@ class BookmarksTest {
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list)),
             ) {
                 longTapDesktopFolder("Desktop Bookmarks")
-                verifySelectDefaultFolderSnackBarText()
+                verifySnackBarText(expectedText = "Can’t edit default folders")
             }
         }
     }
@@ -626,7 +626,7 @@ class BookmarksTest {
             cancelDeletion()
             clickDeleteInEditModeButton()
             confirmDeletion()
-            verifyDeleteSnackBarText()
+            verifySnackBarText(expectedText = "Deleted")
             verifyBookmarkIsDeleted("Test_Page_1")
         }
     }
@@ -787,13 +787,13 @@ class BookmarksTest {
         }.openThreeDotMenu("My Folder") {
         }.clickDelete {
             confirmDeletion()
-            verifyDeleteSnackBarText()
+            verifySnackBarText(expectedText = "Deleted")
             clickUndoDeleteButton()
             verifyFolderTitle("My Folder")
         }.openThreeDotMenu("My Folder") {
         }.clickDelete {
             confirmDeletion()
-            verifyDeleteSnackBarText()
+            verifySnackBarText(expectedText = "Deleted")
             verifyBookmarkIsDeleted("My Folder")
             verifyBookmarkIsDeleted("My Folder 2")
             verifyBookmarkIsDeleted("Test_Page_1")

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeBookmarksTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ComposeBookmarksTest.kt
@@ -28,6 +28,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.clickSnackbarButton
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
+import org.mozilla.fenix.helpers.TestHelper.verifySnackBarText
 import org.mozilla.fenix.ui.robots.bookmarksMenu
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -111,7 +112,7 @@ class ComposeBookmarksTest {
             clickAddFolderButton()
             addNewFolderName(bookmarksFolderName)
             navigateUp()
-            verifyKeyboardHidden()
+            verifyKeyboardHidden(isExpectedToBeVisible = false)
             verifyBookmarkFolderIsNotCreated(bookmarksFolderName)
         }
     }
@@ -183,7 +184,7 @@ class ComposeBookmarksTest {
             ) {}
         }.openThreeDotMenu(defaultWebPage.title) {
         }.clickCopy {
-            verifyCopySnackBarText()
+            verifySnackBarText(expectedText = "URL copied")
             navigateUp()
         }
 
@@ -469,7 +470,7 @@ class ComposeBookmarksTest {
         }
 
         bookmarksMenu {
-            verifyDeleteMultipleBookmarksSnackBar()
+            verifySnackBarText(expectedText = "Bookmarks deleted")
             clickUndoDeleteButton()
             verifyBookmarkedURL(firstWebPage.url.toString())
             verifyBookmarkedURL(secondWebPage.url.toString())
@@ -487,7 +488,7 @@ class ComposeBookmarksTest {
         }
 
         bookmarksMenu {
-            verifyDeleteMultipleBookmarksSnackBar()
+            verifySnackBarText(expectedText = "Bookmarks deleted")
         }
     }
 
@@ -575,7 +576,7 @@ class ComposeBookmarksTest {
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list)),
             ) {
                 longTapDesktopFolder("Desktop Bookmarks")
-                verifySelectDefaultFolderSnackBarText()
+                verifySnackBarText(expectedText = "Can’t edit default folders")
             }
         }
     }
@@ -598,7 +599,7 @@ class ComposeBookmarksTest {
             cancelDeletion()
             clickDeleteInEditModeButton()
             confirmDeletion()
-            verifyDeleteSnackBarText()
+            verifySnackBarText(expectedText = "Deleted")
             verifyBookmarkIsDeleted("Test_Page_1")
         }
     }
@@ -764,13 +765,13 @@ class ComposeBookmarksTest {
         }.openThreeDotMenu("My Folder") {
         }.clickDelete {
             confirmDeletion()
-            verifyDeleteSnackBarText()
+            verifySnackBarText(expectedText = "Deleted")
             clickUndoDeleteButton()
             verifyFolderTitle("My Folder")
         }.openThreeDotMenu("My Folder") {
         }.clickDelete {
             confirmDeletion()
-            verifyDeleteSnackBarText()
+            verifySnackBarText(expectedText = "Deleted")
             verifyBookmarkIsDeleted("My Folder")
             verifyBookmarkIsDeleted("My Folder 2")
             verifyBookmarkIsDeleted("Test_Page_1")

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -79,8 +79,6 @@ class BookmarksRobot {
         Log.i(TAG, "verifyCloseButton: Verified close bookmarks section button is visible")
     }
 
-    fun verifyDeleteMultipleBookmarksSnackBar() = assertSnackBarText("Bookmarks deleted")
-
     fun verifyBookmarkFavicon(forUrl: Uri) {
         bookmarkFavicon(forUrl.toString()).check(
             matches(
@@ -137,8 +135,6 @@ class BookmarksRobot {
         )
     }
 
-    fun verifyDeleteSnackBarText() = assertSnackBarText("Deleted")
-
     fun verifyUndoDeleteSnackBarButton() {
         snackBarUndoButton().check(matches(withText("UNDO")))
         Log.i(TAG, "verifyUndoDeleteSnackBarButton: Verified bookmark deletion undo snack bar button")
@@ -154,8 +150,6 @@ class BookmarksRobot {
         Log.i(TAG, "verifySnackBarHidden: Verified bookmark snack bar does not exist")
     }
 
-    fun verifyCopySnackBarText() = assertSnackBarText("URL copied")
-
     fun verifyEditBookmarksView() =
         assertUIObjectExists(
             itemWithDescription("Navigate up"),
@@ -167,7 +161,15 @@ class BookmarksRobot {
             itemWithResId("$packageName:id/bookmarkParentFolderSelector"),
         )
 
-    fun verifyKeyboardHidden() = assertKeyboardVisibility(isExpectedToBeVisible = false)
+    fun verifyKeyboardHidden(isExpectedToBeVisible: Boolean) {
+        assertEquals(
+            isExpectedToBeVisible,
+            mDevice
+                .executeShellCommand("dumpsys input_method | grep mInputShown")
+                .contains("mInputShown=true"),
+        )
+        Log.i(TAG, "assertKeyboardVisibility: Verified that the keyboard is visible: $isExpectedToBeVisible")
+    }
 
     fun verifyShareOverlay() {
         onView(withId(R.id.shareWrapper)).check(matches(isDisplayed()))
@@ -188,8 +190,6 @@ class BookmarksRobot {
         onView(withId(R.id.share_tab_url)).check(matches(isDisplayed()))
         Log.i(TAG, "verifyShareBookmarkUrl: Verified shared bookmarks url is displayed")
     }
-
-    fun verifySelectDefaultFolderSnackBarText() = assertSnackBarText("Can’t edit default folders")
 
     fun verifyCurrentFolderTitle(title: String) {
         Log.i(TAG, "verifyCurrentFolderTitle: Looking for bookmark with title: $title")
@@ -468,21 +468,3 @@ private fun saveBookmarkButton() = onView(withId(R.id.save_bookmark_button))
 private fun deleteInEditModeButton() = onView(withId(R.id.delete_bookmark_button))
 
 private fun syncSignInButton() = onView(withId(R.id.bookmark_folders_sign_in))
-
-private fun assertEmptyBookmarksList() =
-    onView(withId(R.id.bookmarks_empty_view)).check(matches(withText("No bookmarks here")))
-
-private fun assertSnackBarText(text: String) {
-    snackBarText().check(matches(withText(containsString(text))))
-    Log.i(TAG, "assertSnackBarText: Verified $text snack bar")
-}
-
-private fun assertKeyboardVisibility(isExpectedToBeVisible: Boolean) {
-    assertEquals(
-        isExpectedToBeVisible,
-        mDevice
-            .executeShellCommand("dumpsys input_method | grep mInputShown")
-            .contains("mInputShown=true"),
-    )
-    Log.i(TAG, "assertKeyboardVisibility: Verified that the keyboard is visible: $isExpectedToBeVisible")
-}


### PR DESCRIPTION
Summary:

- As part of the Android test hardening, I've removed the redundant assertion functions
- Removed some unused functions
- Switched to use `verifySnackBarText` from `TestHelper` in the bookmarks related UI tests as it looks I've overlooked it in the previous PR

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1877938