### PR TITLE
Fix UI tests affected by UIAutomator update

### DIFF
--- a/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
+++ b/android-components/plugins/dependencies/src/main/java/DependenciesPlugin.kt
@@ -84,7 +84,7 @@ object Versions {
         const val navigation = "2.7.7"
         const val work = "2.7.1"
         const val arch = "2.2.0"
-        const val uiautomator = "2.2.0"
+        const val uiautomator = "2.3.0"
         const val localbroadcastmanager = "1.0.0"
         const val swiperefreshlayout = "1.1.0"
         const val data_store_preferences="1.0.0"

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -1408,7 +1408,7 @@ fun setPageObjectText(webPageItem: UiObject, text: String) {
                 it.clearTextField()
                 Log.i(TAG, "setPageObjectText: Cleared ${webPageItem.selector} text field")
                 Log.i(TAG, "setPageObjectText: Trying to set ${webPageItem.selector} text to $text")
-                it.text = text
+                it.setText(text)
                 Log.i(TAG, "setPageObjectText: ${webPageItem.selector} text was set to $text")
             }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
@@ -58,7 +58,7 @@ class CollectionRobot {
     // names a collection saved from tab drawer
     fun typeCollectionNameAndSave(collectionName: String) {
         Log.i(TAG, "typeCollectionNameAndSave: Trying to set collection name text field to: $collectionName")
-        collectionNameTextField().text = collectionName
+        collectionNameTextField().setText(collectionName)
         Log.i(TAG, "typeCollectionNameAndSave: Collection name text field set to: $collectionName")
         Log.i(TAG, "typeCollectionNameAndSave: Waiting for $waitingTime ms for add collection button panel to exist")
         addCollectionButtonPanel().waitForExists(waitingTime)
@@ -228,7 +228,7 @@ class CollectionRobot {
             mainMenuEditCollectionNameField().waitForExists(waitingTime)
             Log.i(TAG, "typeCollectionNameAndSave: Waited for $waitingTime ms for collection name text field to exist")
             Log.i(TAG, "typeCollectionNameAndSave: Trying to set collection name text field to: $name")
-            mainMenuEditCollectionNameField().text = name
+            mainMenuEditCollectionNameField().setText(name)
             Log.i(TAG, "typeCollectionNameAndSave: Collection name text field set to: $name")
             Log.i(TAG, "typeCollectionNameAndSave: Trying to press done action button")
             onView(withId(R.id.name_collection_edittext)).perform(pressImeActionButton())

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -27,6 +27,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
 import org.junit.Assert.assertTrue
@@ -295,9 +296,11 @@ class SearchRobot {
     }
 
     fun tapOutsideToDismissSearchBar() {
-        Log.i(TAG, "tapOutsideToDismissSearchBar: Trying to click the search wrapper")
-        itemWithResId("$packageName:id/search_wrapper").click()
-        Log.i(TAG, "tapOutsideToDismissSearchBar: Clicked the search wrapper")
+        Log.i(TAG, "tapOutsideToDismissSearchBar: Trying to perform a backward scroll action")
+        // After updating UIAutomator to 2.3.0 the click action doesn't seem to dismiss anymore the awesome bar
+        // On the other hand, the scroll action seems to be working properly and dismisses the awesome bar
+        UiScrollable(UiSelector().resourceId("$packageName:id/search_wrapper")).scrollBackward()
+        Log.i(TAG, "tapOutsideToDismissSearchBar: Performed a backward scroll action")
         Log.i(TAG, "tapOutsideToDismissSearchBar: Waiting for $waitingTime ms for the edit mode toolbar to be gone")
         browserToolbarEditView().waitUntilGone(waitingTime)
         Log.i(TAG, "tapOutsideToDismissSearchBar: Waited for $waitingTime ms for the edit mode toolbar to be gone")

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
@@ -90,15 +90,6 @@ class SettingsSubMenuAddonsManagerRobot {
             ),
         )
         Log.i(TAG, "clickInstallAddon: Scrolled into view the install $addonName button")
-        Log.i(TAG, "clickInstallAddon: Trying to ensure the full visibility of the the install $addonName button")
-        addonsList().ensureFullyVisible(
-            mDevice.findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/details_container")
-                    .childSelector(UiSelector().text(addonName)),
-            ),
-        )
-        Log.i(TAG, "clickInstallAddon: Ensured the full visibility of the the install $addonName button")
         Log.i(TAG, "clickInstallAddon: Trying to click the install $addonName button")
         installButtonForAddon(addonName).click()
         Log.i(TAG, "clickInstallAddon: Clicked the install $addonName button")

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLanguageRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLanguageRobot.kt
@@ -66,7 +66,7 @@ class SettingsSubMenuLanguageRobot {
         searchBar().waitForExists(waitingTime)
         Log.i(TAG, "typeInSearchBar: Waited for $waitingTime ms for search bar to exist")
         Log.i(TAG, "typeInSearchBar: Trying to set search bar text to: $text")
-        searchBar().text = text
+        searchBar().setText(text)
         Log.i(TAG, "typeInSearchBar: Search bar text was set to: $text")
     }
 

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/AddToHomeScreenRobot.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/AddToHomeScreenRobot.kt
@@ -22,7 +22,7 @@ class AddToHomeScreenRobot {
     fun addShortcutWithTitle(title: String) {
         shortcutTitle.waitForExists(waitingTime)
         shortcutTitle.clearTextField()
-        shortcutTitle.text = title
+        shortcutTitle.setText(title)
         addToHSOKBtn.click()
     }
 

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/BrowserRobot.kt
@@ -214,6 +214,11 @@ class BrowserRobot {
     fun verifySiteSecurityIndicatorShown() = assertTrue(site_security_indicator.waitForExists(waitingTime))
 
     fun verifyLinkContextMenu(linkAddress: String) {
+        assertTrue(
+            mDevice.findObject(
+                UiSelector().resourceId("$packageName:id/parentPanel"),
+            ).waitForExists(waitingTime),
+        )
         onView(withId(R.id.titleView)).check(matches(withText(linkAddress)))
         openLinkInPrivateTab.check(matches(isDisplayed()))
         copyLink.check(matches(isDisplayed()))
@@ -221,6 +226,11 @@ class BrowserRobot {
     }
 
     fun verifyImageContextMenu(hasLink: Boolean, linkAddress: String) {
+        assertTrue(
+            mDevice.findObject(
+                UiSelector().resourceId("$packageName:id/parentPanel"),
+            ).waitForExists(waitingTime),
+        )
         onView(withId(R.id.titleView)).check(matches(withText(linkAddress)))
         if (hasLink) {
             openLinkInPrivateTab.check(matches(isDisplayed()))

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/HomeScreenRobot.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/HomeScreenRobot.kt
@@ -68,7 +68,7 @@ class HomeScreenRobot {
         val okButton = mDevice.findObject(UiSelector().textContains("ok"))
 
         titleTextField.clearTextField()
-        titleTextField.text = newTitle
+        titleTextField.setText(newTitle)
         okButton.click()
         // the dialog is not always dismissed on first click of the Ok button (not manually reproducible)
         if (!mDevice.findObject(UiSelector().text("Rename")).waitUntilGone(waitingTimeShort)) {

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
@@ -23,7 +23,7 @@ class SearchRobot {
     fun typeInSearchBar(searchString: String) {
         assertTrue(searchBar.waitForExists(waitingTime))
         searchBar.clearTextField()
-        searchBar.text = searchString
+        searchBar.setText(searchString)
     }
 
     // Would you like to turn on search suggestions? Yes No

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/activity/robots/SearchRobot.kt
@@ -9,6 +9,7 @@ import androidx.test.uiautomator.UiSelector
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.focus.R
+import org.mozilla.focus.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.focus.helpers.TestHelper.getStringResource
 import org.mozilla.focus.helpers.TestHelper.mDevice
 import org.mozilla.focus.helpers.TestHelper.packageName
@@ -70,7 +71,7 @@ class SearchRobot {
 
     fun longPressSearchBar() {
         searchBar.waitForExists(waitingTime)
-        searchBar.longClick()
+        mDevice.findObject(By.res("$packageName:id/mozac_browser_toolbar_edit_url_view")).click(LONG_CLICK_DURATION)
     }
 
     fun clearSearchBar() = clearSearchButton.click()

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/helpers/Constants.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/helpers/Constants.kt
@@ -5,4 +5,5 @@ package org.mozilla.focus.helpers
 
 object Constants {
     const val RETRY_COUNT = 3
+    const val LONG_CLICK_DURATION: Long = 5000
 }

--- a/focus-android/app/src/androidTest/java/org/mozilla/focus/screenshots/HomeScreenScreenshots.kt
+++ b/focus-android/app/src/androidTest/java/org/mozilla/focus/screenshots/HomeScreenScreenshots.kt
@@ -111,7 +111,7 @@ class HomeScreenScreenshots : ScreenshotTest() {
 
     private fun typeInSearchBar(searchString: String) {
         searchBar.clearTextField()
-        searchBar.text = searchString
+        searchBar.setText(searchString)
     }
 
     private val searchBar =


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1881349