### PR TITLE
Bug 1812712 -  Add "open in background tab" for bookmarks in the bookmarks manager 

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -159,7 +159,11 @@ class DefaultBookmarkController(
         )
     }
 
-    override fun handleOpeningBookmark(item: BookmarkNode, mode: BrowsingMode, openInBackground: Boolean) {
+    override fun handleOpeningBookmark(
+        item: BookmarkNode,
+        mode: BrowsingMode,
+        openInBackground: Boolean,
+    ) {
         openInNewTab(item.url!!, mode)
         showSnackbar(resources.getString(R.string.bookmark_opened_in_background))
         if (!openInBackground)

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -48,7 +48,7 @@ interface BookmarkController {
     fun handleAllBookmarksDeselected()
     fun handleCopyUrl(item: BookmarkNode)
     fun handleBookmarkSharing(item: BookmarkNode)
-    fun handleOpeningBookmark(item: BookmarkNode, mode: BrowsingMode)
+    fun handleOpeningBookmark(item: BookmarkNode, mode: BrowsingMode, openInBackground: Boolean)
     fun handleOpeningFolderBookmarks(folder: BookmarkNode, mode: BrowsingMode)
 
     /**
@@ -159,9 +159,11 @@ class DefaultBookmarkController(
         )
     }
 
-    override fun handleOpeningBookmark(item: BookmarkNode, mode: BrowsingMode) {
+    override fun handleOpeningBookmark(item: BookmarkNode, mode: BrowsingMode, openInBackground: Boolean) {
         openInNewTab(item.url!!, mode)
-        showTabTray(mode.isPrivate)
+        showSnackbar(resources.getString(R.string.bookmark_opened_in_background))
+        if (!openInBackground)
+            showTabTray(mode.isPrivate)
     }
 
     private fun extractURLsFromTree(node: BookmarkNode): MutableList<String> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -48,6 +48,12 @@ interface BookmarkController {
     fun handleAllBookmarksDeselected()
     fun handleCopyUrl(item: BookmarkNode)
     fun handleBookmarkSharing(item: BookmarkNode)
+    /**
+     * Handles opening bookmark
+     * @param item Bookmark node.
+     * @param mode Browsing mode.
+     * @param openInBackground If bookmark should open in background or not
+     */
     fun handleOpeningBookmark(item: BookmarkNode, mode: BrowsingMode, openInBackground: Boolean)
     fun handleOpeningFolderBookmarks(folder: BookmarkNode, mode: BrowsingMode)
 
@@ -166,8 +172,9 @@ class DefaultBookmarkController(
     ) {
         openInNewTab(item.url!!, mode)
         showSnackbar(resources.getString(R.string.bookmark_opened_in_background))
-        if (!openInBackground)
+        if (!openInBackground) {
             showTabTray(mode.isPrivate)
+        }
     }
 
     private fun extractURLsFromTree(node: BookmarkNode): MutableList<String> {

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
@@ -69,7 +69,7 @@ class BookmarkFragmentInteractor(
     override fun onOpenInNormalTab(item: BookmarkNode) {
         require(item.type == BookmarkNodeType.ITEM)
         item.url?.let {
-            bookmarksController.handleOpeningBookmark(item, BrowsingMode.Normal)
+            bookmarksController.handleOpeningBookmark(item, BrowsingMode.Normal, false)
             BookmarksManagement.openInNewTab.record(NoExtras())
         }
         MetricsUtils.recordBookmarkMetrics(
@@ -78,10 +78,21 @@ class BookmarkFragmentInteractor(
         )
     }
 
+    override fun onOpenInBackground(item: BookmarkNode) {
+        require(item.type == BookmarkNodeType.ITEM)
+        item.url?.let {
+            bookmarksController.handleOpeningBookmark(item, BrowsingMode.Normal, true)
+            BookmarksManagement.openInNewTab.record(NoExtras())
+        }
+        MetricsUtils.recordBookmarkMetrics(
+            MetricsUtils.BookmarkAction.OPEN,
+            METRIC_SOURCE,
+        )
+    }
     override fun onOpenInPrivateTab(item: BookmarkNode) {
         require(item.type == BookmarkNodeType.ITEM)
         item.url?.let {
-            bookmarksController.handleOpeningBookmark(item, BrowsingMode.Private)
+            bookmarksController.handleOpeningBookmark(item, BrowsingMode.Private, false)
             BookmarksManagement.openInPrivateTab.record(NoExtras())
         }
         MetricsUtils.recordBookmarkMetrics(

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
@@ -89,6 +89,7 @@ class BookmarkFragmentInteractor(
             METRIC_SOURCE,
         )
     }
+
     override fun onOpenInPrivateTab(item: BookmarkNode) {
         require(item.type == BookmarkNodeType.ITEM)
         item.url?.let {

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkItemMenu.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkItemMenu.kt
@@ -25,6 +25,7 @@ class BookmarkItemMenu(
         Copy,
         Share,
         OpenInNewTab,
+        OpenInBackground,
         OpenInPrivateTab,
         OpenAllInNewTabs,
         OpenAllInPrivateTabs,
@@ -71,6 +72,15 @@ class BookmarkItemMenu(
                     text = context.getString(R.string.bookmark_menu_open_in_new_tab_button),
                 ) {
                     onItemTapped.invoke(Item.OpenInNewTab)
+                }
+            } else {
+                null
+            },
+            if (itemType == BookmarkNodeType.ITEM) {
+                TextMenuCandidate(
+                    text = context.getString(R.string.bookmark_menu_open_in_background_button),
+                ) {
+                    onItemTapped.invoke(Item.OpenInBackground)
                 }
             } else {
                 null

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -75,6 +75,13 @@ interface BookmarkViewInteractor : SelectionInteractor<BookmarkNode> {
     fun onOpenInNormalTab(item: BookmarkNode)
 
     /**
+     * Opens a bookmark item in the background.
+     *
+     * @param item the bookmark item to open in the background
+     */
+    fun onOpenInBackground(item: BookmarkNode)
+
+    /**
      * Opens a bookmark item in a private tab.
      *
      * @param item the bookmark item to open in a private tab

--- a/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolder.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolder.kt
@@ -43,6 +43,7 @@ class BookmarkNodeViewHolder(
                 BookmarkItemMenu.Item.Copy -> interactor.onCopyPressed(item)
                 BookmarkItemMenu.Item.Share -> interactor.onSharePressed(item)
                 BookmarkItemMenu.Item.OpenInNewTab -> interactor.onOpenInNormalTab(item)
+                BookmarkItemMenu.Item.OpenInBackground -> interactor.onOpenInBackground(item)
                 BookmarkItemMenu.Item.OpenInPrivateTab -> interactor.onOpenInPrivateTab(item)
                 BookmarkItemMenu.Item.OpenAllInNewTabs -> interactor.onOpenAllInNewTabs(item)
                 BookmarkItemMenu.Item.OpenAllInPrivateTabs -> interactor.onOpenAllInPrivateTabs(item)

--- a/fenix/app/src/main/res/values/strings.xml
+++ b/fenix/app/src/main/res/values/strings.xml
@@ -1038,6 +1038,8 @@
     <string name="bookmark_menu_share_button">Share</string>
     <!-- Bookmark overflow menu open in new tab button -->
     <string name="bookmark_menu_open_in_new_tab_button">Open in new tab</string>
+    <!-- Bookmark overflow menu open in background button -->
+    <string name="bookmark_menu_open_in_background_button">Open in background</string>
     <!-- Bookmark overflow menu open in private tab button -->
     <string name="bookmark_menu_open_in_private_tab_button">Open in private tab</string>
     <!-- Bookmark overflow menu open all in tabs button -->
@@ -1353,6 +1355,8 @@
     <string name="full_screen_notification">Entering full screen mode</string>
     <!-- Message for copying the URL via long press on the toolbar -->
     <string name="url_copied">URL copied</string>
+    <!-- Message for opening a bookmark in the background -->
+    <string name="bookmark_opened_in_background">Opened in background</string>
     <!-- Sample text for accessibility font size -->
     <string name="accessibility_text_size_sample_text_1">This is sample text. It is here to show how text will appear when you increase or decrease the size with this setting.</string>
     <!-- Summary for Accessibility Text Size Scaling Preference -->

--- a/fenix/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -341,13 +341,14 @@ class BookmarkControllerTest {
     @Test
     fun `handleOpeningBookmark should open the bookmark a new 'Normal' tab`() {
         var showTabTrayInvoked = false
+        val openInBackGround = false
         var openedToPrivateTabsPage: Boolean? = null
         createController(
             showTabTray = { openToPrivateTabsPage ->
                 openedToPrivateTabsPage = openToPrivateTabsPage
                 showTabTrayInvoked = true
             },
-        ).handleOpeningBookmark(item, BrowsingMode.Normal)
+        ).handleOpeningBookmark(item, BrowsingMode.Normal, openInBackGround)
 
         assertTrue(showTabTrayInvoked)
         assertNotNull(openedToPrivateTabsPage)
@@ -361,13 +362,14 @@ class BookmarkControllerTest {
     @Test
     fun `handleOpeningBookmark should open the bookmark a new 'Private' tab`() {
         var showTabTrayInvoked = false
+        val openInBackGround = false
         var openedToPrivateTabsPage: Boolean? = null
         createController(
             showTabTray = { openToPrivateTabsPage ->
                 openedToPrivateTabsPage = openToPrivateTabsPage
                 showTabTrayInvoked = true
             },
-        ).handleOpeningBookmark(item, BrowsingMode.Private)
+        ).handleOpeningBookmark(item, BrowsingMode.Private, openInBackGround)
 
         assertTrue(showTabTrayInvoked)
         assertNotNull(openedToPrivateTabsPage)

--- a/fenix/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
+++ b/fenix/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
@@ -164,7 +164,17 @@ class BookmarkFragmentInteractorTest {
     fun `open a bookmark item in a new tab`() {
         interactor.onOpenInNormalTab(item)
 
-        verify { bookmarkController.handleOpeningBookmark(item, BrowsingMode.Normal) }
+        verify { bookmarkController.handleOpeningBookmark(item, BrowsingMode.Normal, false) }
+        assertNotNull(BookmarksManagement.openInNewTab.testGetValue())
+        assertEquals(1, BookmarksManagement.openInNewTab.testGetValue()!!.size)
+        assertNull(BookmarksManagement.openInNewTab.testGetValue()!!.single().extra)
+    }
+
+    @Test
+    fun `open a bookmark item in the background`() {
+        interactor.onOpenInBackground(item)
+
+        verify { bookmarkController.handleOpeningBookmark(item, BrowsingMode.Normal, true) }
         assertNotNull(BookmarksManagement.openInNewTab.testGetValue())
         assertEquals(1, BookmarksManagement.openInNewTab.testGetValue()!!.size)
         assertNull(BookmarksManagement.openInNewTab.testGetValue()!!.single().extra)
@@ -179,7 +189,7 @@ class BookmarkFragmentInteractorTest {
     fun `open a bookmark item in a private tab`() {
         interactor.onOpenInPrivateTab(item)
 
-        verify { bookmarkController.handleOpeningBookmark(item, BrowsingMode.Private) }
+        verify { bookmarkController.handleOpeningBookmark(item, BrowsingMode.Private, false) }
         assertNotNull(BookmarksManagement.openInPrivateTab.testGetValue())
         assertEquals(1, BookmarksManagement.openInPrivateTab.testGetValue()!!.size)
         assertNull(BookmarksManagement.openInPrivateTab.testGetValue()!!.single().extra)


### PR DESCRIPTION
## Demo video
https://www.loom.com/share/2a30877aee2340edab62e00522316403?sid=aa4e0fa4-68b9-487c-9eef-f9f493e97c05


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
https://bugzilla.mozilla.org/show_bug.cgi?id=1812712