### PR TITLE
Bug 1879649 - Set the data path for the Suggest component

### DIFF
--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestStorage.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestStorage.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.withContext
 import mozilla.appservices.suggest.SuggestApiException
 import mozilla.appservices.suggest.SuggestIngestionConstraints
 import mozilla.appservices.suggest.SuggestStore
+import mozilla.appservices.suggest.SuggestStoreBuilder
 import mozilla.appservices.suggest.Suggestion
 import mozilla.appservices.suggest.SuggestionQuery
 import mozilla.components.concept.base.crash.CrashReporting
@@ -31,7 +32,10 @@ class FxSuggestStorage(context: Context) {
     // does I/O, so `store.value` should only be accessed from the read or write scope.
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal val store: Lazy<SuggestStore> = lazy {
-        SuggestStore(File(context.cacheDir, DATABASE_NAME).absolutePath)
+        SuggestStoreBuilder()
+            .cachePath(File(context.cacheDir, CACHE_DATABASE_NAME).absolutePath)
+            .dataPath(context.getDatabasePath(DATABASE_NAME).absolutePath)
+            .build()
     }
 
     // We expect almost all Suggest storage operations to be reads, with infrequent writes. The
@@ -103,8 +107,13 @@ class FxSuggestStorage(context: Context) {
 
     internal companion object {
         /**
-         * The default Suggest database file name.
+         * The database file name for cached data.
          */
-        const val DATABASE_NAME = "suggest.sqlite"
+        const val CACHE_DATABASE_NAME = "suggest.sqlite"
+
+        /**
+         * The database file name for permanent data.
+         */
+        const val DATABASE_NAME = "suggest_data.sqlite"
     }
 }


### PR DESCRIPTION
This is not used yet, but we're planning on using it to store persistent data that shouldn't be cleared with the cache.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1879649