### PR TITLE
Bug 1880466 - Add logs to SettingsSubMenuAccessibilityRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAccessibilityRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAccessibilityRobot.kt
@@ -6,6 +6,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import android.view.KeyEvent
 import android.view.KeyEvent.ACTION_DOWN
 import android.view.KeyEvent.KEYCODE_DPAD_LEFT
@@ -28,7 +29,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.Matcher
+import org.junit.Assert.assertTrue
 import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.assertIsEnabled
 import org.mozilla.fenix.helpers.isEnabled
@@ -53,50 +56,65 @@ class SettingsSubMenuAccessibilityRobot {
     fun clickFontSizingSwitch() = toggleFontSizingSwitch()
 
     fun verifyEnabledMenuItems() {
-        val view = onView(withText("Font Size"))
-        view.check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-            .check(matches(isEnabled(true)))
-
-        val strFont = "Make text on websites larger or smaller"
-        onView(withText(strFont))
-            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-            .check(matches(isEnabled(true)))
-
+        Log.i(TAG, "verifyEnabledMenuItems: Trying to verify that the \"Font Size\" title is visible")
+        onView(withText("Font Size")).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyEnabledMenuItems: Verified that the \"Font Size\" title is visible")
+        Log.i(TAG, "verifyEnabledMenuItems: Trying to verify that the \"Font Size\" title is enabled")
+        onView(withText("Font Size")).check(matches(isEnabled(true)))
+        Log.i(TAG, "verifyEnabledMenuItems: Verified that the \"Font Size\" title is enabled")
+        Log.i(TAG, "verifyEnabledMenuItems: Trying to verify that the \"Make text on websites larger or smaller\" summary is visible")
+        onView(withText("Make text on websites larger or smaller")).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyEnabledMenuItems: Verified that the \"Make text on websites larger or smaller\" summary is visible")
+        Log.i(TAG, "verifyEnabledMenuItems: Trying to verify that the \"Make text on websites larger or smaller\" summary is enabled")
+        onView(withText("Make text on websites larger or smaller")).check(matches(isEnabled(true)))
+        Log.i(TAG, "verifyEnabledMenuItems: Verified that the \"Make text on websites larger or smaller\" summary is enabled")
+        Log.i(TAG, "verifyEnabledMenuItems: Trying to verify the \"This is sample text. It is here to show how text will appear\" sample text")
         onView(withId(org.mozilla.fenix.R.id.sampleText))
             .check(matches(withText("This is sample text. It is here to show how text will appear when you increase or decrease the size with this setting.")))
-
-        onView(withId(org.mozilla.fenix.R.id.seekbar_value))
-            .check(matches(withText("100%")))
-
-        onView(withId(org.mozilla.fenix.R.id.seekbar))
-            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyEnabledMenuItems: Verified the \"This is sample text. It is here to show how text will appear\" sample text")
+        Log.i(TAG, "verifyEnabledMenuItems: Trying to verify that the seek bar value is set to 100%")
+        onView(withId(org.mozilla.fenix.R.id.seekbar_value)).check(matches(withText("100%")))
+        Log.i(TAG, "verifyEnabledMenuItems: Verified that the seek bar value is set to 100%")
+        Log.i(TAG, "verifyEnabledMenuItems: Trying to verify that the seek bar is visible")
+        onView(withId(org.mozilla.fenix.R.id.seekbar)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyEnabledMenuItems: Verified that the seek bar is visible")
     }
 
     fun verifyMenuItemsAreDisabled() {
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Trying to verify that the \"Font Size\" title is not enabled")
         onView(withText("Font Size")).assertIsEnabled(false)
-
-        val strFont = "Make text on websites larger or smaller"
-
-        onView(withText(strFont)).assertIsEnabled(false)
-
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Verified that the \"Font Size\" title is not enabled")
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Trying to verify that the \"Make text on websites larger or smaller\" summary is not enabled")
+        onView(withText("Make text on websites larger or smaller")).assertIsEnabled(false)
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Verified that the \"Make text on websites larger or smaller\" summary is not enabled")
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Trying to verify that the \"This is sample text. It is here to show how text will appear\" sample text is not enabled")
         onView(withId(org.mozilla.fenix.R.id.sampleText)).assertIsEnabled(false)
-
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Verified that the \"This is sample text. It is here to show how text will appear\" sample text is not enabled")
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Trying to verify that the seek bar value is not enabled")
         onView(withId(org.mozilla.fenix.R.id.seekbar_value)).assertIsEnabled(false)
-
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Verified that the seek bar value is not enabled")
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Trying to verify that the seek bar is not enabled")
         onView(withId(org.mozilla.fenix.R.id.seekbar)).assertIsEnabled(false)
+        Log.i(TAG, "verifyMenuItemsAreDisabled: Verified that the seek bar is not enabled")
     }
 
     fun changeTextSizeSlider(seekBarPercentage: Int) = adjustTextSizeSlider(seekBarPercentage)
 
     fun verifyTextSizePercentage(textSize: Int) {
+        Log.i(TAG, "verifyTextSizePercentage: Trying to verify that the text size percentage is set to: $textSize")
         onView(withId(org.mozilla.fenix.R.id.sampleText))
             .check(textSizePercentageEquals(textSize))
+        Log.i(TAG, "verifyTextSizePercentage: Verified that the text size percentage is set to: $textSize")
     }
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            Log.i(TAG, "goBack: Waiting for device to be idle")
             mDevice.waitForIdle()
+            Log.i(TAG, "goBack: Waited for device to be idle")
+            Log.i(TAG, "goBack: Trying to click the navigate up toolbar button")
             goBackButton().perform(click())
+            Log.i(TAG, "goBack: Clicked the navigate up toolbar button")
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()
@@ -105,15 +123,19 @@ class SettingsSubMenuAccessibilityRobot {
 }
 
 private fun toggleFontSizingSwitch() {
+    Log.i(TAG, "toggleFontSizingSwitch: Trying to click the \"Automatic font sizing\" toggle")
     // Toggle font size to off
     onView(withText("Automatic font sizing"))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
         .perform(click())
+    Log.i(TAG, "toggleFontSizingSwitch: Clicked the \"Automatic font sizing\" toggle")
 }
 
 private fun adjustTextSizeSlider(seekBarPercentage: Int) {
+    Log.i(TAG, "adjustTextSizeSlider: Trying to set the seek bar value to: $seekBarPercentage")
     onView(withId(org.mozilla.fenix.R.id.seekbar))
         .perform(SeekBarChangeProgressViewAction(seekBarPercentage))
+    Log.i(TAG, "adjustTextSizeSlider: Seek bar value was set to: $seekBarPercentage")
 }
 
 private fun goBackButton() =
@@ -167,9 +189,11 @@ fun calculateStepSizeFromPercentage(textSizePercentage: Int): Int {
     return ((textSizePercentage - MIN_VALUE) / STEP_SIZE)
 }
 
-fun checkTextSizeOnWebsite(textSizePercentage: Int, components: Components): Boolean {
+fun checkTextSizeOnWebsite(textSizePercentage: Int, components: Components) {
+    Log.i(TAG, "checkTextSizeOnWebsite: Trying to verify that text size on website is: $textSizePercentage")
     // Checks the Gecko engine settings for the font size
     val textSize = calculateStepSizeFromPercentage(textSizePercentage)
     val newTextScale = ((textSize * STEP_SIZE) + MIN_VALUE).toFloat() / DECIMAL_CONVERSION
-    return components.core.engine.settings.fontSizeFactor == newTextScale
+    assertTrue("$TAG: text size on website was not set to: $textSizePercentage", components.core.engine.settings.fontSizeFactor == newTextScale)
+    Log.i(TAG, "checkTextSizeOnWebsite: Verified that text size on website is: $textSizePercentage")
 }

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAccessibilityRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAccessibilityRobot.kt
@@ -50,17 +50,48 @@ class SettingsSubMenuAccessibilityRobot {
         const val TEXT_SIZE = 16f
     }
 
-    fun verifyAutomaticFontSizingMenuItems() = assertAutomaticFontSizingMenuItems()
-
     fun clickFontSizingSwitch() = toggleFontSizingSwitch()
 
-    fun verifyEnabledMenuItems() = assertEnabledMenuItems()
+    fun verifyEnabledMenuItems() {
+        val view = onView(withText("Font Size"))
+        view.check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+            .check(matches(isEnabled(true)))
 
-    fun verifyMenuItemsAreDisabled() = assertMenuItemsAreDisabled()
+        val strFont = "Make text on websites larger or smaller"
+        onView(withText(strFont))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+            .check(matches(isEnabled(true)))
+
+        onView(withId(org.mozilla.fenix.R.id.sampleText))
+            .check(matches(withText("This is sample text. It is here to show how text will appear when you increase or decrease the size with this setting.")))
+
+        onView(withId(org.mozilla.fenix.R.id.seekbar_value))
+            .check(matches(withText("100%")))
+
+        onView(withId(org.mozilla.fenix.R.id.seekbar))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
+
+    fun verifyMenuItemsAreDisabled() {
+        onView(withText("Font Size")).assertIsEnabled(false)
+
+        val strFont = "Make text on websites larger or smaller"
+
+        onView(withText(strFont)).assertIsEnabled(false)
+
+        onView(withId(org.mozilla.fenix.R.id.sampleText)).assertIsEnabled(false)
+
+        onView(withId(org.mozilla.fenix.R.id.seekbar_value)).assertIsEnabled(false)
+
+        onView(withId(org.mozilla.fenix.R.id.seekbar)).assertIsEnabled(false)
+    }
 
     fun changeTextSizeSlider(seekBarPercentage: Int) = adjustTextSizeSlider(seekBarPercentage)
 
-    fun verifyTextSizePercentage(textSize: Int) = assertTextSizePercentage(textSize)
+    fun verifyTextSizePercentage(textSize: Int) {
+        onView(withId(org.mozilla.fenix.R.id.sampleText))
+            .check(textSizePercentageEquals(textSize))
+    }
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
@@ -73,14 +104,6 @@ class SettingsSubMenuAccessibilityRobot {
     }
 }
 
-private fun assertAutomaticFontSizingMenuItems() {
-    onView(withText("Automatic font sizing"))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-    val strFont = "Font size will match your Android settings. Disable to manage font size here."
-    onView(withText(strFont))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
 private fun toggleFontSizingSwitch() {
     // Toggle font size to off
     onView(withText("Automatic font sizing"))
@@ -88,54 +111,9 @@ private fun toggleFontSizingSwitch() {
         .perform(click())
 }
 
-private fun assertEnabledMenuItems() {
-    assertFontSize()
-    assertSliderBar()
-}
-
-private fun assertFontSize() {
-    val view = onView(withText("Font Size"))
-    view.check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-        .check(matches(isEnabled(true)))
-    val strFont = "Make text on websites larger or smaller"
-    onView(withText(strFont))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-        .check(matches(isEnabled(true)))
-}
-
-private fun assertSliderBar() {
-    onView(withId(org.mozilla.fenix.R.id.sampleText))
-        .check(matches(withText("This is sample text. It is here to show how text will appear when you increase or decrease the size with this setting.")))
-
-    onView(withId(org.mozilla.fenix.R.id.seekbar_value))
-        .check(matches(withText("100%")))
-
-    onView(withId(org.mozilla.fenix.R.id.seekbar))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
 private fun adjustTextSizeSlider(seekBarPercentage: Int) {
     onView(withId(org.mozilla.fenix.R.id.seekbar))
         .perform(SeekBarChangeProgressViewAction(seekBarPercentage))
-}
-
-private fun assertTextSizePercentage(textSize: Int) {
-    onView(withId(org.mozilla.fenix.R.id.sampleText))
-        .check(textSizePercentageEquals(textSize))
-}
-
-private fun assertMenuItemsAreDisabled() {
-    onView(withText("Font Size")).assertIsEnabled(false)
-
-    val strFont = "Make text on websites larger or smaller"
-
-    onView(withText(strFont)).assertIsEnabled(false)
-
-    onView(withId(org.mozilla.fenix.R.id.sampleText)).assertIsEnabled(false)
-
-    onView(withId(org.mozilla.fenix.R.id.seekbar_value)).assertIsEnabled(false)
-
-    onView(withId(org.mozilla.fenix.R.id.seekbar)).assertIsEnabled(false)
 }
 
 private fun goBackButton() =


### PR DESCRIPTION
Summary:

- Added pairs of test logs to the SettingsSubMenuAccessibilityRobot
- Removed the redundant assertion functions from SettingsSubMenuAccessibilityRobot

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880466