### PR TITLE
Bug 1880221 - Add logs to RecentlyClosedTabsRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/RecentlyClosedTabsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/RecentlyClosedTabsRobot.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.ui.robots
 
 import android.net.Uri
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
@@ -17,6 +18,7 @@ import androidx.test.uiautomator.UiSelector
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.HomeActivityComposeTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
@@ -32,28 +34,36 @@ import org.mozilla.fenix.helpers.click
 
 class RecentlyClosedTabsRobot {
 
-    fun waitForListToExist() =
+    fun waitForListToExist() {
+        Log.i(TAG, "waitForListToExist: Waiting for $waitingTime ms for recently closed tabs list to exist")
         mDevice.findObject(UiSelector().resourceId("$packageName:id/recently_closed_list"))
             .waitForExists(waitingTime)
+        Log.i(TAG, "waitForListToExist: Waited for $waitingTime ms for recently closed tabs list to exist")
+    }
 
     fun verifyRecentlyClosedTabsMenuView() {
+        Log.i(TAG, "verifyRecentlyClosedTabsMenuView: Trying to verify that the recently closed tabs menu view is visible")
         onView(
             allOf(
                 withText("Recently closed tabs"),
                 withParent(withId(R.id.navigationToolbar)),
             ),
         ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyRecentlyClosedTabsMenuView: Verified that the recently closed tabs menu view is visible")
     }
 
     fun verifyEmptyRecentlyClosedTabsList() {
+        Log.i(TAG, "verifyEmptyRecentlyClosedTabsList: Waiting for device to be idle")
         mDevice.waitForIdle()
-
+        Log.i(TAG, "verifyEmptyRecentlyClosedTabsList: Waited for device to be idle")
+        Log.i(TAG, "verifyEmptyRecentlyClosedTabsList: Trying to verify that the empty recently closed tabs list is visible")
         onView(
             allOf(
                 withId(R.id.recently_closed_empty_view),
                 withText(R.string.recently_closed_empty_message),
             ),
         ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyEmptyRecentlyClosedTabsList: Verified that the empty recently closed tabs list is visible")
     }
 
     fun verifyRecentlyClosedTabsPageTitle(title: String) =
@@ -62,6 +72,7 @@ class RecentlyClosedTabsRobot {
         )
 
     fun verifyRecentlyClosedTabsUrl(expectedUrl: Uri) {
+        Log.i(TAG, "verifyRecentlyClosedTabsUrl: Trying to verify that the recently closed tab with url: $expectedUrl is visible")
         onView(
             allOf(
                 withId(R.id.url),
@@ -70,45 +81,64 @@ class RecentlyClosedTabsRobot {
                 ),
             ),
         ).check(matches(withText(Matchers.containsString(expectedUrl.toString()))))
+        Log.i(TAG, "verifyRecentlyClosedTabsUrl: Verified that the recently closed tab with url: $expectedUrl is visible")
     }
 
-    fun clickDeleteRecentlyClosedTabs() = recentlyClosedTabDeleteButton().click()
+    fun clickDeleteRecentlyClosedTabs() {
+        Log.i(TAG, "clickDeleteRecentlyClosedTabs: Trying to click the recently closed tab item delete button")
+        recentlyClosedTabDeleteButton().click()
+        Log.i(TAG, "clickDeleteRecentlyClosedTabs: Clicked the recently closed tab item delete button")
+    }
 
     class Transition {
         fun clickRecentlyClosedItem(title: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             recentlyClosedTabsPageTitle(title).also {
+                Log.i(TAG, "clickRecentlyClosedItem: Waiting for $waitingTimeShort ms for recently closed tab with title: $title to exist")
                 it.waitForExists(waitingTimeShort)
+                Log.i(TAG, "clickRecentlyClosedItem: Waited for $waitingTimeShort ms for recently closed tab with title: $title to exist")
+                Log.i(TAG, "clickRecentlyClosedItem: Trying to click the recently closed tab with title: $title")
                 it.click()
+                Log.i(TAG, "clickRecentlyClosedItem: Clicked the recently closed tab with title: $title")
             }
+            Log.i(TAG, "clickRecentlyClosedItem: Waiting for device to be idle")
             mDevice.waitForIdle()
+            Log.i(TAG, "clickRecentlyClosedItem: Waited for device to be idle")
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
 
         fun clickOpenInNewTab(testRule: HomeActivityComposeTestRule, interact: ComposeTabDrawerRobot.() -> Unit): ComposeTabDrawerRobot.Transition {
+            Log.i(TAG, "clickOpenInNewTab: Trying to click the multi-select \"Open in a new tab\" context menu button")
             openInNewTabOption().click()
+            Log.i(TAG, "clickOpenInNewTab: Clicked the multi-select \"Open in a new tab\" context menu button")
 
             ComposeTabDrawerRobot(testRule).interact()
             return ComposeTabDrawerRobot.Transition(testRule)
         }
 
         fun clickOpenInPrivateTab(testRule: HomeActivityComposeTestRule, interact: ComposeTabDrawerRobot.() -> Unit): ComposeTabDrawerRobot.Transition {
+            Log.i(TAG, "clickOpenInPrivateTab: Trying to click the multi-select \"Open in a private tab\" context menu button")
             openInPrivateTabOption().click()
+            Log.i(TAG, "clickOpenInPrivateTab: Clicked the multi-select \"Open in a private tab\" context menu button")
 
             ComposeTabDrawerRobot(testRule).interact()
             return ComposeTabDrawerRobot.Transition(testRule)
         }
 
         fun clickShare(interact: ShareOverlayRobot.() -> Unit): ShareOverlayRobot.Transition {
+            Log.i(TAG, "clickShare: Trying to click the share recently closed tabs button")
             multipleSelectionShareButton().click()
+            Log.i(TAG, "clickShare: Clicked the share recently closed tabs button")
 
             ShareOverlayRobot().interact()
             return ShareOverlayRobot.Transition()
         }
 
         fun goBackToHistoryMenu(interact: HistoryRobot.() -> Unit): HistoryRobot.Transition {
+            Log.i(TAG, "goBackToHistoryMenu: Trying to click navigate up toolbar button")
             onView(withContentDescription("Navigate up")).click()
+            Log.i(TAG, "goBackToHistoryMenu: Clicked navigate up toolbar button")
 
             HistoryRobot().interact()
             return HistoryRobot.Transition()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/RecentlyClosedTabsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/RecentlyClosedTabsRobot.kt
@@ -87,21 +87,21 @@ class RecentlyClosedTabsRobot {
         }
 
         fun clickOpenInNewTab(testRule: HomeActivityComposeTestRule, interact: ComposeTabDrawerRobot.() -> Unit): ComposeTabDrawerRobot.Transition {
-            openInNewTabOption.click()
+            openInNewTabOption().click()
 
             ComposeTabDrawerRobot(testRule).interact()
             return ComposeTabDrawerRobot.Transition(testRule)
         }
 
         fun clickOpenInPrivateTab(testRule: HomeActivityComposeTestRule, interact: ComposeTabDrawerRobot.() -> Unit): ComposeTabDrawerRobot.Transition {
-            openInPrivateTabOption.click()
+            openInPrivateTabOption().click()
 
             ComposeTabDrawerRobot(testRule).interact()
             return ComposeTabDrawerRobot.Transition(testRule)
         }
 
         fun clickShare(interact: ShareOverlayRobot.() -> Unit): ShareOverlayRobot.Transition {
-            multipleSelectionShareButton.click()
+            multipleSelectionShareButton().click()
 
             ShareOverlayRobot().interact()
             return ShareOverlayRobot.Transition()
@@ -132,8 +132,8 @@ private fun recentlyClosedTabDeleteButton() =
         ),
     )
 
-private val openInNewTabOption = onView(withText("Open in new tab"))
+private fun openInNewTabOption() = onView(withText("Open in new tab"))
 
-private val openInPrivateTabOption = onView(withText("Open in private tab"))
+private fun openInPrivateTabOption() = onView(withText("Open in private tab"))
 
-private val multipleSelectionShareButton = onView(withId(R.id.share_history_multi_select))
+private fun multipleSelectionShareButton() = onView(withId(R.id.share_history_multi_select))


### PR DESCRIPTION
Summary:

- Added pairs of test logs to the `RecentlyClosedTabsRobot`
- Converted the private variables to functions so they don't get initialised


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880221