### PR TITLE
Revert "Bug 1833666 - Update original RFC guidelines with stakeholders"

### DIFF
--- a/docs/rfcs/0001-rfc-process.md
+++ b/docs/rfcs/0001-rfc-process.md
@@ -35,7 +35,6 @@ The high-level process of creating an RFC is:
 * Create an RFC document (like this one) using the template.
 * Open a pull request for the RFC document.
 * Ask for feedback on the pull request, via the [mailing list]() or in [chat](https://chat.mozilla.org/#/room/#android-components:mozilla.org).
-* Assign or receive volunteers to act as stakeholders for the RFC. They will be responsible for a final decision on the proposal. This should include at least 2 internal team members, and at least 1 external team member if the proposal has been suggested from an external team.
 
 During the lifetime of an RFC:
 


### PR DESCRIPTION
This reverts commit e1e6e86bf6525a123518919bfc620108396ad3dc.

After discussion, it was agreed that updates to existing RFCs are not a pattern we want to accept. Any changes to process will be captured in additional documents.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1833666