### PR TITLE
Bug 1880829 - Restrict suggest to show a single open tab suggestion for identical tabs

### DIFF
--- a/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
+++ b/android-components/components/feature/awesomebar/src/main/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProvider.kt
@@ -50,15 +50,15 @@ class SessionSuggestionProvider(
         }
 
         val state = store.state
-        val tabs = state.tabs
+        val distinctTabs = state.tabs.distinctBy { it.content.url }
 
         val suggestions = mutableListOf<AwesomeBar.Suggestion>()
-        val iconRequests: List<Deferred<Icon>?> = tabs.map {
+        val iconRequests: List<Deferred<Icon>?> = distinctTabs.map {
             icons?.loadIcon(IconRequest(url = it.content.url, waitOnNetworkLoad = false))
         }
 
         val searchWords = searchText.split(" ")
-        tabs.zip(iconRequests) { result, icon ->
+        distinctTabs.zip(iconRequests) { result, icon ->
             if (
                 resultsUriFilter?.invoke(result.content.url.toUri()) != false &&
                 searchWords.all { result.contains(it) } &&

--- a/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
+++ b/android-components/components/feature/awesomebar/src/test/java/mozilla/components/feature/awesomebar/provider/SessionSuggestionProviderTest.kt
@@ -416,4 +416,34 @@ class SessionSuggestionProviderTest {
         assertTrue(suggestions.map { it.title }.contains("http://www.mobile.mozilla.org"))
         assertTrue(suggestions.map { it.title }.contains("https://www.mozilla.org/vpn"))
     }
+
+    @Test
+    fun `GIVEN multiple tabs have the same url WHEN user inputs the same url THEN provider returns a single suggestion for the matching input`() = runTest {
+        val store = BrowserStore()
+
+        val url = "https://www.mozilla.org"
+        val tab1 = createTab(url)
+        val tab2 = createTab(url)
+        val tab3 = createTab(url)
+
+        val resources: Resources = mock()
+        `when`(resources.getString(anyInt())).thenReturn("Switch to tab")
+
+        val provider = SessionSuggestionProvider(resources, store, mock())
+
+        run {
+            val suggestions = provider.onInputChanged("Mozilla")
+            assertTrue(suggestions.isEmpty())
+        }
+
+        store.dispatch(TabListAction.AddTabAction(tab1)).join()
+        store.dispatch(TabListAction.AddTabAction(tab2)).join()
+        store.dispatch(TabListAction.AddTabAction(tab3)).join()
+
+        run {
+            val suggestions = provider.onInputChanged("Mozilla")
+            assertEquals(1, suggestions.size)
+            assertEquals(tab1.id, suggestions[0].id)
+        }
+    }
 }


### PR DESCRIPTION
Original:

<img src="https://github.com/mozilla-mobile/firefox-android/assets/1833156/27a71e16-7820-423c-beb4-3e57307acc91" width="200">

----------


With patch:

<img src="https://github.com/mozilla-mobile/firefox-android/assets/1833156/46b183ea-fe13-47eb-9373-c61275c2a607" width="200">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880829