### PR TITLE
Bug 1854131 - Three-dot main menu falls off screen, disappears in landscape mode

### DIFF
--- a/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuPositioning.kt
+++ b/android-components/components/browser/menu/src/main/java/mozilla/components/browser/menu/BrowserMenuPositioning.kt
@@ -74,8 +74,8 @@ internal fun inferMenuPositioningData(
     val (availableHeightToTop, availableHeightToBottom) = getMaxAvailableHeightToTopAndBottom(anchor)
     val containerHeight = containerView.measuredHeight
 
-    val fitsUp = availableHeightToTop >= containerHeight
-    val fitsDown = availableHeightToBottom >= containerHeight
+    val fitsUp = availableHeightToTop >= containerHeight || availableHeightToTop > availableHeightToBottom
+    val fitsDown = availableHeightToBottom >= containerHeight || availableHeightToBottom > availableHeightToTop
 
     return inferMenuPosition(
         anchor,

--- a/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuPositioningTest.kt
+++ b/android-components/components/browser/menu/src/test/java/mozilla/components/browser/menu/BrowserMenuPositioningTest.kt
@@ -9,10 +9,12 @@ import android.view.ViewGroup
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.whenever
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
+import org.mockito.Mockito.spy
 import org.robolectric.Shadows
 import org.robolectric.shadows.ShadowDisplay
 
@@ -39,6 +41,56 @@ class BrowserMenuPositioningTest {
             containerViewHeight = 70, // mocked by us above
         )
         Assert.assertEquals(expected, result)
+    }
+
+    @Test
+    fun `GIVEN inferMenuPositioningData WHEN availableHeightToBottom is bigger than availableHeightToTop THEN it returns a new MenuPositioningData populated with all data needed to show a PopupWindow that fits down`() {
+        val view: ViewGroup = mock()
+        Mockito.doReturn(70).`when`(view).measuredHeight
+        val anchor = View(testContext)
+        anchor.layoutParams = ViewGroup.LayoutParams(20, 40)
+
+        setScreenHeight(50)
+
+        val result = inferMenuPositioningData(view, anchor, MenuPositioningData())
+
+        val expected = MenuPositioningData(
+            BrowserMenuPlacement.AnchoredToTop.Dropdown(anchor), // orientation DOWN and fitsDown
+            askedOrientation = BrowserMenu.Orientation.DOWN, // default
+            fitsUp = false, // availableHeightToTop(0) is smaller than containerHeight(70) and smaller than availableHeightToBottom(50)
+            fitsDown = true, // availableHeightToBottom(50) is smaller than containerHeight(70) and bigger than availableHeightToTop(0)
+            availableHeightToTop = 0,
+            availableHeightToBottom = 50, // mocked by us above
+            containerViewHeight = 70, // mocked by us above
+        )
+        Assert.assertEquals(expected, result)
+    }
+
+    @Test
+    fun `GIVEN inferMenuPositioningData WHEN availableHeightToTop is bigger than availableHeightToBottom THEN it returns a new MenuPositioningData populated with all data needed to show a PopupWindow that fits up`() {
+        val view: ViewGroup = mock()
+        Mockito.doReturn(70).`when`(view).measuredHeight
+        val anchor = spy(View(testContext))
+        anchor.layoutParams = ViewGroup.LayoutParams(20, 40)
+
+        whenever(anchor.getLocationOnScreen(IntArray(2))).thenAnswer { invocation ->
+            val args = invocation.arguments
+            val location = args[0] as IntArray
+            location[0] = 0
+            location[1] = 60
+            location
+        }
+
+        setScreenHeight(100)
+
+        val result = inferMenuPositioningData(view, anchor, MenuPositioningData())
+
+        Assert.assertEquals(result.askedOrientation, BrowserMenu.Orientation.DOWN) // default
+        Assert.assertEquals(result.fitsUp, true) // availableHeightToTop(60) is smaller than containerHeight(70) and bigger than availableHeightToBottom(40)
+        Assert.assertEquals(result.fitsDown, false) // availableHeightToBottom(450) is smaller than containerHeight(70) and smaller than availableHeightToTop(60)
+        Assert.assertEquals(result.availableHeightToTop, 60) // mocked by us above
+        Assert.assertEquals(result.availableHeightToBottom, 40)
+        Assert.assertEquals(result.containerViewHeight, 70) // mocked by us above
     }
 
     @Test


### PR DESCRIPTION
Bug 1854131 - Three-dot main menu falls off screen, disappears in landscape mode

The popup doesn't fits up or fits down, because both availableHeightToTop and availableHeightToBottom are smaller than containerHeight. Because of this the popup is not displayed. As the popup is scrollable we should display it where the height is bigger (top or bottom).

https://bugzilla.mozilla.org/show_bug.cgi?id=1854131



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1854131