### PR TITLE
Bug 1880476 — Remove redundant caching and destroy jexl helper after use

### DIFF
--- a/android-components/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorage.kt
+++ b/android-components/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorage.kt
@@ -53,8 +53,15 @@ class NimbusMessagingStorage(
     private val customAttributes: JSONObject
         get() = attributeProvider?.getCustomAttributes(context) ?: JSONObject()
 
-    val helper: NimbusMessagingHelperInterface
-        get() = gleanPlumb.createMessageHelper(customAttributes)
+    /**
+     * Returns a Nimbus message helper, for evaluating JEXL.
+     *
+     * The JEXL context is time-sensitive, so this should be created new for each set of evaluations.
+     *
+     * Since it has a native peer, it should be [destroy]ed after finishing the set of evaluations.
+     */
+    fun createMessagingHelper(): NimbusMessagingHelperInterface =
+        gleanPlumb.createMessageHelper(customAttributes)
 
     /**
      * Returns the [Message] for the given [key] or returns null if none found.
@@ -114,13 +121,14 @@ class NimbusMessagingStorage(
      * Returns the next higher priority message which all their triggers are true.
      */
     fun getNextMessage(surface: MessageSurfaceId, availableMessages: List<Message>): Message? =
-        getNextMessage(
-            surface,
-            availableMessages,
-            setOf(),
-            helper,
-            mutableMapOf(),
-        )
+        createMessagingHelper().use {
+            getNextMessage(
+                surface,
+                availableMessages,
+                setOf(),
+                it,
+            )
+        }
 
     @Suppress("ReturnCount")
     private fun getNextMessage(
@@ -128,12 +136,11 @@ class NimbusMessagingStorage(
         availableMessages: List<Message>,
         excluded: Set<String>,
         helper: NimbusMessagingHelperInterface,
-        jexlCache: MutableMap<String, Boolean>,
     ): Message? {
         val message = availableMessages
             .filter { surface == it.surface }
             .filter { !excluded.contains(it.id) }
-            .firstOrNull { isMessageEligible(it, helper, jexlCache) } ?: return null
+            .firstOrNull { isMessageEligible(it, helper) } ?: return null
 
         val slug = message.data.experiment
         if (slug != null) {
@@ -168,7 +175,6 @@ class NimbusMessagingStorage(
                     availableMessages,
                     excluded + message.id,
                     helper,
-                    jexlCache,
                 )
 
             ControlMessageBehavior.SHOW_NONE -> null
@@ -190,12 +196,12 @@ class NimbusMessagingStorage(
      * The fully resolved (with all substitutions) action is returned as the second value
      * of the [Pair].
      */
-    fun generateUuidAndFormatAction(action: String): Pair<String?, String> {
-        val helper = gleanPlumb.createMessageHelper(customAttributes)
-        val uuid = helper.getUuid(action)
-
-        return Pair(uuid, helper.stringFormat(action, uuid))
-    }
+    fun generateUuidAndFormatAction(action: String): Pair<String?, String> =
+        createMessagingHelper().use { helper ->
+            val uuid = helper.getUuid(action)
+            val url = helper.stringFormat(action, uuid)
+            Pair(uuid, url)
+        }
 
     /**
      * Updated the provided [metadata] in the storage.
@@ -260,23 +266,19 @@ class NimbusMessagingStorage(
     fun isMessageEligible(
         message: Message,
         helper: NimbusMessagingHelperInterface,
-        jexlCache: MutableMap<String, Boolean> = mutableMapOf(),
     ): Boolean {
         return message.triggers.all { condition ->
-            jexlCache[condition]
-                ?: try {
-                    if (malFormedMap.containsKey(condition)) {
-                        return false
-                    }
-                    helper.evalJexl(condition).also { result ->
-                        jexlCache[condition] = result
-                    }
-                } catch (e: NimbusException.EvaluationException) {
-                    reportMalformedMessage(message.id)
-                    malFormedMap[condition] = message.id
-                    logger.info("Unable to evaluate $condition")
-                    false
+            try {
+                if (malFormedMap.containsKey(condition)) {
+                    return false
                 }
+                helper.evalJexl(condition)
+            } catch (e: NimbusException.EvaluationException) {
+                reportMalformedMessage(message.id)
+                malFormedMap[condition] = message.id
+                logger.info("Unable to evaluate $condition")
+                false
+            }
         }
     }
 
@@ -291,3 +293,11 @@ class NimbusMessagingStorage(
         )
     }
 }
+
+/**
+ * A helper method to safely destroy the message helper after use.
+ */
+fun <R> NimbusMessagingHelperInterface.use(block: (NimbusMessagingHelperInterface) -> R) =
+    block(this).also {
+        this.destroy()
+    }

--- a/android-components/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorageTest.kt
+++ b/android-components/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorageTest.kt
@@ -83,6 +83,8 @@ class NimbusMessagingStorageTest {
             gleanPlumb,
             messagingFeature,
         )
+
+        `when`(gleanPlumb.createMessageHelper(any())).thenReturn(mock())
     }
 
     @After
@@ -489,7 +491,7 @@ class NimbusMessagingStorageTest {
             Message.Metadata("same-id"),
         )
 
-        doReturn(false).`when`(spiedStorage).isMessageEligible(any(), any(), any())
+        doReturn(false).`when`(spiedStorage).isMessageEligible(any(), any())
 
         val result = spiedStorage.getNextMessage(HOMESCREEN, listOf(message))
 
@@ -508,7 +510,7 @@ class NimbusMessagingStorageTest {
             Message.Metadata("same-id"),
         )
 
-        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any(), any())
+        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
 
         val result = spiedStorage.getNextMessage(HOMESCREEN, listOf(message))
 
@@ -530,7 +532,7 @@ class NimbusMessagingStorageTest {
             Message.Metadata("same-id"),
         )
 
-        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any(), any())
+        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
 
         val result = spiedStorage.getNextMessage(HOMESCREEN, listOf(message))
 
@@ -565,7 +567,7 @@ class NimbusMessagingStorageTest {
             Message.Metadata("same-id"),
         )
 
-        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any(), any())
+        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
 
         val result = spiedStorage.getNextMessage(
             HOMESCREEN,
@@ -603,7 +605,7 @@ class NimbusMessagingStorageTest {
             Message.Metadata("same-id"),
         )
 
-        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any(), any())
+        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
 
         val result = spiedStorage.getNextMessage(
             HOMESCREEN,
@@ -652,7 +654,7 @@ class NimbusMessagingStorageTest {
             Message.Metadata("same-id"),
         )
 
-        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any(), any())
+        doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
 
         var result = spiedStorage.getNextMessage(
             HOMESCREEN,

--- a/fenix/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingFragment.kt
@@ -23,6 +23,7 @@ import androidx.fragment.app.Fragment
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.navigation.fragment.findNavController
 import mozilla.components.service.nimbus.evalJexlSafe
+import mozilla.components.service.nimbus.messaging.use
 import mozilla.components.support.base.ext.areNotificationsEnabledSafe
 import mozilla.components.support.utils.BrowsersCache
 import org.mozilla.fenix.R
@@ -228,7 +229,7 @@ class OnboardingFragment : Fragment() {
         showAddWidgetPage: Boolean,
     ): List<OnboardingPageUiData> {
         val jexlConditions = FxNimbus.features.junoOnboarding.value().conditions
-        val jexlHelper = requireContext().components.analytics.messagingStorage.helper
+        val jexlHelper = requireContext().components.analytics.messagingStorage.createMessagingHelper()
 
         val privacyCaption = Caption(
             text = getString(R.string.juno_onboarding_privacy_notice_text),
@@ -249,12 +250,14 @@ class OnboardingFragment : Fragment() {
                 },
             ),
         )
-        return FxNimbus.features.junoOnboarding.value().cards.values.toPageUiData(
-            privacyCaption,
-            showDefaultBrowserPage,
-            showNotificationPage,
-            showAddWidgetPage,
-            jexlConditions,
-        ) { condition -> jexlHelper.evalJexlSafe(condition) }
+        return jexlHelper.use {
+            FxNimbus.features.junoOnboarding.value().cards.values.toPageUiData(
+                privacyCaption,
+                showDefaultBrowserPage,
+                showNotificationPage,
+                showAddWidgetPage,
+                jexlConditions,
+            ) { condition -> jexlHelper.evalJexlSafe(condition) }
+        }
     }
 }


### PR DESCRIPTION
Relates to [Bug 1880476](https://bugzilla.mozilla.org/show_bug.cgi?id=1880476).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR is the second part of a Nimbus improvement in the `NimbusMessagingHelper`, which adds JEXL caching to that class, rather than forcing clients to implement their own caching.

The NimbusMessagingHelper also grew a `destroy` method which calls the Rust drop methods on the native peers. This fixes a small, but long standing memory leak.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880476