### PR TITLE
Bug 1882914 - Add `iconOnColorDisabled` color token

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
@@ -140,6 +140,7 @@ private val darkColorPalette = FirefoxColors(
     iconActive = PhotonColors.Violet40,
     iconDisabled = PhotonColors.LightGrey05A40,
     iconOnColor = PhotonColors.LightGrey05,
+    iconOnColorDisabled = PhotonColors.LightGrey05A40,
     iconNotice = PhotonColors.Blue30,
     iconButton = PhotonColors.LightGrey05,
     iconWarning = PhotonColors.Red20,
@@ -214,6 +215,7 @@ private val lightColorPalette = FirefoxColors(
     iconActive = PhotonColors.Ink20,
     iconDisabled = PhotonColors.DarkGrey90A40,
     iconOnColor = PhotonColors.LightGrey05,
+    iconOnColorDisabled = PhotonColors.LightGrey05A40,
     iconNotice = PhotonColors.Blue30,
     iconButton = PhotonColors.Ink20,
     iconWarning = PhotonColors.Red70,
@@ -299,6 +301,7 @@ class FirefoxColors(
     iconActive: Color,
     iconDisabled: Color,
     iconOnColor: Color,
+    iconOnColorDisabled: Color,
     iconNotice: Color,
     iconButton: Color,
     iconWarning: Color,
@@ -531,6 +534,10 @@ class FirefoxColors(
     var iconOnColor by mutableStateOf(iconOnColor)
         private set
 
+    // Disabled icon inverted (on color)
+    var iconOnColorDisabled by mutableStateOf(iconOnColorDisabled)
+        private set
+
     // New
     var iconNotice by mutableStateOf(iconNotice)
         private set
@@ -653,6 +660,7 @@ class FirefoxColors(
         iconActive = other.iconActive
         iconDisabled = other.iconDisabled
         iconOnColor = other.iconOnColor
+        iconOnColorDisabled = other.iconOnColorDisabled
         iconNotice = other.iconNotice
         iconButton = other.iconButton
         iconWarning = other.iconWarning
@@ -730,6 +738,7 @@ class FirefoxColors(
         iconActive: Color = this.iconActive,
         iconDisabled: Color = this.iconDisabled,
         iconOnColor: Color = this.iconOnColor,
+        iconOnColorDisabled: Color = this.iconOnColorDisabled,
         iconNotice: Color = this.iconNotice,
         iconButton: Color = this.iconButton,
         iconWarning: Color = this.iconWarning,
@@ -802,6 +811,7 @@ class FirefoxColors(
         iconActive = iconActive,
         iconDisabled = iconDisabled,
         iconOnColor = iconOnColor,
+        iconOnColorDisabled = iconOnColorDisabled,
         iconNotice = iconNotice,
         iconButton = iconButton,
         iconWarning = iconWarning,


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1882914