### PR TITLE
Bug 1882264 - Add logs to SettingsSubMenuOpenLinksInAppsRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuOpenLinksInAppsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuOpenLinksInAppsRobot.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
@@ -11,6 +12,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.allOf
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
@@ -44,26 +46,35 @@ class SettingsSubMenuOpenLinksInAppsRobot {
         verifySelectedOpenLinksInAppOption(selectedOpenLinkInAppsOption)
     }
 
-    fun verifySelectedOpenLinksInAppOption(openLinkInAppsOption: String) =
+    fun verifySelectedOpenLinksInAppOption(openLinkInAppsOption: String) {
+        Log.i(TAG, "verifySelectedOpenLinksInAppOption: Trying to verify that the $openLinkInAppsOption option is checked")
         onView(
             allOf(
                 withId(R.id.radio_button),
                 hasSibling(withText(openLinkInAppsOption)),
             ),
         ).check(matches(isChecked(true)))
+        Log.i(TAG, "verifySelectedOpenLinksInAppOption: Verified that the $openLinkInAppsOption option is checked")
+    }
 
     fun clickOpenLinkInAppOption(openLinkInAppsOption: String) {
+        Log.i(TAG, "clickOpenLinkInAppOption: Trying to click the $openLinkInAppsOption option")
         when (openLinkInAppsOption) {
             "Always" -> alwaysOption().click()
             "Ask before opening" -> askBeforeOpeningOption().click()
             "Never" -> neverOption().click()
         }
+        Log.i(TAG, "clickOpenLinkInAppOption: Clicked the $openLinkInAppsOption option")
     }
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            Log.i(TAG, "goBack: Waiting for device to be idle")
             mDevice.waitForIdle()
+            Log.i(TAG, "goBack: Waited for device to be idle")
+            Log.i(TAG, "goBack: Trying to click the navigate up button")
             goBackButton().click()
+            Log.i(TAG, "goBack: Clicked the navigate up button")
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuOpenLinksInAppsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuOpenLinksInAppsRobot.kt
@@ -25,7 +25,7 @@ class SettingsSubMenuOpenLinksInAppsRobot {
 
     fun verifyOpenLinksInAppsView(selectedOpenLinkInAppsOption: String) {
         assertUIObjectExists(
-            goBackButton,
+            goBackButton(),
             itemContainingText(getStringResource(R.string.preferences_open_links_in_apps)),
             itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_always)),
             itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_ask)),
@@ -36,7 +36,7 @@ class SettingsSubMenuOpenLinksInAppsRobot {
 
     fun verifyPrivateOpenLinksInAppsView(selectedOpenLinkInAppsOption: String) {
         assertUIObjectExists(
-            goBackButton,
+            goBackButton(),
             itemContainingText(getStringResource(R.string.preferences_open_links_in_apps)),
             itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_ask)),
             itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_never)),
@@ -54,26 +54,26 @@ class SettingsSubMenuOpenLinksInAppsRobot {
 
     fun clickOpenLinkInAppOption(openLinkInAppsOption: String) {
         when (openLinkInAppsOption) {
-            "Always" -> alwaysOption.click()
-            "Ask before opening" -> askBeforeOpeningOption.click()
-            "Never" -> neverOption.click()
+            "Always" -> alwaysOption().click()
+            "Ask before opening" -> askBeforeOpeningOption().click()
+            "Never" -> neverOption().click()
         }
     }
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
             mDevice.waitForIdle()
-            goBackButton.click()
+            goBackButton().click()
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()
         }
     }
 }
-private val goBackButton = itemWithDescription("Navigate up")
-private val alwaysOption =
+private fun goBackButton() = itemWithDescription("Navigate up")
+private fun alwaysOption() =
     itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_always))
-private val askBeforeOpeningOption =
+private fun askBeforeOpeningOption() =
     itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_ask))
-private val neverOption =
+private fun neverOption() =
     itemContainingText(getStringResource(R.string.preferences_open_links_in_apps_never))


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1882264