### PR TITLE
Bug 1884154 - Remove openInApp Button Reference from UI Tests

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PDFViewerTest.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/PDFViewerTest.kt
@@ -13,7 +13,6 @@ import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_DOCS
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
-import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithText
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestSetup
@@ -42,20 +41,6 @@ class PDFViewerTest : TestSetup() {
             clickPageObject(itemContainingText("PDF form file"))
             verifyPageContent("Washington Crossing the Delaware")
             verifyTabCounter("1")
-        }
-    }
-
-    // TestRail link: https://testrail.stage.mozaws.net/index.php?/cases/view/2159718
-    @Test
-    fun verifyPDFViewerOpenInAppButtonTest() {
-        val genericURL = getGenericAsset(mockWebServer, 3)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-            clickPageObject(itemWithText("PDF form file"))
-            verifyPDFReaderToolbarItems()
-            clickPageObject(itemWithResIdAndText("openInApp", "Open in app"))
-            assertExternalAppOpens(GOOGLE_DOCS)
         }
     }
 

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -278,8 +278,8 @@ class BrowserRobot {
     fun verifyPDFReaderToolbarItems() =
         assertUIObjectExists(
             itemWithResIdContainingText("download", "Download"),
-            itemWithResIdContainingText("openInApp", "Open in app"),
         )
+
     fun clickSubmitLoginButton() {
         clickPageObject(itemWithResId("submit"))
         assertUIObjectIsGone(itemWithResId("submit"))

--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
@@ -150,7 +150,6 @@ class CustomTabRobot {
     fun verifyPDFReaderToolbarItems() =
         assertUIObjectExists(
             itemWithResIdAndText("download", "Download"),
-            itemWithResIdAndText("openInApp", "Open in app"),
         )
 
     class Transition {


### PR DESCRIPTION
The `openInApp` button was removed from the PDFViewer context and the tests need to have reference to that element removed.

There is one test for that element that needs to be deleted and 2 references in other Robots that need updated.

Changes:

* Deleting `verifyPDFViewerOpenInAppButtonTest`
* Removing unused import for `itemWithResIdAndText` in `PDFViewerTest.kt`
* Deleting element reference in `verifyPDFReaderToolbarItems` from `BrowserRobot.kt`
* Deleting element reference in `verifyPDFReaderToolbarItems` from `CustomTabRobot.kt`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1884154