### PR TITLE
Bug 1877277 - Translations add Check for isTranslationsEngineSupported

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -300,7 +300,15 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     }
 
     private fun initTranslationsAction(context: Context, view: View) {
-        if (!context.settings().enableTranslations) {
+        val isEngineSupported =
+            context.components.core.store.state.translationEngine.isEngineSupported
+        if (
+            !context.settings().enableTranslations &&
+            (
+                isEngineSupported == null ||
+                    isEngineSupported == false
+                )
+        ) {
             return
         }
 

--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/TranslationsBinding.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/TranslationsBinding.kt
@@ -72,13 +72,16 @@ class TranslationsBinding(
 
                 // Session Translations State Behavior (Tab)
                 val sessionTranslationsState = state.sessionState.translationsState
+
                 if (sessionTranslationsState.isTranslated) {
-                    val fromSelected = sessionTranslationsState.translationEngineState?.initialFromLanguage(
-                        translateFromLanguages,
-                    )
-                    val toSelected = sessionTranslationsState.translationEngineState?.initialToLanguage(
-                        translateToLanguages,
-                    )
+                    val fromSelected =
+                        sessionTranslationsState.translationEngineState?.initialFromLanguage(
+                            translateFromLanguages,
+                        )
+                    val toSelected =
+                        sessionTranslationsState.translationEngineState?.initialToLanguage(
+                            translateToLanguages,
+                        )
 
                     if (fromSelected != null && toSelected != null) {
                         onStateUpdated(

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -198,7 +198,7 @@ open class DefaultToolbarMenu(
      */
     @VisibleForTesting(otherwise = PRIVATE)
     fun shouldShowTranslations(): Boolean = selectedSession?.let {
-        context.settings().enableTranslations
+        context.settings().enableTranslations && store.state.translationEngine.isEngineSupported == true
     } ?: false
     // End of predicates //
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1877277