### PR TITLE
Bug 1866990 - Disable collection, share and menu in multiselect mode when no tab is selected

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayBanner.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayBanner.kt
@@ -426,25 +426,37 @@ private fun MultiSelectBanner(
                 contentDescription = stringResource(
                     id = R.string.tab_tray_collection_button_multiselect_content_description,
                 ),
-                tint = FirefoxTheme.colors.iconOnColor,
+                tint = if (selectedTabCount > 0) {
+                    FirefoxTheme.colors.iconOnColor
+                } else {
+                    FirefoxTheme.colors.iconDisabled
+                },
             )
         }
 
-        IconButton(onClick = onShareSelectedTabs) {
+        IconButton(onClick = onShareSelectedTabs, enabled = selectedTabCount > 0) {
             Icon(
                 painter = painterResource(id = R.drawable.ic_share),
                 contentDescription = stringResource(
                     id = R.string.tab_tray_multiselect_share_content_description,
                 ),
-                tint = FirefoxTheme.colors.iconOnColor,
+                tint = if (selectedTabCount > 0) {
+                    FirefoxTheme.colors.iconOnColor
+                } else {
+                    FirefoxTheme.colors.iconDisabled
+                },
             )
         }
 
-        IconButton(onClick = { showMenu = true }) {
+        IconButton(onClick = { showMenu = true }, enabled = selectedTabCount > 0) {
             Icon(
                 painter = painterResource(id = R.drawable.ic_menu),
                 contentDescription = stringResource(id = R.string.tab_tray_multiselect_menu_content_description),
-                tint = FirefoxTheme.colors.iconOnColor,
+                tint = if (selectedTabCount > 0) {
+                    FirefoxTheme.colors.iconOnColor
+                } else {
+                    FirefoxTheme.colors.iconDisabled
+                },
             )
 
             ContextualMenu(


### PR DESCRIPTION
Disabled collection, share and menu buttons from multi select banner when no tab is selected.

![Screenshot_20240206_202247](https://github.com/mozilla-mobile/firefox-android/assets/35462038/9f8db3c8-d986-4361-9960-8db06d88e29c)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1866990