### PR TITLE
Bug 1872235 - Add lint detector for missing Response#close 

### DIFF
--- a/android-components/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/ConceptFetchDetector.kt
+++ b/android-components/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/ConceptFetchDetector.kt
@@ -1,0 +1,249 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.tooling.lint
+
+import com.android.tools.lint.checks.CheckResultDetector
+import com.android.tools.lint.checks.DataFlowAnalyzer
+import com.android.tools.lint.checks.EscapeCheckingDataFlowAnalyzer
+import com.android.tools.lint.checks.TargetMethodDataFlowAnalyzer
+import com.android.tools.lint.checks.isMissingTarget
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.getUMethod
+import com.android.tools.lint.detector.api.isJava
+import com.android.tools.lint.detector.api.skipLabeledExpression
+import com.intellij.psi.LambdaUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiResourceVariable
+import com.intellij.psi.PsiVariable
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UCallableReferenceExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.getParentOfType
+
+/**
+ * Checks for missing [mozilla.components.concept.fetch.Response.close] call on fetches that might not have used the
+ * resources.
+ *
+ * Review the unit tests for examples on what this [Detector] can identify.
+ */
+class ConceptFetchDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableMethodNames(): List<String> {
+        return listOf("fetch")
+    }
+
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: PsiMethod,
+    ) {
+        val containingClass = method.containingClass ?: return
+        val evaluator = context.evaluator
+
+        if (evaluator.extendsClass(
+                containingClass,
+                CLIENT_CLS,
+                false,
+            )
+        ) {
+            val returnType = method.getUMethod()?.returnTypeReference ?: return
+            val qualifiedName = returnType.getQualifiedName()
+            if (qualifiedName != null && qualifiedName == RESPONSE_CLS) {
+                checkClosed(context, node)
+            }
+        }
+    }
+
+    @Suppress("ReturnCount") // Extracted from `CleanupDetector#checkRecycled`.
+    private fun checkClosed(context: JavaContext, node: UCallExpression) {
+        // If it's an AutoCloseable in a try-with-resources clause, don't flag it: these will be
+        // cleaned up automatically
+        if (node.sourcePsi.isTryWithResources()) {
+            return
+        }
+
+        val parentMethod = node.getParentOfType(UMethod::class.java) ?: return
+
+        // Check if any of the 'body' methods are used. They are all closeable; do not report.
+        val bodyMethodTracker = BodyMethodTracker(listOf(node))
+        if (parentMethod.wasMethodCalled(bodyMethodTracker)) {
+            return
+        }
+
+        // Check if response has escaped (particularly through an extension function); do not report.
+        val responseEscapedTracker = ResponseEscapedTracker(listOf(node))
+        if (parentMethod.hasEscaped(responseEscapedTracker)) {
+            return
+        }
+
+        // Check if 'use' or 'close' were called; do not report.
+        val closeableTracker = CloseableTracker(listOf(node), context)
+        if (!parentMethod.isMissingTarget(closeableTracker)) {
+            return
+        }
+
+        context.report(
+            ISSUE_FETCH_RESPONSE_CLOSE,
+            node,
+            context.getCallLocation(node, includeReceiver = true, includeArguments = false),
+            "Response created but not closed: did you forget to call `close()`?",
+            if (CheckResultDetector.isExpressionValueUnused(node)) {
+                fix()
+                    .replace()
+                    .name("Call close()")
+                    .range(context.getLocation(node))
+                    .end()
+                    .with(".close()")
+                    .build()
+            } else {
+                null
+            },
+        )
+    }
+
+    private fun UMethod.hasEscaped(analyzer: EscapeCheckingDataFlowAnalyzer): Boolean {
+        accept(analyzer)
+        return analyzer.escaped
+    }
+
+    private fun UMethod.wasMethodCalled(analyzer: BodyMethodTracker): Boolean {
+        accept(analyzer)
+        return analyzer.found
+    }
+
+    private fun PsiElement?.isTryWithResources(): Boolean {
+        return this != null &&
+            isJava(this) &&
+            PsiTreeUtil.getParentOfType(this, PsiResourceVariable::class.java) != null
+    }
+
+    private class BodyMethodTracker(
+        initial: Collection<UElement>,
+        initialReferences: Collection<PsiVariable> = emptyList(),
+    ) : DataFlowAnalyzer(initial, initialReferences) {
+        var found = false
+        override fun visitQualifiedReferenceExpression(node: UQualifiedReferenceExpression): Boolean {
+            val methodName: String? = with(node.selector as? UCallExpression) {
+                this?.methodName ?: this?.methodIdentifier?.name
+            }
+
+            when (methodName) {
+                USE_STREAM,
+                USE_BUFFERED_READER,
+                STRING,
+                -> {
+                    if (node.receiver.getExpressionType()?.canonicalText == BODY_CLS) {
+                        // We are using any of the `body` methods which are all closeable.
+                        found = true
+                        return true
+                    }
+                }
+            }
+
+            return super.visitQualifiedReferenceExpression(node)
+        }
+    }
+
+    private class ResponseEscapedTracker(
+        initial: Collection<UElement>,
+    ) : EscapeCheckingDataFlowAnalyzer(initial, emptyList()) {
+        override fun returnsSelf(call: UCallExpression): Boolean {
+            val type = call.receiver?.getExpressionType()?.canonicalText ?: return super.returnsSelf(call)
+            return type == RESPONSE_CLS
+        }
+    }
+
+    // Extracted from `CleanupDetector#checkRecycled#visitor`.
+    private class CloseableTracker(
+        initial: Collection<UElement>,
+        private val context: JavaContext,
+    ) : TargetMethodDataFlowAnalyzer(initial, emptyList()) {
+        override fun isTargetMethodName(name: String): Boolean {
+            return name == USE || name == CLOSE
+        }
+
+        @Suppress("ReturnCount")
+        override fun isTargetMethod(
+            name: String,
+            method: PsiMethod?,
+            call: UCallExpression?,
+            methodRef: UCallableReferenceExpression?,
+        ): Boolean {
+            if (USE == name) {
+                // Kotlin: "use" calls close;
+                // Ensure that "use" call accepts a single lambda parameter, so that it would
+                // loosely match kotlin.io.use() signature and at the same time allow custom
+                // overloads for types not extending Closeable
+                if (call != null && call.valueArgumentCount == 1) {
+                    val argumentType =
+                        call.valueArguments.first().skipLabeledExpression().getExpressionType()
+                    if (argumentType != null && LambdaUtil.isFunctionalType(argumentType)) {
+                        return true
+                    }
+                }
+                return false
+            }
+
+            if (method != null) {
+                val containingClass = method.containingClass
+                val targetName = containingClass?.qualifiedName ?: return true
+                if (targetName == RESPONSE_CLS) {
+                    return true
+                }
+                val recycleClass =
+                    context.evaluator.findClass(RESPONSE_CLS) ?: return true
+                return context.evaluator.extendsClass(recycleClass, targetName, false)
+            } else {
+                // Unresolved method call -- assume it's okay
+                return true
+            }
+        }
+    }
+
+    companion object {
+        @JvmField
+        val ISSUE_FETCH_RESPONSE_CLOSE = Issue.create(
+            id = "FetchResponseClose",
+            briefDescription = "Response stream fetched but not closed.",
+            explanation = """
+                A `Client.fetch` returns a `Response` that, on success, is consumed typically with 
+                a `use` stream in Kotlin or a try-with-resources in Java. In the failure or manual 
+                resource managed cases, we need to ensure that `Response.close` is always called.
+                
+                Additionally, all methods on `Response.body` are AutoCloseable so using any of 
+                those will release those resources after execution.
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.ERROR,
+            androidSpecific = true,
+            implementation = Implementation(
+                ConceptFetchDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+
+        // Target method names
+        private const val CLOSE = "close"
+        private const val USE = "use"
+        private const val USE_STREAM = "useStream"
+        private const val USE_BUFFERED_READER = "useBufferedReader"
+        private const val STRING = "string"
+
+        private const val CLIENT_CLS = "mozilla.components.concept.fetch.Client"
+        private const val RESPONSE_CLS = "mozilla.components.concept.fetch.Response"
+        private const val BODY_CLS = "mozilla.components.concept.fetch.Response.Body"
+    }
+}

--- a/android-components/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/LintIssueRegistry.kt
+++ b/android-components/components/tooling/lint/src/main/java/mozilla/components/tooling/lint/LintIssueRegistry.kt
@@ -20,5 +20,6 @@ class LintIssueRegistry : IssueRegistry() {
         ImageViewAndroidTintXmlDetector.ISSUE_XML_SRC_USAGE,
         FactCollectDetector.ISSUE_FACT_COLLECT_CALLED,
         NotificationManagerChecks.ISSUE_NOTIFICATION_USAGE,
+        ConceptFetchDetector.ISSUE_FETCH_RESPONSE_CLOSE,
     )
 }

--- a/android-components/components/tooling/lint/src/test/java/mozilla/components/tooling/lint/ConceptFetchDetectorTest.kt
+++ b/android-components/components/tooling/lint/src/test/java/mozilla/components/tooling/lint/ConceptFetchDetectorTest.kt
@@ -1,0 +1,277 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.components.tooling.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.gradle
+import com.android.tools.lint.checks.infrastructure.TestFiles.java
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ConceptFetchDetectorTest {
+
+    @Test
+    fun `should report when close is not invoked on a Response instance`() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                        package test
+
+                        import mozilla.components.concept.fetch.*
+                        
+                        val client = Client()
+
+                        fun isSuccessful() : Boolean {
+                            val response = client.fetch(Request("https://mozilla.org"))
+                            return response.isSuccess
+                        }
+                    """.trimIndent(),
+                ),
+                responseClassfileStub,
+                clientClassFileStub,
+            )
+            .issues(ConceptFetchDetector.ISSUE_FETCH_RESPONSE_CLOSE)
+            .run()
+            .expect(
+                """
+                src/test/test.kt:8: Error: Response created but not closed: did you forget to call close()? [FetchResponseClose]
+                    val response = client.fetch(Request("https://mozilla.org"))
+                                   ~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `should not report from a result that is closed in another function`() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                        package test
+                            
+                        import mozilla.components.concept.fetch.*
+
+                        val client = Client()
+
+                        fun getResult() {
+                            return try {
+                                client.fetch(request).toResult()
+                            } catch (e: IOException) {
+                                Logger.debug(message = "Could not fetch region from location service", throwable = e)
+                                null
+                            }
+                        }
+                            
+                        data class Result(
+                            val name: String,
+                        )
+
+                        private fun Response.toResult(): Region? {
+                            if (!this.isSuccess) {
+                                close()
+                                return null
+                            }
+
+                            use {
+                                return try {
+                                    Result("{}")
+                                } catch (e: JSONException) {
+                                    Logger.debug(message = "Could not parse JSON returned from service", throwable = e)
+                                    null
+                                }
+                            }
+                        }
+                    """.trimIndent(),
+                ),
+                responseClassfileStub,
+                clientClassFileStub,
+            )
+            .issues(ConceptFetchDetector.ISSUE_FETCH_RESPONSE_CLOSE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should pass when auto-closeable 'use' function is invoked`() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                        package test
+                        
+                        import mozilla.components.concept.fetch.*
+                        import kotlin.io.*
+
+                        val client = Client()
+                
+                        fun getResult() {
+                            client.fetch(request).use { response ->
+                                response.hashCode()
+                            }
+                        }
+                    """.trimIndent(),
+                ),
+                responseClassfileStub,
+                clientClassFileStub,
+            )
+            .issues(ConceptFetchDetector.ISSUE_FETCH_RESPONSE_CLOSE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should pass if body (auto-closeable methods) is used from the response`() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                        package test
+                        
+                        import mozilla.components.concept.fetch.*
+                        import kotlin.io.*
+
+                        val client = Client()
+                
+                        fun getResult() { // OK
+                            val response = client.fetch(request)
+                            response?.body.string(Charset.UTF_8)
+                        }
+            
+                        fun getResult2() { // OK
+                            client.fetch(request).body.useStream()
+                        }
+                        
+                        fun getResult3() { // OK; escaped.
+                            val response = client.fetch(request)
+                            process(response)
+                        }
+
+                        fun process(response: Response) {
+                            response.hashCode()
+                        }
+                    """.trimIndent(),
+                ),
+                responseClassfileStub,
+                clientClassFileStub,
+            )
+            .issues(ConceptFetchDetector.ISSUE_FETCH_RESPONSE_CLOSE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `should pass if try-with-resources is used from the response`() {
+        lint()
+            .files(
+                gradle(
+                    // For `try (cursor)` (without declaration) we'll need level 9
+                    // or PSI/UAST will return an empty variable list
+                    """
+                android {
+                    compileOptions {
+                        sourceCompatibility JavaVersion.VERSION_1_9
+                        targetCompatibility JavaVersion.VERSION_1_9
+                    }
+                }
+                """,
+                ).indented(),
+                java(
+                    """
+                        package test;
+
+                        import mozilla.components.concept.fetch.Client;
+                        import mozilla.components.concept.fetch.Response;
+                        import mozilla.components.concept.fetch.Response.Body;
+                        import mozilla.components.concept.fetch.Request;
+
+                        public class TryWithResources {
+                            public void test(Client client, Request request) {
+                                try(Response response = client.fetch(request)) {
+                                    if (response != null) {
+                                        //noinspection StatementWithEmptyBody
+                                        while (response.hashCode()) {
+                                            // ..
+                                        }
+                                    }
+                                } catch (Exception e) {
+                                    // do nothing
+                                }
+                            }
+                        }
+                    """.trimIndent(),
+                ),
+                responseClassfileStub,
+                clientClassFileStub,
+            )
+            .issues(ConceptFetchDetector.ISSUE_FETCH_RESPONSE_CLOSE)
+            .run()
+            .expectClean()
+    }
+
+    private val clientClassFileStub = kotlin(
+        """
+        package mozilla.components.concept.fetch
+
+        data class Request(
+            val url: String,
+            val method: Method = Method.GET,
+            val headers: MutableHeaders? = MutableHeaders(),
+            val connectTimeout: Pair<Long, TimeUnit>? = null,
+            val readTimeout: Pair<Long, TimeUnit>? = null,
+            val body: Body? = null,
+            val redirect: Redirect = Redirect.FOLLOW,
+            val cookiePolicy: CookiePolicy = CookiePolicy.INCLUDE,
+            val useCaches: Boolean = true,
+            val private: Boolean = false,
+        )
+
+        class Client {
+            fun fetch(request: Request): Response { 
+                return Response(
+                    url = "https://mozilla.org",
+                ) 
+            }
+        }
+        """.trimIndent(),
+    )
+    private val responseClassfileStub = kotlin(
+        """
+        package mozilla.components.concept.fetch
+
+        data class Response(
+            val url: String,
+            val status: Int,
+            val headers: Headers,
+            val body: Body,
+        ) : Closeable {
+            override fun close() {
+                body.close()
+            }
+
+            open class Body(
+                private val stream: InputStream,
+                contentType: String? = null,
+            ) {
+                fun <R> useStream(block: (InputStream) -> R): R {
+                }
+
+                fun <R> useBufferedReader(charset: Charset? = null, block: (BufferedReader) -> R): R = use {
+                }
+
+                fun string(charset: Charset? = null): String = use {
+                }
+            }
+        }
+
+        val Response.isSuccess: Boolean
+            get() = status in SUCCESS_STATUS_RANGE
+        """,
+    ).indented()
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,9 @@ permalink: /changelog/
 * **feature-session**
   * Update URL in the store immediately when using the optimized load URL code path.
 
+* **tooling-lint**
+  * Added a lint rule to detect when `Response#close` may not have been called. Note: Currently, this rule only runs on Android Components.
+
 # 123.0
 * [Commits](https://github.com/mozilla-mobile/firefox-android/compare/releases_v122..releases_v123)
 * [Dependencies](https://github.com/mozilla-mobile/firefox-android/blob/releases_v123/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt)


### PR DESCRIPTION
In BZ-1839067, we fixed a multiple cases were streams werepotentially leaking resources. As a follow-up, we are adding a lint check that now helps to identify possible missing calls to close those resources.

The implementation is heavily relied on from [`com.android.tools.lint.checks.CleanupDetector`][0] in the AOSP project, so little cleanup is done to change the code from it's original source if we need to reference it later.

Some other references that were quite helpful for this work, were the [Android Lint API Guide][1] and the examples in the [Data Flow Analyzer][2].

Kudos to @jackyzy823 for doing the initial work in BZ-1839067 to start this off.

[0]: https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/CleanupDetector.kt;l=66;drc=042516205eef87810ffe9f6d51ba40b1edbb15b0
[1]: https://googlesamples.github.io/android-custom-lint-rules/api-guide.html
[2]: https://android.googlesource.com/platform/tools/base/+/HEAD/lint/docs/api-guide/dataflow-analyzer.md.html

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1872235