### PR TITLE
Bug 1870425 - Cancel group notification when destroyed

### DIFF
--- a/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
+++ b/android-components/components/feature/downloads/src/main/java/mozilla/components/feature/downloads/AbstractFetchDownloadService.kt
@@ -445,6 +445,9 @@ abstract class AbstractFetchDownloadService : Service() {
             notificationManager.cancel(state.foregroundServiceId)
             state.job?.cancel()
         }
+        if (SDK_INT >= Build.VERSION_CODES.N) {
+            notificationManager.cancel(NOTIFICATION_DOWNLOAD_GROUP_ID)
+        }
     }
 
     @Suppress("TooGenericExceptionCaught")


### PR DESCRIPTION
| Before| After|
|--------|--------|
| <video src="https://github.com/mozilla-mobile/firefox-android/assets/2900871/700c8d76-4337-41d4-b6d9-071b9fdb49ec" /> | <video src="https://github.com/mozilla-mobile/firefox-android/assets/2900871/3f4460d0-13c4-4d5b-ae8d-ca0bcefb6442" /> |




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1870425