### PR TITLE
Bug 1881010 - Add logs to SettingsSubMenuDeleteBrowsingDataRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers.isDialog
@@ -16,6 +17,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectIsGone
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
@@ -30,26 +32,72 @@ import org.mozilla.fenix.helpers.click
 class SettingsSubMenuDeleteBrowsingDataRobot {
 
     fun verifyAllCheckBoxesAreChecked() {
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Trying to verify that the \"Open tabs\" check box is checked")
         openTabsCheckBox().assertIsChecked(true)
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Verified that the \"Open tabs\" check box is checked")
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Trying to verify that the \"Browsing history\" check box is checked")
         browsingHistoryCheckBox().assertIsChecked(true)
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Verified that the \"Browsing history\" check box is checked")
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Trying to verify that the \"Cookies and site data\" check box is checked")
         cookiesAndSiteDataCheckBox().assertIsChecked(true)
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Verified that the \"Cookies and site data\" check box is checked")
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Trying to verify that the \"Cached images and files\" check box is checked")
         cachedFilesCheckBox().assertIsChecked(true)
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Verified that the \"Cached images and files\" check box is checked")
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Trying to verify that the \"Site permissions\" check box is checked")
         sitePermissionsCheckBox().assertIsChecked(true)
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Verified that the \"Site permissions\" check box is checked")
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Trying to verify that the \"Downloads\" check box is checked")
         downloadsCheckBox().assertIsChecked(true)
+        Log.i(TAG, "verifyAllCheckBoxesAreChecked: Verified that the \"Downloads\" check box is checked")
     }
-    fun verifyOpenTabsCheckBox(status: Boolean) = openTabsCheckBox().assertIsChecked(status)
-    fun verifyBrowsingHistoryDetails(status: Boolean) = browsingHistoryCheckBox().assertIsChecked(status)
-    fun verifyCookiesCheckBox(status: Boolean) = cookiesAndSiteDataCheckBox().assertIsChecked(status)
-    fun verifyCachedFilesCheckBox(status: Boolean) = cachedFilesCheckBox().assertIsChecked(status)
-    fun verifySitePermissionsCheckBox(status: Boolean) = sitePermissionsCheckBox().assertIsChecked(status)
-    fun verifyDownloadsCheckBox(status: Boolean) = downloadsCheckBox().assertIsChecked(status)
-    fun verifyOpenTabsDetails(tabNumber: String) = openTabsDescription(tabNumber).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    fun verifyOpenTabsCheckBox(status: Boolean) {
+        Log.i(TAG, "verifyOpenTabsCheckBox: Trying to verify that the \"Open tabs\" check box is checked: $status")
+        openTabsCheckBox().assertIsChecked(status)
+        Log.i(TAG, "verifyOpenTabsCheckBox: Verified that the \"Open tabs\" check box is checked: $status")
+    }
+    fun verifyBrowsingHistoryDetails(status: Boolean) {
+        Log.i(TAG, "verifyBrowsingHistoryDetails: Trying to verify that the \"Browsing history\" check box is checked: $status")
+        browsingHistoryCheckBox().assertIsChecked(status)
+        Log.i(TAG, "verifyBrowsingHistoryDetails: Verified that the \"Browsing history\" check box is checked: $status")
+    }
+    fun verifyCookiesCheckBox(status: Boolean) {
+        Log.i(TAG, "verifyCookiesCheckBox: Trying to verify that the \"Cookies and site data\" check box is checked: $status")
+        cookiesAndSiteDataCheckBox().assertIsChecked(status)
+        Log.i(TAG, "verifyCookiesCheckBox: Verified that the \"Cookies and site data\" check box is checked: $status")
+    }
+    fun verifyCachedFilesCheckBox(status: Boolean) {
+        Log.i(TAG, "verifyCachedFilesCheckBox: Trying to verify that the \"Cached images and files\" check box is checked: $status")
+        cachedFilesCheckBox().assertIsChecked(status)
+        Log.i(TAG, "verifyCachedFilesCheckBox: Verified that the \"Cached images and files\" check box is checked: $status")
+    }
+    fun verifySitePermissionsCheckBox(status: Boolean) {
+        Log.i(TAG, "verifySitePermissionsCheckBox: Trying to verify that the \"Site permissions\" check box is checked: $status")
+        sitePermissionsCheckBox().assertIsChecked(status)
+        Log.i(TAG, "verifySitePermissionsCheckBox: Verified that the \"Site permissions\" check box is checked: $status")
+    }
+    fun verifyDownloadsCheckBox(status: Boolean) {
+        Log.i(TAG, "verifyDownloadsCheckBox: Trying to verify that the \"Downloads\" check box is checked: $status")
+        downloadsCheckBox().assertIsChecked(status)
+        Log.i(TAG, "verifyDownloadsCheckBox: Verified that the \"Downloads\" check box is checked: $status")
+    }
+    fun verifyOpenTabsDetails(tabNumber: String) {
+        Log.i(TAG, "verifyOpenTabsDetails: Trying to verify that the \"Open tabs\" option summary containing $tabNumber open tabs is visible")
+        openTabsDescription(tabNumber).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyOpenTabsDetails: Verified that the \"Open tabs\" option summary containing $tabNumber open tabs is visible")
+    }
     fun verifyBrowsingHistoryDetails(addresses: String) = assertUIObjectExists(browsingHistoryDescription(addresses))
 
     fun verifyDeleteBrowsingDataDialog() {
+        Log.i(TAG, "verifyDeleteBrowsingDataDialog: Trying to verify that the delete browsing data dialog message is visible")
         dialogMessage().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyDeleteBrowsingDataDialog: Verified that the delete browsing data dialog message is visible")
+        Log.i(TAG, "verifyDeleteBrowsingDataDialog: Trying to verify that the delete browsing data dialog \"Cancel\" button is visible")
         dialogCancelButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyDeleteBrowsingDataDialog: Verified that the delete browsing data dialog \"Cancel\" button is visible")
+        Log.i(TAG, "verifyDeleteBrowsingDataDialog: Trying to verify that the delete browsing data dialog \"Delete\" button is visible")
         dialogDeleteButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyDeleteBrowsingDataDialog: Verified that the delete browsing data dialog \"Delete\" button is visible")
     }
 
     fun switchOpenTabsCheckBox() = clickOpenTabsCheckBox()
@@ -58,93 +106,150 @@ class SettingsSubMenuDeleteBrowsingDataRobot {
     fun switchCachedFilesCheckBox() = clickCachedFilesCheckBox()
     fun switchSitePermissionsCheckBox() = clickSitePermissionsCheckBox()
     fun switchDownloadsCheckBox() = clickDownloadsCheckBox()
-    fun clickDeleteBrowsingDataButton() = deleteBrowsingDataButton().click()
-    fun clickDialogCancelButton() = dialogCancelButton().click()
+    fun clickDeleteBrowsingDataButton() {
+        Log.i(TAG, "clickDeleteBrowsingDataButton: Trying to click the \"Delete browsing data\" button")
+        deleteBrowsingDataButton().click()
+        Log.i(TAG, "clickDeleteBrowsingDataButton: Clicked the \"Delete browsing data\" button")
+    }
+    fun clickDialogCancelButton() {
+        Log.i(TAG, "clickDialogCancelButton: Trying to click the delete browsing data dialog \"Cancel\" button")
+        dialogCancelButton().click()
+        Log.i(TAG, "clickDialogCancelButton: Clicked the delete browsing data dialog \"Cancel\" button")
+    }
 
     fun selectOnlyOpenTabsCheckBox() {
         clickBrowsingHistoryCheckBox()
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Trying to verify that the \"Browsing history\" check box is not checked")
         browsingHistoryCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Verified that the \"Browsing history\" check box is not checked")
 
         clickCookiesCheckBox()
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Trying to verify that the \"Cookies and site data\" check box is not checked")
         cookiesAndSiteDataCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Verified that the \"Cookies and site data\" check box is not checked")
 
         clickCachedFilesCheckBox()
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Trying to verify that the \"Cached images and files\" check box is not checked")
         cachedFilesCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Verified that the \"Cached images and files\" check box is not checked")
 
         clickSitePermissionsCheckBox()
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Trying to verify that the \"Site permissions\" check box is not checked")
         sitePermissionsCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Verified that the \"Site permissions\" check box is not checked")
 
         clickDownloadsCheckBox()
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Trying to verify that the \"Downloads\" check box is not checked")
         downloadsCheckBox().assertIsChecked(false)
-
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Verified that the \"Downloads\" check box is not checked")
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Trying to verify that the \"Open tabs\" check box is checked")
         openTabsCheckBox().assertIsChecked(true)
+        Log.i(TAG, "selectOnlyOpenTabsCheckBox: Trying to verify that the \"Open tabs\" check box is checked")
     }
 
     fun selectOnlyBrowsingHistoryCheckBox() {
         clickOpenTabsCheckBox()
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Trying to verify that the \"Open tabs\" check box is not checked")
         openTabsCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Verified that the \"Open tabs\" check box is not checked")
 
         clickCookiesCheckBox()
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Trying to verify that the \"Cookies and site data\" check box is not checked")
         cookiesAndSiteDataCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Verified that the \"Cookies and site data\" check box is not checked")
 
         clickCachedFilesCheckBox()
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Trying to verify that the \"Cached images and files\" check box is not checked")
         cachedFilesCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Verified that the \"Cached images and files\" check box is not checked")
 
         clickSitePermissionsCheckBox()
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Trying to verify that the \"Site permissions\" check box is not checked")
         sitePermissionsCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Verified that the \"Site permissions\" check box is not checked")
 
         clickDownloadsCheckBox()
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Trying to verify that the \"Downloads\" check box is not checked")
         downloadsCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Verified that the \"Downloads\" check box is not checked")
 
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Trying to verify that the \"Browsing history\" check box is checked")
         browsingHistoryCheckBox().assertIsChecked(true)
+        Log.i(TAG, "selectOnlyBrowsingHistoryCheckBox: Verified that the \"Browsing history\" check box is checked")
     }
 
     fun selectOnlyCookiesCheckBox() {
         clickOpenTabsCheckBox()
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Trying to verify that the \"Open tabs\" check box is not checked")
         openTabsCheckBox().assertIsChecked(false)
-
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Verified that the \"Open tabs\" check box is not checked")
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Trying to verify that the \"Cookies and site data\" check box is checked")
         cookiesAndSiteDataCheckBox().assertIsChecked(true)
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Verified that the \"Cookies and site data\" check box is checked")
 
         clickCachedFilesCheckBox()
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Trying to verify that the \"Cached images and files\" check box is not checked")
         cachedFilesCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Verified that the \"Cached images and files\" check box is not checked")
 
         clickSitePermissionsCheckBox()
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Trying to verify that the \"Site permissions\" check box is not checked")
         sitePermissionsCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Verified that the \"Site permissions\" check box is not checked")
 
         clickDownloadsCheckBox()
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Trying to verify that the \"Downloads\" check box is not checked")
         downloadsCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Verified that the \"Downloads\" check box is not checked")
 
         clickBrowsingHistoryCheckBox()
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Trying to verify that the \"Browsing history\" check box is not checked")
         browsingHistoryCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyCookiesCheckBox: Verified that the \"Browsing history\" check box is not checked")
     }
 
     fun selectOnlyCachedFilesCheckBox() {
         clickOpenTabsCheckBox()
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Trying to verify that the \"Open tabs\" check box is not checked")
         openTabsCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Verified that the \"Open tabs\" check box is not checked")
 
         clickBrowsingHistoryCheckBox()
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Trying to verify that the \"Browsing history\" check box is not checked")
         browsingHistoryCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Verified that the \"Browsing history\" check box is not checked")
 
         clickCookiesCheckBox()
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Trying to verify that the \"Cookies and site data\" check box is not checked")
         cookiesAndSiteDataCheckBox().assertIsChecked(false)
-
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Verified that the \"Cookies and site data\" check box is not checked")
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Trying to verify that the \"Cached images and files\" check box is checked")
         cachedFilesCheckBox().assertIsChecked(true)
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Verified that the \"Cached images and files\" check box is checked")
 
         clickSitePermissionsCheckBox()
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Trying to verify that the \"Site permissions\" check box is not checked")
         sitePermissionsCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Verified that the \"Site permissions\" check box is not checked")
 
         clickDownloadsCheckBox()
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Trying to verify that the \"Downloads\" check box is not checked")
         downloadsCheckBox().assertIsChecked(false)
+        Log.i(TAG, "selectOnlyCachedFilesCheckBox: Verified that the \"Downloads\" check box is not checked")
     }
 
     fun confirmDeletionAndAssertSnackbar() {
+        Log.i(TAG, "confirmDeletionAndAssertSnackbar: Trying to click the delete browsing data dialog \"Delete\" button")
         dialogDeleteButton().click()
+        Log.i(TAG, "confirmDeletionAndAssertSnackbar: Clicked the delete browsing data dialog \"Delete\" button")
         assertDeleteBrowsingDataSnackbar()
     }
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            Log.i(TAG, "goBack: Trying to click navigate up toolbar button")
             goBackButton().click()
+            Log.i(TAG, "goBack: Clicked the navigate up toolbar button")
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()
@@ -187,9 +292,33 @@ private fun dialogMessage() =
         .inRoot(isDialog())
 
 private fun assertDeleteBrowsingDataSnackbar() = assertUIObjectIsGone(itemWithText("Browsing data deleted"))
-private fun clickOpenTabsCheckBox() = openTabsCheckBox().click()
-private fun clickBrowsingHistoryCheckBox() = browsingHistoryCheckBox().click()
-private fun clickCookiesCheckBox() = cookiesAndSiteDataCheckBox().click()
-private fun clickCachedFilesCheckBox() = cachedFilesCheckBox().click()
-private fun clickSitePermissionsCheckBox() = sitePermissionsCheckBox().click()
-private fun clickDownloadsCheckBox() = downloadsCheckBox().click()
+private fun clickOpenTabsCheckBox() {
+    Log.i(TAG, "clickOpenTabsCheckBox: Trying to click the \"Open tabs\" check box")
+    openTabsCheckBox().click()
+    Log.i(TAG, "clickOpenTabsCheckBox: Clicked the \"Open tabs\" check box")
+}
+private fun clickBrowsingHistoryCheckBox() {
+    Log.i(TAG, "clickBrowsingHistoryCheckBox: Trying to click the \"Browsing history\" check box")
+    browsingHistoryCheckBox().click()
+    Log.i(TAG, "clickBrowsingHistoryCheckBox: Clicked the \"Browsing history\" check box")
+}
+private fun clickCookiesCheckBox() {
+    Log.i(TAG, "clickCookiesCheckBox: Trying to click the \"Cookies and site data\" check box")
+    cookiesAndSiteDataCheckBox().click()
+    Log.i(TAG, "clickCookiesCheckBox: Clicked the \"Cookies and site data\" check box")
+}
+private fun clickCachedFilesCheckBox() {
+    Log.i(TAG, "clickCachedFilesCheckBox: Trying to click the \"Cached images and files\" check box")
+    cachedFilesCheckBox().click()
+    Log.i(TAG, "clickCachedFilesCheckBox: Clicked the \"Cached images and files\" check box")
+}
+private fun clickSitePermissionsCheckBox() {
+    Log.i(TAG, "clickSitePermissionsCheckBox: Trying to click the \"Site permissions\" check box")
+    sitePermissionsCheckBox().click()
+    Log.i(TAG, "clickSitePermissionsCheckBox: Clicked the \"Site permissions\" check box")
+}
+private fun clickDownloadsCheckBox() {
+    Log.i(TAG, "clickDownloadsCheckBox: Trying to click the \"Downloads\" check box")
+    downloadsCheckBox().click()
+    Log.i(TAG, "clickDownloadsCheckBox: Clicked the \"Downloads\" check box")
+}

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
@@ -29,15 +29,22 @@ import org.mozilla.fenix.helpers.click
  */
 class SettingsSubMenuDeleteBrowsingDataRobot {
 
-    fun verifyAllCheckBoxesAreChecked() = assertAllCheckBoxesAreChecked()
-    fun verifyOpenTabsCheckBox(status: Boolean) = assertOpenTabsCheckBox(status)
-    fun verifyBrowsingHistoryDetails(status: Boolean) = assertBrowsingHistoryCheckBox(status)
-    fun verifyCookiesCheckBox(status: Boolean) = assertCookiesCheckBox(status)
-    fun verifyCachedFilesCheckBox(status: Boolean) = assertCachedFilesCheckBox(status)
-    fun verifySitePermissionsCheckBox(status: Boolean) = assertSitePermissionsCheckBox(status)
-    fun verifyDownloadsCheckBox(status: Boolean) = assertDownloadsCheckBox(status)
-    fun verifyOpenTabsDetails(tabNumber: String) = assertOpenTabsDescription(tabNumber)
-    fun verifyBrowsingHistoryDetails(addresses: String) = assertBrowsingHistoryDescription(addresses)
+    fun verifyAllCheckBoxesAreChecked() {
+        openTabsCheckBox().assertIsChecked(true)
+        browsingHistoryCheckBox().assertIsChecked(true)
+        cookiesAndSiteDataCheckBox().assertIsChecked(true)
+        cachedFilesCheckBox().assertIsChecked(true)
+        sitePermissionsCheckBox().assertIsChecked(true)
+        downloadsCheckBox().assertIsChecked(true)
+    }
+    fun verifyOpenTabsCheckBox(status: Boolean) = openTabsCheckBox().assertIsChecked(status)
+    fun verifyBrowsingHistoryDetails(status: Boolean) = browsingHistoryCheckBox().assertIsChecked(status)
+    fun verifyCookiesCheckBox(status: Boolean) = cookiesAndSiteDataCheckBox().assertIsChecked(status)
+    fun verifyCachedFilesCheckBox(status: Boolean) = cachedFilesCheckBox().assertIsChecked(status)
+    fun verifySitePermissionsCheckBox(status: Boolean) = sitePermissionsCheckBox().assertIsChecked(status)
+    fun verifyDownloadsCheckBox(status: Boolean) = downloadsCheckBox().assertIsChecked(status)
+    fun verifyOpenTabsDetails(tabNumber: String) = openTabsDescription(tabNumber).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    fun verifyBrowsingHistoryDetails(addresses: String) = assertUIObjectExists(browsingHistoryDescription(addresses))
 
     fun verifyDeleteBrowsingDataDialog() {
         dialogMessage().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
@@ -56,78 +63,78 @@ class SettingsSubMenuDeleteBrowsingDataRobot {
 
     fun selectOnlyOpenTabsCheckBox() {
         clickBrowsingHistoryCheckBox()
-        assertBrowsingHistoryCheckBox(false)
+        browsingHistoryCheckBox().assertIsChecked(false)
 
         clickCookiesCheckBox()
-        assertCookiesCheckBox(false)
+        cookiesAndSiteDataCheckBox().assertIsChecked(false)
 
         clickCachedFilesCheckBox()
-        assertCachedFilesCheckBox(false)
+        cachedFilesCheckBox().assertIsChecked(false)
 
         clickSitePermissionsCheckBox()
-        assertSitePermissionsCheckBox(false)
+        sitePermissionsCheckBox().assertIsChecked(false)
 
         clickDownloadsCheckBox()
-        assertDownloadsCheckBox(false)
+        downloadsCheckBox().assertIsChecked(false)
 
-        assertOpenTabsCheckBox(true)
+        openTabsCheckBox().assertIsChecked(true)
     }
 
     fun selectOnlyBrowsingHistoryCheckBox() {
         clickOpenTabsCheckBox()
-        assertOpenTabsCheckBox(false)
+        openTabsCheckBox().assertIsChecked(false)
 
         clickCookiesCheckBox()
-        assertCookiesCheckBox(false)
+        cookiesAndSiteDataCheckBox().assertIsChecked(false)
 
         clickCachedFilesCheckBox()
-        assertCachedFilesCheckBox(false)
+        cachedFilesCheckBox().assertIsChecked(false)
 
         clickSitePermissionsCheckBox()
-        assertSitePermissionsCheckBox(false)
+        sitePermissionsCheckBox().assertIsChecked(false)
 
         clickDownloadsCheckBox()
-        assertDownloadsCheckBox(false)
+        downloadsCheckBox().assertIsChecked(false)
 
-        assertBrowsingHistoryCheckBox(true)
+        browsingHistoryCheckBox().assertIsChecked(true)
     }
 
     fun selectOnlyCookiesCheckBox() {
         clickOpenTabsCheckBox()
-        assertOpenTabsCheckBox(false)
+        openTabsCheckBox().assertIsChecked(false)
 
-        assertCookiesCheckBox(true)
+        cookiesAndSiteDataCheckBox().assertIsChecked(true)
 
         clickCachedFilesCheckBox()
-        assertCachedFilesCheckBox(false)
+        cachedFilesCheckBox().assertIsChecked(false)
 
         clickSitePermissionsCheckBox()
-        assertSitePermissionsCheckBox(false)
+        sitePermissionsCheckBox().assertIsChecked(false)
 
         clickDownloadsCheckBox()
-        assertDownloadsCheckBox(false)
+        downloadsCheckBox().assertIsChecked(false)
 
         clickBrowsingHistoryCheckBox()
-        assertBrowsingHistoryCheckBox(false)
+        browsingHistoryCheckBox().assertIsChecked(false)
     }
 
     fun selectOnlyCachedFilesCheckBox() {
         clickOpenTabsCheckBox()
-        assertOpenTabsCheckBox(false)
+        openTabsCheckBox().assertIsChecked(false)
 
         clickBrowsingHistoryCheckBox()
-        assertBrowsingHistoryCheckBox(false)
+        browsingHistoryCheckBox().assertIsChecked(false)
 
         clickCookiesCheckBox()
-        assertCookiesCheckBox(false)
+        cookiesAndSiteDataCheckBox().assertIsChecked(false)
 
-        assertCachedFilesCheckBox(true)
+        cachedFilesCheckBox().assertIsChecked(true)
 
         clickSitePermissionsCheckBox()
-        assertSitePermissionsCheckBox(false)
+        sitePermissionsCheckBox().assertIsChecked(false)
 
         clickDownloadsCheckBox()
-        assertDownloadsCheckBox(false)
+        downloadsCheckBox().assertIsChecked(false)
     }
 
     fun confirmDeletionAndAssertSnackbar() {
@@ -179,32 +186,10 @@ private fun dialogMessage() =
     onView(withText("$appName will delete the selected browsing data."))
         .inRoot(isDialog())
 
-private fun assertAllCheckBoxesAreChecked() {
-    openTabsCheckBox().assertIsChecked(true)
-    browsingHistoryCheckBox().assertIsChecked(true)
-    cookiesAndSiteDataCheckBox().assertIsChecked(true)
-    cachedFilesCheckBox().assertIsChecked(true)
-    sitePermissionsCheckBox().assertIsChecked(true)
-    downloadsCheckBox().assertIsChecked(true)
-}
-
-private fun assertOpenTabsDescription(tabNumber: String) =
-    openTabsDescription(tabNumber).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun assertBrowsingHistoryDescription(addresses: String) =
-    assertUIObjectExists(browsingHistoryDescription(addresses))
-
 private fun assertDeleteBrowsingDataSnackbar() = assertUIObjectIsGone(itemWithText("Browsing data deleted"))
-
 private fun clickOpenTabsCheckBox() = openTabsCheckBox().click()
-private fun assertOpenTabsCheckBox(status: Boolean) = openTabsCheckBox().assertIsChecked(status)
 private fun clickBrowsingHistoryCheckBox() = browsingHistoryCheckBox().click()
-private fun assertBrowsingHistoryCheckBox(status: Boolean) = browsingHistoryCheckBox().assertIsChecked(status)
 private fun clickCookiesCheckBox() = cookiesAndSiteDataCheckBox().click()
-private fun assertCookiesCheckBox(status: Boolean) = cookiesAndSiteDataCheckBox().assertIsChecked(status)
 private fun clickCachedFilesCheckBox() = cachedFilesCheckBox().click()
-private fun assertCachedFilesCheckBox(status: Boolean) = cachedFilesCheckBox().assertIsChecked(status)
 private fun clickSitePermissionsCheckBox() = sitePermissionsCheckBox().click()
-private fun assertSitePermissionsCheckBox(status: Boolean) = sitePermissionsCheckBox().assertIsChecked(status)
 private fun clickDownloadsCheckBox() = downloadsCheckBox().click()
-private fun assertDownloadsCheckBox(status: Boolean) = downloadsCheckBox().assertIsChecked(status)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1881010