### PR TITLE
Bug 1880476 — NimbusMessaging: Move filtering to getNextMessage

### DIFF
--- a/android-components/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorageTest.kt
+++ b/android-components/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorageTest.kt
@@ -55,6 +55,8 @@ class NimbusMessagingStorageTest {
     }
     private lateinit var featuresInterface: FeaturesInterface
 
+    private val displayOnceStyle = StyleData(maxDisplayCount = 1)
+
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule()
 
@@ -84,7 +86,9 @@ class NimbusMessagingStorageTest {
             messagingFeature,
         )
 
-        `when`(nimbus.createMessageHelper(any())).thenReturn(mock())
+        val helper: NimbusMessagingHelperInterface = mock()
+        `when`(helper.evalJexl(any())).thenReturn(true)
+        `when`(nimbus.createMessageHelper(any())).thenReturn(helper)
     }
 
     @After
@@ -175,8 +179,10 @@ class NimbusMessagingStorageTest {
 
             val results = storage.getMessages()
 
-            assertEquals(1, results.size)
-            assertEquals("normal-message", results[0].id)
+            assertEquals(2, results.size)
+
+            val message = storage.getNextMessage(HOMESCREEN, results)!!
+            assertEquals("normal-message", message.id)
         }
 
     @Test
@@ -210,9 +216,10 @@ class NimbusMessagingStorageTest {
             )
 
             val results = storage.getMessages()
+            assertEquals(2, results.size)
 
-            assertEquals(1, results.size)
-            assertEquals("normal-message", results[0].id)
+            val message = storage.getNextMessage(HOMESCREEN, results)!!
+            assertEquals("normal-message", message.id)
         }
 
     @Test
@@ -258,9 +265,10 @@ class NimbusMessagingStorageTest {
             )
 
             val results = storage.getMessages()
+            assertEquals(3, results.size)
 
-            assertEquals(1, results.size)
-            assertEquals("normal-message", results[0].id)
+            val message = storage.getNextMessage(HOMESCREEN, results)!!
+            assertEquals("normal-message", message.id)
         }
 
     @Test
@@ -489,7 +497,7 @@ class NimbusMessagingStorageTest {
             "same-id",
             createMessageData(surface = HOMESCREEN),
             action = "action",
-            mock(),
+            style = displayOnceStyle,
             listOf("trigger"),
             Message.Metadata("same-id"),
         )
@@ -511,7 +519,7 @@ class NimbusMessagingStorageTest {
             "same-id",
             messageData,
             action = "action",
-            mock(),
+            style = displayOnceStyle,
             listOf("trigger"),
             Message.Metadata("same-id"),
         )
@@ -537,7 +545,7 @@ class NimbusMessagingStorageTest {
             "id",
             messageData,
             action = "action",
-            mock(),
+            style = displayOnceStyle,
             listOf("trigger"),
             Message.Metadata("same-id"),
         )
@@ -546,7 +554,7 @@ class NimbusMessagingStorageTest {
             "control-id",
             controlMessageData,
             action = "action",
-            mock(),
+            style = displayOnceStyle,
             listOf("trigger"),
             Message.Metadata("same-id"),
         )
@@ -575,7 +583,7 @@ class NimbusMessagingStorageTest {
             "id",
             messageData,
             action = "action",
-            mock(),
+            style = displayOnceStyle,
             listOf("trigger"),
             Message.Metadata("same-id"),
         )
@@ -584,7 +592,7 @@ class NimbusMessagingStorageTest {
             "control-id",
             controlMessageData,
             action = "action",
-            mock(),
+            style = displayOnceStyle,
             listOf("trigger"),
             Message.Metadata("same-id"),
         )
@@ -615,7 +623,7 @@ class NimbusMessagingStorageTest {
             "id",
             messageData,
             action = "action",
-            mock(),
+            style = displayOnceStyle,
             listOf("trigger"),
             Message.Metadata("same-id"),
         )
@@ -624,7 +632,7 @@ class NimbusMessagingStorageTest {
             "incorrect-id",
             incorrectMessageData,
             action = "action",
-            mock(),
+            style = displayOnceStyle,
             listOf("trigger"),
             Message.Metadata("same-id"),
         )
@@ -633,7 +641,7 @@ class NimbusMessagingStorageTest {
             "control-id",
             controlMessageData,
             action = "action",
-            mock(),
+            style = displayOnceStyle,
             listOf("trigger"),
             Message.Metadata("same-id"),
         )


### PR DESCRIPTION
Relates to [Bug 1880476](https://bugzilla.mozilla.org/show_bug.cgi?id=1880476).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This moves the filtering of expired and interacted with messages for a given surface from the only-done-once `getMessages()` method to done-every-time a message is asked for. Given that expiry and interactions are based on stored state, these should be done each time, and removes some checking needed to be done in the surfaces.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880476