### PR TITLE
Bug 1883418 - Translate icon is should be visible on Private Browsing Mode

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -316,10 +316,9 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             AppCompatResources.getDrawable(
                 context,
                 R.drawable.mozac_ic_translate_24,
-            )!!.apply {
-                setTint(ContextCompat.getColor(context, R.color.fx_mobile_text_color_primary))
-            },
+            ),
             contentDescription = context.getString(R.string.browser_toolbar_translate),
+            iconTintColorResource = ThemeManager.resolveAttribute(R.attr.textPrimary, context),
             visible = { translationsAvailable },
             listener = {
                 browserToolbarInteractor.onTranslationsButtonClicked()
@@ -339,7 +338,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                             tintColorResource = if (isTranslated) {
                                 R.color.fx_mobile_icon_color_accent_violet
                             } else {
-                                R.color.fx_mobile_text_color_primary
+                                ThemeManager.resolveAttribute(R.attr.textPrimary, context)
                             },
                             contentDescription = if (isTranslated) {
                                 context.getString(


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1883418