### PR TITLE
Bug 1878434 - Add the `awesomebar.{engagement, abandonment}` events.

### DIFF
--- a/fenix/app/metrics.yaml
+++ b/fenix/app/metrics.yaml
@@ -9204,8 +9204,10 @@ awesomebar:
       A sponsored suggestion was visible when the user finished interacting with the awesomebar.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1871156
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1878434
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-android/pull/4914#issuecomment-1874271848
+      - https://github.com/mozilla-mobile/firefox-android/pull/5438#issuecomment-1930970336
     data_sensitivity:
       - interaction
     notification_emails:
@@ -9216,12 +9218,6 @@ awesomebar:
     expires: never
     extra_keys:
       provider: *sponsored_suggestion_provider
-      engagement_abandoned: &awesomebar_engagement_abandoned
-        description: |
-          If `true`, the user dismissed the awesomebar without navigating to a destination. If
-          `false`, the user finished engaging with the awesomebar by navigating to a destination,
-          like a URL, a search results page, or a suggestion.
-        type: boolean
     metadata:
       tags:
         - Search
@@ -9231,8 +9227,10 @@ awesomebar:
       A non-sponsored suggestion was visible when the user finished interacting with the awesomebar.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1871156
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1878434
     data_reviews:
       - https://github.com/mozilla-mobile/firefox-android/pull/4914#issuecomment-1874271848
+      - https://github.com/mozilla-mobile/firefox-android/pull/5438#issuecomment-1930970336
     data_sensitivity:
       - interaction
     notification_emails:
@@ -9243,10 +9241,49 @@ awesomebar:
     expires: never
     extra_keys:
       provider: *non_sponsored_suggestion_provider
-      engagement_abandoned: *awesomebar_engagement_abandoned
     metadata:
       tags:
         - Search
+  engagement:
+    type: event
+    description: |
+      The user completed their search session by tapping a search result,
+      or entering a URL or a search term.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1878434
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/5438#issuecomment-1930970336
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - Search
+  abandonment:
+    type: event
+    description: |
+      The user dismissed the awesomebar without completing their search.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1878434
+    data_reviews:
+      - https://github.com/mozilla-mobile/firefox-android/pull/5438#issuecomment-1930970336
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - lina@mozilla.com
+      - ttran@mozilla.com
+      - najiang@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - Search
+
 android_autofill:
   supported:
     type: boolean

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -339,7 +339,6 @@ internal class ReleaseMetricController(
                     Awesomebar.sponsoredSuggestionImpressed.record(
                         Awesomebar.SponsoredSuggestionImpressedExtra(
                             provider = "amp",
-                            engagementAbandoned = engagementAbandoned,
                         ),
                     )
                 }
@@ -347,7 +346,6 @@ internal class ReleaseMetricController(
                     Awesomebar.nonSponsoredSuggestionImpressed.record(
                         Awesomebar.NonSponsoredSuggestionImpressedExtra(
                             provider = "wikipedia",
-                            engagementAbandoned = engagementAbandoned,
                         ),
                     )
                 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -143,6 +143,7 @@ class SearchDialogController(
     override fun handleEditingCancelled() {
         clearToolbarFocus()
         dismissDialogAndGoBack()
+        store.dispatch(AwesomeBarAction.EngagementFinished(abandoned = true))
     }
 
     override fun handleTextChanged(text: String) {

--- a/fenix/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.telemetry
 
 import android.content.Context
+import mozilla.components.browser.state.action.AwesomeBarAction
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.DownloadAction
@@ -25,6 +26,7 @@ import mozilla.telemetry.glean.internal.TimerId
 import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.Addons
+import org.mozilla.fenix.GleanMetrics.Awesomebar
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.Metrics
 import org.mozilla.fenix.components.metrics.Event
@@ -59,7 +61,7 @@ class TelemetryMiddleware(
 
     private val logger = Logger("TelemetryMiddleware")
 
-    @Suppress("TooGenericExceptionCaught", "ComplexMethod", "NestedBlockDepth")
+    @Suppress("TooGenericExceptionCaught", "ComplexMethod", "NestedBlockDepth", "LongMethod")
     override fun invoke(
         context: MiddlewareContext<BrowserState, BrowserAction>,
         next: (BrowserAction) -> Unit,
@@ -143,6 +145,13 @@ class TelemetryMiddleware(
             }
             is ExtensionsProcessAction.DisabledAction -> {
                 Addons.extensionsProcessUiDisable.add()
+            }
+            is AwesomeBarAction.EngagementFinished -> {
+                if (action.abandoned) {
+                    Awesomebar.abandonment.record()
+                } else {
+                    Awesomebar.engagement.record()
+                }
             }
             else -> {
                 // no-op

--- a/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -313,6 +313,10 @@ class SearchDialogControllerTest {
 
         assertTrue(clearToolbarFocusInvoked)
         assertTrue(dismissAndGoBack)
+
+        middleware.assertLastAction(AwesomeBarAction.EngagementFinished::class) { action ->
+            assertTrue(action.abandoned)
+        }
     }
 
     @Test


### PR DESCRIPTION
This commit:

* Sends the new `awesomebar.{engagement, abandonment}` events when the user finishes interacting with the awesomebar. These events match [iOS's events of the same name](https://github.com/mozilla-mobile/firefox-ios/pull/18452), and Desktop's `urlbar.{engagement, abandonment}` events.
* Removes the `engagement_abandoned` extra key for the `awesomebar.{sponsored, non_sponsored}_suggestion_impressed` events, since they're specific to AMP and Wikipedia suggestions, and are subsumed by the new events.

This is the first step toward unifying our awesomebar search telemetry on all our platforms.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1878434