### PR TITLE
Bug 1880827 - Add test logs to SettingsSubMenuDeleteBrowsingDataOnQuitRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataOnQuitRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataOnQuitRobot.kt
@@ -28,7 +28,7 @@ import org.mozilla.fenix.helpers.isChecked
  */
 class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
 
-    fun verifyNavigationToolBarHeader() =
+    fun verifyNavigationToolBarHeader() {
         onView(
             allOf(
                 withId(R.id.navigationToolbar),
@@ -36,9 +36,10 @@ class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
             ),
         )
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
 
     fun verifyDeleteBrowsingOnQuitEnabled(enabled: Boolean) =
-        deleteBrowsingOnQuitButton.assertIsChecked(enabled)
+        deleteBrowsingOnQuitButton().assertIsChecked(enabled)
 
     fun verifyDeleteBrowsingOnQuitButtonSummary() =
         onView(
@@ -48,25 +49,25 @@ class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
     fun clickDeleteBrowsingOnQuitButtonSwitch() = onView(withResourceName("switch_widget")).click()
 
     fun verifyAllTheCheckBoxesText() {
-        openTabsCheckbox
+        openTabsCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-        browsingHistoryCheckbox
+        browsingHistoryCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-        cookiesAndSiteDataCheckbox
+        cookiesAndSiteDataCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
         onView(withText(R.string.preferences_delete_browsing_data_cookies_subtitle))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-        cachedFilesCheckbox
+        cachedFilesCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
         onView(withText(R.string.preferences_delete_browsing_data_cached_files_subtitle))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-        sitePermissionsCheckbox
+        sitePermissionsCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
     }
 
@@ -91,7 +92,7 @@ class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
-            goBackButton.click()
+            goBackButton().click()
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()
@@ -99,21 +100,21 @@ class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
     }
 }
 
-private val goBackButton = onView(withContentDescription("Navigate up"))
+private fun goBackButton() = onView(withContentDescription("Navigate up"))
 
-private val deleteBrowsingOnQuitButton =
+private fun deleteBrowsingOnQuitButton() =
     onView(withClassName(containsString("android.widget.Switch")))
 
-private val openTabsCheckbox =
+private fun openTabsCheckbox() =
     onView(withText(R.string.preferences_delete_browsing_data_tabs_title_2))
 
-private val browsingHistoryCheckbox =
+private fun browsingHistoryCheckbox() =
     onView(withText(R.string.preferences_delete_browsing_data_browsing_history_title))
 
-private val cookiesAndSiteDataCheckbox = onView(withText(R.string.preferences_delete_browsing_data_cookies_and_site_data))
+private fun cookiesAndSiteDataCheckbox() = onView(withText(R.string.preferences_delete_browsing_data_cookies_and_site_data))
 
-private val cachedFilesCheckbox =
+private fun cachedFilesCheckbox() =
     onView(withText(R.string.preferences_delete_browsing_data_cached_files))
 
-private val sitePermissionsCheckbox =
+private fun sitePermissionsCheckbox() =
     onView(withText(R.string.preferences_delete_browsing_data_site_permissions))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataOnQuitRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataOnQuitRobot.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
@@ -18,6 +19,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.assertIsChecked
 import org.mozilla.fenix.helpers.atPosition
 import org.mozilla.fenix.helpers.click
@@ -29,6 +31,7 @@ import org.mozilla.fenix.helpers.isChecked
 class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
 
     fun verifyNavigationToolBarHeader() {
+        Log.i(TAG, "verifyNavigationToolBarHeader: Trying to verify that the \"Delete browsing data on quit\" toolbar title is visible")
         onView(
             allOf(
                 withId(R.id.navigationToolbar),
@@ -36,43 +39,63 @@ class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
             ),
         )
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyNavigationToolBarHeader: Verified that the \"Delete browsing data on quit\" toolbar title is visible")
     }
 
-    fun verifyDeleteBrowsingOnQuitEnabled(enabled: Boolean) =
+    fun verifyDeleteBrowsingOnQuitEnabled(enabled: Boolean) {
+        Log.i(TAG, "verifyDeleteBrowsingOnQuitEnabled: Trying to verify that the  \"Delete browsing data on quit\" toggle is checked: $enabled")
         deleteBrowsingOnQuitButton().assertIsChecked(enabled)
+        Log.i(TAG, "verifyDeleteBrowsingOnQuitEnabled: Verified that the  \"Delete browsing data on quit\" toggle is checked: $enabled")
+    }
 
-    fun verifyDeleteBrowsingOnQuitButtonSummary() =
+    fun verifyDeleteBrowsingOnQuitButtonSummary() {
+        Log.i(TAG, "verifyDeleteBrowsingOnQuitButtonSummary: Trying to verify that the \"Delete browsing data on quit\" option summary is visible")
         onView(
             withText(R.string.preference_summary_delete_browsing_data_on_quit_2),
         ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyDeleteBrowsingOnQuitButtonSummary: Verified that the \"Delete browsing data on quit\" option summary is visible")
+    }
 
-    fun clickDeleteBrowsingOnQuitButtonSwitch() = onView(withResourceName("switch_widget")).click()
+    fun clickDeleteBrowsingOnQuitButtonSwitch() {
+        Log.i(TAG, "clickDeleteBrowsingOnQuitButtonSwitch: Trying to click the \"Delete browsing data on quit\" toggle")
+        onView(withResourceName("switch_widget")).click()
+        Log.i(TAG, "clickDeleteBrowsingOnQuitButtonSwitch: Clicked the \"Delete browsing data on quit\" toggle")
+    }
 
     fun verifyAllTheCheckBoxesText() {
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Trying to verify that the \"Open tabs\" option is visible")
         openTabsCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Verified that the \"Open tabs\" option is visible")
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Trying to verify that the \"Browsing history\" option is visible")
         browsingHistoryCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Verified that the \"Browsing history\" option is visible")
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Trying to verify that the \"Cookies and site data\" option is visible")
         cookiesAndSiteDataCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Verified that the \"Cookies and site data\" option is visible")
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Trying to verify that the \"Cookies and site data\" option summary is visible")
         onView(withText(R.string.preferences_delete_browsing_data_cookies_subtitle))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Verified that the \"Cookies and site data\" option summary is visible")
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Trying to verify that the \"Cached images and files\" option is visible")
         cachedFilesCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Verified that the \"Cached images and files\" option is visible")
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Trying to verify that the \"Cached images and files\" option summary is visible")
         onView(withText(R.string.preferences_delete_browsing_data_cached_files_subtitle))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Verified that the \"Cached images and files\" option summary is visible")
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Trying to verify that the \"Site permissions\" option is visible")
         sitePermissionsCheckbox()
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyAllTheCheckBoxesText: Verified that the \"Site permissions\" option is visible")
     }
 
     fun verifyAllTheCheckBoxesChecked(checked: Boolean) {
         for (index in 2..7) {
+            Log.i(TAG, "verifyAllTheCheckBoxesChecked: Trying to verify that the the check box at position ${index - 1} is checked: $checked")
             onView(withId(R.id.recycler_view))
                 .check(
                     matches(
@@ -87,12 +110,15 @@ class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
                         ),
                     ),
                 )
+            Log.i(TAG, "verifyAllTheCheckBoxesChecked: Verified that the the check box at position ${index - 1} is checked: $checked")
         }
     }
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            Log.i(TAG, "goBack: Trying to click navigate up toolbar button")
             goBackButton().click()
+            Log.i(TAG, "goBack: Clicked navigate up toolbar button")
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880827