### PR TITLE
Bug 1807067 - Have an option for back button/gesture to close tabs

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1340,6 +1340,7 @@ abstract class BaseBrowserFragment :
             ),
         )
         return true
+
     }
 
     /**
@@ -1391,7 +1392,7 @@ abstract class BaseBrowserFragment :
                 true
             } else {
                 val hasParentSession = session is TabSessionState && session.parentId != null
-                if (hasParentSession) {
+                if (hasParentSession || requireContext().settings().closeOrphanTabOnBack) {
                     requireComponents.useCases.tabsUseCases.removeTab(session.id, selectParentIfExists = true)
                 }
                 // We want to return to home if this session didn't have a parent session to select.

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1340,7 +1340,6 @@ abstract class BaseBrowserFragment :
             ),
         )
         return true
-
     }
 
     /**

--- a/fenix/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
@@ -29,6 +29,7 @@ class TabsSettingsFragment : PreferenceFragmentCompat() {
     private lateinit var radioOneMonth: RadioButtonPreference
     private lateinit var inactiveTabsCategory: PreferenceCategory
     private lateinit var inactiveTabs: SwitchPreference
+    private lateinit var closeOrphanTabOnBack: SwitchPreference
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.tabs_preferences, rootKey)
@@ -59,6 +60,10 @@ class TabsSettingsFragment : PreferenceFragmentCompat() {
         radioOneMonth = requirePreference(R.string.pref_key_close_tabs_after_one_month)
         radioOneWeek = requirePreference(R.string.pref_key_close_tabs_after_one_week)
         radioOneDay = requirePreference(R.string.pref_key_close_tabs_after_one_day)
+
+        closeOrphanTabOnBack = requirePreference<SwitchPreference>(R.string.pref_key_close_orphan_tab_on_back).also {
+            it.onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
 
         inactiveTabs = requirePreference<SwitchPreference>(R.string.pref_key_inactive_tabs).also {
             it.isChecked = requireContext().settings().inactiveTabsAreEnabled

--- a/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -359,6 +359,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     val shouldShowSecurityPinWarningSync: Boolean
         get() = loginsSecureWarningSyncCount.underMaxCount()
 
+    var closeOrphanTabOnBack by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_close_orphan_tab_on_back),
+        default = false,
+    )
+
     val shouldShowSecurityPinWarning: Boolean
         get() = secureWarningCount.underMaxCount()
 

--- a/fenix/app/src/main/res/values/preference_keys.xml
+++ b/fenix/app/src/main/res/values/preference_keys.xml
@@ -325,6 +325,7 @@
     <string name="pref_key_tab_view_grid" translatable="false">pref_key_tab_view_grid</string>
     <string name="pref_key_tabs" translatable="false">pref_key_tabs</string>
     <string name="pref_key_home" translatable="false">pref_key_home</string>
+    <string name="pref_key_close_orphan_tab_on_back" translatable="false">pref_key_close_orphan_tab_on_back</string>
     <string name="pref_key_close_tabs_manually" translatable="false">pref_key_close_tabs_manually</string>
     <string name="pref_key_close_tabs_after_one_day" translatable="false">pref_key_close_tabs_after_one_day</string>
     <string name="pref_key_close_tabs_after_one_week" translatable="false">pref_key_close_tabs_after_one_week</string>

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -841,7 +841,7 @@
     <string name="tab_view_list">List</string>
     <!-- Option for a grid tab view -->
     <string name="tab_view_grid">Grid</string>
-    <!-- Title of preference that allows a user to auto close tabs after a specified amount of time -->
+    <!-- Title of preference category for the close behavior of tabs -->
     <string name="preferences_close_tabs">Close tabs</string>
     <!-- Option for auto closing tabs that will never auto close tabs, always allows user to manually close tabs -->
     <string name="close_tabs_manually">Never</string>
@@ -853,6 +853,8 @@
     <string name="close_tabs_after_one_month">After one month</string>
     <!-- Title of preference that allows a user to specify the auto-close settings for open tabs -->
     <string name="preference_auto_close_tabs" tools:ignore="UnusedResources">Auto-close open tabs</string>
+    <!-- Option for closing the current tab with no history or parent on a back action -->
+    <string name="preference_close_orphan_tab_on_back">Back action closes tab with no history or parent</string>
 
     <!-- Opening screen -->
     <!-- Title of a preference that allows a user to choose what screen to show after opening the app -->

--- a/fenix/app/src/main/res/xml/tabs_preferences.xml
+++ b/fenix/app/src/main/res/xml/tabs_preferences.xml
@@ -44,6 +44,11 @@
             android:defaultValue="false"
             android:key="@string/pref_key_close_tabs_after_one_month"
             android:title="@string/close_tabs_after_one_month" />
+
+        <androidx.preference.SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_close_orphan_tab_on_back"
+            android:title="@string/preference_close_orphan_tab_on_back" />
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory


### PR DESCRIPTION
This is an attempt at reviving the old bug from [here](https://github.com/mozilla-mobile/fenix/issues/19888).
I think this is a great feature and should be added as it allows easier switch from other browsers.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1807067