### PR TITLE
 Bug 1884822 - Suggest: Limit returned suggestion to 1

### DIFF
--- a/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
+++ b/android-components/components/feature/fxsuggest/src/main/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProvider.kt
@@ -13,6 +13,8 @@ import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.ktx.kotlin.toBitmap
 import java.util.UUID
 
+private const val MAX_NUM_OF_FIREFOX_SUGGESTIONS = 1
+
 /**
  * An [AwesomeBar.SuggestionProvider] that returns Firefox Suggest search suggestions.
  *
@@ -66,6 +68,7 @@ class FxSuggestSuggestionProvider(
                 SuggestionQuery(
                     keyword = text,
                     providers = providers,
+                    limit = MAX_NUM_OF_FIREFOX_SUGGESTIONS,
                 ),
             ).into()
         }

--- a/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProviderTest.kt
+++ b/android-components/components/feature/fxsuggest/src/test/java/mozilla/components/feature/fxsuggest/FxSuggestSuggestionProviderTest.kt
@@ -103,13 +103,6 @@ class FxSuggestSuggestionProviderTest {
                     rawClickUrl = "https://example.com/click_url",
                     score = 0.3,
                 ),
-                Suggestion.Wikipedia(
-                    title = "Las Vegas",
-                    url = "https://wikipedia.org/wiki/Las_Vegas",
-                    icon = null,
-                    iconMimetype = null,
-                    fullKeyword = "las",
-                ),
             ),
         )
 
@@ -127,20 +120,16 @@ class FxSuggestSuggestionProviderTest {
                 SuggestionQuery(
                     keyword = "la",
                     providers = listOf(SuggestionProvider.AMP, SuggestionProvider.WIKIPEDIA),
+                    limit = 1,
                 ),
             ),
         )
-        assertEquals(2, suggestions.size)
+        assertEquals(1, suggestions.size)
         assertEquals("Lasagna Come Out Tomorrow", suggestions[0].title)
         assertEquals(testContext.resources.getString(R.string.sponsored_suggestion_description), suggestions[0].description)
         assertNotNull(suggestions[0].icon)
         assertEquals(Int.MIN_VALUE, suggestions[0].score)
         assertTrue(suggestions[0].metadata.isNullOrEmpty())
-        assertEquals("Las Vegas", suggestions[1].title)
-        assertNull(suggestions[1].description)
-        assertNull(suggestions[1].icon)
-        assertEquals(Int.MIN_VALUE, suggestions[1].score)
-        assertTrue(suggestions[1].metadata.isNullOrEmpty())
     }
 
     @Test
@@ -188,6 +177,7 @@ class FxSuggestSuggestionProviderTest {
                 SuggestionQuery(
                     keyword = "la",
                     providers = listOf(SuggestionProvider.WIKIPEDIA),
+                    limit = 1,
                 ),
             ),
         )
@@ -244,6 +234,7 @@ class FxSuggestSuggestionProviderTest {
                 SuggestionQuery(
                     keyword = "la",
                     providers = listOf(SuggestionProvider.AMP),
+                    limit = 1,
                 ),
             ),
         )
@@ -316,6 +307,7 @@ class FxSuggestSuggestionProviderTest {
                 SuggestionQuery(
                     keyword = "la",
                     providers = listOf(SuggestionProvider.AMP_MOBILE),
+                    limit = 1,
                 ),
             ),
         )
@@ -364,6 +356,7 @@ class FxSuggestSuggestionProviderTest {
                 SuggestionQuery(
                     keyword = "la",
                     providers = emptyList(),
+                    limit = 1,
                 ),
             ),
         )
@@ -392,6 +385,7 @@ class FxSuggestSuggestionProviderTest {
                 SuggestionQuery(
                     keyword = "la",
                     providers = emptyList(),
+                    limit = 1,
                 ),
             ),
         )


### PR DESCRIPTION
To consistent with Desktop, we want to limit the number of sponsored/nonsponsored suggestion to be 1.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1884822