### PR TITLE
Bug 1882106 - Show undo snackbar when tab is closed via tab strip

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -161,6 +161,7 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.secure
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.tabClosedUndoMessage
 import org.mozilla.fenix.home.HomeScreenViewModel
 import org.mozilla.fenix.home.SharedViewModel
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
@@ -399,23 +400,7 @@ abstract class BaseBrowserFragment :
             },
             onCloseTab = { closedSession ->
                 val closedTab = store.state.findTab(closedSession.id) ?: return@DefaultBrowserToolbarController
-
-                val snackbarMessage = if (closedTab.content.private) {
-                    requireContext().getString(R.string.snackbar_private_tab_closed)
-                } else {
-                    requireContext().getString(R.string.snackbar_tab_closed)
-                }
-
-                viewLifecycleOwner.lifecycleScope.allowUndo(
-                    binding.dynamicSnackbarContainer,
-                    snackbarMessage,
-                    requireContext().getString(R.string.snackbar_deleted_undo),
-                    {
-                        requireComponents.useCases.tabsUseCases.undo.invoke()
-                    },
-                    paddedForBottomToolbar = true,
-                    operation = { },
-                )
+                showUndoSnackbar(requireContext().tabClosedUndoMessage(closedTab.content.private))
             },
         )
         val browserToolbarMenuController = DefaultBrowserToolbarMenuController(
@@ -1015,6 +1000,19 @@ abstract class BaseBrowserFragment :
             view = view,
         )
         initializeEngineView(toolbarHeight)
+    }
+
+    protected fun showUndoSnackbar(message: String) {
+        viewLifecycleOwner.lifecycleScope.allowUndo(
+            binding.dynamicSnackbarContainer,
+            message,
+            requireContext().getString(R.string.snackbar_deleted_undo),
+            {
+                requireComponents.useCases.tabsUseCases.undo.invoke()
+            },
+            paddedForBottomToolbar = true,
+            operation = { },
+        )
     }
 
     /**

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -53,6 +53,7 @@ import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.tabClosedUndoMessage
 import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.getCookieBannerUIMode
@@ -268,12 +269,18 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                                 ),
                             )
                         },
-                        onLastTabClose = {
+                        onLastTabClose = { isPrivate ->
+                            requireComponents.appStore.dispatch(
+                                AppAction.TabStripAction.UpdateLastTabClosed(isPrivate),
+                            )
                             findNavController().navigate(
                                 BrowserFragmentDirections.actionGlobalHome(),
                             )
                         },
                         onSelectedTabClick = {},
+                        onCloseTabClick = { isPrivate ->
+                            showUndoSnackbar(requireContext().tabClosedUndoMessage(isPrivate))
+                        },
                     )
                 }
             }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -267,4 +267,16 @@ sealed class AppAction : Action {
             val key: ShoppingState.ProductRecommendationImpressionKey,
         ) : ShoppingAction()
     }
+
+    /**
+     * [AppAction]s related to the tab strip.
+     */
+    sealed class TabStripAction : AppAction() {
+
+        /**
+         * [TabStripAction] used to update whether the last remaining tab that was closed was private.
+         * Null means the state should reset and no snackbar should be shown.
+         */
+        data class UpdateLastTabClosed(val private: Boolean?) : TabStripAction()
+    }
 }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppState.kt
@@ -56,6 +56,8 @@ import org.mozilla.fenix.wallpapers.WallpaperState
  * @property wallpaperState The [WallpaperState] to display in the [HomeFragment].
  * @property standardSnackbarError A snackbar error message to display.
  * @property shoppingState Holds state for shopping feature that's required to live the lifetime of a session.
+ * @property wasLastTabClosedPrivate Whether the last remaining tab that was closed in private mode. This is used to
+ * display an undo snackbar message relevant to the browsing mode. If null, no snackbar is shown.
  */
 data class AppState(
     val isForeground: Boolean = true,
@@ -81,4 +83,5 @@ data class AppState(
     val wallpaperState: WallpaperState = WallpaperState.default,
     val standardSnackbarError: StandardSnackbarError? = null,
     val shoppingState: ShoppingState = ShoppingState(),
+    val wasLastTabClosedPrivate: Boolean? = null,
 ) : State

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -239,6 +239,10 @@ internal object AppStoreReducer {
         )
 
         is AppAction.ShoppingAction -> ShoppingStateReducer.reduce(state, action)
+
+        is AppAction.TabStripAction.UpdateLastTabClosed -> state.copy(
+            wasLastTabClosedPrivate = action.private,
+        )
     }
 }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/ext/Context.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/ext/Context.kt
@@ -17,6 +17,7 @@ import android.view.accessibility.AccessibilityManager
 import androidx.annotation.StringRes
 import mozilla.components.support.locale.LocaleManager
 import org.mozilla.fenix.FenixApplication
+import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.settings.advanced.getSelectedLocale
@@ -133,3 +134,14 @@ inline fun Context.startExternalActivitySafe(intent: Intent, onActivityNotPresen
  */
 fun Context.isSystemInDarkTheme(): Boolean =
     resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
+
+/**
+ * Returns the message to be shown when a tab is closed based on whether the tab was private or not.
+ * @param private true if the tab was private, false otherwise.
+ */
+fun Context.tabClosedUndoMessage(private: Boolean): String =
+    if (private) {
+        getString(R.string.snackbar_private_tab_closed)
+    } else {
+        getString(R.string.snackbar_tab_closed)
+    }

--- a/fenix/app/src/test/java/org/mozilla/fenix/components/appstate/TabStripActionTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/components/appstate/TabStripActionTest.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.appstate
+
+import mozilla.components.support.test.ext.joinBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mozilla.fenix.components.AppStore
+
+class TabStripActionTest {
+
+    @Test
+    fun `WHEN the last remaining tab that was closed was private THEN state should reflect that`() {
+        val store = AppStore(initialState = AppState())
+
+        store.dispatch(AppAction.TabStripAction.UpdateLastTabClosed(true)).joinBlocking()
+
+        val expected = AppState(wasLastTabClosedPrivate = true)
+
+        assertEquals(expected, store.state)
+    }
+
+    @Test
+    fun `WHEN the last remaining tab that was closed was not private THEN state should reflect that`() {
+        val store = AppStore(initialState = AppState())
+
+        store.dispatch(AppAction.TabStripAction.UpdateLastTabClosed(false)).joinBlocking()
+
+        val expected = AppState(wasLastTabClosedPrivate = false)
+
+        assertEquals(expected, store.state)
+    }
+}


### PR DESCRIPTION
Details in the bug

### How
– Extract common undo snackbar message utility
– Use that in existing places
– Add callbacks for `onCloseTab(private)` in `TabStrip`
– display snackbar using the callbacks and the utility function

There's a scenario where BrowserFragment navigates to Home when all tabs are closed. To "remember"/"know" to show the snackbar, `HomeScreenViewModel` is used as it's Activity scoped.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1882106