### PR TITLE
Bug 1883412 - Fxa state machine fixes

### DIFF
--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/AppServicesStateMachineChecker.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/AppServicesStateMachineChecker.kt
@@ -185,19 +185,18 @@ object AppServicesStateMachineChecker {
                 )
             }
             Event.Progress.FailedToRecoverFromAuthenticationProblem -> {
-                // `via` should always be `AuthenticationError` if not, we'll probably see a state
-                // check error down the line.
-                if (via is Event.Account.AuthenticationError) {
-                    if (via.errorCountWithinTheTimeWindow >= AUTH_CHECK_CIRCUIT_BREAKER_COUNT) {
-                        // In this case, the state machine fails early and doesn't actualy make any
-                        // calls
-                        return
-                    }
-                    AppServicesStateMachineChecker.checkInternalState(FxaStateCheckerState.CheckAuthorizationStatus)
-                    AppServicesStateMachineChecker.handleInternalEvent(
-                        FxaStateCheckerEvent.CheckAuthorizationStatusSuccess(false),
-                    )
+                if (via is Event.Account.AuthenticationError &&
+                    via.errorCountWithinTheTimeWindow >= AUTH_CHECK_CIRCUIT_BREAKER_COUNT
+                ) {
+                    // In this case, the state machine fails early and doesn't actualy make any
+                    // calls
+                    return
                 }
+
+                AppServicesStateMachineChecker.checkInternalState(FxaStateCheckerState.CheckAuthorizationStatus)
+                AppServicesStateMachineChecker.handleInternalEvent(
+                    FxaStateCheckerEvent.CheckAuthorizationStatusSuccess(false),
+                )
             }
             else -> Unit
         }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1883412 for details.

- Don't assume that all `Event.Progress.FailedToRecoverFromAuthenticationProblem` events come from `AuthenticationError`
- Updated who sends events to the state machine checker in the case of `finalizeDevice`:
   - `finalizeDevice` now sends the event in the case of succesfull calls and auth errors.
   - `FxaAccountManager` now sends the event in the case of other errors.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1883412