### PR TITLE
Uplift for Bug 1892126 - Updated jsonToPocketApiStory function to handle null values r=android-reviewers,rsainani

### DIFF
--- a/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/stories/api/PocketJSONParser.kt
+++ b/android-components/components/service/pocket/src/main/java/mozilla/components/service/pocket/stories/api/PocketJSONParser.kt
@@ -33,23 +33,34 @@ internal class PocketJSONParser {
         val stories = storiesJSON.mapNotNull(JSONArray::getJSONObject) { jsonToPocketApiStory(it) }
 
         // We return null, rather than the empty list, because devs might forget to check an empty list.
-        if (stories.isNotEmpty()) stories else null
+        stories.ifEmpty { null }
     } catch (e: JSONException) {
         logger.warn("invalid JSON from the Pocket endpoint", e)
         null
     }
 
     private fun jsonToPocketApiStory(json: JSONObject): PocketApiStory? = try {
-        PocketApiStory(
-            // These three properties are required for any valid recommendation.
-            title = json.getString(JSON_STORY_TITLE_KEY),
-            url = json.getString(JSON_STORY_URL_KEY),
-            imageUrl = json.getString(JSON_STORY_IMAGE_URL_KEY),
-            // The following three properties are optional.
-            publisher = json.tryGetString(JSON_STORY_PUBLISHER_KEY) ?: STRING_NOT_FOUND_DEFAULT_VALUE,
-            category = json.tryGetString(JSON_STORY_CATEGORY_KEY) ?: STRING_NOT_FOUND_DEFAULT_VALUE,
-            timeToRead = json.tryGetInt(JSON_STORY_TIME_TO_READ_KEY) ?: INT_NOT_FOUND_DEFAULT_VALUE,
-        )
+        val title = json.tryGetString(JSON_STORY_TITLE_KEY)
+        val url = json.tryGetString(JSON_STORY_URL_KEY)
+        val imageUrl = json.tryGetString(JSON_STORY_IMAGE_URL_KEY)
+
+        // These three properties are required for any valid recommendation.
+        if (title == null || url == null || imageUrl == null) {
+            null
+        } else {
+            PocketApiStory(
+                title = title,
+                url = url,
+                imageUrl = imageUrl,
+                // The following three properties are optional.
+                publisher = json.tryGetString(JSON_STORY_PUBLISHER_KEY)
+                    ?: STRING_NOT_FOUND_DEFAULT_VALUE,
+                category = json.tryGetString(JSON_STORY_CATEGORY_KEY)
+                    ?: STRING_NOT_FOUND_DEFAULT_VALUE,
+                timeToRead = json.tryGetInt(JSON_STORY_TIME_TO_READ_KEY)
+                    ?: INT_NOT_FOUND_DEFAULT_VALUE,
+            )
+        }
     } catch (e: JSONException) {
         null
     }

--- a/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResources.kt
+++ b/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/helpers/PocketTestResources.kt
@@ -18,12 +18,24 @@ private const val POCKET_DIR = "pocket"
  * Accessors to resources used in testing.
  */
 internal object PocketTestResources {
-    val pocketEndointFiveStoriesResponse = this::class.java.classLoader!!.getResource(
+    val pocketEndpointFiveStoriesResponse = this::class.java.classLoader!!.getResource(
         "$POCKET_DIR/stories_recommendations_response.json",
     )!!.readText()
 
     val pocketEndpointThreeSpocsResponse = this::class.java.classLoader!!.getResource(
         "$POCKET_DIR/sponsored_stories_response.json",
+    )!!.readText()
+
+    val pocketEndpointNullTitleStoryBadResponse = this::class.java.classLoader!!.getResource(
+        "$POCKET_DIR/story_recommendation_null_title_response.json",
+    )!!.readText()
+
+    val pocketEndpointNullUrlStoryBadResponse = this::class.java.classLoader!!.getResource(
+        "$POCKET_DIR/story_recommendation_null_url_response.json",
+    )!!.readText()
+
+    val pocketEndpointNullImageUrlStoryBadResponse = this::class.java.classLoader!!.getResource(
+        "$POCKET_DIR/story_recommendation_null_imageUrl_response.json",
     )!!.readText()
 
     val apiExpectedPocketStoriesRecommendations: List<PocketApiStory> = listOf(

--- a/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/api/PocketJSONParserTest.kt
+++ b/android-components/components/service/pocket/src/test/java/mozilla/components/service/pocket/stories/api/PocketJSONParserTest.kt
@@ -35,7 +35,7 @@ class PocketJSONParserTest {
     @Test
     fun `GIVEN PocketJSONParser WHEN parsing valid stories recommendations THEN PocketApiStories are returned`() {
         val expectedStories = PocketTestResources.apiExpectedPocketStoriesRecommendations
-        val pocketJSON = PocketTestResources.pocketEndointFiveStoriesResponse
+        val pocketJSON = PocketTestResources.pocketEndpointFiveStoriesResponse
         val actualStories = parser.jsonToPocketApiStories(pocketJSON)
 
         assertNotNull(actualStories)
@@ -45,7 +45,7 @@ class PocketJSONParserTest {
 
     @Test
     fun `WHEN parsing stories recommendations with missing titles THEN those entries are dropped`() {
-        val pocketJSON = PocketTestResources.pocketEndointFiveStoriesResponse
+        val pocketJSON = PocketTestResources.pocketEndpointFiveStoriesResponse
         val expectedStoriesIfMissingTitle = ArrayList(PocketTestResources.apiExpectedPocketStoriesRecommendations)
             .apply { removeAt(4) }
         val pocketJsonWithMissingTitle = removeJsonFieldFromArrayIndex("title", 4, pocketJSON)
@@ -57,8 +57,16 @@ class PocketJSONParserTest {
     }
 
     @Test
+    fun `WHEN parsing stories recommendations with a null title value THEN those entries are dropped`() {
+        val pocketJSON = PocketTestResources.pocketEndpointNullTitleStoryBadResponse
+        val result = parser.jsonToPocketApiStories(pocketJSON)
+
+        assertNull(result)
+    }
+
+    @Test
     fun `WHEN parsing stories recommendations with missing urls THEN those entries are dropped`() {
-        val pocketJSON = PocketTestResources.pocketEndointFiveStoriesResponse
+        val pocketJSON = PocketTestResources.pocketEndpointFiveStoriesResponse
         val expectedStoriesIfMissingUrl = ArrayList(PocketTestResources.apiExpectedPocketStoriesRecommendations)
             .apply { removeAt(3) }
         val pocketJsonWithMissingUrl = removeJsonFieldFromArrayIndex("url", 3, pocketJSON)
@@ -70,8 +78,16 @@ class PocketJSONParserTest {
     }
 
     @Test
+    fun `WHEN parsing stories recommendations with a null url THEN those entries are dropped`() {
+        val pocketJSON = PocketTestResources.pocketEndpointNullUrlStoryBadResponse
+        val result = parser.jsonToPocketApiStories(pocketJSON)
+
+        assertNull(result)
+    }
+
+    @Test
     fun `WHEN parsing stories recommendations with missing imageUrls THEN those entries are dropped`() {
-        val pocketJSON = PocketTestResources.pocketEndointFiveStoriesResponse
+        val pocketJSON = PocketTestResources.pocketEndpointFiveStoriesResponse
         val expectedStoriesIfMissingImageUrl = ArrayList(PocketTestResources.apiExpectedPocketStoriesRecommendations)
             .apply { removeAt(2) }
         val pocketJsonWithMissingImageUrl = removeJsonFieldFromArrayIndex("imageUrl", 2, pocketJSON)
@@ -83,8 +99,16 @@ class PocketJSONParserTest {
     }
 
     @Test
+    fun `WHEN parsing story recommendations with a null imageUrl THEN those entries are dropped`() {
+        val pocketJSON = PocketTestResources.pocketEndpointNullImageUrlStoryBadResponse
+        val result = parser.jsonToPocketApiStories(pocketJSON)
+
+        assertNull(result)
+    }
+
+    @Test
     fun `WHEN parsing stories recommendations with missing publishers THEN those entries are kept but with default values`() {
-        val pocketJSON = PocketTestResources.pocketEndointFiveStoriesResponse
+        val pocketJSON = PocketTestResources.pocketEndpointFiveStoriesResponse
         val expectedStoriesIfMissingPublishers = PocketTestResources.apiExpectedPocketStoriesRecommendations
             .mapIndexed { index, story ->
                 if (index == 2) {
@@ -103,7 +127,7 @@ class PocketJSONParserTest {
 
     @Test
     fun `WHEN parsing stories recommendations with missing categories THEN those entries are kept but with default values`() {
-        val pocketJSON = PocketTestResources.pocketEndointFiveStoriesResponse
+        val pocketJSON = PocketTestResources.pocketEndpointFiveStoriesResponse
         val expectedStoriesIfMissingCategories = PocketTestResources.apiExpectedPocketStoriesRecommendations
             .mapIndexed { index, story ->
                 if (index == 3) {
@@ -122,7 +146,7 @@ class PocketJSONParserTest {
 
     @Test
     fun `WHEN parsing stories recommendations with missing timeToRead THEN those entries are kept but with default values`() {
-        val pocketJSON = PocketTestResources.pocketEndointFiveStoriesResponse
+        val pocketJSON = PocketTestResources.pocketEndpointFiveStoriesResponse
         val expectedStoriesIfMissingTimeToRead = PocketTestResources.apiExpectedPocketStoriesRecommendations
             .mapIndexed { index, story ->
                 if (index == 4) {

--- a/android-components/components/service/pocket/src/test/resources/pocket/story_recommendation_null_imageUrl_response.json
+++ b/android-components/components/service/pocket/src/test/resources/pocket/story_recommendation_null_imageUrl_response.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    {
+      "category": "science",
+      "url": "https://getpocket.com/explore/item/you-think-you-know-what-blue-is-but-you-have-no-idea",
+      "title": "You Think You Know What Blue Is, But You Have No Idea",
+      "imageUrl": null,
+      "publisher": "Pocket",
+      "timeToRead": 3
+    }
+  ]
+}

--- a/android-components/components/service/pocket/src/test/resources/pocket/story_recommendation_null_title_response.json
+++ b/android-components/components/service/pocket/src/test/resources/pocket/story_recommendation_null_title_response.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    {
+      "category": "science",
+      "url": "https://getpocket.com/explore/item/you-think-you-know-what-blue-is-but-you-have-no-idea",
+      "title": null,
+      "imageUrl": "https://img-getpocket.cdn.mozilla.net/{wh}/filters:format(jpeg):quality(60):no_upscale():strip_exif()/https%3A%2F%2Fpocket-image-cache.com%2F1200x%2Ffilters%3Aformat(jpg)%3Aextract_focal()%2Fhttps%253A%252F%252Fpocket-syndicated-images.s3.amazonaws.com%252Farticles%252F3713%252F1584373694_GettyImages-83522858.jpg",
+      "publisher": "Pocket",
+      "timeToRead": 3
+    }
+  ]
+}

--- a/android-components/components/service/pocket/src/test/resources/pocket/story_recommendation_null_url_response.json
+++ b/android-components/components/service/pocket/src/test/resources/pocket/story_recommendation_null_url_response.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    {
+      "category": "science",
+      "url": null,
+      "title": "You Think You Know What Blue Is, But You Have No Idea",
+      "imageUrl": "https://img-getpocket.cdn.mozilla.net/{wh}/filters:format(jpeg):quality(60):no_upscale():strip_exif()/https%3A%2F%2Fpocket-image-cache.com%2F1200x%2Ffilters%3Aformat(jpg)%3Aextract_focal()%2Fhttps%253A%252F%252Fpocket-syndicated-images.s3.amazonaws.com%252Farticles%252F3713%252F1584373694_GettyImages-83522858.jpg",
+      "publisher": "Pocket",
+      "timeToRead": 3
+    }
+  ]
+}


### PR DESCRIPTION
Original Revision: https://phabricator.services.mozilla.com/D207990

Differential Revision: https://phabricator.services.mozilla.com/D208117

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/changelog.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/firefox-android/blob/main/docs/shared/android/accessibility_guide.md) or does not include any user facing features

### After merge
- **Breaking Changes**: If this is a breaking Android Components change, please push a draft PR on [Reference Browser](https://github.com/mozilla-mobile/reference-browser) to address the breaking issues.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-apk-{fenix,focus,klar}-debug` task you're interested in.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
