### PR TITLE
Bug 1881976 - Replace web-de with bild-de pageload test.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -117,7 +117,7 @@ tasks:
             - reddit
             - sina
             - [stackoverflow, stacko]
-            - web-de
+            - bild-de
             - cnn
             - [google-search-restaurants, gsearch-r]
 


### PR DESCRIPTION
This patch changes the web-de test to bild-de since the web-de test can no longer be recorded due to a cookie banner. See bug 1880115.
https://bugzilla.mozilla.org/show_bug.cgi?id=1881976