### PR TITLE
Bug 1884459 - Prevent Offers to Translate after a Translation Occurs

### DIFF
--- a/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TranslationsStateReducer.kt
+++ b/android-components/components/browser/state/src/main/java/mozilla/components/browser/state/reducer/TranslationsStateReducer.kt
@@ -97,7 +97,10 @@ internal object TranslationsStateReducer {
 
         is TranslationsAction.TranslateAction ->
             state.copyWithTranslationsState(action.tabId) {
-                it.copy(isTranslateProcessing = true)
+                it.copy(
+                    isOfferTranslate = false,
+                    isTranslateProcessing = true,
+                )
             }
 
         is TranslationsAction.TranslateRestoreAction ->

--- a/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/TranslationsActionTest.kt
+++ b/android-components/components/browser/state/src/test/java/mozilla/components/browser/state/action/TranslationsActionTest.kt
@@ -117,6 +117,22 @@ class TranslationsActionTest {
     }
 
     @Test
+    fun `GIVEN isOfferTranslate is true WHEN a TranslateAction is dispatched THEN isOfferTranslate should be set to false`() {
+        // Initial State
+        assertFalse(tabState().translationsState.isOfferTranslate)
+
+        // Initial Offer State
+        store.dispatch(TranslationsAction.TranslateOfferAction(tabId = tab.id)).joinBlocking()
+        assertTrue(tabState().translationsState.isOfferTranslate)
+
+        // Action
+        store.dispatch(TranslationsAction.TranslateAction(tabId = tab.id, fromLanguage = "en", toLanguage = "en", options = null)).joinBlocking()
+
+        // Should revert to false
+        assertFalse(tabState().translationsState.isOfferTranslate)
+    }
+
+    @Test
     fun `WHEN a TranslateStateChangeAction is dispatched THEN the isExpectedTranslate status updates accordingly`() {
         // Initial State
         assertNull(tabState().translationsState.translationEngineState)


### PR DESCRIPTION
This bug slightly adjusts the reducer to set `isOfferTranslate` to false once a translation occurs.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1884459