### PR TITLE
Bug 1880483 — Add inverse triggers to messaging component

### DIFF
--- a/android-components/components/service/nimbus/messaging.fml.yaml
+++ b/android-components/components/service/nimbus/messaging.fml.yaml
@@ -133,13 +133,20 @@ objects:
           The surface identifier for this message.
         type: SurfaceName
         default: homescreen
-      trigger:
+      trigger-if-all:
         type: List<TriggerName>
         description: >
           A list of strings corresponding to
           targeting expressions. The message will be
-          shown if all expressions `true`.
+          shown if all expressions are `true`.
         default: []
+      exclude-if-any:
+        type: List<TriggerName>
+        description: >
+          A list of strings corresponding to
+          targeting expressions. The message will not be
+          shown if any of the expressions are `true`.
+        default: [ ]
   StyleData:
     description: >
       A group of properties (predominantly visual) to

--- a/android-components/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/messaging/Message.kt
+++ b/android-components/components/service/nimbus/src/main/java/mozilla/components/service/nimbus/messaging/Message.kt
@@ -7,15 +7,20 @@ package mozilla.components.service.nimbus.messaging
 import androidx.annotation.VisibleForTesting
 
 /**
- * A data class that holds a representation of GleanPlum message from Nimbus.
+ * A data class that holds a representation of a message from Nimbus.
+ *
+ * In order to be eligible to be shown, all `triggerIfAll` expressions
+ * AND none of the `excludeIfAny` expressions must evaluate to `true`.
  *
  * @param id identifies a message as unique.
  * @param data Data information provided from Nimbus.
  * @param action A strings that represents which action should be performed
  * after a message is clicked.
  * @param style Indicates how a message should be styled.
- * @param triggers A list of strings corresponding to targeting expressions. The message
- * will be shown if all expressions `true`.
+ * @param triggerIfAll A list of strings corresponding to JEXL targeting expressions. The message
+ * will be shown if _all_ expressions evaluate to `true`.
+ * @param excludeIfAny A list of strings corresponding to JEXL targeting expressions. The message
+ * will _not_ be shown if _any_ expressions evaluate to `true`.
  * @param metadata Metadata that help to identify if a message should shown.
  */
 data class Message(
@@ -23,7 +28,8 @@ data class Message(
     internal val data: MessageData,
     internal val action: String,
     internal val style: StyleData,
-    internal val triggers: List<String>,
+    internal val triggerIfAll: List<String>,
+    internal val excludeIfAny: List<String> = listOf(),
     internal val metadata: Metadata,
 ) {
     val text: String

--- a/android-components/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingControllerTest.kt
+++ b/android-components/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingControllerTest.kt
@@ -273,7 +273,8 @@ class NimbusMessagingControllerTest {
             data = messageData,
             style = style,
             metadata = Message.Metadata(id, displayCount),
-            triggers = emptyList(),
+            triggerIfAll = emptyList(),
+            excludeIfAny = emptyList(),
             action = action,
         )
 }

--- a/android-components/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorageTest.kt
+++ b/android-components/components/service/nimbus/src/test/java/mozilla/components/service/nimbus/messaging/NimbusMessagingStorageTest.kt
@@ -16,6 +16,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -427,7 +428,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             mock(),
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         `when`(helper.evalJexl(any())).thenReturn(true)
@@ -455,18 +456,18 @@ class NimbusMessagingStorageTest {
             action = "action",
             mock(),
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         `when`(helper.evalJexl(any())).then { throw NimbusException.EvaluationException("") }
 
-        val result = storage.isMessageEligible(message, helper)
-
-        assertFalse(result)
+        assertThrows(NimbusException.EvaluationException::class.java) {
+            storage.isMessageEligible(message, helper)
+        }
     }
 
     @Test
-    fun `GIVEN a previously malformed trigger WHEN calling isMessageEligible THEN return false and not evaluate`() {
+    fun `GIVEN a previously malformed trigger WHEN calling isMessageEligible THEN throw and not evaluate`() {
         val helper: NimbusMessagingHelperInterface = mock()
         val message = Message(
             "same-id",
@@ -474,22 +475,22 @@ class NimbusMessagingStorageTest {
             action = "action",
             mock(),
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         storage.malFormedMap["trigger"] = "same-id"
 
         `when`(helper.evalJexl(any())).then { throw NimbusException.EvaluationException("") }
 
-        val result = storage.isMessageEligible(message, helper)
+        assertThrows(NimbusException.EvaluationException::class.java) {
+            storage.isMessageEligible(message, helper)
+        }
 
-        assertFalse(result)
         verify(helper, never()).evalJexl("trigger")
-        assertFalse(malformedWasReported)
     }
 
     @Test
-    fun `GIVEN a non previously malformed trigger WHEN calling isMessageEligible THEN return false and not evaluate`() {
+    fun `GIVEN a non previously malformed trigger WHEN calling isMessageEligible THEN throw and not evaluate`() {
         val helper: NimbusMessagingHelperInterface = mock()
         val message = Message(
             "same-id",
@@ -497,18 +498,18 @@ class NimbusMessagingStorageTest {
             action = "action",
             mock(),
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         `when`(helper.evalJexl(any())).then { throw NimbusException.EvaluationException("") }
 
         assertFalse(storage.malFormedMap.containsKey("trigger"))
 
-        val result = storage.isMessageEligible(message, helper)
+        assertThrows(NimbusException.EvaluationException::class.java) {
+            storage.isMessageEligible(message, helper)
+        }
 
-        assertFalse(result)
         assertTrue(storage.malFormedMap.containsKey("trigger"))
-        assertTrue(malformedWasReported)
     }
 
     @Test
@@ -520,7 +521,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             mock(),
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         doReturn(false).`when`(spiedStorage).isMessageEligible(any(), any())
@@ -539,7 +540,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             style = displayOnceStyle,
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
@@ -561,7 +562,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             style = displayOnceStyle,
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
@@ -589,7 +590,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             style = displayOnceStyle,
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         val controlMessage = Message(
@@ -598,7 +599,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             style = displayOnceStyle,
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
@@ -627,7 +628,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             style = displayOnceStyle,
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         val controlMessage = Message(
@@ -636,7 +637,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             style = displayOnceStyle,
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
@@ -667,7 +668,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             style = displayOnceStyle,
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         val incorrectMessage = Message(
@@ -676,7 +677,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             style = displayOnceStyle,
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         val controlMessage = Message(
@@ -685,7 +686,7 @@ class NimbusMessagingStorageTest {
             action = "action",
             style = displayOnceStyle,
             listOf("trigger"),
-            Message.Metadata("same-id"),
+            metadata = Message.Metadata("same-id"),
         )
 
         doReturn(true).`when`(spiedStorage).isMessageEligible(any(), any())
@@ -800,7 +801,7 @@ class NimbusMessagingStorageTest {
     ) = MessageData(
         action = Res.string(action),
         style = style,
-        trigger = triggers,
+        triggerIfAll = triggers,
         surface = surface,
         isControl = isControl,
         text = Res.string(text),

--- a/fenix/app/messaging-evergreen-messages.fml.yaml
+++ b/fenix/app/messaging-evergreen-messages.fml.yaml
@@ -29,9 +29,10 @@ import:
                 text: default_browser_experiment_card_text
                 surface: homescreen
                 action: "MAKE_DEFAULT_BROWSER"
-                trigger:
-                  - I_AM_NOT_DEFAULT_BROWSER
+                trigger-if-all:
                   - USER_ESTABLISHED_INSTALL
+                exclude-if-any:
+                  - I_AM_DEFAULT_BROWSER
                 style: PERSISTENT
                 button-label: preferences_set_as_default_browser
 
@@ -47,7 +48,8 @@ import:
                 text: nimbus_notification_default_browser_text
                 surface: notification
                 style: NOTIFICATION
-                trigger:
-                  - I_AM_NOT_DEFAULT_BROWSER
+                trigger-if-all:
                   - DAY_3_AFTER_INSTALL
+                exclude-if-any:
+                  - I_AM_DEFAULT_BROWSER
                 action: MAKE_DEFAULT_BROWSER

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NimbusMessagingHomescreenTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/NimbusMessagingHomescreenTest.kt
@@ -66,7 +66,7 @@ class NimbusMessagingHomescreenTest {
                         buttonLabel = Res.string(messageButtonLabel),
                         text = Res.string(messageText),
                         title = Res.string(messageTitle),
-                        trigger = listOf("ALWAYS"),
+                        triggerIfAll = listOf("ALWAYS"),
                     ),
                 ),
                 styles = mapOf(

--- a/fenix/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
@@ -113,6 +113,7 @@ class AppStoreTest {
                 "action",
                 mockk(),
                 emptyList(),
+                emptyList(),
                 mockk(),
             )
             appStore.dispatch(UpdateMessageToShow(message)).join()

--- a/fenix/app/src/test/java/org/mozilla/fenix/messaging/DefaultMessageControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/messaging/DefaultMessageControllerTest.kt
@@ -69,7 +69,8 @@ class DefaultMessageControllerTest {
         data = data,
         style = mockk(relaxed = true),
         action = "action",
-        triggers = emptyList(),
+        triggerIfAll = emptyList(),
+        excludeIfAny = emptyList(),
         metadata = Message.Metadata(
             id = "id",
             displayCount = 0,

--- a/fenix/app/src/test/java/org/mozilla/fenix/messaging/state/MessagingMiddlewareTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/messaging/state/MessagingMiddlewareTest.kt
@@ -355,7 +355,8 @@ private fun createMessage(
     action: String = "action",
     styleData: StyleData = StyleData(),
     triggers: List<String> = listOf("triggers"),
-) = Message(messageId, data, action, styleData, triggers, metadata)
+    except: List<String> = listOf(),
+) = Message(messageId, data, action, styleData, triggers, except, metadata)
 
 private fun createMetadata(
     displayCount: Int = 0,

--- a/fenix/app/src/test/java/org/mozilla/fenix/messaging/state/MessagingReducerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/messaging/state/MessagingReducerTest.kt
@@ -52,7 +52,7 @@ class MessagingReducerTest {
             data = MessageData(surface = surface),
             action = action,
             style = StyleData(),
-            triggers = listOf(),
+            triggerIfAll = listOf(),
             metadata = Message.Metadata(id = id),
         )
 


### PR DESCRIPTION
Relates to [Bug 1880483](https://bugzilla.mozilla.org/show_bug.cgi?id=1880483).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This is a breaking change. It is one of two breaking changes outline in the [Transition Phase 1](https://docs.google.com/document/d/1m6hBG7rjut1Q84Wy9SxxTz8bEXlFkoV-H4GMzZfZ4pY/edit#heading=h.mhha8y8yhj1n) of the Mobile Messaging Go Forward plan.

This changes the `trigger` key to `trigger-if-all` to document that all triggers in this list must evaluate to true.

It also adds `exclude-if-any`, a list of triggers which, if any are true will exclude the message.

This will remove the need for triggers like `I_AM_NOT_BROWSER_DEFAULT`.

~~It should not land until user-research (@El and @roseanne) have been informed.~~ Publicised via email.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1880483