### PR TITLE
Bug 1567912 - Add signing-bundle as a dependency for notify-promote

### DIFF
--- a/taskcluster/ci/release-notify-promote/kind.yml
+++ b/taskcluster/ci/release-notify-promote/kind.yml
@@ -11,6 +11,7 @@ transforms:
 
 kind-dependencies:
     - signing-apk
+    - signing-bundle
 
 task-defaults:
     name: notify-release-drivers-promote


### PR DESCRIPTION
Donal noticed this today.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1567912