### PR TITLE
Bug 1880476 — Refactor onMessageDisplayed bookkeeping

### DIFF
--- a/android-components/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorage.kt
+++ b/android-components/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorage.kt
@@ -41,6 +41,7 @@ class NimbusMessagingStorage(
     private val nimbus: NimbusMessagingInterface,
     private val messagingFeature: FeatureHolder<Messaging>,
     private val attributeProvider: JexlAttributeProvider? = null,
+    private val now: () -> Long = { System.currentTimeMillis() },
 ) {
     /**
      * Contains all malformed messages where they key can be the value or a trigger of the message
@@ -179,28 +180,17 @@ class NimbusMessagingStorage(
             .filter { !excluded.contains(it.id) }
             .firstOrNull { isMessageEligible(it, helper) } ?: return null
 
-        val slug = message.data.experiment
-        if (slug != null) {
-            // We know that it's experimental, and we know which experiment it came from.
-            messagingFeature.recordExperimentExposure(slug)
-        } else if (message.data.isControl) {
-            // It's not experimental, but it is a control. This is obviously malformed.
-            reportMalformedMessage(message.id)
-        }
-
         // If this is an experimental message, but not a placebo, then just return the message.
         if (!message.data.isControl) {
             return message
         }
 
-        // If a message is a control then it's considered as displayed
-        val updatedMetadata = message.metadata.copy(
-            displayCount = message.metadata.displayCount + 1,
-            lastTimeShown = System.currentTimeMillis(),
-        )
-
+        // This is a control message which we're definitely not going to show to anyone,
+        // however, we need to do the bookkeeping and as if we were.
+        //
+        // Since no one is going to see it, then we need to do it ourselves, here.
         runBlocking {
-            updateMetadata(updatedMetadata)
+            onMessageDisplayed(message)
         }
 
         // This is a control, so we need to either return the next message (there may not be one)
@@ -239,6 +229,38 @@ class NimbusMessagingStorage(
             val url = helper.stringFormat(action, uuid)
             Pair(uuid, url)
         }
+
+    /**
+     * Record the time and optional [bootIdentifier] of the display of the given message.
+     *
+     * If the message is part of an experiment, then record an exposure event for that
+     * experiment.
+     *
+     * This is determined by the value in the [message.data.experiment] property.
+     */
+    suspend fun onMessageDisplayed(message: Message, bootIdentifier: String? = null): Message {
+        // Record an exposure event if this is an experimental message.
+        val slug = message.data.experiment
+        if (slug != null) {
+            // We know that it's experimental, and we know which experiment it came from.
+            messagingFeature.recordExperimentExposure(slug)
+        } else if (message.data.isControl) {
+            // It's not experimental, but it is a control. This is obviously malformed.
+            reportMalformedMessage(message.id)
+        }
+
+        // Now update the display counts.
+        val updatedMetadata = message.metadata.copy(
+            displayCount = message.metadata.displayCount + 1,
+            lastTimeShown = now(),
+            latestBootIdentifier = bootIdentifier,
+        )
+        val nextMessage = message.copy(
+            metadata = updatedMetadata,
+        )
+        updateMetadata(nextMessage.metadata)
+        return nextMessage
+    }
 
     /**
      * Updated the provided [metadata] in the storage.

--- a/fenix/app/src/test/java/org/mozilla/fenix/messaging/DefaultMessageControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/messaging/DefaultMessageControllerTest.kt
@@ -4,6 +4,8 @@
 
 package org.mozilla.fenix.messaging
 
+import android.content.Intent
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import mozilla.components.service.nimbus.messaging.Message
@@ -44,6 +46,7 @@ class DefaultMessageControllerTest {
     @Test
     fun `WHEN calling onMessagePressed THEN process the action intent and update the app store`() {
         val message = mockMessage()
+        every { messagingController.getIntentForMessage(message) }.returns(Intent())
 
         defaultMessageController.onMessagePressed(message)
 

--- a/fenix/app/src/test/java/org/mozilla/fenix/messaging/state/MessagingMiddlewareTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/messaging/state/MessagingMiddlewareTest.kt
@@ -232,7 +232,7 @@ class MessagingMiddlewareTest {
         val message1 = createMessage()
         val message2 = message1.copy(id = "message2", action = "action2")
         // An updated message1 that has been displayed once.
-        val messageDisplayed1 = message1.copy(metadata = createMetadata(displayCount = 1))
+        val messageDisplayed1 = incrementDisplayCount(message1)
         val store = AppStore(
             AppState(
                 messaging = MessagingState(
@@ -253,6 +253,9 @@ class MessagingMiddlewareTest {
                 any(),
             )
         } returns message1
+        coEvery {
+            controller.onMessageDisplayed(message1, any())
+        } returns messageDisplayed1
 
         coEvery {
             controller.onMessageDisplayed(eq(message1), any())
@@ -269,7 +272,7 @@ class MessagingMiddlewareTest {
     fun `GIVEN a message has not surpassed the maxDisplayCount WHEN evaluate THEN update the message displayCount`() = runTestOnMain {
         val message = createMessage()
         // An updated message that has been displayed once.
-        val messageDisplayed = message.copy(metadata = createMetadata(displayCount = 1))
+        val messageDisplayed = incrementDisplayCount(message)
         val store = AppStore(
             AppState(
                 messaging = MessagingState(
@@ -289,6 +292,9 @@ class MessagingMiddlewareTest {
                 any(),
             )
         } returns message
+        coEvery {
+            controller.onMessageDisplayed(message, any())
+        } returns messageDisplayed
 
         coEvery {
             controller.onMessageDisplayed(eq(message), any())
@@ -327,6 +333,9 @@ class MessagingMiddlewareTest {
                 any(),
             )
         } returns message
+        coEvery {
+            controller.onMessageDisplayed(message, any())
+        } returns incrementDisplayCount(message)
 
         coEvery {
             controller.onMessageDisplayed(eq(message), any())
@@ -363,3 +372,10 @@ private fun createMetadata(
     lastTimeShown,
     latestBootIdentifier,
 )
+
+private fun incrementDisplayCount(message: Message) =
+    message.copy(
+        metadata = createMetadata(
+            displayCount = message.displayCount + 1,
+        ),
+    )


### PR DESCRIPTION
Relates to [Bug 1880476](https://bugzilla.mozilla.org/show_bug.cgi?id=1880476).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR moves the generated Glean events for message display (message_shown and exposure events) into a single place. This should reduce the disparity between these events down to zero.

`getNextMessage` now only emits exposure events when the message is a control message.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880476