### PR TITLE
Bug 1886083 - Don't call onHomePressed when notification permission prompt is shown

### DIFF
--- a/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/fenix/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -833,9 +833,13 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     }
 
     final override fun onUserLeaveHint() {
-        supportFragmentManager.primaryNavigationFragment?.childFragmentManager?.fragments?.forEach {
-            if (it is UserInteractionHandler && it.onHomePressed()) {
-                return
+        // The notification permission prompt will trigger onUserLeaveHint too.
+        // We shouldn't treat this situation as user leaving.
+        if (!components.notificationsDelegate.isRequestingPermission) {
+            supportFragmentManager.primaryNavigationFragment?.childFragmentManager?.fragments?.forEach {
+                if (it is UserInteractionHandler && it.onHomePressed()) {
+                    return
+                }
             }
         }
 

--- a/focus-android/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
+++ b/focus-android/app/src/main/java/org/mozilla/focus/activity/MainActivity.kt
@@ -197,10 +197,14 @@ open class MainActivity : LocaleAwareAppCompatActivity() {
     }
 
     final override fun onUserLeaveHint() {
-        val browserFragment =
-            supportFragmentManager.findFragmentByTag(BrowserFragment.FRAGMENT_TAG) as BrowserFragment?
-        if (browserFragment is UserInteractionHandler && browserFragment.onHomePressed()) {
-            return
+        // The notification permission prompt will trigger onUserLeaveHint too.
+        // We shouldn't treat this situation as user leaving.
+        if (!components.notificationsDelegate.isRequestingPermission) {
+            val browserFragment =
+                supportFragmentManager.findFragmentByTag(BrowserFragment.FRAGMENT_TAG) as BrowserFragment?
+            if (browserFragment is UserInteractionHandler && browserFragment.onHomePressed()) {
+                return
+            }
         }
         super.onUserLeaveHint()
     }


### PR DESCRIPTION
Fixes the bug: Video goes to picture-in-picture then disappears when you tap fullscreen

Link to the patch on Phabricator: https://phabricator.services.mozilla.com/D205793

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
