### PR TITLE
Bug 1880912 - Remove TestRail Script and Dependencies from ui-test-apk TC Task

### DIFF
--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -170,72 +170,18 @@ tasks:
                   key: firebaseToken
                   path: .firebase_token.json
                   json: true
-                - name: project/mobile/ci/testrail
-                  key: testrailCredentials
-                  path: .testrail_credentials.json
-                  json: true
             pre-commands:
                 - ["cd", "focus-android"]
             commands:
                 - [wget, {artifact-reference: '<signed-apk-debug-apk/public/build/target.arm64-v8a.apk>'}, '-O', app.apk]
                 - [wget, {artifact-reference: '<signed-apk-android-test/public/build/target.noarch.apk>'}, '-O', android-test.apk]
                 - ['automation/taskcluster/androidTest/ui-test.sh', 'arm-beta-tests', 'app.apk', 'android-test.apk', '1']
-                - [python3, automation/taskcluster/androidTest/testrail.py]
         treeherder:
             platform: 'focus-ui-test/opt'
             symbol: focus-beta(ui-test-arm-beta)
         worker:
             env:
                 GOOGLE_PROJECT: 'moz-focus-android'
-                PRODUCT_TYPE: Focus
-                RELEASE_TYPE: Beta
-        routes:
-            - notify.slack-channel.G016BC5FUHJ.on-completed
-        scopes:
-            - queue:route:notify.slack-channel.G016BC5FUHJ.on-completed
-                - notify:slack-channel:G016BC5FUHJ
-        extra:
-            notify:
-                # slackText: 'https://firefox-ci-tc.services.mozilla.com/tasks/${status.taskId} | ${task.metadata.name} | ${task.metadata.source}'
-                slackBlocks: |
-                    [
-                      {
-                        "type": "header",
-                        "text": {
-                          "type": "plain_text",
-                          "text": "firefox-android :tada: Testrail Release Milestone Creation :tada:\n "
-                        }
-                      },
-                      {
-                        "type": "divider"
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": "*Testrail Release Milestone*: <https://testrail.stage.mozaws.net/index.php?/projects/overview/53|Milestone> :clown_face:"
-                        }
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "*Testrail Release Milestone* has been created"
-                        }
-                      },
-                      {
-                        "type": "divider"
-                      },
-                      {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": ":testops-notify: created by <https://mozilla-hub.atlassian.net/wiki/spaces/MTE/overview|Mobile Test Engineering>"
-                            }
-                        ]
-                      }
-                    ]
     fenix-arm-debug:
         attributes:
             shipping-product: fenix
@@ -307,72 +253,18 @@ tasks:
                   key: firebaseToken
                   path: .firebase_token.json
                   json: true
-                - name: project/mobile/ci/testrail
-                  key: testrailCredentials
-                  path: .testrail_credentials.json
-                  json: true
             pre-commands:
                 - ["cd", "fenix"]
             commands:
                 - [wget, {artifact-reference: '<signed-apk-debug-apk/public/build/target.arm64-v8a.apk>'}, '-O', app.apk]
                 - [wget, {artifact-reference: '<signed-apk-android-test/public/build/target.noarch.apk>'}, '-O', android-test.apk]
                 - [automation/taskcluster/androidTest/ui-test.sh, arm-beta-tests, app.apk, android-test.apk, '2']
-                - [python3, automation/taskcluster/androidTest/testrail.py]
         treeherder:
             platform: 'fenix-ui-test/opt'
             symbol: fenix-beta(ui-test-arm-beta)
         worker:
             env:
                 GOOGLE_PROJECT: moz-fenix
-                PRODUCT_TYPE: Firefox
-                RELEASE_TYPE: Beta
-        routes:
-            - notify.slack-channel.G016BC5FUHJ.on-completed
-        scopes:
-            - queue:route:notify.slack-channel.G016BC5FUHJ.on-completed
-                - notify:slack-channel:G016BC5FUHJ
-        extra:
-            notify:
-                # slackText: 'https://firefox-ci-tc.services.mozilla.com/tasks/${status.taskId} | ${task.metadata.name} | ${task.metadata.source}'
-                slackBlocks: |
-                    [
-                      {
-                        "type": "header",
-                        "text": {
-                          "type": "plain_text",
-                          "text": "firefox-android :tada: Testrail Release Milestone Creation :tada:\n "
-                        }
-                      },
-                      {
-                        "type": "divider"
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": "*Testrail Release Milestone*: <https://testrail.stage.mozaws.net/index.php?/projects/overview/53|Milestone> :clown_face:"
-                        }
-                      },
-                      {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": "*Testrail Release Milestone* has been created"
-                        }
-                      },
-                      {
-                        "type": "divider"
-                      },
-                      {
-                        "type": "context",
-                        "elements": [
-                            {
-                                "type": "mrkdwn",
-                                "text": ":testops-notify: created by <https://mozilla-hub.atlassian.net/wiki/spaces/MTE/overview|Mobile Test Engineering>"
-                            }
-                        ]
-                      }
-                    ]
     fenix-arm-nightly:
         attributes:
             build-type: fenix-nightly-firebase


### PR DESCRIPTION
The update from a previous PR to decouple the `ui-test-apk` `Taskcluster` task was reverted, causing the task to call an old python script `testrail.py` that has since been renamed to `testrail_main.py`.

Moreover, other changes that decoupled that script from ui-test-apk have been reverted and need to be changed back.

The changes include removing the following from `focus-arm-beta` and `fenix-arm-beta`:

- removing call to `testrail.py`
- removing `extra.notify slackBlocks`
- removing `secret` fetching for `testrailCredentials`





### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880912