### PR TITLE
Bug 1879027 - Add missing pairs of logs to CollectionRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
@@ -48,6 +48,7 @@ class CollectionRobot {
         )
 
     fun clickAddNewCollection() {
+        Log.i(TAG, "clickAddNewCollection: Trying to click the add new collection button")
         addNewCollectionButton().click()
         Log.i(TAG, "clickAddNewCollection: Clicked the add new collection button")
     }
@@ -56,25 +57,33 @@ class CollectionRobot {
 
     // names a collection saved from tab drawer
     fun typeCollectionNameAndSave(collectionName: String) {
+        Log.i(TAG, "typeCollectionNameAndSave: Trying to set collection name text field to: $collectionName")
         collectionNameTextField().text = collectionName
         Log.i(TAG, "typeCollectionNameAndSave: Collection name text field set to: $collectionName")
+        Log.i(TAG, "typeCollectionNameAndSave: Waiting for $waitingTime ms for add collection button panel to exist")
         addCollectionButtonPanel().waitForExists(waitingTime)
+        Log.i(TAG, "typeCollectionNameAndSave: Waited for $waitingTime ms for add collection button panel to exist")
+        Log.i(TAG, "typeCollectionNameAndSave: Trying to click \"OK\" panel button")
         addCollectionOkButton().click()
         Log.i(TAG, "typeCollectionNameAndSave: Clicked \"OK\" panel button")
     }
 
     fun verifyTabsSelectedCounterText(numOfTabs: Int) {
-        Log.i(TAG, "verifyTabsSelectedCounterText: Waiting for \"Select tabs to save\" prompt to be gone")
+        Log.i(TAG, "verifyTabsSelectedCounterText: Waiting for $waitingTime ms for \"Select tabs to save\" prompt to be gone")
         itemWithText("Select tabs to save").waitUntilGone(waitingTime)
+        Log.i(TAG, "verifyTabsSelectedCounterText: Waited for $waitingTime ms for \"Select tabs to save\" prompt to be gone")
 
         val tabsCounter = mDevice.findObject(UiSelector().resourceId("$packageName:id/bottom_bar_text"))
+        Log.i(TAG, "verifyTabsSelectedCounterText: Trying to assert that number of tabs selected is: $numOfTabs")
         when (numOfTabs) {
             1 -> assertItemTextEquals(tabsCounter, expectedText = "$numOfTabs tab selected")
             2 -> assertItemTextEquals(tabsCounter, expectedText = "$numOfTabs tabs selected")
         }
+        Log.i(TAG, "verifyTabsSelectedCounterText: Asserted number of tabs selected is: $numOfTabs")
     }
 
     fun saveTabsSelectedForCollection() {
+        Log.i(TAG, "saveTabsSelectedForCollection: Trying to click \"Save\" button")
         itemWithResId("$packageName:id/save_button").click()
         Log.i(TAG, "saveTabsSelectedForCollection: Clicked \"Save\" button")
     }
@@ -96,11 +105,14 @@ class CollectionRobot {
 
     fun verifyCollectionMenuIsVisible(visible: Boolean, rule: ComposeTestRule) {
         if (visible) {
-            collectionThreeDotButton(rule)
-                .assertExists()
-                .assertIsDisplayed()
+            Log.i(TAG, "verifyCollectionMenuIsVisible: Trying to verify collection three dot button exists")
+            collectionThreeDotButton(rule).assertExists()
             Log.i(TAG, "verifyCollectionMenuIsVisible: Verified collection three dot button exists")
+            Log.i(TAG, "verifyCollectionMenuIsVisible: Trying to verify collection three dot button is displayed")
+            collectionThreeDotButton(rule).assertIsDisplayed()
+            Log.i(TAG, "verifyCollectionMenuIsVisible: Verified collection three dot button is displayed")
         } else {
+            Log.i(TAG, "verifyCollectionMenuIsVisible: Trying to verify collection three dot button does not exist")
             collectionThreeDotButton(rule)
                 .assertDoesNotExist()
             Log.i(TAG, "verifyCollectionMenuIsVisible: Verified collection three dot button does not exist")
@@ -108,40 +120,52 @@ class CollectionRobot {
     }
 
     fun clickCollectionThreeDotButton(rule: ComposeTestRule) {
-        collectionThreeDotButton(rule)
-            .assertIsDisplayed()
-            .performClick()
+        Log.i(TAG, "clickCollectionThreeDotButton: Trying to verify three dot button is displayed")
+        collectionThreeDotButton(rule).assertIsDisplayed()
+        Log.i(TAG, "clickCollectionThreeDotButton: Verified three dot button is displayed")
+        Log.i(TAG, "clickCollectionThreeDotButton: Trying to click three dot button")
+        collectionThreeDotButton(rule).performClick()
         Log.i(TAG, "clickCollectionThreeDotButton: Clicked three dot button")
     }
 
     fun selectOpenTabs(rule: ComposeTestRule) {
-        rule.onNode(hasText("Open tabs"))
-            .assertIsDisplayed()
-            .performClick()
+        Log.i(TAG, "selectOpenTabs: Trying to verify \"Open tabs\" menu option is displayed")
+        rule.onNode(hasText("Open tabs")).assertIsDisplayed()
+        Log.i(TAG, "selectOpenTabs: Verified \"Open tabs\" menu option is displayed")
+        Log.i(TAG, "selectOpenTabs: Trying to click \"Open tabs\" menu option")
+        rule.onNode(hasText("Open tabs")).performClick()
         Log.i(TAG, "selectOpenTabs: Clicked \"Open tabs\" menu option")
     }
 
     fun selectRenameCollection(rule: ComposeTestRule) {
-        rule.onNode(hasText("Rename collection"))
-            .assertIsDisplayed()
-            .performClick()
+        Log.i(TAG, "selectRenameCollection: Trying to verify \"Rename collection\" menu option is displayed")
+        rule.onNode(hasText("Rename collection")).assertIsDisplayed()
+        Log.i(TAG, "selectRenameCollection: Verified \"Rename collection\" menu option is displayed")
+        Log.i(TAG, "selectRenameCollection: Trying to click \"Rename collection\" menu option")
+        rule.onNode(hasText("Rename collection")).performClick()
         Log.i(TAG, "selectRenameCollection: Clicked \"Rename collection\" menu option")
+        Log.i(TAG, "selectRenameCollection: Waiting for $waitingTime ms for collection name text field to exist")
         mainMenuEditCollectionNameField().waitForExists(waitingTime)
+        Log.i(TAG, "selectRenameCollection: Waited for $waitingTime ms for collection name text field to exist")
     }
 
     fun selectAddTabToCollection(rule: ComposeTestRule) {
-        rule.onNode(hasText("Add tab"))
-            .assertIsDisplayed()
-            .performClick()
+        Log.i(TAG, "selectAddTabToCollection: Trying to verify \"Add tab\" menu option is displayed")
+        rule.onNode(hasText("Add tab")).assertIsDisplayed()
+        Log.i(TAG, "selectAddTabToCollection: Verified \"Add tab\" menu option is displayed")
+        Log.i(TAG, "selectAddTabToCollection: Trying to click \"Add tab\" menu option")
+        rule.onNode(hasText("Add tab")).performClick()
         Log.i(TAG, "selectAddTabToCollection: Clicked \"Add tab\" menu option")
 
         mDevice.waitNotNull(Until.findObject(By.text("Select Tabs")))
     }
 
     fun selectDeleteCollection(rule: ComposeTestRule) {
-        rule.onNode(hasText("Delete collection"))
-            .assertIsDisplayed()
-            .performClick()
+        Log.i(TAG, "selectDeleteCollection: Trying to verify \"Delete collection\" menu option is displayed")
+        rule.onNode(hasText("Delete collection")).assertIsDisplayed()
+        Log.i(TAG, "selectDeleteCollection: Verified \"Delete collection\" menu option is displayed")
+        Log.i(TAG, "selectDeleteCollection: Trying to click \"Delete collection\" menu option")
+        rule.onNode(hasText("Delete collection")).performClick()
         Log.i(TAG, "selectDeleteCollection: Clicked \"Delete collection\" menu option")
     }
 
@@ -149,27 +173,33 @@ class CollectionRobot {
         assertUIObjectExists(removeTabFromCollectionButton(title), exists = visible)
 
     fun removeTabFromCollection(title: String) {
+        Log.i(TAG, "removeTabFromCollection: Trying to click remove button for tab: $title")
         removeTabFromCollectionButton(title).click()
         Log.i(TAG, "removeTabFromCollection: Clicked remove button for tab: $title")
     }
 
     fun swipeTabLeft(title: String, rule: ComposeTestRule) {
+        Log.i(TAG, "swipeTabLeft: Trying to remove tab: $title using swipe left action")
         rule.onNode(hasText(title), useUnmergedTree = true)
             .performTouchInput { swipeLeft() }
         Log.i(TAG, "swipeTabLeft: Removed tab: $title using swipe left action")
+        Log.i(TAG, "swipeTabLeft: Waiting for rule to be idle")
         rule.waitForIdle()
         Log.i(TAG, "swipeTabLeft: Waited for rule to be idle")
     }
 
     fun swipeTabRight(title: String, rule: ComposeTestRule) {
+        Log.i(TAG, "swipeTabRight: Trying to remove tab: $title using swipe right action")
         rule.onNode(hasText(title), useUnmergedTree = true)
             .performTouchInput { swipeRight() }
         Log.i(TAG, "swipeTabRight: Removed tab: $title using swipe right action")
+        Log.i(TAG, "swipeTabRight: Waiting for rule to be idle")
         rule.waitForIdle()
         Log.i(TAG, "swipeTabRight: Waited for rule to be idle")
     }
 
     fun goBackInCollectionFlow() {
+        Log.i(TAG, "goBackInCollectionFlow: Trying to click collection creation flow back button")
         backButton().click()
         Log.i(TAG, "goBackInCollectionFlow: Clicked collection creation flow back button")
     }
@@ -180,8 +210,9 @@ class CollectionRobot {
             interact: HomeScreenRobot.() -> Unit,
         ): HomeScreenRobot.Transition {
             assertUIObjectExists(itemContainingText(title))
+            Log.i(TAG, "collapseCollection: Trying to click collection $title and wait for $waitingTimeShort ms for a new window")
             itemContainingText(title).clickAndWaitForNewWindow(waitingTimeShort)
-            Log.i(TAG, "collapseCollection: Clicked collection $title")
+            Log.i(TAG, "collapseCollection: Clicked collection $title and waited for $waitingTimeShort ms for a new window")
             assertUIObjectExists(itemWithDescription(getStringResource(R.string.remove_tab_from_collection)), exists = false)
 
             HomeScreenRobot().interact()
@@ -193,9 +224,13 @@ class CollectionRobot {
             name: String,
             interact: BrowserRobot.() -> Unit,
         ): BrowserRobot.Transition {
+            Log.i(TAG, "typeCollectionNameAndSave: Waiting for $waitingTime ms for collection name text field to exist")
             mainMenuEditCollectionNameField().waitForExists(waitingTime)
+            Log.i(TAG, "typeCollectionNameAndSave: Waited for $waitingTime ms for collection name text field to exist")
+            Log.i(TAG, "typeCollectionNameAndSave: Trying to set collection name text field to: $name")
             mainMenuEditCollectionNameField().text = name
             Log.i(TAG, "typeCollectionNameAndSave: Collection name text field set to: $name")
+            Log.i(TAG, "typeCollectionNameAndSave: Trying to press done action button")
             onView(withId(R.id.name_collection_edittext)).perform(pressImeActionButton())
             Log.i(TAG, "typeCollectionNameAndSave: Pressed done action button")
 
@@ -210,7 +245,10 @@ class CollectionRobot {
             title: String,
             interact: BrowserRobot.() -> Unit,
         ): BrowserRobot.Transition {
+            Log.i(TAG, "selectExistingCollection: Waiting for $waitingTime ms for collection with title: $title to exist")
             collectionTitle(title).waitForExists(waitingTime)
+            Log.i(TAG, "selectExistingCollection: Waited for $waitingTime ms for collection with title: $title to exist")
+            Log.i(TAG, "selectExistingCollection: Trying to click collection with title: $title")
             collectionTitle(title).click()
             Log.i(TAG, "selectExistingCollection: Clicked collection with title: $title")
 
@@ -219,7 +257,10 @@ class CollectionRobot {
         }
 
         fun clickShareCollectionButton(interact: ShareOverlayRobot.() -> Unit): ShareOverlayRobot.Transition {
+            Log.i(TAG, "clickShareCollectionButton: Waiting for $waitingTime ms for share collection button to exist")
             shareCollectionButton().waitForExists(waitingTime)
+            Log.i(TAG, "clickShareCollectionButton: Waited for $waitingTime ms for share collection button to exist")
+            Log.i(TAG, "clickShareCollectionButton: Trying to click share collection button")
             shareCollectionButton().click()
             Log.i(TAG, "clickShareCollectionButton: Clicked share collection button")
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1879027