### PR TITLE
Bug 1870050 - Properly define buildConfigField SUPPORTED_LOCALE_ARRAY

### DIFF
--- a/fenix/app/build.gradle
+++ b/fenix/app/build.gradle
@@ -82,6 +82,8 @@ android {
                 "targetActivity": targetActivity,
                 "deepLinkScheme": deepLinkSchemeValue
         ]
+
+        buildConfigField "String[]", "SUPPORTED_LOCALE_ARRAY", getSupportedLocales()
     }
 
     def releaseTemplate = {
@@ -488,7 +490,6 @@ android.applicationVariants.configureEach { variant ->
     } else {
         buildConfigField "boolean", "LEAKCANARY", "false"
     }
-
 }
 
 // Generate Kotlin code for the Fenix Glean metrics.
@@ -819,25 +820,6 @@ tasks.register('printVariants') {
     }
 }
 
-tasks.register('buildTranslationArray') {
-    // This isn't running as a task, instead the array is build when the gradle file is parsed.
-    // https://github.com/mozilla-mobile/fenix/issues/14175
-    def foundLocales = new StringBuilder()
-    foundLocales.append("new String[]{")
-
-    fileTree("src/main/res").visit { FileVisitDetails details ->
-        if (details.file.path.endsWith("${File.separator}strings.xml")) {
-            def languageCode = details.file.parent.tokenize(File.separator).last().replaceAll('values-', '').replaceAll('-r', '-')
-            languageCode = (languageCode == "values") ? "en-US" : languageCode
-            foundLocales.append("\"").append(languageCode).append("\"").append(",")
-        }
-    }
-
-    foundLocales.append("}")
-    def foundLocalesString = foundLocales.toString().replaceAll(',}', '}')
-    android.defaultConfig.buildConfigField "String[]", "SUPPORTED_LOCALE_ARRAY", foundLocalesString
-}
-
 afterEvaluate {
 
     // Format test output. Ported from AC #2401
@@ -902,6 +884,25 @@ android.applicationVariants.configureEach { variant ->
         apks = variant.outputs.collect { output -> output.outputFile.name }
         dependsOn "package${variant.name.capitalize()}"
     }
+}
+
+def getSupportedLocales() {
+    // This isn't running as a task, instead the array is build when the gradle file is parsed.
+    // https://github.com/mozilla-mobile/fenix/issues/14175
+    def foundLocales = new StringBuilder()
+    foundLocales.append("new String[]{")
+
+    fileTree("src/main/res").visit { FileVisitDetails details ->
+        if (details.file.path.endsWith("${File.separator}strings.xml")) {
+            def languageCode = details.file.parent.tokenize(File.separator).last().replaceAll('values-', '').replaceAll('-r', '-')
+            languageCode = (languageCode == "values") ? "en-US" : languageCode
+            foundLocales.append("\"").append(languageCode).append("\"").append(",")
+        }
+    }
+
+    foundLocales.append("}")
+    def foundLocalesString = foundLocales.toString().replaceAll(',}', '}')
+    return foundLocalesString
 }
 
 // Enable expiration by major version.


### PR DESCRIPTION
This was previously generated as a side effect, and fails with the new AGP version. See also https://github.com/mozilla-mobile/fenix/issues/14175.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
