### PR TITLE
Bug 1812181 - Firefox for Android crashes submitting form

### DIFF
--- a/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/creditcard/CreditCardSaveDialogFragment.kt
+++ b/android-components/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/creditcard/CreditCardSaveDialogFragment.kt
@@ -5,6 +5,7 @@
 package mozilla.components.feature.prompts.creditcard
 
 import android.app.Dialog
+import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -137,6 +138,11 @@ internal class CreditCardSaveDialogFragment : PromptDialogFragment() {
         confirmResult = validationDelegate.shouldCreateOrUpdate(creditCard)
 
         withContext(Main) {
+            setConfirmResultText(view)
+        }
+    }
+    private fun setConfirmResultText(view: View) {
+        checkIfFragmentAttached {
             when (confirmResult) {
                 is Result.CanBeCreated -> setViewText(
                     view = view,
@@ -144,6 +150,7 @@ internal class CreditCardSaveDialogFragment : PromptDialogFragment() {
                     cancelButtonText = requireContext().getString(R.string.mozac_feature_prompt_not_now),
                     confirmButtonText = requireContext().getString(R.string.mozac_feature_prompt_save_confirmation),
                 )
+
                 is Result.CanBeUpdated -> setViewText(
                     view = view,
                     header = requireContext().getString(R.string.mozac_feature_prompts_update_credit_card_prompt_title),
@@ -152,6 +159,12 @@ internal class CreditCardSaveDialogFragment : PromptDialogFragment() {
                     showMessageBody = false,
                 )
             }
+        }
+    }
+
+    private fun checkIfFragmentAttached(operation: Context.() -> Unit) {
+        if (isAdded && context != null) {
+            operation(requireContext())
         }
     }
 


### PR DESCRIPTION
Add a check for fragment attached and current context nullability before using requireContext.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1812181