### PR TITLE
Bug 1883870 - Improve test logs in bookmarks and downloads storage deletion in UI test

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestSetup.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/helpers/TestSetup.kt
@@ -72,9 +72,6 @@ open class TestSetup {
     open fun tearDown() {
         Log.i(TAG, "TestSetup: Starting the @After tearDown methods.")
         runBlocking {
-            // Check and clear the downloads folder.
-            AppAndSystemHelper.clearDownloadsFolder()
-
             // Reset locale to EN-US if needed.
             // This method is only here temporarily, to set the language before a new activity is started.
             // TODO: When https://bugzilla.mozilla.org/show_bug.cgi?id=1812183 is fixed, it should be removed.


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1883870