### PR TITLE
Bug 1882404 - Expose granted permissions on AC.

### DIFF
--- a/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
+++ b/android-components/components/browser/engine-gecko/src/main/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtension.kt
@@ -367,6 +367,8 @@ class GeckoWebExtension(
                 version = it.version,
                 permissions = it.permissions.toList(),
                 optionalPermissions = it.optionalPermissions.toList(),
+                grantedOptionalPermissions = it.grantedOptionalPermissions.toList(),
+                grantedOptionalOrigins = it.grantedOptionalOrigins.toList(),
                 optionalOrigins = it.optionalOrigins.toList(),
                 // Origins is marked as @NonNull but may be null: https://bugzilla.mozilla.org/show_bug.cgi?id=1629957
                 hostPermissions = it.origins.orEmpty().toList(),

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/GeckoWebExtensionTest.kt
@@ -416,7 +416,9 @@ class GeckoWebExtensionTest {
                 temporary = true,
                 permissions = arrayOf("p1", "p2"),
                 optionalPermissions = arrayOf("clipboardRead"),
+                grantedOptionalPermissions = arrayOf("clipboardRead"),
                 optionalOrigins = arrayOf("*://*.example.com/*", "*://opt-host-perm.example.com/*"),
+                grantedOptionalOrigins = arrayOf("*://*.example.com/*"),
                 fullDescription = "fullDescription",
                 downloadUrl = "downloadUrl",
                 reviewUrl = "reviewUrl",
@@ -432,7 +434,9 @@ class GeckoWebExtensionTest {
 
         assertEquals("1.0", metadata.version)
         assertEquals(listOf("clipboardRead"), metadata.optionalPermissions)
+        assertEquals(listOf("clipboardRead"), metadata.grantedOptionalPermissions)
         assertEquals(listOf("*://*.example.com/*", "*://opt-host-perm.example.com/*"), metadata.optionalOrigins)
+        assertEquals(listOf("*://*.example.com/*"), metadata.grantedOptionalOrigins)
         assertEquals(listOf("p1", "p2"), metadata.permissions)
         assertEquals(listOf("o1", "o2"), metadata.hostPermissions)
         assertEquals("desc", metadata.description)

--- a/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/MockWebExtension.kt
+++ b/android-components/components/browser/engine-gecko/src/test/java/mozilla/components/browser/engine/gecko/webextension/MockWebExtension.kt
@@ -33,6 +33,8 @@ fun mockNativeWebExtensionMetaData(
     icon: Image = mock(),
     permissions: Array<String> = emptyArray(),
     optionalPermissions: Array<String> = emptyArray(),
+    grantedOptionalPermissions: Array<String> = emptyArray(),
+    grantedOptionalOrigins: Array<String> = emptyArray(),
     optionalOrigins: Array<String> = emptyArray(),
     origins: Array<String> = emptyArray(),
     name: String? = null,
@@ -63,7 +65,9 @@ fun mockNativeWebExtensionMetaData(
     ReflectionUtils.setField(metadata, "icon", icon)
     ReflectionUtils.setField(metadata, "permissions", permissions)
     ReflectionUtils.setField(metadata, "optionalPermissions", optionalPermissions)
+    ReflectionUtils.setField(metadata, "grantedOptionalPermissions", grantedOptionalPermissions)
     ReflectionUtils.setField(metadata, "optionalOrigins", optionalOrigins)
+    ReflectionUtils.setField(metadata, "grantedOptionalOrigins", grantedOptionalOrigins)
     ReflectionUtils.setField(metadata, "origins", origins)
     ReflectionUtils.setField(metadata, "name", name)
     ReflectionUtils.setField(metadata, "description", description)

--- a/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
+++ b/android-components/components/concept/engine/src/main/java/mozilla/components/concept/engine/webextension/WebExtension.kt
@@ -365,11 +365,22 @@ data class Metadata(
     val optionalPermissions: List<String>,
 
     /**
+     * Optional permissions granted to this extension:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions
+     */
+    val grantedOptionalPermissions: List<String>,
+
+    /**
      * Optional origin permissions requested or granted to this extension:
      * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions
      */
     val optionalOrigins: List<String>,
 
+    /**
+     * Optional origin permissions granted to this extension:
+     * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions
+     */
+    val grantedOptionalOrigins: List<String>,
     /**
      * Required host permissions:
      * https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#Host_permissions

--- a/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
+++ b/android-components/components/feature/addons/src/main/java/mozilla/components/feature/addons/Addon.kt
@@ -61,8 +61,8 @@ data class Addon(
     val downloadUrl: String = "",
     val version: String = "",
     val permissions: List<String> = emptyList(),
-    val optionalPermissions: List<String> = emptyList(),
-    val optionalOrigins: List<String> = emptyList(),
+    val optionalPermissions: List<Permission> = emptyList(),
+    val optionalOrigins: List<Permission> = emptyList(),
     val translatableName: Map<String, String> = emptyMap(),
     val translatableDescription: Map<String, String> = emptyMap(),
     val translatableSummary: Map<String, String> = emptyMap(),
@@ -110,6 +110,19 @@ data class Addon(
     data class Rating(
         val average: Float,
         val reviews: Int,
+    ) : Parcelable
+
+    /**
+     * Required or optional permission.
+     *
+     * @property name The name of this permission.
+     * @property granted Indicate if this permission is granted or not.
+     */
+    @SuppressLint("ParcelCreator")
+    @Parcelize
+    data class Permission(
+        val name: String,
+        val granted: Boolean,
     ) : Parcelable
 
     /**
@@ -350,13 +363,29 @@ data class Addon(
                 else -> Incognito.SPANNING
             }
 
+            val grantedOptionalPermissions = metadata?.grantedOptionalPermissions ?: emptyList()
+            val grantedOptionalOrigins = metadata?.grantedOptionalOrigins ?: emptyList()
+            val optionalPermissions = metadata?.optionalPermissions?.map { permission ->
+                Permission(
+                    name = permission,
+                    granted = grantedOptionalPermissions.contains(permission),
+                )
+            } ?: emptyList()
+
+            val optionalOrigins = metadata?.optionalOrigins?.map { origin ->
+                Permission(
+                    name = origin,
+                    granted = grantedOptionalOrigins.contains(origin),
+                )
+            } ?: emptyList()
+
             return Addon(
                 id = extension.id,
                 author = author,
                 version = metadata?.version.orEmpty(),
                 permissions = permissions,
-                optionalPermissions = metadata?.optionalPermissions.orEmpty(),
-                optionalOrigins = metadata?.optionalOrigins.orEmpty(),
+                optionalPermissions = optionalPermissions,
+                optionalOrigins = optionalOrigins,
                 downloadUrl = metadata?.downloadUrl.orEmpty(),
                 rating = Rating(averageRating, reviewCount),
                 homepageUrl = homepageUrl,

--- a/android-components/components/feature/addons/src/test/java/AddonTest.kt
+++ b/android-components/components/feature/addons/src/test/java/AddonTest.kt
@@ -365,7 +365,9 @@ class AddonTest {
         whenever(metadata.version).thenReturn(version)
         whenever(metadata.permissions).thenReturn(permissions)
         whenever(metadata.optionalPermissions).thenReturn(listOf("clipboardRead"))
+        whenever(metadata.grantedOptionalPermissions).thenReturn(listOf("clipboardRead"))
         whenever(metadata.optionalOrigins).thenReturn(listOf("*://*.example.com/*", "*://opt-host-perm.example.com/*"))
+        whenever(metadata.grantedOptionalOrigins).thenReturn(listOf("*://*.example.com/*"))
         whenever(metadata.hostPermissions).thenReturn(hostPermissions)
         whenever(metadata.name).thenReturn(name)
         whenever(metadata.description).thenReturn(description)
@@ -388,8 +390,14 @@ class AddonTest {
         assertEquals("some-url", addon.homepageUrl)
         assertEquals("some-download-url", addon.downloadUrl)
         assertEquals(permissions + hostPermissions, addon.permissions)
-        assertEquals(listOf("clipboardRead"), addon.optionalPermissions)
-        assertEquals(listOf("*://*.example.com/*", "*://opt-host-perm.example.com/*"), addon.optionalOrigins)
+        assertEquals(
+            listOf(Addon.Permission(name = "clipboardRead", granted = true)),
+            addon.optionalPermissions,
+        )
+        assertEquals(
+            listOf(Addon.Permission(name = "*://*.example.com/*", granted = true), Addon.Permission(name = "*://opt-host-perm.example.com/*", granted = false)),
+            addon.optionalOrigins,
+        )
         assertEquals("", addon.updatedAt)
         assertEquals("some name", addon.translatableName[Addon.DEFAULT_LOCALE])
         assertEquals("fullDescription", addon.translatableDescription[Addon.DEFAULT_LOCALE])


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1882404