### PR TITLE
Bug 1882732 - Add logs to SettingsSubMenuSitePermissionsRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsRobot.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import androidx.preference.R
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
@@ -17,6 +18,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.allOf
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.click
 
@@ -25,13 +27,20 @@ import org.mozilla.fenix.helpers.click
  */
 class SettingsSubMenuSitePermissionsRobot {
 
-    fun verifySitePermissionsToolbarTitle() =
+    fun verifySitePermissionsToolbarTitle() {
+        Log.i(TAG, "verifySitePermissionsToolbarTitle: Trying to verify that the \"Site permissions\" toolbar title is visible")
         onView(withText("Site permissions")).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifySitePermissionsToolbarTitle: Verified that the \"Site permissions\" toolbar title is visible")
+    }
 
-    fun verifyToolbarGoBackButton() =
+    fun verifyToolbarGoBackButton() {
+        Log.i(TAG, "verifyToolbarGoBackButton: Trying to verify that the navigate up toolbar button is visible")
         goBackButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifyToolbarGoBackButton: Verified that the navigate up toolbar button is visible")
+    }
 
     fun verifySitePermissionOption(option: String, summary: String = "") {
+        Log.i(TAG, "verifySitePermissionOption: Trying to verify that the $option option with $summary summary is visible")
         scrollToElementByText(option)
         onView(
             allOf(
@@ -39,11 +48,14 @@ class SettingsSubMenuSitePermissionsRobot {
                 hasSibling(withText(summary)),
             ),
         ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        Log.i(TAG, "verifySitePermissionOption: Trying to verify that the $option option with $summary summary is visible")
     }
 
     class Transition {
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            Log.i(TAG, "goBack: Trying to click navigate up toolbar button")
             goBackButton().click()
+            Log.i(TAG, "goBack: Clicked the navigate up toolbar button")
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()
@@ -52,13 +64,16 @@ class SettingsSubMenuSitePermissionsRobot {
         fun openAutoPlay(
             interact: SettingsSubMenuSitePermissionsCommonRobot.() -> Unit,
         ): SettingsSubMenuSitePermissionsCommonRobot.Transition {
+            Log.i(TAG, "openAutoPlay: Trying to perform scroll action to the \"Autoplay\" button")
             onView(withId(R.id.recycler_view)).perform(
                 RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
                     hasDescendant(withText("Autoplay")),
                 ),
             )
-
+            Log.i(TAG, "openAutoPlay: Performed scroll action to the \"Autoplay\" button")
+            Log.i(TAG, "openAutoPlay: Trying to click the \"Autoplay\" button")
             openAutoPlay().click()
+            Log.i(TAG, "openAutoPlay: Clicked the \"Autoplay\" button")
 
             SettingsSubMenuSitePermissionsCommonRobot().interact()
             return SettingsSubMenuSitePermissionsCommonRobot.Transition()
@@ -67,13 +82,16 @@ class SettingsSubMenuSitePermissionsRobot {
         fun openCamera(
             interact: SettingsSubMenuSitePermissionsCommonRobot.() -> Unit,
         ): SettingsSubMenuSitePermissionsCommonRobot.Transition {
+            Log.i(TAG, "openCamera: Trying to perform scroll action to the \"Camera\" button")
             onView(withId(R.id.recycler_view)).perform(
                 RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
                     hasDescendant(withText("Camera")),
                 ),
             )
-
+            Log.i(TAG, "openCamera: Performed scroll action to the \"Camera\" button")
+            Log.i(TAG, "openCamera: Trying to click the \"Camera\" button")
             openCamera().click()
+            Log.i(TAG, "openCamera: Clicked the \"Camera\" button")
 
             SettingsSubMenuSitePermissionsCommonRobot().interact()
             return SettingsSubMenuSitePermissionsCommonRobot.Transition()
@@ -82,13 +100,16 @@ class SettingsSubMenuSitePermissionsRobot {
         fun openLocation(
             interact: SettingsSubMenuSitePermissionsCommonRobot.() -> Unit,
         ): SettingsSubMenuSitePermissionsCommonRobot.Transition {
+            Log.i(TAG, "openLocation: Trying to perform scroll action to the \"Location\" button")
             onView(withId(R.id.recycler_view)).perform(
                 RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
                     hasDescendant(withText("Location")),
                 ),
             )
-
+            Log.i(TAG, "openLocation: Performed scroll action to the \"Location\" button")
+            Log.i(TAG, "openLocation: Trying to click the \"Location\" button")
             openLocation().click()
+            Log.i(TAG, "openLocation: Clicked the \"Location\" button")
 
             SettingsSubMenuSitePermissionsCommonRobot().interact()
             return SettingsSubMenuSitePermissionsCommonRobot.Transition()
@@ -97,13 +118,16 @@ class SettingsSubMenuSitePermissionsRobot {
         fun openMicrophone(
             interact: SettingsSubMenuSitePermissionsCommonRobot.() -> Unit,
         ): SettingsSubMenuSitePermissionsCommonRobot.Transition {
+            Log.i(TAG, "openMicrophone: Trying to perform scroll action to the \"Microphone\" button")
             onView(withId(R.id.recycler_view)).perform(
                 RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
                     hasDescendant(withText("Microphone")),
                 ),
             )
-
+            Log.i(TAG, "openMicrophone: Performed scroll action to the \"Microphone\" button")
+            Log.i(TAG, "openMicrophone: Trying to click the \"Microphone\" button")
             openMicrophone().click()
+            Log.i(TAG, "openMicrophone: Clicked the \"Microphone\" button")
 
             SettingsSubMenuSitePermissionsCommonRobot().interact()
             return SettingsSubMenuSitePermissionsCommonRobot.Transition()
@@ -112,13 +136,16 @@ class SettingsSubMenuSitePermissionsRobot {
         fun openNotification(
             interact: SettingsSubMenuSitePermissionsCommonRobot.() -> Unit,
         ): SettingsSubMenuSitePermissionsCommonRobot.Transition {
+            Log.i(TAG, "openNotification: Trying to perform scroll action to the \"Notification\" button")
             onView(withId(R.id.recycler_view)).perform(
                 RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
                     hasDescendant(withText("Notification")),
                 ),
             )
-
+            Log.i(TAG, "openNotification: Performed scroll action to the \"Notification\" button")
+            Log.i(TAG, "openNotification: Trying to click the \"Notification\" button")
             openNotification().click()
+            Log.i(TAG, "openNotification: Clicked the \"Notification\" button")
 
             SettingsSubMenuSitePermissionsCommonRobot().interact()
             return SettingsSubMenuSitePermissionsCommonRobot.Transition()
@@ -127,13 +154,16 @@ class SettingsSubMenuSitePermissionsRobot {
         fun openPersistentStorage(
             interact: SettingsSubMenuSitePermissionsCommonRobot.() -> Unit,
         ): SettingsSubMenuSitePermissionsCommonRobot.Transition {
+            Log.i(TAG, "openPersistentStorage: Trying to perform scroll action to the \"Persistent Storage\" button")
             onView(withId(R.id.recycler_view)).perform(
                 RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
                     hasDescendant(withText("Persistent Storage")),
                 ),
             )
-
+            Log.i(TAG, "openPersistentStorage: Performed scroll action to the \"Persistent Storage\" button")
+            Log.i(TAG, "openPersistentStorage: Trying to click the \"Persistent Storage\" button")
             openPersistentStorage().click()
+            Log.i(TAG, "openPersistentStorage: Clicked the \"Persistent Storage\" button")
 
             SettingsSubMenuSitePermissionsCommonRobot().interact()
             return SettingsSubMenuSitePermissionsCommonRobot.Transition()
@@ -142,13 +172,16 @@ class SettingsSubMenuSitePermissionsRobot {
         fun openDRMControlledContent(
             interact: SettingsSubMenuSitePermissionsCommonRobot.() -> Unit,
         ): SettingsSubMenuSitePermissionsCommonRobot.Transition {
+            Log.i(TAG, "openDRMControlledContent: Trying to perform scroll action to the \"DRM-controlled content\" button")
             onView(withId(R.id.recycler_view)).perform(
                 RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
                     hasDescendant(withText("DRM-controlled content")),
                 ),
             )
-
+            Log.i(TAG, "openDRMControlledContent: Performed scroll action to the \"DRM-controlled content\" button")
+            Log.i(TAG, "openDRMControlledContent: Trying to click the \"DRM-controlled content\" button")
             openDrmControlledContent().click()
+            Log.i(TAG, "openDRMControlledContent: Clicked the \"DRM-controlled content\" button")
 
             SettingsSubMenuSitePermissionsCommonRobot().interact()
             return SettingsSubMenuSitePermissionsCommonRobot.Transition()
@@ -157,13 +190,16 @@ class SettingsSubMenuSitePermissionsRobot {
         fun openExceptions(
             interact: SettingsSubMenuSitePermissionsExceptionsRobot.() -> Unit,
         ): SettingsSubMenuSitePermissionsExceptionsRobot.Transition {
+            Log.i(TAG, "openExceptions: Trying to perform scroll action to the \"Exceptions\" button")
             onView(withId(R.id.recycler_view)).perform(
                 RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
                     hasDescendant(withText("Exceptions")),
                 ),
             )
-
+            Log.i(TAG, "openExceptions: Performed scroll action to the \"Exceptions\" button")
+            Log.i(TAG, "openExceptions: Trying to click the \"Exceptions\" button")
             openExceptions().click()
+            Log.i(TAG, "openExceptions: Clicked the \"Exceptions\" button")
 
             SettingsSubMenuSitePermissionsExceptionsRobot().interact()
             return SettingsSubMenuSitePermissionsExceptionsRobot.Transition()


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1882732