### PR TITLE
Bug 1880064 - Add logs to ReaderViewRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/AppAndSystemHelper.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/AppAndSystemHelper.kt
@@ -226,6 +226,7 @@ object AppAndSystemHelper {
      * @return Boolean value that helps us know if the current activity supports custom tabs or PWAs.
      */
     fun isExternalAppBrowserActivityInCurrentTask(): Boolean {
+        Log.i(TAG, "Trying to verify that the latest activity of the application is used for custom tabs or PWAs")
         val activityManager = TestHelper.appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
 
         mDevice.waitForIdle(TestAssetHelper.waitingTimeShort)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/PwaRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/PwaRobot.kt
@@ -4,24 +4,32 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.helpers.AppAndSystemHelper.isExternalAppBrowserActivityInCurrentTask
+import org.mozilla.fenix.helpers.Constants
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 
 class PwaRobot {
-    fun verifyCustomTabToolbarIsNotDisplayed() = assertUIObjectExists(customTabToolbar(), exists = false)
-    fun verifyPwaActivityInCurrentTask() = assertTrue(isExternalAppBrowserActivityInCurrentTask())
+    fun verifyCustomTabToolbarIsNotDisplayed() = assertUIObjectExists(itemWithResId("$packageName:id/toolbar"), exists = false)
+    fun verifyPwaActivityInCurrentTask() {
+        Log.i(TAG, "Trying to verify that the latest activity of the application is used for custom tabs or PWAs")
+        assertTrue(isExternalAppBrowserActivityInCurrentTask())
+        Log.i(TAG, "Verified that the latest activity of the application is used for custom tabs or PWAs")
+    }
 
     class Transition
 }
 
 fun pwaScreen(interact: PwaRobot.() -> Unit): PwaRobot.Transition {
+    Log.i(TAG, "pwaScreen: Trying to find the engine view")
     mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
+    Log.i(Constants.TAG, "pwaScreen: Found the engine view")
     PwaRobot().interact()
     return PwaRobot.Transition()
 }
-
-private fun customTabToolbar() = mDevice.findObject(UiSelector().resourceId("$packageName:id/toolbar"))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/PwaRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/PwaRobot.kt
@@ -18,9 +18,7 @@ import org.mozilla.fenix.helpers.TestHelper.packageName
 class PwaRobot {
     fun verifyCustomTabToolbarIsNotDisplayed() = assertUIObjectExists(itemWithResId("$packageName:id/toolbar"), exists = false)
     fun verifyPwaActivityInCurrentTask() {
-        Log.i(TAG, "Trying to verify that the latest activity of the application is used for custom tabs or PWAs")
-        assertTrue(isExternalAppBrowserActivityInCurrentTask())
-        Log.i(TAG, "Verified that the latest activity of the application is used for custom tabs or PWAs")
+        assertTrue("$TAG: The latest activity of the application is not used for custom tabs or PWAs", isExternalAppBrowserActivityInCurrentTask())
     }
 
     class Transition

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ReaderViewRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ReaderViewRobot.kt
@@ -7,8 +7,8 @@
 package org.mozilla.fenix.ui.robots
 
 import android.content.Context
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
@@ -16,6 +16,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.click
 
@@ -24,70 +25,98 @@ import org.mozilla.fenix.helpers.click
  */
 class ReaderViewRobot {
 
-    fun verifyAppearanceFontGroup(visible: Boolean = false): ViewInteraction =
+    fun verifyAppearanceFontGroup(visible: Boolean = false) {
+        Log.i(TAG, "verifyAppearanceFontGroup: Trying to verify that the font group buttons are visible: $visible")
         onView(
             withId(R.id.mozac_feature_readerview_font_group),
         ).check(
             matches(withEffectiveVisibility(visibleOrGone(visible))),
         )
+        Log.i(TAG, "verifyAppearanceFontGroup: Verified that the font group buttons are visible: $visible")
+    }
 
-    fun verifyAppearanceFontSansSerif(visible: Boolean = false): ViewInteraction =
+    fun verifyAppearanceFontSansSerif(visible: Boolean = false) {
+        Log.i(TAG, "verifyAppearanceFontSansSerif: Trying to verify that the sans serif font button is visible: $visible")
         onView(
             withId(R.id.mozac_feature_readerview_font_sans_serif),
         ).check(
             matches(withEffectiveVisibility(visibleOrGone(visible))),
         )
+        Log.i(TAG, "verifyAppearanceFontSansSerif: Verified that the sans serif font button is visible: $visible")
+    }
 
-    fun verifyAppearanceFontSerif(visible: Boolean = false): ViewInteraction =
+    fun verifyAppearanceFontSerif(visible: Boolean = false) {
+        Log.i(TAG, "verifyAppearanceFontSerif: Trying to verify that the serif font button is visible: $visible")
         onView(
             withId(R.id.mozac_feature_readerview_font_serif),
         ).check(
             matches(withEffectiveVisibility(visibleOrGone(visible))),
         )
+        Log.i(TAG, "verifyAppearanceFontSerif: Verified that the serif font button is visible: $visible")
+    }
 
-    fun verifyAppearanceFontDecrease(visible: Boolean = false): ViewInteraction =
+    fun verifyAppearanceFontDecrease(visible: Boolean = false) {
+        Log.i(TAG, "verifyAppearanceFontDecrease: Trying to verify that the decrease font button is visible: $visible")
         onView(
             withId(R.id.mozac_feature_readerview_font_size_decrease),
         ).check(
             matches(withEffectiveVisibility(visibleOrGone(visible))),
         )
+        Log.i(TAG, "verifyAppearanceFontDecrease: Verified that the decrease font button is visible: $visible")
+    }
 
-    fun verifyAppearanceFontIncrease(visible: Boolean = false): ViewInteraction =
+    fun verifyAppearanceFontIncrease(visible: Boolean = false) {
+        Log.i(TAG, "verifyAppearanceFontIncrease: Trying to verify that the increase font button is visible: $visible")
         onView(
             withId(R.id.mozac_feature_readerview_font_size_increase),
         ).check(
             matches(withEffectiveVisibility(visibleOrGone(visible))),
         )
+        Log.i(TAG, "verifyAppearanceFontIncrease: Verified that the increase font button is visible: $visible")
+    }
 
-    fun verifyAppearanceColorGroup(visible: Boolean = false): ViewInteraction =
+    fun verifyAppearanceColorGroup(visible: Boolean = false) {
+        Log.i(TAG, "verifyAppearanceColorGroup: Trying to verify that the color group buttons are visible: $visible")
         onView(
             withId(R.id.mozac_feature_readerview_color_scheme_group),
         ).check(
             matches(withEffectiveVisibility(visibleOrGone(visible))),
         )
+        Log.i(TAG, "verifyAppearanceColorGroup: Verified that the color group buttons are visible: $visible")
+    }
 
-    fun verifyAppearanceColorSepia(visible: Boolean = false): ViewInteraction =
+    fun verifyAppearanceColorSepia(visible: Boolean = false) {
+        Log.i(TAG, "verifyAppearanceColorSepia: Trying to verify that the sepia color button is visible: $visible")
         onView(
             withId(R.id.mozac_feature_readerview_color_sepia),
         ).check(
             matches(withEffectiveVisibility(visibleOrGone(visible))),
         )
+        Log.i(TAG, "verifyAppearanceColorSepia: Verified that the sepia color button is visible: $visible")
+    }
 
-    fun verifyAppearanceColorDark(visible: Boolean = false): ViewInteraction =
+    fun verifyAppearanceColorDark(visible: Boolean = false) {
+        Log.i(TAG, "verifyAppearanceColorDark: Trying to verify that the dark color button is visible: $visible")
         onView(
             withId(R.id.mozac_feature_readerview_color_dark),
         ).check(
             matches(withEffectiveVisibility(visibleOrGone(visible))),
         )
+        Log.i(TAG, "verifyAppearanceColorDark: Verified that the dark color button is visible: $visible")
+    }
 
-    fun verifyAppearanceColorLight(visible: Boolean = false): ViewInteraction =
+    fun verifyAppearanceColorLight(visible: Boolean = false) {
+        Log.i(TAG, "verifyAppearanceColorLight: Trying to verify that the light color button is visible: $visible")
         onView(
             withId(R.id.mozac_feature_readerview_color_light),
         ).check(
             matches(withEffectiveVisibility(visibleOrGone(visible))),
         )
+        Log.i(TAG, "verifyAppearanceColorLight: Verified that the light color button is visible: $visible")
+    }
 
     fun verifyAppearanceFontIsActive(fontType: String) {
+        Log.i(TAG, "verifyAppearanceFontIsActive: Trying to verify that the font type is: $fontType")
         val fontTypeKey: String = "mozac-readerview-fonttype"
 
         val prefs = InstrumentationRegistry.getInstrumentation()
@@ -97,9 +126,11 @@ class ReaderViewRobot {
             )
 
         assertEquals(fontType, prefs.getString(fontTypeKey, ""))
+        Log.i(TAG, "verifyAppearanceFontIsActive: Verified that the font type is: $fontType")
     }
 
     fun verifyAppearanceFontSize(expectedFontSize: Int) {
+        Log.i(TAG, "verifyAppearanceFontSize: Trying to verify that the font size is: $expectedFontSize")
         val fontSizeKey: String = "mozac-readerview-fontsize"
 
         val prefs = InstrumentationRegistry.getInstrumentation()
@@ -111,9 +142,11 @@ class ReaderViewRobot {
         val fontSizeKeyValue = prefs.getInt(fontSizeKey, 3)
 
         assertEquals(expectedFontSize, fontSizeKeyValue)
+        Log.i(TAG, "verifyAppearanceFontSize: Verified that the font size is: $expectedFontSize")
     }
 
     fun verifyAppearanceColorSchemeChange(expectedColorScheme: String) {
+        Log.i(TAG, "verifyAppearanceColorSchemeChange: Trying to verify that the color scheme is: $expectedColorScheme")
         val colorSchemeKey: String = "mozac-readerview-colorscheme"
 
         val prefs = InstrumentationRegistry.getInstrumentation()
@@ -123,12 +156,15 @@ class ReaderViewRobot {
             )
 
         assertEquals(expectedColorScheme, prefs.getString(colorSchemeKey, ""))
+        Log.i(TAG, "verifyAppearanceColorSchemeChange: Verified that the color scheme is: $expectedColorScheme")
     }
 
     class Transition {
 
         fun closeAppearanceMenu(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            Log.i(TAG, "closeAppearanceMenu: Trying to click device back button")
             mDevice.pressBack()
+            Log.i(TAG, "closeAppearanceMenu: Clicked device back button")
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
@@ -139,8 +175,9 @@ class ReaderViewRobot {
                 onView(
                     withId(R.id.mozac_feature_readerview_font_sans_serif),
                 )
-
+            Log.i(TAG, "toggleSansSerif: Trying to click sans serif button")
             sansSerifButton().click()
+            Log.i(TAG, "toggleSansSerif: Clicked sans serif button")
 
             ReaderViewRobot().interact()
             return Transition()
@@ -151,8 +188,9 @@ class ReaderViewRobot {
                 onView(
                     withId(R.id.mozac_feature_readerview_font_serif),
                 )
-
+            Log.i(TAG, "toggleSerif: Trying to click serif button")
             serifButton().click()
+            Log.i(TAG, "toggleSerif: Clicked serif button")
 
             ReaderViewRobot().interact()
             return Transition()
@@ -163,8 +201,9 @@ class ReaderViewRobot {
                 onView(
                     withId(R.id.mozac_feature_readerview_font_size_decrease),
                 )
-
+            Log.i(TAG, "toggleFontSizeDecrease: Trying to click the decrease font button")
             fontSizeDecrease().click()
+            Log.i(TAG, "toggleFontSizeDecrease: Clicked the decrease font button")
 
             ReaderViewRobot().interact()
             return Transition()
@@ -175,8 +214,9 @@ class ReaderViewRobot {
                 onView(
                     withId(R.id.mozac_feature_readerview_font_size_increase),
                 )
-
+            Log.i(TAG, "toggleFontSizeIncrease: Trying to click the increase font button")
             fontSizeIncrease().click()
+            Log.i(TAG, "toggleFontSizeIncrease: Clicked the increase font button")
 
             ReaderViewRobot().interact()
             return Transition()
@@ -187,8 +227,9 @@ class ReaderViewRobot {
                 onView(
                     withId(R.id.mozac_feature_readerview_color_light),
                 )
-
+            Log.i(TAG, "toggleColorSchemeChangeLight: Trying to click the light color button")
             toggleLightColorSchemeButton().click()
+            Log.i(TAG, "toggleColorSchemeChangeLight: Clicked the light color button")
 
             ReaderViewRobot().interact()
             return Transition()
@@ -199,8 +240,9 @@ class ReaderViewRobot {
                 onView(
                     withId(R.id.mozac_feature_readerview_color_dark),
                 )
-
+            Log.i(TAG, "toggleColorSchemeChangeDark: Trying to click the dark color button")
             toggleDarkColorSchemeButton().click()
+            Log.i(TAG, "toggleColorSchemeChangeDark: Clicked the dark color button")
 
             ReaderViewRobot().interact()
             return Transition()
@@ -211,18 +253,14 @@ class ReaderViewRobot {
                 onView(
                     withId(R.id.mozac_feature_readerview_color_sepia),
                 )
-
+            Log.i(TAG, "toggleColorSchemeChangeSepia: Trying to click the sepia color button")
             toggleSepiaColorSchemeButton().click()
+            Log.i(TAG, "toggleColorSchemeChangeSepia: Clicked the sepia color button")
 
             ReaderViewRobot().interact()
             return Transition()
         }
     }
-}
-
-fun readerViewRobot(interact: ReaderViewRobot.() -> Unit): ReaderViewRobot.Transition {
-    ReaderViewRobot().interact()
-    return ReaderViewRobot.Transition()
 }
 
 private fun visibleOrGone(visibility: Boolean) =

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ReaderViewRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ReaderViewRobot.kt
@@ -25,31 +25,67 @@ import org.mozilla.fenix.helpers.click
 class ReaderViewRobot {
 
     fun verifyAppearanceFontGroup(visible: Boolean = false): ViewInteraction =
-        assertAppearanceFontGroup(visible)
+        onView(
+            withId(R.id.mozac_feature_readerview_font_group),
+        ).check(
+            matches(withEffectiveVisibility(visibleOrGone(visible))),
+        )
 
     fun verifyAppearanceFontSansSerif(visible: Boolean = false): ViewInteraction =
-        assertAppearanceFontSansSerif(visible)
+        onView(
+            withId(R.id.mozac_feature_readerview_font_sans_serif),
+        ).check(
+            matches(withEffectiveVisibility(visibleOrGone(visible))),
+        )
 
     fun verifyAppearanceFontSerif(visible: Boolean = false): ViewInteraction =
-        assertAppearanceFontSerif(visible)
+        onView(
+            withId(R.id.mozac_feature_readerview_font_serif),
+        ).check(
+            matches(withEffectiveVisibility(visibleOrGone(visible))),
+        )
 
     fun verifyAppearanceFontDecrease(visible: Boolean = false): ViewInteraction =
-        assertAppearanceFontDecrease(visible)
+        onView(
+            withId(R.id.mozac_feature_readerview_font_size_decrease),
+        ).check(
+            matches(withEffectiveVisibility(visibleOrGone(visible))),
+        )
 
     fun verifyAppearanceFontIncrease(visible: Boolean = false): ViewInteraction =
-        assertAppearanceFontIncrease(visible)
+        onView(
+            withId(R.id.mozac_feature_readerview_font_size_increase),
+        ).check(
+            matches(withEffectiveVisibility(visibleOrGone(visible))),
+        )
 
     fun verifyAppearanceColorGroup(visible: Boolean = false): ViewInteraction =
-        assertAppearanceColorGroup(visible)
+        onView(
+            withId(R.id.mozac_feature_readerview_color_scheme_group),
+        ).check(
+            matches(withEffectiveVisibility(visibleOrGone(visible))),
+        )
 
     fun verifyAppearanceColorSepia(visible: Boolean = false): ViewInteraction =
-        assertAppearanceColorSepia(visible)
+        onView(
+            withId(R.id.mozac_feature_readerview_color_sepia),
+        ).check(
+            matches(withEffectiveVisibility(visibleOrGone(visible))),
+        )
 
     fun verifyAppearanceColorDark(visible: Boolean = false): ViewInteraction =
-        assertAppearanceColorDark(visible)
+        onView(
+            withId(R.id.mozac_feature_readerview_color_dark),
+        ).check(
+            matches(withEffectiveVisibility(visibleOrGone(visible))),
+        )
 
     fun verifyAppearanceColorLight(visible: Boolean = false): ViewInteraction =
-        assertAppearanceColorLight(visible)
+        onView(
+            withId(R.id.mozac_feature_readerview_color_light),
+        ).check(
+            matches(withEffectiveVisibility(visibleOrGone(visible))),
+        )
 
     fun verifyAppearanceFontIsActive(fontType: String) {
         val fontTypeKey: String = "mozac-readerview-fonttype"
@@ -188,69 +224,6 @@ fun readerViewRobot(interact: ReaderViewRobot.() -> Unit): ReaderViewRobot.Trans
     ReaderViewRobot().interact()
     return ReaderViewRobot.Transition()
 }
-
-private fun assertAppearanceFontGroup(visible: Boolean) =
-    onView(
-        withId(R.id.mozac_feature_readerview_font_group),
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible))),
-    )
-
-private fun assertAppearanceFontSansSerif(visible: Boolean) =
-    onView(
-        withId(R.id.mozac_feature_readerview_font_sans_serif),
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible))),
-    )
-
-private fun assertAppearanceFontSerif(visible: Boolean) =
-    onView(
-        withId(R.id.mozac_feature_readerview_font_serif),
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible))),
-    )
-
-private fun assertAppearanceFontDecrease(visible: Boolean) =
-    onView(
-        withId(R.id.mozac_feature_readerview_font_size_decrease),
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible))),
-    )
-
-private fun assertAppearanceFontIncrease(visible: Boolean) =
-    onView(
-        withId(R.id.mozac_feature_readerview_font_size_increase),
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible))),
-    )
-
-private fun assertAppearanceColorDark(visible: Boolean) =
-    onView(
-        withId(R.id.mozac_feature_readerview_color_dark),
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible))),
-    )
-
-private fun assertAppearanceColorLight(visible: Boolean) =
-    onView(
-        withId(R.id.mozac_feature_readerview_color_light),
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible))),
-    )
-
-private fun assertAppearanceColorSepia(visible: Boolean) =
-    onView(
-        withId(R.id.mozac_feature_readerview_color_sepia),
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible))),
-    )
-
-private fun assertAppearanceColorGroup(visible: Boolean) =
-    onView(
-        withId(R.id.mozac_feature_readerview_color_scheme_group),
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible))),
-    )
 
 private fun visibleOrGone(visibility: Boolean) =
     if (visibility) ViewMatchers.Visibility.VISIBLE else ViewMatchers.Visibility.GONE


### PR DESCRIPTION
Summary:

- Added pairs of test logs to the `PwaRobot`
- Added pairs of test logs to the `ReaderViewRobot`
- Remove redundant assertion functions from `ReaderViewRobot`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880064