### PR TITLE
Bug 1682027 - Disable failing facebook android test.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -128,7 +128,8 @@ tasks:
             - [amazon-search, amazon-s]
             - [microsoft-support, micros-sup]
             - espn
-            - facebook
+            # Bug 1682027 - Disabled due to high failure rate
+            # - facebook
             - [youtube-watch, youtube-w]
             - allrecipes
 


### PR DESCRIPTION
This patch disables a failing android test on this branch.
https://bugzilla.mozilla.org/show_bug.cgi?id=1682027