### PR TITLE
Bug 1879332 - ensure synced tabs includes the inactive property

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/state/TabSessionState.kt
@@ -139,3 +139,12 @@ fun createTab(
         historyMetadata = historyMetadata,
     )
 }
+
+/**
+ * Indicates if the specified tab should be considered "inactive"
+ */
+fun TabSessionState.isActive(maxActiveTime: Long): Boolean {
+    val lastActiveTime = maxOf(lastAccess, createdAt)
+    val now = System.currentTimeMillis()
+    return (now - lastActiveTime <= maxActiveTime)
+}

--- a/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
+++ b/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/RemoteTabsStorage.kt
@@ -48,7 +48,7 @@ open class RemoteTabsStorage(
                     tabs.map {
                         val activeTab = it.active()
                         val urlHistory = listOf(activeTab.url) + it.previous().reversed().map { it.url }
-                        RemoteTab(activeTab.title, urlHistory, activeTab.iconUrl, it.lastUsed)
+                        RemoteTab(activeTab.title, urlHistory, activeTab.iconUrl, it.lastUsed, it.inactive)
                     },
                 )
             } catch (e: RemoteTabProviderException) {
@@ -71,7 +71,7 @@ open class RemoteTabsStorage(
                         val icon = tab.icon
                         val lastUsed = tab.lastUsed
                         val history = tab.urlHistory.reversed().map { url -> TabEntry(title, url, icon) }
-                        Tab(history, tab.urlHistory.lastIndex, lastUsed)
+                        Tab(history, tab.urlHistory.lastIndex, lastUsed, tab.inactive)
                     }
                     // Map device to tabs
                     SyncClient(device.clientId) to tabs
@@ -109,6 +109,7 @@ data class Tab(
     val history: List<TabEntry>,
     val active: Int,
     val lastUsed: Long,
+    val inactive: Boolean,
 ) {
     /**
      * The current active tab entry. In other words, this is the page that's currently shown for a

--- a/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/RemoteTabsStorageTest.kt
+++ b/android-components/components/browser/storage-sync/src/test/java/mozilla/components/browser/storage/sync/RemoteTabsStorageTest.kt
@@ -57,6 +57,7 @@ class RemoteTabsStorageTest {
                     ),
                     0,
                     1574458165555,
+                    false,
                 ),
                 Tab(
                     listOf(
@@ -66,6 +67,7 @@ class RemoteTabsStorageTest {
                     ),
                     2,
                     0,
+                    false,
                 ),
                 Tab(
                     listOf(
@@ -75,6 +77,7 @@ class RemoteTabsStorageTest {
                     ),
                     1,
                     1574457405635,
+                    false,
                 ),
             ),
         )
@@ -125,6 +128,7 @@ class RemoteTabsStorageTest {
                         ),
                         2,
                         1574457405635,
+                        false,
                     ),
                 ),
                 SyncClient("client2") to listOf(
@@ -134,6 +138,7 @@ class RemoteTabsStorageTest {
                         ),
                         0,
                         1574458165555,
+                        false,
                     ),
                     Tab(
                         listOf(
@@ -141,6 +146,7 @@ class RemoteTabsStorageTest {
                         ),
                         0,
                         0,
+                        false,
                     ),
                 ),
             ),

--- a/android-components/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorage.kt
+++ b/android-components/components/feature/syncedtabs/src/main/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorage.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.map
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.isActive
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.sync.RemoteTabsStorage
 import mozilla.components.browser.storage.sync.SyncedDeviceTabs
@@ -38,6 +39,7 @@ class SyncedTabsStorage(
     private val accountManager: FxaAccountManager,
     private val store: BrowserStore,
     private val tabsStorage: RemoteTabsStorage,
+    private val maxActiveTime: Long,
     private val debounceMillis: Long = 1000L,
 ) : SyncedTabsProvider {
     private var scope: CoroutineScope? = null
@@ -53,9 +55,8 @@ class SyncedTabsStorage(
                     // TO-DO: https://github.com/mozilla-mobile/android-components/issues/5179
                     val iconUrl = null
                     state.tabs.filter { !it.content.private && !it.content.loading }.map { tab ->
-                        // TO-DO: https://github.com/mozilla-mobile/android-components/issues/1340
                         val history = listOf(TabEntry(tab.content.title, tab.content.url, iconUrl))
-                        Tab(history, 0, tab.lastAccess)
+                        Tab(history, 0, tab.lastAccess, !tab.isActive(maxActiveTime))
                     }
                 }
                 .debounce(debounceMillis)

--- a/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/helper/SyncedTabsProvider.kt
+++ b/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/helper/SyncedTabsProvider.kt
@@ -34,6 +34,7 @@ internal fun getDevice1Tabs() = SyncedDeviceTabs(
             ),
             0,
             1,
+            false,
         ),
         Tab(
             listOf(
@@ -41,6 +42,7 @@ internal fun getDevice1Tabs() = SyncedDeviceTabs(
             ),
             0,
             5,
+            false,
         ),
         Tab(
             listOf(
@@ -48,6 +50,7 @@ internal fun getDevice1Tabs() = SyncedDeviceTabs(
             ),
             0,
             2,
+            false,
         ),
     ),
 )
@@ -74,6 +77,7 @@ internal fun getDevice2Tabs() = SyncedDeviceTabs(
             ),
             1,
             1,
+            false,
         ),
     ),
 )

--- a/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
+++ b/android-components/components/feature/syncedtabs/src/test/java/mozilla/components/feature/syncedtabs/storage/SyncedTabsStorageTest.kt
@@ -72,6 +72,7 @@ class SyncedTabsStorageTest {
             accountManager,
             store,
             tabsStorage,
+            0,
             debounceMillis = 0,
         )
         feature.start()
@@ -81,8 +82,8 @@ class SyncedTabsStorageTest {
 
         verify(tabsStorage, times(2)).store(
             listOf(
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L),
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L, true),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L, true),
                 // Private tab is absent.
             ),
         )
@@ -99,6 +100,7 @@ class SyncedTabsStorageTest {
             accountManager,
             store,
             tabsStorage,
+            0,
             debounceMillis = 0,
         )
         feature.start()
@@ -107,8 +109,8 @@ class SyncedTabsStorageTest {
 
         verify(tabsStorage, times(2)).store(
             listOf(
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L),
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L, true),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L, true),
             ),
         )
 
@@ -126,6 +128,7 @@ class SyncedTabsStorageTest {
                 accountManager,
                 store,
                 tabsStorage,
+                0,
             ),
         )
         val device1 = Device(
@@ -149,13 +152,13 @@ class SyncedTabsStorageTest {
             subscription = null,
         )
         doReturn(listOf(device1, device2)).`when`(feature).syncClients()
-        val tabsClient1 = listOf(Tab(listOf(TabEntry("Foo", "https://foo.bar", null)), 0, 0))
-        val tabsClient2 = listOf(Tab(listOf(TabEntry("Foo", "https://foo.bar", null)), 0, 0))
+        val tabsClient1 = listOf(Tab(listOf(TabEntry("Foo", "https://foo.bar", null)), 0, 0, true))
+        val tabsClient2 = listOf(Tab(listOf(TabEntry("Foo", "https://foo.bar", null)), 0, 0, true))
         whenever(tabsStorage.getAll()).thenReturn(
             mapOf(
                 SyncClient("client1") to tabsClient1,
                 SyncClient("client2") to tabsClient2,
-                SyncClient("client-unknown") to listOf(Tab(listOf(TabEntry("Foo", "https://foo.bar", null)), 0, 0)),
+                SyncClient("client-unknown") to listOf(Tab(listOf(TabEntry("Foo", "https://foo.bar", null)), 0, 0, true)),
             ),
         )
 
@@ -173,6 +176,7 @@ class SyncedTabsStorageTest {
                 accountManager,
                 store,
                 tabsStorage,
+                0,
             ),
         )
         doReturn(null).`when`(feature).syncClients()
@@ -186,6 +190,7 @@ class SyncedTabsStorageTest {
                 accountManager,
                 store,
                 tabsStorage,
+                0,
             ),
         )
         val account: OAuthAccount = mock()
@@ -217,6 +222,7 @@ class SyncedTabsStorageTest {
                 accountManager,
                 store,
                 tabsStorage,
+                0,
             ),
         )
         val account: OAuthAccount = mock()
@@ -234,6 +240,7 @@ class SyncedTabsStorageTest {
                 accountManager,
                 store,
                 tabsStorage,
+                0,
             ),
         )
         whenever(accountManager.authenticatedAccount()).thenReturn(null)
@@ -256,6 +263,7 @@ class SyncedTabsStorageTest {
                 accountManager,
                 store,
                 tabsStorage,
+                0,
                 debounceMillis = 0,
             ),
         )
@@ -264,8 +272,8 @@ class SyncedTabsStorageTest {
         // Tabs are only stored when initial state is collected, since they are already loaded
         verify(tabsStorage, times(1)).store(
             listOf(
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L),
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L, true),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L, true),
             ),
         )
 
@@ -293,6 +301,7 @@ class SyncedTabsStorageTest {
                 accountManager,
                 store,
                 tabsStorage,
+                0,
                 debounceMillis = 0,
             ),
         )
@@ -302,7 +311,7 @@ class SyncedTabsStorageTest {
 
         verify(tabsStorage).store(
             listOf(
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L, true),
             ),
         )
     }
@@ -323,6 +332,7 @@ class SyncedTabsStorageTest {
                 accountManager,
                 store,
                 tabsStorage,
+                System.currentTimeMillis() * 2,
                 debounceMillis = 0,
             ),
         )
@@ -332,8 +342,8 @@ class SyncedTabsStorageTest {
 
         verify(tabsStorage, times(2)).store(
             listOf(
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L),
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L, false),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L, false),
             ),
         )
     }
@@ -354,6 +364,7 @@ class SyncedTabsStorageTest {
                 accountManager,
                 store,
                 tabsStorage,
+                0,
                 debounceMillis = 0,
             ),
         )
@@ -363,14 +374,14 @@ class SyncedTabsStorageTest {
 
         verify(tabsStorage, times(1)).store(
             listOf(
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L),
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 123L, true),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L, true),
             ),
         )
         verify(tabsStorage, times(1)).store(
             listOf(
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 300L),
-                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.mozilla.org", iconUrl = null)), active = 0, lastUsed = 300L, true),
+                Tab(history = listOf(TabEntry(title = "", url = "https://www.foo.bar", iconUrl = null)), active = 0, lastUsed = 124L, true),
             ),
         )
     }

--- a/fenix/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -43,6 +43,7 @@ import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.SyncAuth
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.maxActiveTime
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.perf.StrictModeManager
 import org.mozilla.fenix.perf.lazyMonitored
@@ -143,7 +144,7 @@ class BackgroundServices(
     }
 
     val syncedTabsStorage by lazyMonitored {
-        SyncedTabsStorage(accountManager, context.components.core.store, remoteTabsStorage.value)
+        SyncedTabsStorage(accountManager, context.components.core.store, remoteTabsStorage.value, maxActiveTime)
     }
     val syncedTabsAutocompleteProvider by lazyMonitored {
         SyncedTabsAutocompleteProvider(syncedTabsStorage)

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/TabsTray.kt
@@ -615,5 +615,6 @@ private fun generateFakeSyncedTab(tabName: String, tabUrl: String): SyncedTabsLi
             history = listOf(TabEntry(tabName, tabUrl, null)),
             active = 0,
             lastUsed = 0L,
+            inactive = false,
         ),
     )

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabSorter.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabSorter.kt
@@ -6,12 +6,12 @@ package org.mozilla.fenix.tabstray.browser
 
 import mozilla.components.browser.state.state.TabPartition
 import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.isActive
 import mozilla.components.browser.tabstray.TabsTray
 import mozilla.components.feature.tabs.tabstray.TabsFeature
 import org.mozilla.fenix.ext.maxActiveTime
 import org.mozilla.fenix.tabstray.TabsTrayAction
 import org.mozilla.fenix.tabstray.TabsTrayStore
-import org.mozilla.fenix.tabstray.ext.isActive
 import org.mozilla.fenix.utils.Settings
 
 /**

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabSessionState.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabSessionState.kt
@@ -5,13 +5,8 @@
 package org.mozilla.fenix.tabstray.ext
 
 import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.isActive
 import mozilla.components.support.ktx.kotlin.trimmed
-
-fun TabSessionState.isActive(maxActiveTime: Long): Boolean {
-    val lastActiveTime = maxOf(lastAccess, createdAt)
-    val now = System.currentTimeMillis()
-    return (now - lastActiveTime <= maxActiveTime)
-}
 
 /**
  * Returns true if the [TabSessionState] has a search term.

--- a/fenix/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
@@ -309,5 +309,6 @@ private fun generateFakeTab(tabName: String, tabUrl: String): SyncedTabsListItem
             history = listOf(TabEntry(tabName, tabUrl, null)),
             active = 0,
             lastUsed = 0L,
+            inactive = false,
         ),
     )

--- a/fenix/app/src/test/java/org/mozilla/fenix/sync/ext/SyncedDeviceTabsTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/sync/ext/SyncedDeviceTabsTest.kt
@@ -43,6 +43,7 @@ class SyncedDeviceTabsTest {
                 ),
                 active = 0,
                 lastUsed = 0L,
+                inactive = false,
             ),
         ),
     )
@@ -64,6 +65,7 @@ class SyncedDeviceTabsTest {
                 ),
                 active = 0,
                 lastUsed = 0L,
+                inactive = false,
             ),
             Tab(
                 history = listOf(
@@ -75,6 +77,7 @@ class SyncedDeviceTabsTest {
                 ),
                 active = 0,
                 lastUsed = 0L,
+                inactive = false,
             ),
         ),
     )


### PR DESCRIPTION
This approach seems like a reasonable first step and we can do further cleanups in followups.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1879332