### PR TITLE
 Bug 1877203 - Update Translations Page Settings

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/action/BrowserAction.kt
@@ -49,6 +49,7 @@ import mozilla.components.concept.engine.translate.TranslationEngineState
 import mozilla.components.concept.engine.translate.TranslationError
 import mozilla.components.concept.engine.translate.TranslationOperation
 import mozilla.components.concept.engine.translate.TranslationOptions
+import mozilla.components.concept.engine.translate.TranslationPageSettingOperation
 import mozilla.components.concept.engine.translate.TranslationPageSettings
 import mozilla.components.concept.engine.translate.TranslationSupport
 import mozilla.components.concept.engine.webextension.WebExtensionBrowserAction
@@ -968,6 +969,20 @@ sealed class TranslationsAction : BrowserAction() {
     data class SetPageSettingsAction(
         override val tabId: String,
         val pageSettings: TranslationPageSettings?,
+    ) : TranslationsAction(), ActionWithTab
+
+    /**
+     * Updates the specified page setting operation on the translation engine and ensures the final
+     * state on the given [tabId]'s store remains in-sync.
+     *
+     * @property tabId The ID of the tab the [EngineSession] should be linked to.
+     * @property operation The page setting update operation to perform.
+     * @property setting The boolean value of the corresponding [operation].
+     */
+    data class UpdatePageSettingAction(
+        override val tabId: String,
+        val operation: TranslationPageSettingOperation,
+        val setting: Boolean,
     ) : TranslationsAction(), ActionWithTab
 
     /**

--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TranslationsStateReducer.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TranslationsStateReducer.kt
@@ -9,6 +9,8 @@ import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TranslationsState
 import mozilla.components.concept.engine.translate.TranslationOperation
+import mozilla.components.concept.engine.translate.TranslationPageSettingOperation
+import mozilla.components.concept.engine.translate.TranslationPageSettings
 
 internal object TranslationsStateReducer {
 
@@ -229,6 +231,53 @@ internal object TranslationsStateReducer {
                     state
                 }
             }
+
+        is TranslationsAction.UpdatePageSettingAction -> {
+            var pageSettings = state.findTab(action.tabId)?.translationsState?.pageSettings
+            // Initialize page settings, if null.
+            if (pageSettings == null) {
+                pageSettings = TranslationPageSettings()
+            }
+            when (action.operation) {
+                TranslationPageSettingOperation.UPDATE_ALWAYS_OFFER_POPUP -> {
+                    pageSettings.alwaysOfferPopup = action.setting
+                    state.copyWithTranslationsState(action.tabId) {
+                        it.copy(
+                            pageSettings = pageSettings,
+                        )
+                    }
+                }
+                TranslationPageSettingOperation.UPDATE_ALWAYS_TRANSLATE_LANGUAGE -> {
+                    pageSettings.alwaysTranslateLanguage = action.setting
+                    // Always and never translate sites are always opposites.
+                    pageSettings.neverTranslateLanguage = !action.setting
+
+                    state.copyWithTranslationsState(action.tabId) {
+                        it.copy(
+                            pageSettings = pageSettings,
+                        )
+                    }
+                }
+                TranslationPageSettingOperation.UPDATE_NEVER_TRANSLATE_LANGUAGE -> {
+                    pageSettings.neverTranslateLanguage = action.setting
+                    // Always and never translate sites are always opposites.
+                    pageSettings.alwaysTranslateLanguage = !action.setting
+                    state.copyWithTranslationsState(action.tabId) {
+                        it.copy(
+                            pageSettings = pageSettings,
+                        )
+                    }
+                }
+                TranslationPageSettingOperation.UPDATE_NEVER_TRANSLATE_SITE -> {
+                    pageSettings.neverTranslateSite = action.setting
+                    state.copyWithTranslationsState(action.tabId) {
+                        it.copy(
+                            pageSettings = pageSettings,
+                        )
+                    }
+                }
+            }
+        }
     }
 
     private inline fun BrowserState.copyWithTranslationsState(

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/TranslationsActionTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/TranslationsActionTest.kt
@@ -14,6 +14,7 @@ import mozilla.components.concept.engine.translate.Language
 import mozilla.components.concept.engine.translate.TranslationEngineState
 import mozilla.components.concept.engine.translate.TranslationError
 import mozilla.components.concept.engine.translate.TranslationOperation
+import mozilla.components.concept.engine.translate.TranslationPageSettingOperation
 import mozilla.components.concept.engine.translate.TranslationPageSettings
 import mozilla.components.concept.engine.translate.TranslationPair
 import mozilla.components.concept.engine.translate.TranslationSupport
@@ -411,5 +412,110 @@ class TranslationsActionTest {
 
         // Action success
         assertNull(tabState().translationsState.supportedLanguages)
+    }
+
+    @Test
+    fun `WHEN a UpdatePageSettingAction is dispatched for UPDATE_ALWAYS_OFFER_POPUP THEN set page settings for alwaysOfferPopup `() {
+        // Action started
+        store.dispatch(
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_ALWAYS_OFFER_POPUP,
+                setting = true,
+            ),
+        ).joinBlocking()
+
+        // Action success
+        assertTrue(tabState().translationsState.pageSettings?.alwaysOfferPopup!!)
+    }
+
+    @Test
+    fun `WHEN a UpdatePageSettingAction is dispatched for UPDATE_ALWAYS_TRANSLATE_LANGUAGE THEN set page settings for alwaysTranslateLanguage `() {
+        // Action started
+        store.dispatch(
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_ALWAYS_TRANSLATE_LANGUAGE,
+                setting = true,
+            ),
+        ).joinBlocking()
+
+        // Action success
+        assertTrue(tabState().translationsState.pageSettings?.alwaysTranslateLanguage!!)
+        assertFalse(tabState().translationsState.pageSettings?.neverTranslateLanguage!!)
+    }
+
+    @Test
+    fun `WHEN a UpdatePageSettingAction is dispatched for UPDATE_NEVER_TRANSLATE_LANGUAGE THEN set page settings for alwaysTranslateLanguage `() {
+        // Action started
+        store.dispatch(
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_NEVER_TRANSLATE_LANGUAGE,
+                setting = true,
+            ),
+        ).joinBlocking()
+
+        // Action success
+        assertTrue(tabState().translationsState.pageSettings?.neverTranslateLanguage!!)
+        assertFalse(tabState().translationsState.pageSettings?.alwaysTranslateLanguage!!)
+    }
+
+    @Test
+    fun `WHEN a UpdatePageSettingAction is dispatched for UPDATE_NEVER_TRANSLATE_SITE THEN set page settings for neverTranslateSite`() {
+        // Action started
+        store.dispatch(
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_NEVER_TRANSLATE_SITE,
+                setting = true,
+            ),
+        ).joinBlocking()
+
+        // Action success
+        assertTrue(tabState().translationsState.pageSettings?.neverTranslateSite!!)
+    }
+
+    @Test
+    fun `WHEN a UpdatePageSettingAction is dispatched for each option THEN the page setting is consistent`() {
+        // Action started
+        store.dispatch(
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_ALWAYS_OFFER_POPUP,
+                setting = true,
+            ),
+        ).joinBlocking()
+
+        store.dispatch(
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_ALWAYS_TRANSLATE_LANGUAGE,
+                setting = true,
+            ),
+        ).joinBlocking()
+
+        store.dispatch(
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_NEVER_TRANSLATE_LANGUAGE,
+                setting = true,
+            ),
+        ).joinBlocking()
+
+        store.dispatch(
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_NEVER_TRANSLATE_SITE,
+                setting = true,
+            ),
+        ).joinBlocking()
+
+        // Action success
+        assertTrue(tabState().translationsState.pageSettings?.alwaysOfferPopup!!)
+        // neverTranslateLanguage was posted last and will prevent a contradictory state on the alwaysTranslateLanguage state.
+        assertFalse(tabState().translationsState.pageSettings?.alwaysTranslateLanguage!!)
+        assertTrue(tabState().translationsState.pageSettings?.neverTranslateLanguage!!)
+        assertTrue(tabState().translationsState.pageSettings?.neverTranslateSite!!)
     }
 }

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TranslationsMiddlewareTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/engine/middleware/TranslationsMiddlewareTest.kt
@@ -21,6 +21,7 @@ import mozilla.components.concept.engine.translate.LanguageSetting
 import mozilla.components.concept.engine.translate.TranslationEngineState
 import mozilla.components.concept.engine.translate.TranslationError
 import mozilla.components.concept.engine.translate.TranslationOperation
+import mozilla.components.concept.engine.translate.TranslationPageSettingOperation
 import mozilla.components.concept.engine.translate.TranslationPageSettings
 import mozilla.components.concept.engine.translate.TranslationSupport
 import mozilla.components.lib.state.MiddlewareContext
@@ -238,6 +239,106 @@ class TranslationsMiddlewareTest {
         )
 
         waitForIdle()
+    }
+
+    @Test
+    fun `WHEN UpdatePageSettingAction is dispatched WITH UPDATE_ALWAYS_TRANSLATE_LANGUAGE AND updating the setting is unsuccessful THEN OperationRequestedAction with FETCH_PAGE_SETTINGS is dispatched`() = runTest {
+        // Setup
+        setupMockState()
+        val errorCallback = argumentCaptor<((Throwable) -> Unit)>()
+        whenever(
+            engine.setLanguageSetting(
+                languageCode = any(),
+                languageSetting = any(),
+                onSuccess = any(),
+                onError = errorCallback.capture(),
+            ),
+        ).thenAnswer { errorCallback.value.invoke(Throwable()) }
+
+        // Send Action
+        val action =
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_ALWAYS_TRANSLATE_LANGUAGE,
+                setting = true,
+            )
+        translationsMiddleware.invoke(context, {}, action)
+        waitForIdle()
+
+        // Verify Dispatch
+        verify(store).dispatch(
+            TranslationsAction.OperationRequestedAction(
+                tabId = tab.id,
+                operation = TranslationOperation.FETCH_PAGE_SETTINGS,
+            ),
+        )
+    }
+
+    @Test
+    fun `WHEN UpdatePageSettingAction is dispatched WITH UPDATE_NEVER_TRANSLATE_LANGUAGE AND updating the setting is unsuccessful THEN OperationRequestedAction with FETCH_PAGE_SETTINGS is dispatched`() = runTest {
+        // Setup
+        setupMockState()
+        val errorCallback = argumentCaptor<((Throwable) -> Unit)>()
+        whenever(
+            engine.setLanguageSetting(
+                languageCode = any(),
+                languageSetting = any(),
+                onSuccess = any(),
+                onError = errorCallback.capture(),
+            ),
+        )
+            .thenAnswer { errorCallback.value.invoke(Throwable()) }
+
+        // Send Action
+        val action =
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_NEVER_TRANSLATE_LANGUAGE,
+                setting = true,
+            )
+        translationsMiddleware.invoke(context, {}, action)
+        waitForIdle()
+
+        // Verify Dispatch
+        verify(store).dispatch(
+            TranslationsAction.OperationRequestedAction(
+                tabId = tab.id,
+                operation = TranslationOperation.FETCH_PAGE_SETTINGS,
+            ),
+        )
+    }
+
+    @Test
+    fun `WHEN UpdatePageSettingAction is dispatched WITH UPDATE_NEVER_TRANSLATE_SITE AND updating the setting is unsuccessful THEN OperationRequestedAction with FETCH_PAGE_SETTINGS is dispatched`() = runTest {
+        // Setup
+        setupMockState()
+        val errorCallback = argumentCaptor<((Throwable) -> Unit)>()
+        whenever(
+            engineSession.setNeverTranslateSiteSetting(
+                setting = anyBoolean(),
+                onResult = any(),
+                onException = errorCallback.capture(),
+            ),
+        )
+            .thenAnswer { errorCallback.value.invoke(Throwable()) }
+
+        // Send Action
+        val action =
+            TranslationsAction.UpdatePageSettingAction(
+                tabId = tab.id,
+                operation = TranslationPageSettingOperation.UPDATE_NEVER_TRANSLATE_SITE,
+                setting = true,
+            )
+        translationsMiddleware.invoke(context, {}, action)
+        waitForIdle()
+
+        // Verify Dispatch
+        verify(store).dispatch(
+            TranslationsAction.OperationRequestedAction(
+                tabId = tab.id,
+                operation = TranslationOperation.FETCH_PAGE_SETTINGS,
+            ),
+        )
     }
 
     @Test

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationPageSettingOperation.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationPageSettingOperation.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.concept.engine.translate
+
+/**
+ * The container for referring to the different page settings.
+ *
+ * See [TranslationPageSettings] for the corresponding data model
+ */
+enum class TranslationPageSettingOperation {
+    /**
+     * The system should offer a translation on a page.
+     */
+    UPDATE_ALWAYS_OFFER_POPUP,
+
+    /**
+     * The page's always translate language setting.
+     */
+    UPDATE_ALWAYS_TRANSLATE_LANGUAGE,
+
+    /**
+     * The page's never translate language setting.
+     */
+    UPDATE_NEVER_TRANSLATE_LANGUAGE,
+
+    /**
+     *  The page's never translate site setting.
+     */
+    UPDATE_NEVER_TRANSLATE_SITE,
+}

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationPageSettings.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/translate/TranslationPageSettings.kt
@@ -19,8 +19,8 @@ package mozilla.components.concept.engine.translate
  * When true, the engine will not offer a translation on the current host site.
  */
 data class TranslationPageSettings(
-    val alwaysOfferPopup: Boolean? = null,
-    val alwaysTranslateLanguage: Boolean? = null,
-    val neverTranslateLanguage: Boolean? = null,
-    val neverTranslateSite: Boolean? = null,
+    var alwaysOfferPopup: Boolean? = null,
+    var alwaysTranslateLanguage: Boolean? = null,
+    var neverTranslateLanguage: Boolean? = null,
+    var neverTranslateSite: Boolean? = null,
 )


### PR DESCRIPTION
  The goal of this bug is to have a way to update page settings.
  
  It adds:
  * A new action, `UpdatePageSettingAction`
    * This action has four options:
       * `UPDATE_ALWAYS_OFFER_POPUP`
       * `UPDATE_ALWAYS_TRANSLATE_LANGUAGE`
       * `UPDATE_NEVER_TRANSLATE_LANGUAGE`
       * `UPDATE_NEVER_TRANSLATE_SITE`
  * Each operation eagerly sets the new setting on the browser store, then
  sends the request to the engine. If setting on the engine fails, then
  they will re-request the page settings in order to remain in-sync.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1877203