### PR TITLE
Bug 1884329 - Add logs to TabDrawerRobot

### DIFF
--- a/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -28,7 +28,6 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.By.text
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
-import androidx.test.uiautomator.Until
 import androidx.test.uiautomator.Until.findObject
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import org.hamcrest.CoreMatchers.allOf
@@ -38,6 +37,7 @@ import org.hamcrest.Matcher
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
+import org.mozilla.fenix.helpers.Constants.TAG
 import org.mozilla.fenix.helpers.DataGenerationHelper.getStringResource
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectExists
 import org.mozilla.fenix.helpers.MatcherHelper.assertUIObjectIsGone
@@ -65,14 +65,29 @@ import org.mozilla.fenix.helpers.matchers.BottomSheetBehaviorStateMatcher
  */
 class TabDrawerRobot {
 
-    fun verifyNormalBrowsingButtonIsSelected(isSelected: Boolean) = normalBrowsingButton().check(matches(isSelected(isSelected)))
+    fun verifyNormalBrowsingButtonIsSelected(isSelected: Boolean) {
+        Log.i(TAG, "verifyNormalBrowsingButtonIsSelected: Trying to verify that the normal browsing button is selected: $isSelected")
+        normalBrowsingButton().check(matches(isSelected(isSelected)))
+        Log.i(TAG, "verifyNormalBrowsingButtonIsSelected: Verified that the normal browsing button is selected: $isSelected")
+    }
 
-    fun verifyPrivateBrowsingButtonIsSelected(isSelected: Boolean) = privateBrowsingButton().check(matches(isSelected(isSelected)))
+    fun verifyPrivateBrowsingButtonIsSelected(isSelected: Boolean) {
+        Log.i(TAG, "verifyPrivateBrowsingButtonIsSelected: Trying to verify that the private browsing button is selected: $isSelected")
+        privateBrowsingButton().check(matches(isSelected(isSelected)))
+        Log.i(TAG, "verifyPrivateBrowsingButtonIsSelected: Verified that the private browsing button is selected: $isSelected")
+    }
 
-    fun verifySyncedTabsButtonIsSelected(isSelected: Boolean) =
+    fun verifySyncedTabsButtonIsSelected(isSelected: Boolean) {
+        Log.i(TAG, "verifySyncedTabsButtonIsSelected: Trying to verify that the synced tabs button is selected: $isSelected")
         syncedTabsButton().check(matches(isSelected(isSelected)))
+        Log.i(TAG, "verifySyncedTabsButtonIsSelected: Verified that the synced tabs button is selected: $isSelected")
+    }
 
-    fun clickSyncedTabsButton() = syncedTabsButton().click()
+    fun clickSyncedTabsButton() {
+        Log.i(TAG, "clickSyncedTabsButton: Trying to click the synced tabs button")
+        syncedTabsButton().click()
+        Log.i(TAG, "clickSyncedTabsButton: Clicked the synced tabs button")
+    }
 
     fun verifyExistingOpenTabs(vararg tabTitles: String) {
         var retries = 0
@@ -87,6 +102,7 @@ class TabDrawerRobot {
     }
 
     fun verifyOpenTabsOrder(position: Int, title: String) {
+        Log.i(TAG, "verifyOpenTabsOrder: Trying to verify that the open tab at position: $position has title: $title")
         mDevice.findObject(
             UiSelector()
                 .resourceId("$packageName:id/tab_item")
@@ -98,6 +114,7 @@ class TabDrawerRobot {
                 .resourceId("$packageName:id/tab_tray_grid_item")
                 .index(position - 1),
         )
+        Log.i(TAG, "verifyOpenTabsOrder: Verified that the open tab at position: $position has title: $title")
     }
     fun verifyNoExistingOpenTabs(vararg tabTitles: String) {
         for (title in tabTitles) {
@@ -108,93 +125,165 @@ class TabDrawerRobot {
         assertUIObjectExists(itemWithDescription("Close tab").getFromParent(UiSelector().textContains(title)))
 
     fun verifyExistingTabList() {
+        Log.i(TAG, "verifyExistingTabList: Waiting for $waitingTime ms for tab tray to exist")
         mDevice.findObject(
             UiSelector().resourceId("$packageName:id/tabsTray"),
         ).waitForExists(waitingTime)
+        Log.i(TAG, "verifyExistingTabList: Waited for $waitingTime ms for tab tray to exist")
         assertUIObjectExists(itemWithResId("$packageName:id/tray_list_item"))
     }
 
-    fun verifyNoOpenTabsInNormalBrowsing() =
+    fun verifyNoOpenTabsInNormalBrowsing() {
+        Log.i(TAG, "verifyNoOpenTabsInNormalBrowsing: Trying to verify that the empty normal tabs list is visible")
         onView(
             allOf(
                 withId(R.id.tab_tray_empty_view),
                 withText(R.string.no_open_tabs_description),
             ),
         ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyNoOpenTabsInNormalBrowsing: Verified that the empty normal tabs list is visible")
+    }
 
-    fun verifyNoOpenTabsInPrivateBrowsing() =
+    fun verifyNoOpenTabsInPrivateBrowsing() {
+        Log.i(TAG, "verifyNoOpenTabsInPrivateBrowsing: Trying to verify that the empty private tabs list is visible")
         onView(
             allOf(
                 withId(R.id.tab_tray_empty_view),
                 withText(R.string.no_private_tabs_description),
             ),
         ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyNoOpenTabsInPrivateBrowsing: Verified that the empty private tabs list is visible")
+    }
 
-    fun verifyPrivateModeSelected() = privateBrowsingButton().check(matches(ViewMatchers.isSelected()))
+    fun verifyPrivateModeSelected() {
+        Log.i(TAG, "verifyPrivateModeSelected: Trying to verify that the private browsing button is selected")
+        privateBrowsingButton().check(matches(ViewMatchers.isSelected()))
+        Log.i(TAG, "verifyPrivateModeSelected: Verified that the private browsing button is selected")
+    }
 
-    fun verifyNormalModeSelected() = normalBrowsingButton().check(matches(ViewMatchers.isSelected()))
+    fun verifyNormalModeSelected() {
+        Log.i(TAG, "verifyNormalModeSelected: Trying to verify that the normal browsing button is selected")
+        normalBrowsingButton().check(matches(ViewMatchers.isSelected()))
+        Log.i(TAG, "verifyNormalModeSelected: Verified that the normal browsing button is selected")
+    }
 
-    fun verifyNormalBrowsingNewTabButton() =
+    fun verifyNormalBrowsingNewTabButton() {
+        Log.i(TAG, "verifyNormalBrowsingNewTabButton: Trying to verify that the new tab FAB button is visible")
         onView(
             allOf(
                 withId(R.id.new_tab_button),
                 withContentDescription(R.string.add_tab),
             ),
         ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    fun verifyPrivateBrowsingNewTabButton() =
+        Log.i(TAG, "verifyNormalBrowsingNewTabButton: Verified that the new tab FAB button is visible")
+    }
+
+    fun verifyPrivateBrowsingNewTabButton() {
+        Log.i(TAG, "verifyPrivateBrowsingNewTabButton: Trying to verify that the new private tab FAB button is visible")
         onView(
             allOf(
                 withId(R.id.new_tab_button),
                 withContentDescription(R.string.add_private_tab),
             ),
         ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyPrivateBrowsingNewTabButton: Verified that the new private tab FAB button is visible")
+    }
 
     fun verifyEmptyTabsTrayMenuButtons() {
+        Log.i(TAG, "verifyEmptyTabsTrayMenuButtons: Trying to click the three dot button")
         threeDotMenu().click()
+        Log.i(TAG, "verifyEmptyTabsTrayMenuButtons: Clicked the three dot button")
+        Log.i(TAG, "verifyEmptyTabsTrayMenuButtons: Trying to verify that the \"Tab settings\" menu button is visible")
         tabsSettingsButton()
             .inRoot(RootMatchers.isPlatformPopup())
             .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyEmptyTabsTrayMenuButtons: Verified that the \"Tab settings\" menu button is visible")
+        Log.i(TAG, "verifyEmptyTabsTrayMenuButtons: Trying to verify that the \"Recently closed tabs\" menu button is visible")
         recentlyClosedTabsButton()
             .inRoot(RootMatchers.isPlatformPopup())
             .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyEmptyTabsTrayMenuButtons: Verified that the \"Recently closed tabs\" menu button exists")
     }
 
-    fun verifyTabTrayOverflowMenu(visibility: Boolean) =
-        onView(withId(R.id.tab_tray_overflow)).check(matches(withEffectiveVisibility(visibleOrGone(visibility))))
-    fun verifyTabsTrayCounter() = tabsTrayCounterBox().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    fun verifyTabTrayOverflowMenu(visibility: Boolean) {
+        Log.i(TAG, "verifyTabTrayOverflowMenu: Trying to verify that the three dot menu is visible: $visibility")
+        onView(withId(R.id.tab_tray_overflow)).check(
+            matches(
+                withEffectiveVisibility(
+                    visibleOrGone(
+                        visibility,
+                    ),
+                ),
+            ),
+        )
+        Log.i(TAG, "verifyTabTrayOverflowMenu: Verified that the three dot menu is visible: $visibility")
+    }
+    fun verifyTabsTrayCounter() {
+        Log.i(TAG, "verifyTabsTrayCounter: Trying to verify that the tabs list counter is visible")
+        tabsTrayCounterBox().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyTabsTrayCounter: Verified that the tabs list counter is visible")
+    }
 
-    fun verifyTabTrayIsOpened() = onView(withId(R.id.tab_wrapper)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    fun verifyTabTrayIsClosed() = onView(withId(R.id.tab_wrapper)).check(doesNotExist())
-    fun verifyHalfExpandedRatio() =
-        onView(withId(R.id.tab_wrapper)).check(matches(BottomSheetBehaviorHalfExpandedMaxRatioMatcher(0.001f)))
-    fun verifyBehaviorState(expectedState: Int) =
+    fun verifyTabTrayIsOpened() {
+        Log.i(TAG, "verifyTabTrayIsOpened: Trying to verify that the tabs tray is visible")
+        onView(withId(R.id.tab_wrapper)).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        Log.i(TAG, "verifyTabTrayIsOpened: Verified that the tabs tray is visible")
+    }
+    fun verifyTabTrayIsClosed() {
+        Log.i(TAG, "verifyTabTrayIsClosed: Trying to verify that the tabs tray does not exist")
+        onView(withId(R.id.tab_wrapper)).check(doesNotExist())
+        Log.i(TAG, "verifyTabTrayIsClosed: Verified that the tabs tray does not exist")
+    }
+    fun verifyHalfExpandedRatio() {
+        Log.i(TAG, "verifyHalfExpandedRatio: Trying to verify the tabs tray half expanded ratio")
+        onView(withId(R.id.tab_wrapper)).check(
+            matches(
+                BottomSheetBehaviorHalfExpandedMaxRatioMatcher(0.001f),
+            ),
+        )
+        Log.i(TAG, "verifyHalfExpandedRatio: Verified the tabs tray half expanded ratio")
+    }
+    fun verifyBehaviorState(expectedState: Int) {
+        Log.i(TAG, "verifyBehaviorState: Trying to verify that the tabs tray state matches: $expectedState")
         onView(withId(R.id.tab_wrapper)).check(matches(BottomSheetBehaviorStateMatcher(expectedState)))
+        Log.i(TAG, "verifyBehaviorState: Verified that the tabs tray state matches: $expectedState")
+    }
     fun verifyOpenedTabThumbnail() =
         assertUIObjectExists(itemWithResId("$packageName:id/mozac_browser_tabstray_thumbnail"))
 
     fun closeTab() {
+        Log.i(TAG, "closeTab: Waiting for $waitingTime ms for the close tab button to exist")
         closeTabButton().waitForExists(waitingTime)
+        Log.i(TAG, "closeTab: Waited for $waitingTime ms for the close tab button to exist")
 
         var retries = 0 // number of retries before failing, will stop at 2
         do {
+            Log.i(TAG, "closeTab: Trying to click the close tab button")
             closeTabButton().click()
-            Log.i("MozTestLog", "Clicked the close tab button in tabs tray. Retry #$retries")
+            Log.i(TAG, "closeTab: Clicked the close tab button")
             retries++
         } while (closeTabButton().exists() && retries < 3)
     }
 
-    fun closeTabWithTitle(title: String) =
+    fun closeTabWithTitle(title: String) {
         itemWithResIdAndDescription(
             "$packageName:id/mozac_browser_tabstray_close",
             "Close tab $title",
         ).also {
+            Log.i(TAG, "closeTabWithTitle: Waiting for $waitingTime ms for the close button for tab with title: $title to exist")
             it.waitForExists(waitingTime)
+            Log.i(TAG, "closeTabWithTitle: Waited for $waitingTime ms for the close button for tab with title: $title to exist")
+            Log.i(TAG, "closeTabWithTitle: Trying to click the close button for tab with title: $title")
             it.click()
+            Log.i(TAG, "closeTabWithTitle: Clicked the close button for tab with title: $title")
         }
+    }
 
     fun swipeTabRight(title: String) {
         for (i in 1..RETRY_COUNT) {
+            Log.i(TAG, "swipeTabRight: Started try #$i")
             try {
+                Log.i(TAG, "swipeTabRight: Trying to perform swipe right action on tab: $title")
                 onView(
                     allOf(
                         withId(R.id.tab_item),
@@ -206,7 +295,7 @@ class TabDrawerRobot {
                         ),
                     ),
                 ).perform(swipeRight())
-                Log.i("MozTestLog", "Tab $title swiped right from tabs tray. Retry # $i")
+                Log.i(TAG, "swipeTabRight: Performed swipe right action on tab: $title")
                 assertUIObjectIsGone(
                     itemWithResIdContainingText(
                         "$packageName:id/mozac_browser_tabstray_title",
@@ -216,6 +305,7 @@ class TabDrawerRobot {
 
                 break
             } catch (e: AssertionError) {
+                Log.i(TAG, "swipeTabRight: AssertionError caught, executing fallback methods")
                 if (i == RETRY_COUNT) {
                     throw e
                 }
@@ -226,6 +316,7 @@ class TabDrawerRobot {
     fun swipeTabLeft(title: String) {
         for (i in 1..RETRY_COUNT) {
             try {
+                Log.i(TAG, "swipeTabLeft: Trying to perform swipe left action on tab: $title")
                 onView(
                     allOf(
                         withId(R.id.tab_item),
@@ -237,7 +328,7 @@ class TabDrawerRobot {
                         ),
                     ),
                 ).perform(swipeLeft())
-                Log.i("MozTestLog", "Tab $title swiped left from tabs tray. Retry # $i")
+                Log.i(TAG, "swipeTabLeft: Performed swipe left action on tab: $title")
                 assertUIObjectIsGone(
                     itemWithResIdContainingText(
                         "$packageName:id/mozac_browser_tabstray_title",
@@ -247,6 +338,7 @@ class TabDrawerRobot {
 
                 break
             } catch (e: AssertionError) {
+                Log.i(TAG, "swipeTabLeft: AssertionError caught, executing fallback methods")
                 if (i == RETRY_COUNT) {
                     throw e
                 }
@@ -255,32 +347,45 @@ class TabDrawerRobot {
     }
 
     fun snackBarButtonClick(expectedText: String) {
-        val snackBarButton =
-            mDevice.findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/snackbar_btn")
-                    .text(expectedText),
-            )
-
-        snackBarButton.waitForExists(waitingTime)
-        snackBarButton.click()
+        mDevice.findObject(
+            UiSelector()
+                .resourceId("$packageName:id/snackbar_btn")
+                .text(expectedText),
+        ).also {
+            Log.i(TAG, "snackBarButtonClick: Waiting for $waitingTime ms for the snack bar button: $expectedText to exist")
+            it.waitForExists(waitingTime)
+            Log.i(TAG, "snackBarButtonClick: Waited for $waitingTime ms for the snack bar button: $expectedText to exist")
+            Log.i(TAG, "snackBarButtonClick: Trying to click the $expectedText snack bar button")
+            it.click()
+            Log.i(TAG, "snackBarButtonClick: Clicked the $expectedText snack bar button")
+        }
     }
 
     fun verifyTabMediaControlButtonState(action: String) = assertUIObjectExists(tabMediaControlButton(action))
 
     fun clickTabMediaControlButton(action: String) {
         tabMediaControlButton(action).also {
+            Log.i(TAG, "clickTabMediaControlButton: Waiting for $waitingTime ms for the media tab control button: $action to exist")
             it.waitForExists(waitingTime)
+            Log.i(TAG, "clickTabMediaControlButton: Waited for $waitingTime ms for the media tab control button: $action to exists")
+            Log.i(TAG, "clickTabMediaControlButton: Trying to click the tab media control button: $action")
             it.click()
+            Log.i(TAG, "clickTabMediaControlButton: Clicked the tab media control button: $action")
         }
     }
 
     fun clickSelectTabsOption() {
+        Log.i(TAG, "clickSelectTabsOption: Trying to click the three dot button")
         threeDotMenu().click()
-
-        val selectTabsButton = mDevice.findObject(UiSelector().text("Select tabs"))
-        selectTabsButton.waitForExists(waitingTime)
-        selectTabsButton.click()
+        Log.i(TAG, "clickSelectTabsOption: Clicked the three dot button")
+        mDevice.findObject(UiSelector().text("Select tabs")).also {
+            Log.i(TAG, "clickSelectTabsOption: Waiting for $waitingTime ms for the the \"Select tabs\" menu button to exist")
+            it.waitForExists(waitingTime)
+            Log.i(TAG, "clickSelectTabsOption: Waited for $waitingTime ms for the the \"Select tabs\" menu button to exists")
+            Log.i(TAG, "clickSelectTabsOption: Trying to click the \"Select tabs\" menu button")
+            it.click()
+            Log.i(TAG, "clickSelectTabsOption: Clicked the \"Select tabs\" menu button")
+        }
     }
 
     fun selectTab(title: String, numOfTabs: Int) {
@@ -289,8 +394,12 @@ class TabDrawerRobot {
         var retries = 0 // number of retries before failing
 
         while (!tabsSelected.exists() && retries++ < 3) {
+            Log.i(TAG, "selectTab: Waiting for $waitingTime ms for tab with title: $title to exist")
             tabItem(title).waitForExists(waitingTime)
+            Log.i(TAG, "selectTab: Waited for $waitingTime ms for tab with title: $title to exist")
+            Log.i(TAG, "selectTab: Trying to click tab with title: $title")
             tabItem(title).click()
+            Log.i(TAG, "selectTab: Clicked tab with title: $title")
         }
     }
 
@@ -299,12 +408,13 @@ class TabDrawerRobot {
             findObject(text(title)),
             waitingTime,
         )
-
+        Log.i(TAG, "longClickTab: Trying to long click tab with title: $title")
         mDevice.findObject(
             By
                 .textContains(title)
                 .res("$packageName:id/mozac_browser_tabstray_title"),
         ).click(LONG_CLICK_DURATION)
+        Log.i(TAG, "longClickTab: Long clicked tab with title: $title")
     }
 
     fun createCollection(
@@ -340,10 +450,14 @@ class TabDrawerRobot {
 
     class Transition {
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): Transition {
+            Log.i(TAG, "openTabDrawer: Waiting for device to be idle for $waitingTime ms")
             mDevice.waitForIdle(waitingTime)
+            Log.i(TAG, "openTabDrawer: Waited for device to be idle for $waitingTime ms")
+            Log.i(TAG, "openTabDrawer: Trying to click the tab counter button")
             tabsCounter().click()
+            Log.i(TAG, "openTabDrawer: Clicked the tab counter button")
             mDevice.waitNotNull(
-                Until.findObject(By.res("$packageName:id/tab_layout")),
+                findObject(By.res("$packageName:id/tab_layout")),
                 waitingTime,
             )
 
@@ -352,50 +466,66 @@ class TabDrawerRobot {
         }
 
         fun closeTabDrawer(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            Log.i(TAG, "closeTabDrawer: Waiting for device to be idle for $waitingTime ms")
             mDevice.waitForIdle(waitingTime)
-
+            Log.i(TAG, "closeTabDrawer: Waited for device to be idle for $waitingTime ms")
+            Log.i(TAG, "closeTabDrawer: Trying to click the tabs tray handler")
             onView(withId(R.id.handle)).perform(
                 click(),
             )
+            Log.i(TAG, "closeTabDrawer: Clicked the tabs tray handler")
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
 
         fun openNewTab(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
+            Log.i(TAG, "openNewTab: Waiting for device to be idle")
             mDevice.waitForIdle()
-
+            Log.i(TAG, "openNewTab: Waited for device to be idle")
+            Log.i(TAG, "openNewTab: Trying to click the new tab FAB button")
             newTabButton().click()
+            Log.i(TAG, "openNewTab: Clicked the new tab FAB button")
             SearchRobot().interact()
             return SearchRobot.Transition()
         }
 
         fun toggleToNormalTabs(interact: TabDrawerRobot.() -> Unit): Transition {
+            Log.i(TAG, "toggleToNormalTabs: Trying to click the normal browsing button")
             normalBrowsingButton().perform(click())
+            Log.i(TAG, "toggleToNormalTabs: Clicked the normal browsing button")
             TabDrawerRobot().interact()
             return Transition()
         }
 
         fun toggleToPrivateTabs(interact: TabDrawerRobot.() -> Unit): Transition {
+            Log.i(TAG, "toggleToPrivateTabs: Trying to click the private browsing button")
             privateBrowsingButton().perform(click())
+            Log.i(TAG, "toggleToPrivateTabs: Clicked the private browsing button")
             TabDrawerRobot().interact()
             return Transition()
         }
 
         fun toggleToSyncedTabs(interact: TabDrawerRobot.() -> Unit): Transition {
+            Log.i(TAG, "toggleToSyncedTabs: Trying to click the synced tabs button")
             syncedTabsButton().perform(click())
+            Log.i(TAG, "toggleToSyncedTabs: Clicked the synced tabs button")
             TabDrawerRobot().interact()
             return Transition()
         }
 
         fun clickSignInToSyncButton(interact: SyncSignInRobot.() -> Unit): Transition {
+            Log.i(TAG, "clickSignInToSyncButton: Trying to click the sign in to sync button and wait for $waitingTimeShort ms for a new window")
             itemContainingText(getStringResource(R.string.sync_sign_in))
                 .clickAndWaitForNewWindow(waitingTimeShort)
+            Log.i(TAG, "clickSignInToSyncButton: Clicked the sign in to sync button and waited for $waitingTimeShort ms for a new window")
             SyncSignInRobot().interact()
             return Transition()
         }
 
         fun openTabsListThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
+            Log.i(TAG, "openTabsListThreeDotMenu: Trying to click the three dot button")
             threeDotMenu().perform(click())
+            Log.i(TAG, "openTabsListThreeDotMenu: Clicked three dot button")
 
             ThreeDotMenuMainRobot().interact()
             return ThreeDotMenuMainRobot.Transition()
@@ -403,8 +533,12 @@ class TabDrawerRobot {
 
         fun openTab(title: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             scrollToElementByText(title)
+            Log.i(TAG, "openTab: Waiting for $waitingTime ms for tab with title: $title to exist")
             tabItem(title).waitForExists(waitingTime)
+            Log.i(TAG, "openTab: Waited for $waitingTime ms for tab with title: $title to exist")
+            Log.i(TAG, "openTab: Trying to click tab with title: $title")
             tabItem(title).click()
+            Log.i(TAG, "openTab: Clicked tab with title: $title")
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
@@ -420,8 +554,12 @@ class TabDrawerRobot {
                     .resourceId("$packageName:id/tab_tray_grid_item")
                     .index(tabPosition),
             ).also {
+                Log.i(TAG, "openTabWithIndex: Waiting for $waitingTime ms for tab at position: ${tabPosition + 1} to exist")
                 it.waitForExists(waitingTime)
+                Log.i(TAG, "openTabWithIndex: Waited for $waitingTime ms for tab at position: ${tabPosition + 1} to exist")
+                Log.i(TAG, "openTabWithIndex: Trying to click tab at position: ${tabPosition + 1}")
                 it.click()
+                Log.i(TAG, "openTabWithIndex: Clicked tab at position: ${tabPosition + 1}")
             }
 
             BrowserRobot().interact()
@@ -431,7 +569,9 @@ class TabDrawerRobot {
         fun clickTopBar(interact: TabDrawerRobot.() -> Unit): Transition {
             // The topBar contains other views.
             // Don't do the default click in the middle, rather click in some free space - top right.
+            Log.i(TAG, "clickTopBar: Trying to click the tabs tray top bar")
             onView(withId(R.id.topBar)).clickAtLocationInView(GeneralLocation.TOP_RIGHT)
+            Log.i(TAG, "clickTopBar: Clicked the tabs tray top bar")
             TabDrawerRobot().interact()
             return Transition()
         }
@@ -488,7 +628,9 @@ class TabDrawerRobot {
         }
 
         fun clickSaveCollection(interact: CollectionRobot.() -> Unit): CollectionRobot.Transition {
+            Log.i(TAG, "clickSaveCollection: Trying to click the collections button")
             saveTabsToCollectionButton().click()
+            Log.i(TAG, "clickSaveCollection: Clicked the collections button")
 
             CollectionRobot().interact()
             return CollectionRobot.Transition()


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1884329