### PR TITLE
Bug 1880620 - Add logs to SettingsSubMenuAddonsManagerRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.kt
@@ -5,6 +5,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import android.view.View
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -17,6 +18,7 @@ import org.hamcrest.CoreMatchers.allOf
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.AppAndSystemHelper.registerAndCleanupIdlingResources
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.helpers.click
 
@@ -28,8 +30,9 @@ class SettingsSubMenuAddonsManagerAddonDetailedMenuRobot {
 
     class Transition {
         fun goBack(interact: SettingsSubMenuAddonsManagerRobot.() -> Unit): SettingsSubMenuAddonsManagerRobot.Transition {
-            fun goBackButton() = onView(allOf(withContentDescription("Navigate up")))
-            goBackButton().click()
+            Log.i(TAG, "goBack: Trying to click the navigate up button")
+            onView(allOf(withContentDescription("Navigate up"))).click()
+            Log.i(TAG, "goBack: Clicked the navigate up button")
 
             SettingsSubMenuAddonsManagerRobot().interact()
             return SettingsSubMenuAddonsManagerRobot.Transition()
@@ -42,8 +45,12 @@ class SettingsSubMenuAddonsManagerAddonDetailedMenuRobot {
                     View.VISIBLE,
                 ),
             ) {
+                Log.i(TAG, "removeAddon: Trying to verify that the remove add-on button is visible")
                 removeAddonButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+                Log.i(TAG, "removeAddon: Verified that the remove add-on button is visible")
+                Log.i(TAG, "removeAddon: Trying to click the remove add-on button")
                 removeAddonButton().click()
+                Log.i(TAG, "removeAddon: Clicked the remove add-on button")
             }
 
             SettingsSubMenuAddonsManagerRobot().interact()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
@@ -55,12 +55,15 @@ class SettingsSubMenuAddonsManagerRobot {
     fun verifyAddonsListIsDisplayed(shouldBeDisplayed: Boolean) =
         assertUIObjectExists(addonsList(), exists = shouldBeDisplayed)
 
-    fun verifyAddonDownloadOverlay() =
+    fun verifyAddonDownloadOverlay() {
+        Log.i(TAG, "verifyAddonDownloadOverlay: Trying to verify that the \"Downloading and verifying add-on\" prompt is displayed")
         onView(withText(R.string.mozac_add_on_install_progress_caption)).check(matches(isDisplayed()))
+        Log.i(TAG, "verifyAddonDownloadOverlay: Verified that the \"Downloading and verifying add-on\" prompt is displayed")
+    }
 
     fun verifyAddonPermissionPrompt(addonName: String) {
         mDevice.waitNotNull(Until.findObject(By.text("Add $addonName?")), waitingTime)
-
+        Log.i(TAG, "verifyAddonPermissionPrompt: Trying to verify that the add-ons permission prompt items are displayed")
         onView(
             allOf(
                 withText("Add $addonName?"),
@@ -71,11 +74,14 @@ class SettingsSubMenuAddonsManagerRobot {
         )
             .inRoot(isDialog())
             .check(matches(isDisplayed()))
+        Log.i(TAG, "verifyAddonPermissionPrompt: Verified that the add-ons permission prompt items are displayed")
     }
 
     fun clickInstallAddon(addonName: String) {
-        Log.i(TAG, "clickInstallAddon: Looking for $addonName install button")
+        Log.i(TAG, "clickInstallAddon: Waiting for $waitingTime ms for add-ons list to exist")
         addonsList().waitForExists(waitingTime)
+        Log.i(TAG, "clickInstallAddon: Waited for $waitingTime ms for add-ons list to exist")
+        Log.i(TAG, "clickInstallAddon: Trying to scroll into view the install $addonName button")
         addonsList().scrollIntoView(
             mDevice.findObject(
                 UiSelector()
@@ -83,6 +89,8 @@ class SettingsSubMenuAddonsManagerRobot {
                     .childSelector(UiSelector().text(addonName)),
             ),
         )
+        Log.i(TAG, "clickInstallAddon: Scrolled into view the install $addonName button")
+        Log.i(TAG, "clickInstallAddon: Trying to ensure the full visibility of the the install $addonName button")
         addonsList().ensureFullyVisible(
             mDevice.findObject(
                 UiSelector()
@@ -90,22 +98,24 @@ class SettingsSubMenuAddonsManagerRobot {
                     .childSelector(UiSelector().text(addonName)),
             ),
         )
-        Log.i(TAG, "clickInstallAddon: Found $addonName install button")
+        Log.i(TAG, "clickInstallAddon: Ensured the full visibility of the the install $addonName button")
+        Log.i(TAG, "clickInstallAddon: Trying to click the install $addonName button")
         installButtonForAddon(addonName).click()
-        Log.i(TAG, "clickInstallAddon: Clicked Install $addonName button")
+        Log.i(TAG, "clickInstallAddon: Clicked the install $addonName button")
     }
 
     fun verifyAddonInstallCompleted(addonName: String, activityTestRule: HomeActivityIntentTestRule) {
         for (i in 1..RETRY_COUNT) {
+            Log.i(TAG, "verifyAddonInstallCompleted: Started try #$i")
             try {
                 assertUIObjectExists(itemWithText("OK"), waitingTime = waitingTimeLong)
 
                 break
             } catch (e: AssertionError) {
+                Log.i(TAG, "verifyAddonInstallCompleted: AssertionError caught, executing fallback methods")
                 if (i == RETRY_COUNT) {
                     throw e
                 } else {
-                    Log.i(TAG, "verifyAddonInstallCompleted: $addonName failed to install on try #$i")
                     restartApp(activityTestRule)
                     homeScreen {
                     }.openThreeDotMenu {
@@ -121,6 +131,7 @@ class SettingsSubMenuAddonsManagerRobot {
     }
 
     fun verifyAddonInstallCompletedPrompt(addonName: String) {
+        Log.i(TAG, "verifyAddonInstallCompletedPrompt: Trying to verify that completed add-on install prompt items are visible")
         onView(
             allOf(
                 withText("OK"),
@@ -131,14 +142,18 @@ class SettingsSubMenuAddonsManagerRobot {
             ),
         )
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyAddonInstallCompletedPrompt: Verified that completed add-on install prompt items are visible")
     }
 
     fun closeAddonInstallCompletePrompt() {
+        Log.i(TAG, "closeAddonInstallCompletePrompt: Trying to click the \"OK\" button from the completed add-on install prompt")
         onView(withText("OK")).click()
+        Log.i(TAG, "closeAddonInstallCompletePrompt: Clicked the \"OK\" button from the completed add-on install prompt")
     }
 
     fun verifyAddonIsInstalled(addonName: String) {
         scrollToElementByText(addonName)
+        Log.i(TAG, "verifyAddonIsInstalled: Trying to verify that the $addonName add-on was installed")
         onView(
             allOf(
                 withId(R.id.add_button),
@@ -146,19 +161,24 @@ class SettingsSubMenuAddonsManagerRobot {
                 hasSibling(hasDescendant(withText(addonName))),
             ),
         ).check(matches(withEffectiveVisibility(Visibility.INVISIBLE)))
+        Log.i(TAG, "verifyAddonIsInstalled: Verified that the $addonName add-on was installed")
     }
 
     fun verifyEnabledTitleDisplayed() {
+        Log.i(TAG, "verifyEnabledTitleDisplayed: Trying to verify that the \"Enabled\" heading is displayed")
         onView(withText("Enabled"))
             .check(matches(isCompletelyDisplayed()))
+        Log.i(TAG, "verifyEnabledTitleDisplayed: Verified that the \"Enabled\" heading is displayed")
     }
 
     fun cancelInstallAddon() = cancelInstall()
     fun acceptPermissionToInstallAddon() = allowPermissionToInstall()
     fun verifyAddonsItems() {
+        Log.i(TAG, "verifyAddonsItems: Trying to verify that the \"Recommended\" heading is visible")
         onView(allOf(withId(R.id.title), withText("Recommended")))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
+        Log.i(TAG, "verifyAddonsItems: Verified that the \"Recommended\" heading is visible")
+        Log.i(TAG, "verifyAddonsItems: Trying to verify that all uBlock Origin items are completely displayed")
         onView(
             allOf(
                 isAssignableFrom(RelativeLayout::class.java),
@@ -176,11 +196,12 @@ class SettingsSubMenuAddonsManagerRobot {
                 hasDescendant(withId(R.id.add_button)),
             ),
         ).check(matches(isCompletelyDisplayed()))
+        Log.i(TAG, "verifyAddonsItems: Verified that all uBlock Origin items are completely displayed")
     }
     fun verifyAddonCanBeInstalled(addonName: String) {
         scrollToElementByText(addonName)
         mDevice.waitNotNull(Until.findObject(By.text(addonName)), waitingTime)
-
+        Log.i(TAG, "verifyAddonCanBeInstalled: Trying to verify that the install $addonName button is visible")
         onView(
             allOf(
                 withId(R.id.add_button),
@@ -194,11 +215,14 @@ class SettingsSubMenuAddonsManagerRobot {
                 ),
             ),
         ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyAddonCanBeInstalled: Verified that the install $addonName button is visible")
     }
 
     fun selectAllowInPrivateBrowsing() {
         assertUIObjectExists(itemWithText("Allow in private browsing"), waitingTime = waitingTimeLong)
+        Log.i(TAG, "selectAllowInPrivateBrowsing: Trying to click the \"Allow in private browsing\" check box")
         onView(withId(R.id.allow_in_private_browsing)).click()
+        Log.i(TAG, "selectAllowInPrivateBrowsing: Clicked the \"Allow in private browsing\" check box")
     }
 
     fun installAddon(addonName: String, activityTestRule: HomeActivityIntentTestRule) {
@@ -214,8 +238,9 @@ class SettingsSubMenuAddonsManagerRobot {
 
     class Transition {
         fun goBack(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
-            fun goBackButton() = onView(allOf(withContentDescription("Navigate up")))
-            goBackButton().click()
+            Log.i(TAG, "goBack: Trying to click navigate up toolbar button")
+            onView(allOf(withContentDescription("Navigate up"))).click()
+            Log.i(TAG, "goBack: Clicked the navigate up toolbar button")
 
             HomeScreenRobot().interact()
             return HomeScreenRobot.Transition()
@@ -226,19 +251,12 @@ class SettingsSubMenuAddonsManagerRobot {
             interact: SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.() -> Unit,
         ): SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.Transition {
             scrollToElementByText(addonName)
-
-            onView(
-                allOf(
-                    withId(R.id.add_on_item),
-                    hasDescendant(
-                        allOf(
-                            withId(R.id.add_on_name),
-                            withText(addonName),
-                        ),
-                    ),
-                ),
-            ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-                .perform(click())
+            Log.i(TAG, "openDetailedMenuForAddon: Trying to verify that the $addonName add-on is visible")
+            addonItem(addonName).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+            Log.i(TAG, "openDetailedMenuForAddon: Verified that the $addonName add-on is visible")
+            Log.i(TAG, "openDetailedMenuForAddon: Trying to click the $addonName add-on")
+            addonItem(addonName).perform(click())
+            Log.i(TAG, "openDetailedMenuForAddon: Clicked the $addonName add-on")
 
             SettingsSubMenuAddonsManagerAddonDetailedMenuRobot().interact()
             return SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.Transition()
@@ -255,17 +273,22 @@ class SettingsSubMenuAddonsManagerRobot {
         )
 
     private fun cancelInstall() {
-        onView(allOf(withId(R.id.deny_button), withText("Cancel")))
-            .check(matches(isCompletelyDisplayed()))
-            .perform(click())
+        Log.i(TAG, "cancelInstall: Trying to verify that the \"Cancel\" button is completely displayed")
+        onView(allOf(withId(R.id.deny_button), withText("Cancel"))).check(matches(isCompletelyDisplayed()))
+        Log.i(TAG, "cancelInstall: Verified that the \"Cancel\" button is completely displayed")
+        Log.i(TAG, "cancelInstall: Trying to click the \"Cancel\" button")
+        onView(allOf(withId(R.id.deny_button), withText("Cancel"))).perform(click())
+        Log.i(TAG, "cancelInstall: Clicked the \"Cancel\" button")
     }
 
     private fun allowPermissionToInstall() {
         mDevice.waitNotNull(Until.findObject(By.text("Add")), waitingTime)
-
-        onView(allOf(withId(R.id.allow_button), withText("Add")))
-            .check(matches(isCompletelyDisplayed()))
-            .perform(click())
+        Log.i(TAG, "allowPermissionToInstall: Trying to verify that the \"Add\" button is completely displayed")
+        onView(allOf(withId(R.id.allow_button), withText("Add"))).check(matches(isCompletelyDisplayed()))
+        Log.i(TAG, "allowPermissionToInstall: Verified that the \"Add\" button is completely displayed")
+        Log.i(TAG, "allowPermissionToInstall: Trying to click the \"Add\" button")
+        onView(allOf(withId(R.id.allow_button), withText("Add"))).perform(click())
+        Log.i(TAG, "allowPermissionToInstall: Clicked the \"Add\" button")
     }
 }
 
@@ -273,6 +296,19 @@ fun addonsMenu(interact: SettingsSubMenuAddonsManagerRobot.() -> Unit): Settings
     SettingsSubMenuAddonsManagerRobot().interact()
     return SettingsSubMenuAddonsManagerRobot.Transition()
 }
+
+private fun addonItem(addonName: String) =
+    onView(
+        allOf(
+            withId(R.id.add_on_item),
+            hasDescendant(
+                allOf(
+                    withId(R.id.add_on_name),
+                    withText(addonName),
+                ),
+            ),
+        ),
+    )
 
 private fun addonsList() =
     UiScrollable(UiSelector().resourceId("$packageName:id/add_ons_list")).setAsVerticalList()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
@@ -139,7 +139,13 @@ class SettingsSubMenuAddonsManagerRobot {
 
     fun verifyAddonIsInstalled(addonName: String) {
         scrollToElementByText(addonName)
-        assertAddonIsInstalled(addonName)
+        onView(
+            allOf(
+                withId(R.id.add_button),
+                isDescendantOfA(withId(R.id.add_on_item)),
+                hasSibling(hasDescendant(withText(addonName))),
+            ),
+        ).check(matches(withEffectiveVisibility(Visibility.INVISIBLE)))
     }
 
     fun verifyEnabledTitleDisplayed() {
@@ -149,8 +155,46 @@ class SettingsSubMenuAddonsManagerRobot {
 
     fun cancelInstallAddon() = cancelInstall()
     fun acceptPermissionToInstallAddon() = allowPermissionToInstall()
-    fun verifyAddonsItems() = assertAddonsItems()
-    fun verifyAddonCanBeInstalled(addonName: String) = assertAddonCanBeInstalled(addonName)
+    fun verifyAddonsItems() {
+        onView(allOf(withId(R.id.title), withText("Recommended")))
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+        onView(
+            allOf(
+                isAssignableFrom(RelativeLayout::class.java),
+                withId(R.id.add_on_item),
+                hasDescendant(allOf(withId(R.id.add_on_icon), isCompletelyDisplayed())),
+                hasDescendant(
+                    allOf(
+                        withId(R.id.details_container),
+                        hasDescendant(withText("uBlock Origin")),
+                        hasDescendant(withText("Finally, an efficient wide-spectrum content blocker. Easy on CPU and memory.")),
+                        hasDescendant(withId(R.id.rating)),
+                        hasDescendant(withId(R.id.review_count)),
+                    ),
+                ),
+                hasDescendant(withId(R.id.add_button)),
+            ),
+        ).check(matches(isCompletelyDisplayed()))
+    }
+    fun verifyAddonCanBeInstalled(addonName: String) {
+        scrollToElementByText(addonName)
+        mDevice.waitNotNull(Until.findObject(By.text(addonName)), waitingTime)
+
+        onView(
+            allOf(
+                withId(R.id.add_button),
+                hasSibling(
+                    hasDescendant(
+                        allOf(
+                            withId(R.id.add_on_name),
+                            withText(addonName),
+                        ),
+                    ),
+                ),
+            ),
+        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
 
     fun selectAllowInPrivateBrowsing() {
         assertUIObjectExists(itemWithText("Allow in private browsing"), waitingTime = waitingTimeLong)
@@ -210,16 +254,6 @@ class SettingsSubMenuAddonsManagerRobot {
             ),
         )
 
-    private fun assertAddonIsInstalled(addonName: String) {
-        onView(
-            allOf(
-                withId(R.id.add_button),
-                isDescendantOfA(withId(R.id.add_on_item)),
-                hasSibling(hasDescendant(withText(addonName))),
-            ),
-        ).check(matches(withEffectiveVisibility(Visibility.INVISIBLE)))
-    }
-
     private fun cancelInstall() {
         onView(allOf(withId(R.id.deny_button), withText("Cancel")))
             .check(matches(isCompletelyDisplayed()))
@@ -232,59 +266,6 @@ class SettingsSubMenuAddonsManagerRobot {
         onView(allOf(withId(R.id.allow_button), withText("Add")))
             .check(matches(isCompletelyDisplayed()))
             .perform(click())
-    }
-
-    private fun assertAddonsItems() {
-        assertRecommendedTitleDisplayed()
-        assertAddons()
-    }
-
-    private fun assertRecommendedTitleDisplayed() {
-        onView(allOf(withId(R.id.title), withText("Recommended")))
-            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-    }
-
-    private fun assertAddons() {
-        assertAddonUblock()
-    }
-
-    private fun assertAddonUblock() {
-        onView(
-            allOf(
-                isAssignableFrom(RelativeLayout::class.java),
-                withId(R.id.add_on_item),
-                hasDescendant(allOf(withId(R.id.add_on_icon), isCompletelyDisplayed())),
-                hasDescendant(
-                    allOf(
-                        withId(R.id.details_container),
-                        hasDescendant(withText("uBlock Origin")),
-                        hasDescendant(withText("Finally, an efficient wide-spectrum content blocker. Easy on CPU and memory.")),
-                        hasDescendant(withId(R.id.rating)),
-                        hasDescendant(withId(R.id.review_count)),
-                    ),
-                ),
-                hasDescendant(withId(R.id.add_button)),
-            ),
-        ).check(matches(isCompletelyDisplayed()))
-    }
-
-    private fun assertAddonCanBeInstalled(addonName: String) {
-        scrollToElementByText(addonName)
-        mDevice.waitNotNull(Until.findObject(By.text(addonName)), waitingTime)
-
-        onView(
-            allOf(
-                withId(R.id.add_button),
-                hasSibling(
-                    hasDescendant(
-                        allOf(
-                            withId(R.id.add_on_name),
-                            withText(addonName),
-                        ),
-                    ),
-                ),
-            ),
-        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
     }
 }
 


### PR DESCRIPTION
Summary:

- Added pairs of test logs to the `SettingsSubMenuAddonsManagerAddonDetailedMenuRobot`
- Added pairs of test logs to the `SettingsSubMenuAddonsManagerRobot`
- Removed the redundant assertion functions from `SettingsSubMenuAddonsManagerRobot`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880620