### PR TITLE
Bug 1877945 - Remove redundant assertion functions from FindInPageRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/FindInPageRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/FindInPageRobot.kt
@@ -27,9 +27,21 @@ import org.mozilla.fenix.helpers.ext.waitNotNull
  * Implementation of Robot Pattern for the find in page UI.
  */
 class FindInPageRobot {
-    fun verifyFindInPageNextButton() = assertFindInPageNextButton()
-    fun verifyFindInPagePrevButton() = assertFindInPagePrevButton()
-    fun verifyFindInPageCloseButton() = assertFindInPageCloseButton()
+    fun verifyFindInPageNextButton() {
+        findInPageNextButton()
+            .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyFindInPageNextButton: Verified find in page next result button is visible")
+    }
+    fun verifyFindInPagePrevButton() {
+        findInPagePrevButton()
+            .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyFindInPagePrevButton: Verified find in page previous result button is visible")
+    }
+    fun verifyFindInPageCloseButton() {
+        findInPageCloseButton()
+            .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyFindInPageCloseButton: Verified find in page close button is visible")
+    }
     fun clickFindInPageNextButton() {
         findInPageNextButton().click()
         Log.i(TAG, "clickFindInPageNextButton: Clicked next result button")
@@ -84,21 +96,3 @@ private fun findInPageResult() = onView(withId(R.id.find_in_page_result_text))
 private fun findInPageNextButton() = onView(withId(R.id.find_in_page_next_btn))
 private fun findInPagePrevButton() = onView(withId(R.id.find_in_page_prev_btn))
 private fun findInPageCloseButton() = onView(withId(R.id.find_in_page_close_btn))
-
-private fun assertFindInPageNextButton() {
-    findInPageNextButton()
-        .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    Log.i(TAG, "assertFindInPageNextButton: Verified find in page next result button is visible")
-}
-
-private fun assertFindInPagePrevButton() {
-    findInPagePrevButton()
-        .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    Log.i(TAG, "assertFindInPagePrevButton: Verified find in page previous result button is visible")
-}
-
-private fun assertFindInPageCloseButton() {
-    findInPageCloseButton()
-        .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    Log.i(TAG, "assertFindInPageCloseButton: Verified find in page close button is visible")
-}

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/FindInPageRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/FindInPageRobot.kt
@@ -28,48 +28,59 @@ import org.mozilla.fenix.helpers.ext.waitNotNull
  */
 class FindInPageRobot {
     fun verifyFindInPageNextButton() {
+        Log.i(TAG, "verifyFindInPageNextButton: Trying to verify find in page next result button is visible")
         findInPageNextButton()
             .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
         Log.i(TAG, "verifyFindInPageNextButton: Verified find in page next result button is visible")
     }
     fun verifyFindInPagePrevButton() {
+        Log.i(TAG, "verifyFindInPagePrevButton: Trying to verify find in page previous result button is visible")
         findInPagePrevButton()
             .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
         Log.i(TAG, "verifyFindInPagePrevButton: Verified find in page previous result button is visible")
     }
     fun verifyFindInPageCloseButton() {
+        Log.i(TAG, "verifyFindInPageCloseButton: Trying to verify find in page close button is visible")
         findInPageCloseButton()
             .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
         Log.i(TAG, "verifyFindInPageCloseButton: Verified find in page close button is visible")
     }
     fun clickFindInPageNextButton() {
+        Log.i(TAG, "clickFindInPageNextButton: Trying to click next result button")
         findInPageNextButton().click()
         Log.i(TAG, "clickFindInPageNextButton: Clicked next result button")
     }
     fun clickFindInPagePrevButton() {
+        Log.i(TAG, "clickFindInPagePrevButton: Trying to click previous result button")
         findInPagePrevButton().click()
         Log.i(TAG, "clickFindInPagePrevButton: Clicked previous result button")
     }
 
     fun enterFindInPageQuery(expectedText: String) {
         mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/find_in_page_query_text")), waitingTime)
+        Log.i(TAG, "enterFindInPageQuery: Trying to clear find in page bar text")
         findInPageQuery().perform(clearText())
         Log.i(TAG, "enterFindInPageQuery: Cleared find in page bar text")
         mDevice.waitNotNull(Until.gone(By.res("org.mozilla.fenix.debug:id/find_in_page_result_text")), waitingTime)
+        Log.i(TAG, "enterFindInPageQuery: Trying to type $expectedText in find in page bar")
         findInPageQuery().perform(typeText(expectedText))
-        Log.i(TAG, "enterFindInPageQuery: Typed $expectedText to find in page bar")
+        Log.i(TAG, "enterFindInPageQuery: Typed $expectedText in find page bar")
         mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/find_in_page_result_text")), waitingTime)
     }
 
     fun verifyFindInPageResult(ratioCounter: String) {
         mDevice.waitNotNull(Until.findObject(By.text(ratioCounter)), waitingTime)
+        Log.i(TAG, "verifyFindInPageResult: Trying to verify $ratioCounter results")
         findInPageResult().check(matches(withText((ratioCounter))))
         Log.i(TAG, "verifyFindInPageResult: Verified $ratioCounter results")
     }
 
     class Transition {
         fun closeFindInPageWithCloseButton(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            Log.i(TAG, "closeFindInPageWithCloseButton: Waiting for device to be idle")
             mDevice.waitForIdle()
+            Log.i(TAG, "closeFindInPageWithCloseButton: Device was idle")
+            Log.i(TAG, "closeFindInPageWithCloseButton: Trying to close find in page button")
             findInPageCloseButton().click()
             Log.i(TAG, "closeFindInPageWithCloseButton: Clicked close find in page button")
             BrowserRobot().interact()
@@ -77,11 +88,15 @@ class FindInPageRobot {
         }
 
         fun closeFindInPageWithBackButton(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            Log.i(TAG, "closeFindInPageWithBackButton: Waiting for device to be idle")
             mDevice.waitForIdle()
+            Log.i(TAG, "closeFindInPageWithBackButton: Device was idle")
 
             // Will need to press back 2x, the first will only dismiss the keyboard
+            Log.i(TAG, "closeFindInPageWithBackButton: Trying to press 1x the device back button")
             mDevice.pressBack()
             Log.i(TAG, "closeFindInPageWithBackButton: Pressed 1x the device back button")
+            Log.i(TAG, "closeFindInPageWithBackButton: Trying to press 2x the device back button")
             mDevice.pressBack()
             Log.i(TAG, "closeFindInPageWithBackButton: Pressed 2x the device back button")
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1877945