### PR TITLE
Bug 1853107 - Fix a race condition on CreateEngineSession

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddleware.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/engine/middleware/CreateEngineSessionMiddleware.kt
@@ -35,7 +35,8 @@ internal class CreateEngineSessionMiddleware(
         action: BrowserAction,
     ) {
         if (action is EngineAction.CreateEngineSessionAction) {
-            if (context.state.findTabOrCustomTab(action.tabId)?.engineState?.initializing == false) {
+            val engineState = context.state.findTabOrCustomTab(action.tabId)?.engineState
+            if (engineState?.initializing == false && engineState.engineSession == null && !engineState.crashed) {
                 context.dispatch(EngineAction.UpdateEngineSessionInitializingAction(action.tabId, true))
                 createEngineSession(context.store, action)
             } else {


### PR DESCRIPTION
Previously on #5257 

Follow the condition logic according to @MatthewTighe 's review: https://github.com/mozilla-mobile/firefox-android/pull/5257#discussion_r1501135176

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1853107