### PR TITLE
Bug 1882170 - Disable Auto-Fill View Tests After Address Fields Were Consolidated

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui
 
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -116,6 +117,7 @@ class AddressAutofillTest : TestSetup() {
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1836840
+    @Ignore("Disabled: https://bugzilla.mozilla.org/show_bug.cgi?id=1882170")
     @Test
     fun verifyAddAddressViewTest() {
         homeScreen {
@@ -130,6 +132,7 @@ class AddressAutofillTest : TestSetup() {
     }
 
     // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/1836841
+    @Ignore("Disabled: https://bugzilla.mozilla.org/show_bug.cgi?id=1882170")
     @Test
     fun verifyEditAddressViewTest() {
         autofillScreen {


### PR DESCRIPTION
Temporarily disabling these auto-fill view tests until test assets are updated. They will then require updating the scroll gesture to keep from scrolling past the elements we are asserting exist.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1882170