### PR TITLE
Bug 1885946 - Fix Fenix/Focus beta test run calls in ui-tests-apk configuration

### DIFF
--- a/taskcluster/ci/ui-test-apk/kind.yml
+++ b/taskcluster/ci/ui-test-apk/kind.yml
@@ -175,7 +175,7 @@ tasks:
             commands:
                 - [wget, {artifact-reference: '<signed-apk-debug-apk/public/build/target.arm64-v8a.apk>'}, '-O', app.apk]
                 - [wget, {artifact-reference: '<signed-apk-android-test/public/build/target.noarch.apk>'}, '-O', android-test.apk]
-                - [python3, ../taskcluster/scripts/tests/test-lab.py, arm-beta-tests, app.apk, --apk_test, android-test.apk]
+                - [python3, ../taskcluster/scripts/tests/test-lab.py, arm-beta, app.apk, --apk_test, android-test.apk]
         treeherder:
             platform: 'focus-ui-test/opt'
             symbol: focus-beta(ui-test-arm-beta)
@@ -258,7 +258,7 @@ tasks:
             commands:
                 - [wget, {artifact-reference: '<signed-apk-debug-apk/public/build/target.arm64-v8a.apk>'}, '-O', app.apk]
                 - [wget, {artifact-reference: '<signed-apk-android-test/public/build/target.noarch.apk>'}, '-O', android-test.apk]
-                - [python3, ../taskcluster/scripts/tests/test-lab.py, arm-beta-tests, app.apk, --apk_test, android-test.apk]
+                - [python3, ../taskcluster/scripts/tests/test-lab.py, arm-beta, app.apk, --apk_test, android-test.apk]
         treeherder:
             platform: 'fenix-ui-test/opt'
             symbol: fenix-beta(ui-test-arm-beta)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1885946

Beta Flank configuration (Fenix) https://github.com/mozilla-mobile/firefox-android/blob/releases_v125/fenix/automation/taskcluster/androidTest/flank-arm-beta.yml

Beta Flank configuration (Focus) https://github.com/mozilla-mobile/firefox-android/blob/releases_v125/focus-android/automation/taskcluster/androidTest/flank-arm-beta.yml


Older shell script was doing a direct assignment of configuration based on parameter `arm-beta-tests` passed in from `ui-test-apk` kind.yml
https://github.com/mozilla-mobile/firefox-android/blob/47e42ede7190947891ec2276601462d01af771e7/fenix/automation/taskcluster/androidTest/ui-test.sh#L83

Newer Python script doesn't do that as it just takes in the portion of the Flank configuration file name https://github.com/mozilla-mobile/firefox-android/blob/47e42ede7190947891ec2276601462d01af771e7/taskcluster/scripts/tests/test-lab.py#L112 but I was still passing in `arm-beta-tests` in https://github.com/mozilla-mobile/firefox-android/blob/47e42ede7190947891ec2276601462d01af771e7/taskcluster/ci/ui-test-apk/kind.yml#L178C75-L178C79 rather than `arm-beta` so it couldn't find the configurations for both apps (`arm-beta`).