### PR TITLE
Bug 1870339 - Make list of add-ons more accessible

### DIFF
--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/ui/AddonsManagerAdapter.kt
@@ -6,9 +6,11 @@ package mozilla.components.feature.addons.ui
 
 import android.annotation.SuppressLint
 import android.graphics.Typeface
+import android.os.Build
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityNodeInfo
 import android.widget.ImageView
 import android.widget.RatingBar
 import android.widget.TextView
@@ -183,6 +185,32 @@ class AddonsManagerAdapter(
 
     override fun onBindViewHolder(holder: CustomViewHolder, position: Int) {
         val item = getItem(position)
+
+        // Configure an accessibility delegate for each item.
+        holder.itemView.accessibilityDelegate = object : View.AccessibilityDelegate() {
+            override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfo) {
+                super.onInitializeAccessibilityNodeInfo(host, info)
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    info.collectionItemInfo = AccessibilityNodeInfo.CollectionItemInfo(
+                        holder.bindingAdapterPosition,
+                        1,
+                        1,
+                        1,
+                        holder is SectionViewHolder,
+                    )
+                } else {
+                    @Suppress("DEPRECATION")
+                    info.collectionItemInfo = AccessibilityNodeInfo.CollectionItemInfo.obtain(
+                        holder.bindingAdapterPosition,
+                        1,
+                        1,
+                        1,
+                        holder is SectionViewHolder,
+                    )
+                }
+            }
+        }
 
         when (holder) {
             is SectionViewHolder -> bindSection(holder, item as Section, position)

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
@@ -36,6 +36,7 @@ import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
@@ -43,7 +44,6 @@ import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.TestHelper.restartApp
-import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
@@ -120,7 +120,7 @@ class SettingsSubMenuAddonsManagerRobot {
                     homeScreen {
                     }.openThreeDotMenu {
                     }.openAddonsManagerMenu {
-                        scrollToElementByText(addonName)
+                        scrollToAddon(addonName)
                         clickInstallAddon(addonName)
                         verifyAddonPermissionPrompt(addonName)
                         acceptPermissionToInstallAddon()
@@ -152,7 +152,7 @@ class SettingsSubMenuAddonsManagerRobot {
     }
 
     fun verifyAddonIsInstalled(addonName: String) {
-        scrollToElementByText(addonName)
+        scrollToAddon(addonName)
         Log.i(TAG, "verifyAddonIsInstalled: Trying to verify that the $addonName add-on was installed")
         onView(
             allOf(
@@ -199,7 +199,7 @@ class SettingsSubMenuAddonsManagerRobot {
         Log.i(TAG, "verifyAddonsItems: Verified that all uBlock Origin items are completely displayed")
     }
     fun verifyAddonCanBeInstalled(addonName: String) {
-        scrollToElementByText(addonName)
+        scrollToAddon(addonName)
         mDevice.waitNotNull(Until.findObject(By.text(addonName)), waitingTime)
         Log.i(TAG, "verifyAddonCanBeInstalled: Trying to verify that the install $addonName button is visible")
         onView(
@@ -250,7 +250,7 @@ class SettingsSubMenuAddonsManagerRobot {
             addonName: String,
             interact: SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.() -> Unit,
         ): SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.Transition {
-            scrollToElementByText(addonName)
+            scrollToAddon(addonName)
             Log.i(TAG, "openDetailedMenuForAddon: Trying to verify that the $addonName add-on is visible")
             addonItem(addonName).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
             Log.i(TAG, "openDetailedMenuForAddon: Verified that the $addonName add-on is visible")
@@ -295,6 +295,17 @@ class SettingsSubMenuAddonsManagerRobot {
 fun addonsMenu(interact: SettingsSubMenuAddonsManagerRobot.() -> Unit): SettingsSubMenuAddonsManagerRobot.Transition {
     SettingsSubMenuAddonsManagerRobot().interact()
     return SettingsSubMenuAddonsManagerRobot.Transition()
+}
+
+private fun scrollToAddon(addonName: String) {
+    Log.i(TAG, "scrollToAddon: Trying to scroll into view add-on: $addonName")
+    addonsList().scrollIntoView(
+        itemWithResIdContainingText(
+            resourceId = "$packageName:id/add_on_name",
+            text = addonName,
+        ),
+    )
+    Log.i(TAG, "scrollToAddon: Scrolled into view add-on: $addonName")
 }
 
 private fun addonItem(addonName: String) =

--- a/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -115,6 +116,29 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management) 
                         binding?.addOnsEmptyMessage?.isVisible = false
 
                         recyclerView?.adapter = adapter
+                        recyclerView?.accessibilityDelegate = object : View.AccessibilityDelegate() {
+                            override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfo) {
+                                super.onInitializeAccessibilityNodeInfo(host, info)
+
+                                adapter?.let {
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                                        info.collectionInfo = AccessibilityNodeInfo.CollectionInfo(
+                                            it.itemCount,
+                                            1,
+                                            false,
+                                        )
+                                    } else {
+                                        @Suppress("DEPRECATION")
+                                        info.collectionInfo = AccessibilityNodeInfo.CollectionInfo.obtain(
+                                            it.itemCount,
+                                            1,
+                                            false,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
                         if (shouldRefresh) {
                             adapter?.updateAddons(addons)
                         }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1870339