### PR TITLE
Bug 1882308 - Updated custom tab to support private mode

### DIFF
--- a/android-components/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
+++ b/android-components/components/feature/customtabs/src/test/java/mozilla/components/feature/customtabs/CustomTabsToolbarFeatureTest.kt
@@ -13,6 +13,7 @@ import android.view.Window
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.TextView
+import androidx.core.content.ContextCompat.getColor
 import androidx.core.view.forEach
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.Dispatchers
@@ -35,6 +36,7 @@ import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.tabs.CustomTabsUseCases
+import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.support.test.any
 import mozilla.components.support.test.argumentCaptor
 import mozilla.components.support.test.ext.joinBlocking
@@ -1092,6 +1094,44 @@ class CustomTabsToolbarFeatureTest {
         verify(feature).addCloseButton(toolbar.display.colors.menu, tab.config.closeButtonIcon)
         verify(feature).addActionButton(toolbar.display.colors.menu, tab.config.actionButtonConfig)
         assertEquals(Color.WHITE, toolbar.display.colors.menu)
+    }
+
+    @Test
+    fun `WHEN tab is private THEN readableColor is the default private color`() {
+        val tab = createCustomTab(
+            "https://www.mozilla.org",
+            id = "mozilla",
+            config = CustomTabConfig(showShareMenuItem = true),
+        )
+        val store = BrowserStore(
+            BrowserState(
+                customTabs = listOf(tab),
+            ),
+        )
+        val toolbar = spy(BrowserToolbar(testContext))
+        val useCases = CustomTabsUseCases(
+            store = store,
+            loadUrlUseCase = SessionUseCases(store).loadUrl,
+        )
+        val feature = spy(
+            CustomTabsToolbarFeature(
+                store = store,
+                toolbar = toolbar,
+                sessionId = "mozilla",
+                useCases = useCases,
+                menuBuilder = BrowserMenuBuilder(listOf(mock(), mock())),
+                menuItemIndex = 4,
+                updateToolbarBackground = false,
+            ) {},
+        )
+
+        feature.start()
+
+        val colorResId = testContext.theme.resolveAttribute(android.R.attr.textColorPrimary)
+        val privateColor = getColor(testContext, colorResId)
+        verify(feature).addCloseButton(privateColor, tab.config.closeButtonIcon)
+        verify(feature).addActionButton(privateColor, tab.config.actionButtonConfig)
+        verify(feature).addShareButton(privateColor)
     }
 
     @Test

--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -878,8 +878,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
 
     private fun setupTheme() {
         themeManager = createThemeManager()
-        // ExternalAppBrowserActivity handles it's own theming as it can be customized.
-        if (this !is ExternalAppBrowserActivity) {
+        // ExternalAppBrowserActivity exclusively handles it's own theming unless in private mode.
+        if (this !is ExternalAppBrowserActivity || browsingModeManager.mode.isPrivate) {
             themeManager.setActivityTheme(this)
             themeManager.applyStatusBarTheme(this)
         }

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -274,8 +274,8 @@ abstract class BaseBrowserFragment :
         _binding = FragmentBrowserBinding.inflate(inflater, container, false)
 
         val activity = activity as HomeActivity
-        // ExternalAppBrowserActivity handles it's own theming as it can be customized.
-        if (activity !is ExternalAppBrowserActivity) {
+        // ExternalAppBrowserActivity exclusively handles it's own theming unless in private mode.
+        if (activity !is ExternalAppBrowserActivity || activity.browsingModeManager.mode.isPrivate) {
             activity.themeManager.applyStatusBarTheme(activity)
         }
 
@@ -1615,8 +1615,8 @@ abstract class BaseBrowserFragment :
             activity?.exitImmersiveMode()
             (view as? SwipeGestureLayout)?.isSwipeEnabled = true
             (activity as? HomeActivity)?.let { activity ->
-                // ExternalAppBrowserActivity handles it's own theming as it can be customized.
-                if (activity !is ExternalAppBrowserActivity) {
+                // ExternalAppBrowserActivity exclusively handles it's own theming unless in private mode.
+                if (activity !is ExternalAppBrowserActivity || activity.browsingModeManager.mode.isPrivate) {
                     activity.themeManager.applyStatusBarTheme(activity)
                 }
             }


### PR DESCRIPTION
Fix non-private mode:
<img src="https://github.com/mozilla-mobile/firefox-android/assets/1833156/b494dc71-ebd2-4d21-858b-3f607d5b7719" width=300>

---

Fix private mode:
<img src="https://github.com/mozilla-mobile/firefox-android/assets/1833156/bd85b3c2-aaf7-40e7-80ce-31dcf51ae178" width=300>


🍦 for those curious, the ice cream in the article is vanilla and chocolate chips. Arguably not really a 'flavour', it's vanilla ice cream with a topping...

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.












### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1882308