### PR TITLE
Bug 1885650 - Stop FxA state machine breadcrumbs from being scrubbed

### DIFF
--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/FxaAccountManager.kt
@@ -454,7 +454,7 @@ open class FxaAccountManager(
      */
     private suspend fun processQueue(event: Event) {
         crashReporter?.recordCrashBreadcrumb(
-            Breadcrumb("fxa-state-machine-checker: a-c transition started (event: $event)"),
+            Breadcrumb("fxa-state-machine-checker: a-c transition started (event: ${event.breadcrumbDisplay()})"),
         )
         eventQueue.add(event)
         do {
@@ -462,7 +462,10 @@ open class FxaAccountManager(
             val transitionInto = state.next(toProcess)
 
             crashReporter?.recordCrashBreadcrumb(
-                Breadcrumb("fxa-state-machine-checker: a-c transition (event: $toProcess, into: $transitionInto)"),
+                Breadcrumb(
+                    "fxa-state-machine-checker: a-c transition " +
+                        "(event: ${toProcess.breadcrumbDisplay()}, into: ${transitionInto?.breadcrumbDisplay()})",
+                ),
             )
 
             if (transitionInto == null) {

--- a/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
+++ b/android-components/components/service/firefox-accounts/src/main/java/mozilla/components/service/fxa/manager/State.kt
@@ -102,11 +102,60 @@ internal sealed class Event {
         data class StartedOAuthFlow(val oAuthUrl: String) : Progress()
         data class CompletedAuthentication(val authType: AuthType) : Progress()
     }
+
+    /**
+     * Get a string to display in the breadcrumbs
+     *
+     * The main point of this function is to avoid using the string "auth", which gets filtered by
+     * Sentry.  Use "ath" as a hacky replacement.
+     */
+    fun breadcrumbDisplay(): String = when (this) {
+        is Account.Start -> "Account.Start"
+        is Account.BeginEmailFlow -> "Account.BeginEmailFlow"
+        is Account.BeginPairingFlow -> "Account.BeginPairingFlow"
+        is Account.AuthenticationError -> "Account.AthenticationError($operation)"
+        is Account.AccessTokenKeyError -> "Account.AccessTknKeyError"
+        is Account.Logout -> "Account.Logout"
+        is Progress.AccountNotFound -> "Progress.AccountNotFound"
+        is Progress.AccountRestored -> "Progress.AccountRestored"
+        is Progress.AuthData -> "Progress.LoggedOut"
+        is Progress.FailedToBeginAuth -> "Progress.FailedToBeginAth"
+        is Progress.FailedToCompleteAuthRestore -> "Progress.FailedToCompleteAthRestore"
+        is Progress.FailedToCompleteAuth -> "Progress.FailedToCompleteAth"
+        is Progress.CancelAuth -> "Progress.CancelAth"
+        is Progress.FailedToRecoverFromAuthenticationProblem -> "Progress.FailedToRecoverFromAthenticationProblem"
+        is Progress.RecoveredFromAuthenticationProblem -> "Progress.RecoveredFromAthenticationProblem"
+        is Progress.LoggedOut -> "Progress.LoggedOut"
+        is Progress.StartedOAuthFlow -> "Progress.StartedOAthFlow"
+        is Progress.CompletedAuthentication -> "Progress.CompletedAthentication"
+    }
 }
 
 internal sealed class State {
     data class Idle(val accountState: AccountState) : State()
     data class Active(val progressState: ProgressState) : State()
+
+    /**
+     * Get a string to display in the breadcrumbs
+     *
+     * The main point of this function is to avoid using the string "auth", which gets filtered by
+     * Sentry.  Use "ath" as a hacky replacement.
+     */
+    fun breadcrumbDisplay(): String = when (this) {
+        is Idle -> when (accountState) {
+            is AccountState.Authenticated -> "AccountState.Athenticated"
+            is AccountState.Authenticating -> "AccountState.Athenticating"
+            is AccountState.AuthenticationProblem -> "AccountState.AthenticationProblem"
+            is AccountState.NotAuthenticated -> "AccountState.NotAthenticated"
+        }
+        is Active -> when (progressState) {
+            ProgressState.Initializing -> "ProgressState.Initializing"
+            ProgressState.BeginningAuthentication -> "ProgressState.BeginningAthentication"
+            ProgressState.CompletingAuthentication -> "ProgressState.CompletingAthentication"
+            ProgressState.RecoveringFromAuthProblem -> "ProgressState.RecoveringFromAthProblem"
+            ProgressState.LoggingOut -> "ProgressState.LoggingOut"
+        }
+    }
 }
 
 internal fun State.next(event: Event): State? = when (this) {


### PR DESCRIPTION
Our org-wide Sentry settings use the default data scrubbing settings, which filter out any breadcrumb with the string "auth" in it (case insensitive).  This is filtering out most FxA state machine breadrcumbs since there's a lot of events/states with that string.

To work around this use the string "Ath", which is easy enough to translate and bypasses the default scrubbing.

More info: https://docs.sentry.io/product/data-management-settings/scrubbing/server-side-scrubbing/

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1885650