### PR TITLE
Bug 1870319 - Announce title in add-ons sub-menu

### DIFF
--- a/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
+++ b/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/WebExtensionBrowserMenuBuilder.kt
@@ -91,7 +91,7 @@ class WebExtensionBrowserMenuBuilder(
     ): List<BrowserMenuItem> {
         val addonsMenuItem = if (filteredExtensionMenuItems.isNotEmpty()) {
             val backPressMenuItem = BackPressMenuItem(
-                contentDescription = context.getString(R.string.action_bar_up_description),
+                contentDescription = context.getString(R.string.mozac_browser_menu_addons_description),
                 label = context.getString(R.string.mozac_browser_menu_addons),
                 imageResource = style.backPressMenuItemDrawableRes,
                 iconTintColorResource = style.webExtIconTintColorResource,

--- a/android-components/components/browser/menu/src/main/res/values/strings.xml
+++ b/android-components/components/browser/menu/src/main/res/values/strings.xml
@@ -13,4 +13,6 @@
     <string name="mozac_browser_menu_addons_manager">Add-ons Manager</string>
     <!-- Content description for the action bar "up" button -->
     <string name="action_bar_up_description">Navigate up</string>
+    <!-- Content description for the action bar "up" button of the add-ons sub menu item -->
+    <string name="mozac_browser_menu_addons_description">Add-ons, navigate up</string>
 </resources>

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -2101,7 +2101,7 @@
     <string name="radio_preference_info_content_description">Click for more details</string>
 
     <!-- Content description for the action bar "up" button -->
-    <string name="action_bar_up_description">Navigate up</string>
+    <string name="action_bar_up_description" moz:removedIn="124" tools:ignore="UnusedResources">Navigate up</string>
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Close</string>


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1870319