### PR TITLE
Bug 1875668 - Bypass cache when intercepting URL requests

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/components/UrlRequestInterceptor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/UrlRequestInterceptor.kt
@@ -8,6 +8,7 @@ import androidx.annotation.VisibleForTesting
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags.Companion.ALLOW_ADDITIONAL_HEADERS
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags.Companion.BYPASS_CACHE
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags.Companion.LOAD_FLAGS_BYPASS_LOAD_URI_DELEGATE
 import mozilla.components.concept.engine.request.RequestInterceptor
 
@@ -58,12 +59,24 @@ class UrlRequestInterceptor(private val isDeviceRamAboveThreshold: Boolean) : Re
             return null
         }
 
-        return RequestInterceptor.InterceptionResponse.Url(
-            url = uri,
-            flags = LoadUrlFlags.select(
+        // This is a workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1875668
+        // Remove this by implementing https://bugzilla.mozilla.org/show_bug.cgi?id=1883496
+        val loadUrlFlags = if (uri.endsWith("#ip=1", true)) {
+            LoadUrlFlags.select(
                 LOAD_FLAGS_BYPASS_LOAD_URI_DELEGATE,
                 ALLOW_ADDITIONAL_HEADERS,
-            ),
+                BYPASS_CACHE,
+            )
+        } else {
+            LoadUrlFlags.select(
+                LOAD_FLAGS_BYPASS_LOAD_URI_DELEGATE,
+                ALLOW_ADDITIONAL_HEADERS,
+            )
+        }
+
+        return RequestInterceptor.InterceptionResponse.Url(
+            url = uri,
+            flags = loadUrlFlags,
             additionalHeaders = getAdditionalHeaders(isDeviceRamAboveThreshold),
         )
     }

--- a/fenix/app/src/test/java/org/mozilla/fenix/components/UrlRequestInterceptorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/UrlRequestInterceptorTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags.Companion.ALLOW_ADDITIONAL_HEADERS
+import mozilla.components.concept.engine.EngineSession.LoadUrlFlags.Companion.BYPASS_CACHE
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags.Companion.LOAD_FLAGS_BYPASS_LOAD_URI_DELEGATE
 import mozilla.components.concept.engine.request.RequestInterceptor
 import org.junit.Assert.assertEquals
@@ -134,6 +135,27 @@ class UrlRequestInterceptorTest {
             RequestInterceptor.InterceptionResponse.Url(
                 url = uri,
                 flags = LoadUrlFlags.select(
+                    LOAD_FLAGS_BYPASS_LOAD_URI_DELEGATE,
+                    ALLOW_ADDITIONAL_HEADERS,
+                ),
+                additionalHeaders = mapOf(
+                    "X-Search-Subdivision" to "0",
+                ),
+            ),
+            getUrlRequestInterceptor().onLoadRequest(
+                uri = uri,
+            ),
+        )
+    }
+
+    @Test
+    fun `WHEN a Google request end in #ip=1 is loaded THEN request bypass cache`() {
+        val uri = "https://www.google.com/search?q=test&ie=utf-8#ip=1"
+        assertEquals(
+            RequestInterceptor.InterceptionResponse.Url(
+                url = uri,
+                flags = LoadUrlFlags.select(
+                    BYPASS_CACHE,
                     LOAD_FLAGS_BYPASS_LOAD_URI_DELEGATE,
                     ALLOW_ADDITIONAL_HEADERS,
                 ),


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1875668